### PR TITLE
[Docs] Update contributing

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,21 +4,20 @@
 
 Please take a look at our [issue tracker](https://github.com/stride3d/stride/issues), especially issues marked with [help wanted](https://github.com/stride3d/stride/labels/help%20wanted).
 
-If you are just getting started with Stride, issues marked with [good first issue](https://github.com/stride3d/stride/labels/good%20first%20issue) can be a good entry point.
+If you are just getting started with Stride, issues marked with ['good first issue'](https://github.com/stride3d/stride/labels/good%20first%20issue) can be a good entry point.
 
-## Let other people know what you are doing
+## Notify users
 
-Once you work on some task, notify people on the appropriate issue (create one if none exists) to:
-* make sure that no two people waste time doing the same thing
-* lay out your plans and discuss it with collaborators to make sure it is properly architectured and would fit well in the project
-* get feedbacks from other people
+Once you start working leave a message on the appropriate issue or create one if none exists to:
+* make sure that no one else is working on that same issue
+* lay out your plans and discuss it with collaborators and users to make sure it is properly architectured and would fit well in the project
 
 ## Coding style
 
-There's no Coding Style spec yet (and it will properly be done through a StyleCop & editorconfig file), but in the meantime please follow the coding style of other Stride files.
+Please use and follow Stride's `.editorconfig` when making changes to files.
 
 ## Submitting Changes
 
-* Push your changes to a topic branch in your fork of the repository.
-* If it's your first time contributing, [CLA assistant](https://cla-assistant.io/) will ask you to sign the [Contributor License Agreement](https://github.com/stride3d/stride/blob/master/docs/ContributorLicenseAgreement.md).
-* Submit a pull request to the repository in Stride organization following pull-request template.
+* Push your changes to a specific branch in your fork.
+* Use that branch to create and fill out a pull request to the official repository.
+* After creating that pull request and if it's your first time contributing a [CLA assistant](https://cla-assistant.io/) will ask you to sign the [Contributor License Agreement](https://github.com/stride3d/stride/blob/master/docs/ContributorLicenseAgreement.md).


### PR DESCRIPTION
# PR Details
Welp, didn't mean to open a new branch on the official, github's online editor is kind of weird to use, anyway:
Update contribution to the changes we made since then, fix spelling and change the wording in certain places to be stay succinct.
AFAIK `.editorconfig` is ready by now, tell me if it isn't.

## Motivation and Context
Changes speaks for themselves.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation. (Screenshots may need updating)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.