### PR TITLE
[WIP] Add selection center rotation and scaling

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameEntityTransformService.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameEntityTransformService.cs
@@ -36,6 +36,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
         private EntityHierarchyEditorGame game;
         private Transformation activeTransformation;
         private TransformationSpace space;
+        private OriginMode originMode;
         private double gizmoSize = 1.0f;
 
         public EditorGameEntityTransformService([NotNull] EntityHierarchyEditorViewModel editor, [NotNull] IEditorGameController controller)
@@ -129,6 +130,8 @@ namespace Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
         }
 
         TransformationSpace IEditorGameTransformViewModelService.TransformationSpace { get { return space; } set { space = value; controller.InvokeAsync(() => transformationGizmos.ForEach(x => x.Space = value)); } }
+
+        OriginMode IEditorGameTransformViewModelService.OriginMode { get { return originMode; } set { originMode = value; controller.InvokeAsync(() => transformationGizmos.ForEach(x => x.OriginMode = value)); } }
 
         double IEditorGameEntityTransformViewModelService.GizmoSize { get { return gizmoSize; } set { gizmoSize = value; controller.InvokeAsync(() => transformationGizmos.ForEach(x => x.SizeFactor = SmoothGizmoSize((float)value))); } }
 

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityTransformationViewModel.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityTransformationViewModel.cs
@@ -33,6 +33,8 @@ namespace Xenko.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewModel
 
         public TransformationSpace Space { get { return Service.TransformationSpace; } set { SetValue(Service.TransformationSpace != value, () => Service.TransformationSpace = value); } }
 
+        public OriginMode OriginMode { get { return Service.OriginMode; } set { SetValue(Service.OriginMode != value, () => Service.OriginMode = value); } }
+
         public IReadOnlyCollection<TransformationSpace> AvailableSpaces { get { return availableSpaces; } private set { SetValue(ref availableSpaces, value); } }
 
         public SnapInfoViewModel TranslationSnap { get; }

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
@@ -738,6 +738,9 @@
                 </ListBox.ItemContainerStyle>
               </ListBox>
               <Separator Background="{StaticResource ToggleButtonNormalBackground}"/>
+              <ListBox Style="{StaticResource EnumListBox}" SelectedItem="{Binding Transform.OriginMode, Mode=TwoWay}"
+                       ItemsSource="{Binding Source={x:Type gameEditor:OriginMode}, Converter={xk:EnumValues}}"/>
+              <Separator Background="{StaticResource ToggleButtonNormalBackground}"/>
               <ToggleButton IsChecked="{Binding MaterialSelectionMode}" Background="Transparent"
                             Content="{xk:Image {StaticResource ImageToggleMaterialMode}, 16, 16, NearestNeighbor}" Width="28" Height="28"
                             ToolTip="{xk:Localize Toggle material selection (click a selected asset to select its material), Context=ToolTip}" xk:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True" />

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/OriginMode.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/OriginMode.cs
@@ -19,7 +19,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor
         /// <summary>
         /// Places the origin in the center of the last selected entity.
         /// </summary>
-        [Translation("Last selected")]
+        [Translation("Switch to last selected scaling")]
         LastSelected,
     }
 }

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/OriginMode.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/OriginMode.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Xenko.Assets.Presentation.AssetEditors.GameEditor
+{
+    /// <summary>
+    /// This enum represents the different positions the transformation origin can be.
+    /// </summary>
+    public enum OriginMode
+    {
+        /// <summary>
+        /// Places the origin in the center of the selection.
+        /// </summary>
+        SelectionCenter,
+        /// <summary>
+        /// Places the origin in the center of the last selected entity.
+        /// </summary>
+        LastSelected,
+    }
+}

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/OriginMode.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/OriginMode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Xenko.Core.Translation.Annotations;
+
 namespace Xenko.Assets.Presentation.AssetEditors.GameEditor
 {
     /// <summary>
@@ -11,10 +13,13 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor
         /// <summary>
         /// Places the origin in the center of the selection.
         /// </summary>
+        [Translation("Switch to selection center scaling")]
         SelectionCenter,
+
         /// <summary>
         /// Places the origin in the center of the last selected entity.
         /// </summary>
+        [Translation("Last selected")]
         LastSelected,
     }
 }

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/Services/IEditorGameEntityTransformViewModelService.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/Services/IEditorGameEntityTransformViewModelService.cs
@@ -15,6 +15,10 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor.Services
         /// Gets or sets the currently transformation space.
         /// </summary>
         TransformationSpace TransformationSpace { get; set; }
