### PR TITLE
[Editor] Don't append track name to Audio asset name if there's only one track

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/SoundFromFileTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/SoundFromFileTemplateGenerator.cs
@@ -4,9 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Stride.Assets.Media;
 using Stride.Core.Assets;
 using Stride.Core.Assets.Templates;
-using Stride.Assets.Media;
+using Stride.Core.IO;
 using Stride.Video.FFmpeg;
 
 namespace Stride.Assets.Presentation.Templates
@@ -46,13 +47,18 @@ namespace Stride.Assets.Presentation.Templates
                     using (var media = new FFmpegMedia())
                     {
                         media.Open(soundAsset.Source.ToWindowsPath());
-                        foreach (var audioTrack in media.Streams.OfType<AudioStream>().ToList())
+                        var audioStreams = media.Streams.OfType<AudioStream>().ToList();
+                        foreach (var audioTrack in audioStreams)
                         {
                             var assetCopy = AssetCloner.Clone(soundAsset);
                             assetCopy.Index = audioTrack.Index;
                             assetCopy.SampleRate = audioTrack.SampleRate;
 
-                            importedAssets.Add(new AssetItem(assetItem.Location + " track " + audioTrack.Index, assetCopy));
+                            // If there's more than one streams, append the track index to the asset name
+                            var fileLocation = audioStreams.Count > 1
+                                ? (UFile)(assetItem.Location + " track " + audioTrack.Index)
+                                : assetItem.Location;
+                            importedAssets.Add(new AssetItem(fileLocation, assetCopy));
                         }
                     }
                 }


### PR DESCRIPTION
##  Description

<!--- Describe your changes in detail -->
Imported audio assets won't append ' track ' + index to the name if there's only track.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Majority of audio that I import are wav, mp3, etc, that don't have multiple tracks, so this naming appending feature is not needed for those cases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.