### PR TITLE
[Editor] Add ability to make material deduping from Assimp importer optional

### DIFF
--- a/sources/assets/Stride.Core.Assets/AssetImporterParameters.cs
+++ b/sources/assets/Stride.Core.Assets/AssetImporterParameters.cs
@@ -24,6 +24,7 @@ namespace Stride.Core.Assets
         /// </summary>
         public AssetImporterParameters()
         {
+            InputParameters = new PropertyCollection();
             SelectedOutputTypes = new Dictionary<Type, bool>();
         }
 
@@ -53,6 +54,12 @@ namespace Stride.Core.Assets
                 SelectedOutputTypes[type] = true;
             }
         }
+
+        /// <summary>
+        /// Gets the import input parameters.
+        /// </summary>
+        /// <value>The import input parameters.</value>
+        public PropertyCollection InputParameters { get; private set; }
 
         /// <summary>
         /// Gets the selected output types.

--- a/sources/editor/Stride.Assets.Presentation/Templates/ModelAssetTemplateWindow.xaml
+++ b/sources/editor/Stride.Assets.Presentation/Templates/ModelAssetTemplateWindow.xaml
@@ -24,6 +24,8 @@
     <Border Margin="20,10,20,20">
       <StackPanel>
         <CheckBox Content="{sd:Localize Import materials, Context=Button}" IsChecked="{Binding ImportMaterials}" Margin="5"/>
+        <CheckBox Content="{sd:Localize Deduplicate materials, Context=Button}" IsChecked="{Binding DeduplicateMaterials}" Margin="5" Visibility="{Binding ShowDeduplicateMaterialsCheckBox, Converter={sd:VisibleOrCollapsed}}"/>
+        <TextBlock Text="{sd:Localize Warning\: Deduplicate materials is currently not supported for FBX files}" Margin="5" Visibility="{Binding ShowFbxDedupeNotSupportedWarning, Converter={sd:VisibleOrCollapsed}}"/>
         <CheckBox Content="{sd:Localize Import textures, Context=Button}" IsChecked="{Binding ImportTextures}" Margin="5"/>
       </StackPanel>
     </Border>

--- a/sources/editor/Stride.Assets.Presentation/Templates/ModelAssetTemplateWindow.xaml.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/ModelAssetTemplateWindow.xaml.cs
@@ -40,6 +40,9 @@ namespace Stride.Assets.Presentation.Templates
         private readonly DummyReferenceContainer referenceContainer = new DummyReferenceContainer();
 
         private bool importMaterials = true;
+        private bool showDeduplicateMaterialsCheckBox = true;
+        private bool showFbxDedupeNotSupportedWarning = false;
+        private bool deduplicateMaterials = true;
         private bool importTextures = true;
         private bool importSkeleton = true;
         private bool dontImportSkeleton;
@@ -52,6 +55,10 @@ namespace Stride.Assets.Presentation.Templates
         }
 
         public bool ImportMaterials { get { return importMaterials; } set { SetValue(ref importMaterials, value); } }
+
+        public bool ShowDeduplicateMaterialsCheckBox { get { return showDeduplicateMaterialsCheckBox; } set { SetValue(ref showDeduplicateMaterialsCheckBox, value); } }
+        public bool ShowFbxDedupeNotSupportedWarning { get { return showFbxDedupeNotSupportedWarning; } set { SetValue(ref showFbxDedupeNotSupportedWarning, value); } }
+        public bool DeduplicateMaterials { get { return deduplicateMaterials; } set { SetValue(ref deduplicateMaterials, value); } }
 
         public bool ImportTextures { get { return importTextures; } set { SetValue(ref importTextures, value); } }
 

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/ModelViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/ModelViewModel.cs
@@ -47,6 +47,12 @@ namespace Stride.Assets.Presentation.ViewModel
             return AssetRegistry.FindImporterForFile(Asset.Source).OfType<ModelAssetImporter>().FirstOrDefault();
         }
 
+        protected override void PrepareImporterInputParametersForUpdateFromSource(PropertyCollection importerInputParameters, ModelAsset asset)
+        {
+            // This setting will be ignored if it's the FBX importer
+            importerInputParameters.Set(ModelAssetImporter.DeduplicateMaterialsKey, asset.DeduplicateMaterials);
+        }
+
         protected override void UpdateAssetFromSource(ModelAsset assetToMerge)
         {
             // Create a dictionary containing all new and old materials, favoring old ones to maintain existing references

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/ImportedAssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/ImportedAssetViewModel.cs
@@ -18,6 +18,11 @@ namespace Stride.Core.Assets.Editor.ViewModel
             return null;
         }
 
