### PR TITLE
[Editor] Fix property value showing '(Not supported)' for null values

### DIFF
--- a/sources/core/Stride.Core.Reflection/TypeDescriptorFactory.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptorFactory.cs
@@ -96,7 +96,7 @@ namespace Stride.Core.Reflection
             }
             else if (type.IsArray)
             {
-                if (type.GetArrayRank() == 1)
+                if (type.GetArrayRank() == 1 && !type.GetElementType().IsArray)
                 {
                     // array[] - only single dimension array is supported
                     descriptor = new ArrayDescriptor(this, type, emitDefaultValues, namingConvention);
@@ -104,7 +104,7 @@ namespace Stride.Core.Reflection
                 else
                 {
                     // multi-dimension array to be treated as a 'standard' object
-                    descriptor = new ObjectDescriptor(this, type, emitDefaultValues, namingConvention);
+                    descriptor = new NotSupportedObjectDescriptor(this, type, emitDefaultValues, namingConvention);
                 }
             }
             else if (NullableDescriptor.IsNullable(type))

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/DescriptorCategory.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/DescriptorCategory.cs
@@ -33,6 +33,11 @@ namespace Stride.Core.Reflection
         Object,
 
         /// <summary>
+        /// An unsupported object. This will be treated the same as Object.
+        /// </summary>
+        NotSupportedObject,
+
+        /// <summary>
         /// A nullable value
         /// </summary>
         Nullable,

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/NotSupportedObjectDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/NotSupportedObjectDescriptor.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Stride contributors (https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using Stride.Core.Yaml.Serialization;
+
+namespace Stride.Core.Reflection
+{
+    /// <summary>
+    /// Describes a descriptor for an unsupported object type.
+    /// This will be treated as an <see cref="ObjectDescriptor"/>
+    /// </summary>
+    public class NotSupportedObjectDescriptor : ObjectDescriptor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotSupportedObjectDescriptor" /> class.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="type">The type.</param>
+        /// <exception cref="System.ArgumentException">Type [{0}] is not a primitive</exception>
+        public NotSupportedObjectDescriptor(ITypeDescriptorFactory factory, Type type, bool emitDefaultValues, IMemberNamingConvention namingConvention)
+            : base(factory, type, emitDefaultValues, namingConvention)
+        {
+        }
+
+        public override DescriptorCategory Category => DescriptorCategory.NotSupportedObject;
+    }
+}

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
@@ -213,7 +213,7 @@ namespace Stride.Core.Reflection
             }
 
             // TODO: we might want an option to disable non-public.
-            if (Category == DescriptorCategory.Object)
+            if (Category == DescriptorCategory.Object || Category == DescriptorCategory.NotSupportedObject)
                 bindingFlags |= BindingFlags.NonPublic;
 
             var memberList = (from propertyInfo in Type.GetProperties(bindingFlags)

--- a/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -1343,7 +1343,7 @@
   <sd:DefaultTemplateProvider x:Key="ObjectPropertyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="None">
     <DataTemplate DataType="qvm:NodeViewModel">
       <TextBlock Margin="2,0" VerticalAlignment="Center" x:Name="DefaultTextBlock"
-                       Text="{sd:PriorityBinding {Binding AttributeDisplayName, Mode=OneWay}, {Binding NodeValue, Mode=OneWay, StringFormat={sd:Localize {}{0} (Not supported)}, Converter={sd:ObjectToTypeName}}}"/>
+                 Text="{sd:PriorityBinding {Binding AttributeDisplayName, Mode=OneWay}, {Binding Type, Mode=OneWay, StringFormat={sd:Localize {}{0} (Not supported)}, Converter={sd:NotSupportedTypeToTypeName}}, {Binding NodeValue, Mode=OneWay, Converter={sd:ObjectToTypeName}}}"/>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="DefaultTextBlock" Property="Text" Value="{sd:Localize (Different values)}"/>

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/CopyPasteProcessors/AssetPropertyPasteProcessor.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/CopyPasteProcessors/AssetPropertyPasteProcessor.cs
@@ -93,6 +93,7 @@ namespace Stride.Core.Assets.Editor.ViewModel.CopyPasteProcessors
                     break;
                 case DescriptorCategory.Primitive:
                 case DescriptorCategory.Object:
+                case DescriptorCategory.NotSupportedObject:
                 case DescriptorCategory.Nullable:
                     result = ConvertForProperty(targetTypeDescriptor.Type, ref data);
                     break;

--- a/sources/presentation/Stride.Core.Presentation/ValueConverters/NotSupportedTypeToTypeName.cs
+++ b/sources/presentation/Stride.Core.Presentation/ValueConverters/NotSupportedTypeToTypeName.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Stride contributors (https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using System.Windows;
+using Stride.Core.Annotations;
+using Stride.Core.Presentation.Extensions;
+using Stride.Core.Reflection;
+
+namespace Stride.Core.Presentation.ValueConverters
+{
+    /// <summary>
+    /// This converter convert any unsupported object type to a string representing the name of its type (without assembly or namespace qualification).
+    /// </summary>
+    /// <seealso cref="ObjectToFullTypeName"/>
+    /// <seealso cref="ObjectToType"/>
+    public class NotSupportedTypeToTypeName : OneWayValueConverter<NotSupportedTypeToTypeName>
+    {
+        /// <inheritdoc/>
+        [NotNull]
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is Type objectType) || value == DependencyProperty.UnsetValue)
+                return DependencyProperty.UnsetValue;
+
+            var typeDescriptor = TypeDescriptorFactory.Default.Find(objectType);
+            if (typeDescriptor is NotSupportedObjectDescriptor)
+                return objectType.ToSimpleCSharpName();
+
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}


### PR DESCRIPTION
## PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fixes bug introduced by #646

## Description

<!--- Describe your changes in detail -->
Can't just append the '(Not supported)' message to all objects.
A specific `ObjectDescriptor` type is needed to mark these types.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #650 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Unfortunately, this means only multi-array types can be marked.
The problem is that some properties accept null as a valid object type (this outputs 'None'). There are also properties that accept an actual object, eg. the 'Sort Mode' on the render stage.

A minor issue is that things like `DateTime` will not say '(Not supported)', however it does already just say DateTime and isn't editable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.