### PR TITLE
[Editor] Fix closing then reopening asset when undocked

### DIFF
--- a/sources/editor/Stride.GameStudio/AssetEditorsManager.cs
+++ b/sources/editor/Stride.GameStudio/AssetEditorsManager.cs
@@ -165,10 +165,6 @@ namespace Stride.GameStudio
 
         private void CurveEditorClosed(object sender, EventArgs eventArgs)
         {
-            var editorPane = (LayoutAnchorable)sender;
-            if (editorPane.IsVisible)
-                return;
-
             RemoveCurveEditor(true);
         }
 
@@ -522,8 +518,6 @@ namespace Stride.GameStudio
         private void EditorPaneClosed(object sender, EventArgs eventArgs)
         {
             var editorPane = (LayoutAnchorable)sender;
-            if (editorPane.IsVisible)
-                return;
 
             var element = editorPane.Content as FrameworkElement;
             var asset = element?.DataContext as AssetViewModel;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Remove visibility logic check when closing event is raised so the asset window can actually close, otherwise it's hidden in limbo and the asset can't be reopened.
I have also removed the check in the CurveEditor code, but didn't test that which I'm not sure if it exists anymore.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This bug is occurring to due to adding the new forked AvalonDock.
Not sure if this logic check was originally meant as some workaround for some bug in the original AvalonDock, eg. it raised close event when it shouldn't have, or if there's some condition where this is raised and we don't want it to close?


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.