+        /// <summary>
+        /// Gets or sets the origin position.
+        /// </summary>
+        OriginMode OriginMode { get; set; }
 
         /// <summary>
         /// Updates the snapping parameters for the given transformation.

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
@@ -125,9 +125,6 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         {
             const float MaxScaleValue = 1f / MathUtil.ZeroTolerance;
 
-            if (UseSnap)
-                translation = MathUtil.Snap(translation, SnapValue);
-
             return Math.Max(-MaxScaleValue, Math.Min(MaxScaleValue, translation));
         }
 

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
@@ -125,13 +125,10 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         {
             const float MaxScaleValue = 1f / MathUtil.ZeroTolerance;
 
-            // snap the value if needed BEFORE the scale function
             if (UseSnap)
                 translation = MathUtil.Snap(translation, SnapValue);
 
-            //var scaleValue = translation > 0 ? (float)Math.Exp(translation) : 1 / ((float)Math.Exp(-translation));
-
-            return Math.Max(MathUtil.ZeroTolerance, Math.Min(MaxScaleValue, translation));
+            return Math.Max(-MaxScaleValue, Math.Min(MaxScaleValue, translation));
         }
 
         protected override void UpdateColors()

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
@@ -105,7 +105,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         protected override InitialTransformation CalculateTransformation()
         {
             var transform = base.CalculateTransformation();
-
+            
             if (TransformationAxes == GizmoTransformationAxes.XYZ) // special transformation mode
             {
                 var mouseDrag = Input.MousePosition - StartMousePosition;
@@ -125,13 +125,13 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         {
             const float MaxScaleValue = 1f / MathUtil.ZeroTolerance;
 
-            // snap the value if needed BEFORE the exp function
+            // snap the value if needed BEFORE the scale function
             if (UseSnap)
                 translation = MathUtil.Snap(translation, SnapValue);
 
-            var scaleValue = translation > 0 ? (float)Math.Exp(translation) : 1 / ((float)Math.Exp(-translation));
+            //var scaleValue = translation > 0 ? (float)Math.Exp(translation) : 1 / ((float)Math.Exp(-translation));
 
-            return Math.Max(MathUtil.ZeroTolerance, Math.Min(MaxScaleValue, scaleValue));
+            return Math.Max(MathUtil.ZeroTolerance, Math.Min(MaxScaleValue, translation));
         }
 
         protected override void UpdateColors()

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -515,10 +515,10 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
 
         protected float GetScaledAxis(float position, float scaleOrigin, float scale)
         {
-            return (scaleOrigin + (position - scaleOrigin) * scale);
+            return scaleOrigin + (position - scaleOrigin) * scale;
         }
 
-        public static Vector3 Transform(Vector3 vector, Matrix transform)
+        protected Vector3 Transform(Vector3 vector, Matrix transform)
         {
             Vector3 result;
             Vector3.Transform(ref vector, ref transform, out result);

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -481,10 +481,11 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
                     Vector3 one = Vector3.One;
                     Matrix.Transformation(ref one, ref AnchorEntity.Transform.Rotation, ref scaleLocation, out var scaleSpace);
 
-                    var position = Transform(initialTranslation, Matrix.Invert(scaleSpace));
-                    var scaleOrigin = Transform(scaleLocation, Matrix.Invert(scaleSpace));
+                    var invertedScaleSpace = Matrix.Invert(scaleSpace);
+                    Vector3.Transform(ref initialTranslation, ref invertedScaleSpace, out Vector3 position);
+                    Vector3.Transform(ref scaleLocation, ref invertedScaleSpace, out Vector3 scaleOrigin);
                     var offset = GetScaledLocation(position, scaleOrigin, entityTransfo.Scale / initialTransfo.Scale);
-                    initialTranslation = Transform(offset, scaleSpace);
+                    Vector3.Transform(ref offset, ref scaleSpace, out initialTranslation);
                 }
 
                 // translation (transform the translation from gizmo space to the selected root's parent space)
@@ -516,13 +517,6 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         protected float GetScaledAxis(float position, float scaleOrigin, float scale)
         {
             return scaleOrigin + (position - scaleOrigin) * scale;
-        }
-
-        protected Vector3 Transform(Vector3 vector, Matrix transform)
-        {
-            Vector3 result;
-            Vector3.Transform(ref vector, ref transform, out result);
-            return result;
         }
 
         public virtual async Task Update()

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -465,6 +465,8 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
                 if (transformation.Scale != Vector3.One)
                 {
                     entityTransfo.Scale = initialTransfo.Scale + scaledScale;
+                    if (UseSnap)
+                        entityTransfo.Scale = MathUtil.Snap(entityTransfo.Scale, SnapValue);
                     var scaleLocation = ScaleOrigin ?? (OriginMode == OriginMode.LastSelected
                         ? AnchorEntity.Transform.Position
                         : SelectionCenter);

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -102,6 +102,11 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         protected Vector2 TransformationDirection;
 
         /// <summary>
+        /// The center of the selection.
+        /// </summary>
+        protected Vector3 SelectionCenter;
+
+        /// <summary>
         /// Gets or sets the snap value.
         /// </summary>
         public float SnapValue { get; set; }
@@ -125,6 +130,16 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         /// Gets or sets the entity modified by the gizmo.
         /// </summary>
         public IReadOnlyCollection<Entity> ModifiedEntities { get; set; }
+
+        /// <summary>
+        /// Gets or sets the origin mode.
+        /// </summary>
+        public OriginMode OriginMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scale origin. If null, defaults to the origin mode.
+        /// </summary>
+        public Vector3? ScaleOrigin { get; set; } = null;
         
         protected TransformationGizmo()
         {
@@ -176,10 +191,21 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         {
             Matrix worldMatrix = Matrix.Identity;
 
+            Vector3 anchorLocation;
+            if (OriginMode == OriginMode.SelectionCenter)
+            {
+                RecalculateCenter(); // maybe only do this when needed?
+                anchorLocation = SelectionCenter;
+            }
+            else
+            {
+                anchorLocation = AnchorEntity.Transform.Position;
+            }
+
             switch (Space)
             {
                 case TransformationSpace.WorldSpace:
-                    worldMatrix.TranslationVector = AnchorEntity.Transform.WorldMatrix.TranslationVector;
+                    worldMatrix.TranslationVector = anchorLocation;
                     break;
                 case TransformationSpace.ObjectSpace:
                     var parentMatrix = Matrix.Identity;
@@ -187,13 +213,15 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
                         parentMatrix = AnchorEntity.TransformValue.Parent.WorldMatrix;
 
                     // We don't use the entity's "WorldMatrix" because it's scale could be zero, which would break the gizmo.
+                    // Note: Blender uses last selected object's (AnchorEntity) rotation, Unity uses average
+                    // For simplicity we'll just use the last selected object
                     worldMatrix = Matrix.RotationQuaternion(AnchorEntity.Transform.Rotation) *
-                                  Matrix.Translation(AnchorEntity.Transform.Position) *
+                                  Matrix.Translation(anchorLocation) *
                                   parentMatrix;
                     break;
                 case TransformationSpace.ViewSpace:
                     worldMatrix = Matrix.Invert(cameraService.ViewMatrix);
-                    worldMatrix.TranslationVector = AnchorEntity.Transform.WorldMatrix.TranslationVector;
+                    worldMatrix.TranslationVector = anchorLocation;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -206,7 +234,13 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
         {
             if (cameraService.Component.Projection == CameraProjectionMode.Perspective)
             {
-                var distanceToSelectedEntity = Math.Abs(Vector3.TransformCoordinate(AnchorEntity.Transform.WorldMatrix.TranslationVector, cameraService.ViewMatrix).Z);
+                Vector3 anchorLocation;
+                if (OriginMode == OriginMode.SelectionCenter)
+                    anchorLocation = SelectionCenter;
+                else
+                    anchorLocation = AnchorEntity.Transform.Position;
+
+                var distanceToSelectedEntity = Math.Abs(Vector3.TransformCoordinate(anchorLocation, cameraService.ViewMatrix).Z);
                 return SizeFactor * DefaultScale * 2f * (float)Math.Tan(MathUtil.DegreesToRadians(cameraService.VerticalFieldOfView / 2)) * distanceToSelectedEntity;
             }
 
@@ -259,6 +293,16 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
                 InitialTransformations.Clear();
                 TransformationEnded?.Invoke(this, EventArgs.Empty);
             }
+        }
+
+        protected void RecalculateCenter()
+        {
+            var totalPositions = new Vector3();
+            foreach (var entity in ModifiedEntities)
+            {
+                totalPositions += entity.Transform.Position;
+            }
+            SelectionCenter = totalPositions / ModifiedEntities.Count;
         }
 
         /// <summary>
@@ -413,12 +457,22 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
                 // calculate the gizmo to parent space matrix
                 Matrix gizmoToParentMatrix;
                 Matrix.Multiply(ref StartWorldMatrix, ref initialTransfo.InverseParentMatrix, out gizmoToParentMatrix);
-                
+
+                var initialTranslation = initialTransfo.Translation;
+                var scaledScale = transformation.Scale * initialTransfo.Scale;
+
                 // the scale
-                entityTransfo.Scale = initialTransfo.Scale * transformation.Scale;
+                if (transformation.Scale != Vector3.One)
+                {
+                    entityTransfo.Scale = initialTransfo.Scale + scaledScale;
+                    var scaleLocation = ScaleOrigin ?? (OriginMode == OriginMode.LastSelected
+                        ? AnchorEntity.Transform.Position
+                        : SelectionCenter);
+                    initialTranslation = GetScaledLocation(initialTransfo.Translation, scaleLocation, entityTransfo.Scale / initialTransfo.Scale);
+                }
 
                 // translation (transform the translation from gizmo space to the selected root's parent space)
-                entityTransfo.Position = initialTransfo.Translation + Vector3.TransformNormal(transformation.Translation, gizmoToParentMatrix);
+                entityTransfo.Position = initialTranslation + Vector3.TransformNormal(transformation.Translation, gizmoToParentMatrix);
 
                 // the rotation
                 if (transformation.Rotation != Quaternion.Identity)
@@ -432,6 +486,20 @@ namespace Xenko.Assets.Presentation.AssetEditors.Gizmos
                     entityTransfo.Rotation = initialTransfo.Rotation * Quaternion.RotationAxis(rotationAxisParent, transformation.Rotation.Angle);
                 }
             }
+        }
+
+        protected Vector3 GetScaledLocation(Vector3 position, Vector3 scaleOrigin, Vector3 scale)
+        {
+            var vec = new Vector3();
+            vec.X = GetScaledAxis(position.X, scaleOrigin.X, scale.X);
+            vec.Y = GetScaledAxis(position.Y, scaleOrigin.Y, scale.Y);
+            vec.Z = GetScaledAxis(position.Z, scaleOrigin.Z, scale.Z);
+            return vec;
+        }
+
+        protected float GetScaledAxis(float position, float scaleOrigin, float scale)
+        {
+            return scaleOrigin + (position - scaleOrigin) * scale;
         }
 
         public virtual async Task Update()

--- a/sources/editor/Xenko.Assets.Presentation/SceneEditor/PackageSceneSettings.cs
+++ b/sources/editor/Xenko.Assets.Presentation/SceneEditor/PackageSceneSettings.cs
@@ -37,7 +37,7 @@ namespace Xenko.Assets.Presentation.SceneEditor
         public bool RotationSnapActive = false;
         public float RotationSnapValue = 22.5f;
         public bool ScaleSnapActive = false;
-        public float ScaleSnapValue = 1.1f;
+        public float ScaleSnapValue = 1.0f;
         public float SceneUnit = 1.0f;
 
         // Gizmos

--- a/sources/editor/Xenko.Assets.Presentation/View/ImageDictionary.xaml
+++ b/sources/editor/Xenko.Assets.Presentation/View/ImageDictionary.xaml
@@ -399,6 +399,26 @@
     </DrawingImage.Drawing>
   </DrawingImage>
 
+  <DrawingImage x:Key="{x:Static gameEditor:OriginMode.SelectionCenter}" >
+    <DrawingImage.Drawing>
+      <DrawingGroup>
+        <GeometryDrawing Brush="#FFF6F6F6" Geometry="M11.741 11.741c-.748 2.462-3.038 4.259-5.741 4.259-3.309 0-6-2.691-6-6 0-2.703 1.797-4.993 4.259-5.741.748-2.462 3.038-4.259 5.741-4.259 3.309 0 6 2.691 6 6 0 2.703-1.797 4.993-4.259 5.741z" />
+        <GeometryDrawing Brush="#FF424242" Geometry="M 15 6 C 15 8.062 13.751 9.829 11.97 10.594 11.989 10.399 12 10.201 12 10 12 6.691 9.309 4 6 4 5.799 4 5.601 4.011 5.406 4.03 6.171 2.249 7.938 1 10 1 c 2.762 0 5 2.238 5 5 z m -4 4 C 11 12.762 8.762 15 6 15 3.238 15 1 12.762 1 10 1 7.238 3.238 5 6 5 c 2.762 0 5 2.238 5 5 z" />
+        <GeometryDrawing Brush="#FFF6F6F6" Geometry="m 8.0000002 4.9999998 c -0.3760001 2.319 -0.6810001 2.624 -3.0000001 3 2.319 0.3760004 2.624 0.6810004 3.0000001 3.0000002 C 8.3760002 8.6810002 8.6810001 8.3760002 11 7.9999998 c -2.3189999 -0.376 -2.6239998 -0.681 -2.9999998 -3 z" />
+      </DrawingGroup>
+    </DrawingImage.Drawing>
+  </DrawingImage>
+
+  <DrawingImage x:Key="{x:Static gameEditor:OriginMode.LastSelected}" >
+    <DrawingImage.Drawing>
+      <DrawingGroup>
+        <GeometryDrawing Brush="#FFF6F6F6" Geometry="M11.741 11.741c-.748 2.462-3.038 4.259-5.741 4.259-3.309 0-6-2.691-6-6 0-2.703 1.797-4.993 4.259-5.741.748-2.462 3.038-4.259 5.741-4.259 3.309 0 6 2.691 6 6 0 2.703-1.797 4.993-4.259 5.741z" />
+        <GeometryDrawing Brush="#FF424242" Geometry="M 15 6 C 15 8.062 13.751 9.829 11.97 10.594 11.989 10.399 12 10.201 12 10 12 6.691 9.309 4 6 4 5.799 4 5.601 4.011 5.406 4.03 6.171 2.249 7.938 1 10 1 c 2.762 0 5 2.238 5 5 z m -4 4 C 11 12.762 8.762 15 6 15 3.238 15 1 12.762 1 10 1 7.238 3.238 5 6 5 c 2.762 0 5 2.238 5 5 z" />
+        <GeometryDrawing Brush="#FFF6F6F6" Geometry="m 6 6.9999996 c -0.376 2.319 -0.681 2.624 -3 3 C 5.319 10.376 5.624 10.681 6 13 6.376 10.681 6.681 10.376 8.9999997 9.9999996 6.681 9.6239996 6.376 9.3189996 6 6.9999996 Z" />
+      </DrawingGroup>
+    </DrawingImage.Drawing>
+  </DrawingImage>
+
   <DrawingImage x:Key="{x:Static data:ConfigPlatforms.Android}">
     <DrawingImage.Drawing>
       <DrawingGroup>


### PR DESCRIPTION
# PR Details

Adds rotation and scaling from the center or from the last selected object

## Description

You can now scale from the center from a selection as well as transforming away from the center rather than from the origin of each object. The selection can also be rotated from the center rather than only the last selected object.

## Related Issue

#488 

## Motivation and Context

Sometimes it makes more sense to scale from the center rather than the last selected object. For example, something that takes up multiple objects like a room would be hard to scale otherwise.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.