### PR TITLE
Multiple Editor fixes

### DIFF
--- a/sources/core/Stride.Core/PropertyContainerClass.cs
+++ b/sources/core/Stride.Core/PropertyContainerClass.cs
@@ -84,6 +84,11 @@ namespace Stride.Core
             inner.CopyTo(ref destination);
         }
 
+        public void CopyTo(PropertyContainerClass destination)
+        {
+            inner.CopyTo(ref destination.inner);
+        }
+
         /// <inheritdoc />
         public object Get([NotNull] PropertyKey propertyKey)
         {

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/UIEditor/ViewModels/PanelViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/UIEditor/ViewModels/PanelViewModel.cs
@@ -540,7 +540,7 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.ViewModels
             CopyCommonProperties(Editor.NodeContainer, sourcePanel.AssetSidePanel, targetPanelElement);
 
             // Initialize the new hierarchy of elements that starts from the target and contains all the children
-            IEnumerable <UIElementViewModel> children = sourcePanel.Children.ToList();
+            IEnumerable<UIElementViewModel> children = sourcePanel.Children.ToList();
             var hierarchy = UIAssetPropertyGraph.CloneSubHierarchies(Asset.Session.AssetNodeContainer, Asset.Asset, children.Select(c => c.Id.ObjectId), SubHierarchyCloneFlags.None, out _);
             hierarchy.RootParts.Add(targetPanel.UIElement);
             hierarchy.Parts.Add(targetPanel);
@@ -631,7 +631,7 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.ViewModels
             var sourceNode = nodeContainer.GetOrCreateNode(sourcePanel);
             var targetNode = nodeContainer.GetOrCreateNode(targetPanel);
 
-            foreach (var targetChild in targetNode.Members.Where(x => x.Name != nameof(Panel.Children) && x.Name != nameof(UIElement.Id)))
+            foreach (var targetChild in targetNode.Members.Where(x => x.Name != nameof(Panel.Children) && x.Name != nameof(UIElement.Id) && x.Name != nameof(UIElement.DependencyProperties)))
             {
                 var name = targetChild.Name;
                 var sourceChild = sourceNode.TryGetChild(name);
@@ -640,6 +640,9 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.ViewModels
                     targetChild.Update(AssetCloner.Clone(sourceChild.Retrieve()));
                 }
             }
+
+            // Copy the dependency properties, eg. the source panel may be inside a grid and has set grid row/column
+            sourcePanel.DependencyProperties.CopyTo(targetPanel.DependencyProperties);
         }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/Templates/SoundFromFileTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/SoundFromFileTemplateGenerator.cs
@@ -39,14 +39,14 @@ namespace Stride.Assets.Presentation.Templates
         protected override IEnumerable<AssetItem> CreateAssets(AssetTemplateGeneratorParameters parameters)
         {
             var importedAssets = new List<AssetItem>();
-            using (var media = new FFmpegMedia())
+            foreach (var assetItem in base.CreateAssets(parameters))
             {
-                foreach (var assetItem in base.CreateAssets(parameters))
+                if (assetItem.Asset is SoundAsset soundAsset)
                 {
-                    if (assetItem.Asset is SoundAsset soundAsset)
+                    using (var media = new FFmpegMedia())
                     {
                         media.Open(soundAsset.Source.ToWindowsPath());
-                        foreach( var audioTrack in media.Streams.OfType<AudioStream>().ToList())
+                        foreach (var audioTrack in media.Streams.OfType<AudioStream>().ToList())
                         {
                             var assetCopy = AssetCloner.Clone(soundAsset);
                             assetCopy.Index = audioTrack.Index;

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/EditorViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/EditorViewModel.cs
@@ -237,8 +237,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
         public void RemoveRecentFile(UFile filePath)
         {
-            //Get all versions of showing on recent files
-            var strideVersions = RecentFiles?.Select(x => x.Version).ToList();
+            // Get all versions of showing on recent files
+            var strideVersions = RecentFiles?.Select(x => x.Version).Distinct().ToList();
             if (strideVersions != null)
             {
                 foreach (var item in strideVersions)
@@ -250,7 +250,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
         private void ClearRecentFiles()
         {
-            //Clear considering old projects that have been deleted or upgraded from older versions
+            // Clear considering old projects that have been deleted or upgraded from older versions
             var strideVersions = RecentFiles?.Select(x => x.Version).ToList();
             if (strideVersions != null)
             {
@@ -265,7 +265,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         {
             RecentFiles.Clear();
 
-            //Get only files that is current version or older
+            // Get only files that is current version or older
             foreach (var item in MRU.MostRecentlyUsedFiles.Where(x => string.Compare(x.Version, EditorVersionMajor, StringComparison.Ordinal) <= 0).Take(10))
             {
                 RecentFiles.Add(new MostRecentlyUsedFile() { FilePath = item.FilePath, Timestamp = item.Timestamp, Version = item.Version });

--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
@@ -648,9 +648,9 @@
                     </i:Interaction.Behaviors>
                   </TabControl>
                   <i:Interaction.Behaviors>
-                    <sd:OnEventCommandBehavior Command="{Binding Debugging.ResetOutputTitleCommand}" EventName="IsActiveChanged"/>
-                    <gs:LayoutAnchorableActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Debugging.BuildLog.Messages}"/>
-                    <gs:LayoutAnchorableActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Debugging.LiveScriptingLog.Messages}"/>
+                    <sd:OnEventCommandBehavior Command="{Binding Debugging.ResetOutputTitleCommand, Source={x:Static gs:GameStudioViewModel.GameStudio}}" EventName="IsActiveChanged"/>
+                    <gs:LayoutAnchorableActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Debugging.BuildLog.Messages, Source={x:Static gs:GameStudioViewModel.GameStudio}}"/>
+                    <gs:LayoutAnchorableActivateOnLogBehavior MinimumLevel="Error" Collection="{Binding Debugging.LiveScriptingLog.Messages, Source={x:Static gs:GameStudioViewModel.GameStudio}}"/>
                   </i:Interaction.Behaviors>
                 </xcad:LayoutAnchorable>
               </xcad:LayoutAnchorablePane>

--- a/sources/editor/Stride.GameStudio/LayoutAnchorableActivateOnLogBehavior.cs
+++ b/sources/editor/Stride.GameStudio/LayoutAnchorableActivateOnLogBehavior.cs
@@ -14,6 +14,7 @@ namespace Stride.GameStudio
         {
             AssociatedObject.Show();
             AssociatedObject.IsSelected = true;
+            AssociatedObject.IsActive = true;       // This ensures this 'tab' is the selected one in a tab group
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
General bug fixes to the Game Studio editor.

## Description

<!--- Describe your changes in detail -->
1. Fix redundant settings file save when removing a project from the recently used projects list.
2. Fix bug when you drag&drop multiple audio files to the Asset view where `FFmpegMedia` cannot be reused.
3. Fix Asset Log grid where it doesn't display new messages unless you actively press some filter buttons.
4. Layout controls' behaviors break due to reloading the layouts. It must bind to the global instance `GameStudioViewModel.GameStudio` like the others have already done.
5. Don't crash when `Change layout type` is selected, and reinstate the dependency properties (eg. `Grid.Row`, `Grid.Column`

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
(4.) fixes #281 so it'll show the Build Log tab when an error occurs.
(5.) fixes #169 so `Change layout type` doesn't crash the editor.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.