### PR TITLE
Change to open source AvalonDock & remove Xceed library

### DIFF
--- a/THIRD PARTY.md
+++ b/THIRD PARTY.md
@@ -45,6 +45,7 @@ Stride uses the following open-source products.
 
 * [Assimp](http://assimp.sourceforge.net/) (BSD 3-clause License)
 * [AsyncEx](https://github.com/StephenCleary/AsyncEx) (MIT License)
+* [AvalonDock](https://github.com/Dirkster99/AvalonDock) (Ms-PL)
 * [DocFX](https://dotnet.github.io/docfx/) (MIT License)
 * [ffmpeg](https://ffmpeg.org/) (GPL 3)
 * [FreeImage](http://freeimage.sourceforge.net/) (FreeImage Public License - Version 1.0)

--- a/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
+++ b/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.8.1" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.10.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <Reference Include="System.ComponentModel.Composition" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
@@ -82,8 +82,5 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   <Target Name="IncludeExtraAssemblies">
-    <ItemGroup>
-      <BuildOutputInPackage Include="$(OutputPath)Xceed.Wpf.Toolkit.dll" />
-    </ItemGroup>
   </Target>
 </Project>

--- a/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Xceed.Wpf.Toolkit.Core;
 using Stride.Core.Assets.Editor.View.Controls;
 using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Presentation.Collections;
@@ -308,12 +307,6 @@ namespace Stride.Core.Assets.Editor.View
         {
             var control = (AssetViewUserControl)sender;
             e.CanExecute = control.CanBeginEdit();
-        }
-
-        private static void CanBeginEditEvent(object sender, CancelRoutedEventArgs e)
-        {
-            var control = (AssetViewUserControl)sender;
-            e.Cancel = !control.CanBeginEdit();
         }
 
         private static void BeginEdit(object sender, ExecutedRoutedEventArgs e)

--- a/sources/editor/Stride.GameStudio/ActivateParentPaneOnGotFocusBehavior.cs
+++ b/sources/editor/Stride.GameStudio/ActivateParentPaneOnGotFocusBehavior.cs
@@ -4,7 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Xaml.Behaviors;
 using Stride.Core.Presentation.Extensions;
-using Xceed.Wpf.AvalonDock.Controls;
+using AvalonDock.Controls;
 
 namespace Stride.GameStudio
 {

--- a/sources/editor/Stride.GameStudio/AssetEditorsManager.cs
+++ b/sources/editor/Stride.GameStudio/AssetEditorsManager.cs
@@ -22,7 +22,7 @@ using Stride.Core.Threading;
 using Stride.Animations;
 using Stride.Assets.Presentation.CurveEditor.ViewModels;
 using Stride.Assets.Presentation.CurveEditor.Views;
-using Xceed.Wpf.AvalonDock.Layout;
+using AvalonDock.Layout;
 
 namespace Stride.GameStudio
 {

--- a/sources/editor/Stride.GameStudio/AvalonDockHelper.cs
+++ b/sources/editor/Stride.GameStudio/AvalonDockHelper.cs
@@ -7,9 +7,9 @@ using System.Windows;
 using Stride.Core.Extensions;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.ViewModel;
-using Xceed.Wpf.AvalonDock;
-using Xceed.Wpf.AvalonDock.Controls;
-using Xceed.Wpf.AvalonDock.Layout;
+using AvalonDock;
+using AvalonDock.Controls;
+using AvalonDock.Layout;
 
 namespace Stride.GameStudio
 {

--- a/sources/editor/Stride.GameStudio/DockingLayoutManager.cs
+++ b/sources/editor/Stride.GameStudio/DockingLayoutManager.cs
@@ -12,9 +12,9 @@ using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Extensions;
 using Stride.Core.Presentation.Behaviors;
 using Stride.Core.Presentation.Extensions;
-using Xceed.Wpf.AvalonDock;
-using Xceed.Wpf.AvalonDock.Layout;
-using Xceed.Wpf.AvalonDock.Layout.Serialization;
+using AvalonDock;
+using AvalonDock.Layout;
+using AvalonDock.Layout.Serialization;
 using Microsoft.Xaml.Behaviors;
 
 namespace Stride.GameStudio

--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:strings="clr-namespace:Stride.GameStudio.Resources.Strings"
         xmlns:stringsEd="clr-namespace:Stride.Core.Assets.Editor.Resources.Strings;assembly=Stride.Core.Assets.Editor"
         xmlns:gs="clr-namespace:Stride.GameStudio"
-        xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
+        xmlns:xcad="https://github.com/Dirkster99/AvalonDock"
         xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
         xmlns:viewModels="clr-namespace:Stride.Core.Presentation.Quantum.ViewModels;assembly=Stride.Core.Presentation.Quantum"
         xmlns:viewModels1="clr-namespace:Stride.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels;assembly=Stride.Core.Assets.Editor"

--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml.cs
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml.cs
@@ -24,7 +24,7 @@ using Stride.Core.Presentation.Extensions;
 using Stride.Core.Presentation.Interop;
 using Stride.Core.Presentation.Windows;
 using Stride.Core.Translation;
-using Xceed.Wpf.AvalonDock.Layout;
+using AvalonDock.Layout;
 #if DEBUG
 using Stride.Assets.Presentation.Test;
 #endif

--- a/sources/editor/Stride.GameStudio/LayoutAnchorableActivateOnLocationChangedBehavior.cs
+++ b/sources/editor/Stride.GameStudio/LayoutAnchorableActivateOnLocationChangedBehavior.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using Stride.Core.Assets.Editor.View.Behaviors;
-using Xceed.Wpf.AvalonDock.Layout;
+using AvalonDock.Layout;
 
 namespace Stride.GameStudio
 {

--- a/sources/editor/Stride.GameStudio/LayoutAnchorableActivateOnLogBehavior.cs
+++ b/sources/editor/Stride.GameStudio/LayoutAnchorableActivateOnLogBehavior.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using Stride.Core.Assets.Editor.View.Behaviors;
-using Xceed.Wpf.AvalonDock.Layout;
+using AvalonDock.Layout;
 
 namespace Stride.GameStudio
 {

--- a/sources/editor/Stride.GameStudio/Theme.AvalonDock.xaml
+++ b/sources/editor/Stride.GameStudio/Theme.AvalonDock.xaml
@@ -17,11 +17,11 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=Xceed.Wpf.AvalonDock"
-    xmlns:avalonDock="clr-namespace:Xceed.Wpf.AvalonDock;assembly=Xceed.Wpf.AvalonDock"
-    xmlns:avalonDockControls="clr-namespace:Xceed.Wpf.AvalonDock.Controls;assembly=Xceed.Wpf.AvalonDock"
-    xmlns:avalonDockConverters="clr-namespace:Xceed.Wpf.AvalonDock.Converters;assembly=Xceed.Wpf.AvalonDock"
-    xmlns:avalonDockProperties="clr-namespace:Xceed.Wpf.AvalonDock.Properties;assembly=Xceed.Wpf.AvalonDock"
+    xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=AvalonDock"
+    xmlns:avalonDock="clr-namespace:AvalonDock;assembly=AvalonDock"
+    xmlns:avalonDockControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
+    xmlns:avalonDockConverters="clr-namespace:AvalonDock.Converters;assembly=AvalonDock"
+    xmlns:avalonDockProperties="clr-namespace:AvalonDock.Properties;assembly=AvalonDock"
     xmlns:view="clr-namespace:Stride.GameStudio.View">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="/Stride.Core.Assets.Editor;component/View/CommonResources.xaml" />

--- a/sources/editor/Stride.GameStudio/View/CustomDocumentPaneTabPanel.cs
+++ b/sources/editor/Stride.GameStudio/View/CustomDocumentPaneTabPanel.cs
@@ -2,7 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Windows;
-using Xceed.Wpf.AvalonDock.Controls;
+using AvalonDock.Controls;
 
 namespace Stride.GameStudio.View
 {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Change to open source MS-PL AvalonDock fork.
Removed Xceed library which doesn't seem to be used anymore (DataGrid removed prior, and AvalonDock changed in this pull).
Note that the `THIRD PARTY.md` still references `WPFToolKit` which is the old (expired?) link to the Xceed, which is not removed because we have a few xaml pages that were copied over from them (this was done before their license change so remains under the MS-PL license). Not a lawyer so leaving it unless advised otherwise.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #661
Fixes #659

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The forked version fixes the docking layout resize bug, which we don't know when Xceed will release for the open source public.
Xceed license was changed, so using proper open-source is probably more welcome (in my opinion...)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.