+        protected virtual void PrepareImporterInputParametersForUpdateFromSource(PropertyCollection importerInputParameters, TAsset asset)
+        {
+            // Do nothing by default
+        }
+
         protected virtual void UpdateAssetFromSource(TAsset assetToMerge)
         {
             // Do nothing by default
@@ -29,6 +34,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             if (importer != null)
             {
                 var importParameters = new AssetImporterParameters { Logger = logger };
+                PrepareImporterInputParametersForUpdateFromSource(importParameters.InputParameters, Asset);
                 importParameters.SelectedOutputTypes.Add(AssetType, true);
                 try
                 {

--- a/sources/engine/Stride.Assets.Models/AssimpAssetImporter.cs
+++ b/sources/engine/Stride.Assets.Models/AssimpAssetImporter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Collections.Generic;
 using Stride.Core.Assets;
 using Stride.Core;
 using Stride.Core.Diagnostics;
@@ -33,7 +34,11 @@ namespace Stride.Assets.Models
         public override EntityInfo GetEntityInfo(UFile localPath, Logger logger, AssetImporterParameters importParameters)
         {
             var meshConverter = new Importer.AssimpNET.MeshConverter(logger);
-            var entityInfo = meshConverter.ExtractEntity(localPath.FullPath, null, importParameters.IsTypeSelectedForOutput(typeof(TextureAsset)));
+
+            if (!importParameters.InputParameters.TryGet(DeduplicateMaterialsKey, out var deduplicateMaterials))
+                deduplicateMaterials = true;    // Dedupe is the default value
+
+            var entityInfo = meshConverter.ExtractEntity(localPath.FullPath, null, importParameters.IsTypeSelectedForOutput(typeof(TextureAsset)), deduplicateMaterials);
             return entityInfo;
         }
 
@@ -64,6 +69,22 @@ namespace Stride.Assets.Models
                 startTime = CompressedTimeSpan.Zero;
             if (endTime == CompressedTimeSpan.MinValue)
                 endTime = CompressedTimeSpan.Zero;
+        }
+
+        public override IEnumerable<AssetItem> Import(UFile localPath, AssetImporterParameters importParameters)
+        {
+            var assetItems = base.Import(localPath, importParameters);
+            // Need to remember the DeduplicateMaterials setting per ModelAsset since the importer may be rerun on this asset
+            if (!importParameters.InputParameters.TryGet(DeduplicateMaterialsKey, out var deduplicateMaterials))
+                deduplicateMaterials = true;    // Dedupe is the default value
+            foreach (var item in assetItems)
+            {
+                if (item.Asset is ModelAsset modelAsset)
+                {
+                    modelAsset.DeduplicateMaterials = deduplicateMaterials;
+                }
+            }
+            return assetItems;
         }
     }
 }

--- a/sources/engine/Stride.Assets.Models/ImportAssimpCommand.cs
+++ b/sources/engine/Stride.Assets.Models/ImportAssimpCommand.cs
@@ -47,7 +47,7 @@ namespace Stride.Assets.Models
             // Note: FBX exporter uses Materials for the mapping, but Assimp already uses indices so we can reuse them
             // We should still unify the behavior to be more consistent at some point (i.e. if model was changed on the HDD but not in the asset).
             // This should probably be better done during a large-scale FBX/Assimp refactoring.
-            var sceneData = converter.Convert(SourcePath, Location);
+            var sceneData = converter.Convert(SourcePath, Location, DeduplicateMaterials);
             return sceneData;
         }
 

--- a/sources/engine/Stride.Assets.Models/ImportModelCommand.Model.cs
+++ b/sources/engine/Stride.Assets.Models/ImportModelCommand.Model.cs
@@ -28,6 +28,7 @@ namespace Stride.Assets.Models
         public bool Allow32BitIndex { get; set; }
         public int MaxInputSlots { get; set; }
         public bool AllowUnsignedBlendIndices { get; set; }
+        public bool DeduplicateMaterials { get; set; }
         public List<ModelMaterial> Materials { get; set; }
         public string EffectName { get; set; }
 

--- a/sources/engine/Stride.Assets.Models/ModelAsset.cs
+++ b/sources/engine/Stride.Assets.Models/ModelAsset.cs
@@ -66,10 +66,10 @@ namespace Stride.Assets.Models
 
 
         /// <summary>
-        /// Gets or sets the model meshe merge property. When set to true to a model without skeleton, the meshes of the model are merged together by material.
+        /// Gets or sets the model meshes merge property. When set to true to a model without skeleton, the meshes of the model are merged together by material.
         /// </summary>
         /// <userdoc>
