### PR TITLE
[Editor] Add ability to 'Show source file in Explorer' for an asset

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -173,6 +173,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
         public ICommandBase ExploreCommand { get; }
 
+        public ICommandBase ExploreSourceFileCommand { get; }
+
         public ICommandBase OpenWithTextEditorCommand { get; }
 
         public ICommandBase OpenAssetFileCommand { get; }
@@ -580,6 +582,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             RenameDirectoryOrPackageCommand = new AnonymousCommand<IEnumerable>(ServiceProvider, x => RenameDirectoryOrPackage(x.Cast<object>().LastOrDefault()));
             DeleteSelectedSolutionItemsCommand = new AnonymousTaskCommand(ServiceProvider, async () => await DeleteItems(ActiveAssetView.SelectedLocations));
             ExploreCommand = new AnonymousTaskCommand<object>(ServiceProvider, Explore);
+            ExploreSourceFileCommand = new AnonymousTaskCommand<AssetViewModel>(ServiceProvider, ExploreSourceFile);
             OpenWithTextEditorCommand = new AnonymousTaskCommand<AssetViewModel>(ServiceProvider, OpenWithTextEditor);
             OpenAssetFileCommand = new AnonymousTaskCommand<AssetViewModel>(ServiceProvider, OpenAssetFile);
             OpenSourceFileCommand = new AnonymousTaskCommand<AssetViewModel>(ServiceProvider, OpenSourceFile);
@@ -818,6 +821,42 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 {
                     await Dialogs.MessageBox(Tr._p("Message", "You need to save the asset before you can explore it."), MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
+                }
+
+                ProcessStartInfo startInfo = fileSelection ? new ProcessStartInfo("explorer.exe", "/select," + stringPath) : new ProcessStartInfo(stringPath);
+                startInfo.UseShellExecute = true;
+                var explorer = new Process { StartInfo = startInfo };
+                explorer.Start();
+            }
+            catch (Exception)
+            {
+                await Dialogs.MessageBox(Tr._p("Message", "There was a problem starting the file explorer."), MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private async Task ExploreSourceFile(AssetViewModel asset)
+        {
+            var filePathToOpen = asset?.Asset?.MainSource;
+            if (filePathToOpen == null)
+            {
+                await Dialogs.MessageBox(Tr._p("Message", "This asset doesn't have a source file."), MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                bool fileSelection = true;
+                var stringPath = filePathToOpen.ToString().Replace('/', '\\');
+                if (!File.Exists(stringPath))
+                {
+                    // If the file doesn't exist, we want to at least try to go to the directory it belonged to
+                    stringPath = Path.GetDirectoryName(stringPath);
+                    fileSelection = false;
+                    if (!Directory.Exists(stringPath))
+                    {
+                        await Dialogs.MessageBox(Tr._p("Message", "Source file and path no longer exists."), MessageBoxButton.OK, MessageBoxImage.Information);
+                        return;
+                    }
                 }
 
                 ProcessStartInfo startInfo = fileSelection ? new ProcessStartInfo("explorer.exe", "/select," + stringPath) : new ProcessStartInfo(stringPath);
@@ -1470,6 +1509,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             SetCurrentProjectCommand.IsEnabled = projectSelected;
             DeleteSelectedSolutionItemsCommand.IsEnabled = canDelete;
             ExploreCommand.IsEnabled = ActiveAssetView.SelectedContent.Count > 0 || ActiveAssetView.SelectedLocations.Count == 1;
+            ExploreSourceFileCommand.IsEnabled = asset?.Asset?.MainSource != null;
             RenameDirectoryOrPackageCommand.IsEnabled = canRename;
             NewDirectoryCommand.IsEnabled = packageSelected || directorySelected;
             ActivatePackagePropertiesCommand.IsEnabled = packageSelected || directorySelected;

--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
@@ -105,6 +105,7 @@
         <MenuItem Header="{sd:Localize Open asset file, Context=Menu}" Command="{Binding Session.OpenAssetFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{sd:Image {StaticResource ImageOpenAssetFile}}"/>
         <MenuItem Header="{sd:Localize Open source file, Context=Menu}" Command="{Binding Session.OpenSourceFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{sd:Image {StaticResource ImageOpenSourceFile}}"/>
         <MenuItem Header="{sd:Localize Show in Explorer, Context=Menu}" Command="{Binding Session.ExploreCommand}" CommandParameter="{Binding SelectedContent}" Icon="{sd:Image {StaticResource ImageExplore}}"/>
+        <MenuItem Header="{sd:Localize Show source file in Explorer, Context=Menu}" Command="{Binding Session.ExploreSourceFileCommand}" CommandParameter="{Binding SingleSelectedAsset}" Icon="{sd:Image {StaticResource ImageExplore}}"/>
       </ContextMenu>
 
     </ResourceDictionary>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add new right-click Asset context menu to 'Show source file in Explorer'
If the file no longer exists, then try to browse to the folder it belonged to.
If the folder no longer exists, then show an error message.
Menu is always disabled for Assets that don't have `MainSource` set.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I want to browse to the actual file that the asset is pointing to because I want to do something with it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.