-        /// When checked and the model has no skeleton, the meshes of the model are merged together by material. 
+        /// When checked and the model has no skeleton, the meshes of the model are merged together by material.
         /// In most cases this improves the performances but prevents the meshes to be culled independently.
         /// </userdoc>
         [DataMember(35)]
@@ -81,6 +81,11 @@ namespace Stride.Assets.Models
         [MemberCollection(ReadOnly = true)]
         [Category]
         public List<ModelMaterial> Materials { get; } = new List<ModelMaterial>();
+
+        [DataMember(45)]
+        [DefaultValue(true)]
+        [Display(Browsable = false)]
+        public bool DeduplicateMaterials { get; set; } = true;
 
         [DataMember(50)]
         [Category]

--- a/sources/engine/Stride.Assets.Models/ModelAssetCompiler.cs
+++ b/sources/engine/Stride.Assets.Models/ModelAssetCompiler.cs
@@ -67,6 +67,7 @@ namespace Stride.Assets.Models
             importModelCommand.ScaleImport = asset.ScaleImport;
             importModelCommand.PivotPosition = asset.PivotPosition;
             importModelCommand.MergeMeshes = asset.MergeMeshes;
+            importModelCommand.DeduplicateMaterials = asset.DeduplicateMaterials;
             importModelCommand.ModelModifiers = asset.Modifiers;
 
             if (skeleton != null)

--- a/sources/engine/Stride.Assets.Models/ModelAssetImporter.cs
+++ b/sources/engine/Stride.Assets.Models/ModelAssetImporter.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using Stride.Core;
 using Stride.Core.Assets;
 using Stride.Core.Assets.Analysis;
 using Stride.Core.Diagnostics;
@@ -19,6 +20,8 @@ namespace Stride.Assets.Models
 {
     public abstract class ModelAssetImporter : AssetImporterBase
     {
+        public static readonly PropertyKey<bool> DeduplicateMaterialsKey = new PropertyKey<bool>("DeduplicateMaterials", typeof(ModelAssetImporter));
+
         public override IEnumerable<Type> RootAssetTypes
         {
             get


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Not sure if anyone else wants this feature, but I was caught out with Assimp's importer deduping my materials on my model when I didn't want it to.

## Description

<!--- Describe your changes in detail -->
I've now added a checkbox so you can choose not to dedupe materials. It's ticked by default so it behaves the same as currently. However, note that FBX and Assimp importers actually behave inconsistently in this regard, since FBX importer does _not_ dedupe materials at all.

Here's a screenshot of what the option looks like:
![image](https://user-images.githubusercontent.com/1356956/80113680-bc7c9c00-85d6-11ea-9722-26e390f2c155.png)

Note that I've only added it for the Assimp importer since it's a flag option for the importer.
I did not do it for FBX importer, I couldn't find any option for the FBX SDK (or I didn't look hard enough), and I don't want to troll though the code to figure out what the correct logic is to manually deduped it.

Note that the warning only appears if a user drags&drops a mix of fbx and non-fbx models (ie. some using assimp importer and some using fbx importer).
If only assimp importer is used, then the warning doesn't appear.
If only fbx importer is used, then no option appears for it.

The property must also exist on the ModelAsset since reloading the asset goes though the importer during loading, so we must persist telling the importer to dedupe or not dedupe.
It's not made visible because ticking/unticking doesn't update the material slots properly, so it's better to just delete the model and re-import it again with the correct options.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I exported a model from Blender as a Collada file and had multiple meshes with separate materials, but the materials shared the same texture file, so Assimp (rightly) detected they could be the same material. I still wanted the model to have all the material slots (so they could be changed at run-time), but since Assimp deduped the materials, the model ends up with less material slots.

A workaround is to force the Blender file to make each material distinct, but it's a bit of a hacky workflow.


For testing purposes (sorry, no unit tests!), attached is a Collada file (zipped so Github doesn't complain) with a model with three meshes, each with its own material but the materials are the same values (ie. can be deduped).
[material_test.zip](https://github.com/stride3d/stride/files/4532116/material_test.zip)

This is what the actual model looks like in Blender. Materials are just a simple blue color.
![image](https://user-images.githubusercontent.com/1356956/80267091-8aad2780-86f3-11ea-8ec5-fd0d6f309562.png)

On import with dedupe ticked, the model only has one material slot (as per default).
On import with dedupe unticked, the model has all three material slots.
After placing in the scene, changing the material's color correctly updates the right mesh (or just selecting the material will highlight the affected mesh).
The dedupe flag still persists when you select the 'update from source' options.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.