### PR TITLE
[Logger] Enhance logger and ExceptionInfo formatting

### DIFF
--- a/sources/core/Stride.Core/Diagnostics/ExceptionInfo.cs
+++ b/sources/core/Stride.Core/Diagnostics/ExceptionInfo.cs
@@ -73,14 +73,30 @@ namespace Stride.Core.Diagnostics
         /// <inheritdoc/>
         public override string ToString()
         {
-            var sb = new StringBuilder();
-            sb.AppendLine(Message);
-            if (StackTrace != null)
-                sb.AppendLine(StackTrace);
-            foreach (var innerException in InnerExceptions)
+            StringBuilder sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(TypeName))
             {
-                sb.AppendFormat("Inner/Loader Exception: {0}{1}", innerException, Environment.NewLine);
+                sb.Append(TypeName);
             }
+
+            if (!string.IsNullOrEmpty(Message))
+            {
+                if(sb.Length != 0)
+                    sb.Append(": ");
+                sb.Append(Message);
+            }
+
+            foreach(var child in InnerExceptions)
+            {
+                sb.AppendFormat("{0} ---> {1}", Environment.NewLine, child.ToString());
+            }
+
+            if (StackTrace != null)
+            {
+                sb.AppendLine();
+                sb.Append(StackTrace);
+            }
+
             return sb.ToString();
         }
     }

--- a/sources/editor/Stride.Core.Assets.Editor/Themes/generic.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/Themes/generic.xaml
@@ -36,7 +36,7 @@
                   <Path Width="12" Height="12" Stretch="Uniform" Fill="{StaticResource TextBrush}" Data="{StaticResource GeometryFatalMessage}" />
                 </ToggleButton>
                 <ToggleButton IsChecked="{Binding ShowStacktrace, RelativeSource={RelativeSource Mode=TemplatedParent}}">
-                  <Label Content="..." Width="12" Height="12" HorizontalContentAlignment="Center" />
+                  <Label Content="(...)" Width="16" Height="12" FontSize="10" HorizontalContentAlignment="Center" />
                 </ToggleButton>
               </ToolBar>
             </ToolBarTray>

--- a/sources/presentation/Stride.Core.Presentation/Controls/TextLogViewer.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/TextLogViewer.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -343,13 +344,34 @@ namespace Stride.Core.Presentation.Controls
                 var paragraph = (Paragraph)document.Blocks.AsEnumerable().First();
                 var stringComparison = SearchMatchCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
                 var searchToken = SearchToken;
+                var sb = new StringBuilder();
                 foreach (var message in logMessages.Where(x => ShouldDisplayMessage(x.Type)))
                 {
-                    string content = message.Text;
+                    sb.Clear();
+
+                    if (message.Module != null)
+                    {
+                        sb.AppendFormat("[{0}]: ", message.Module);
+                    }
+
+                    sb.AppendFormat("{0}: {1}", message.Type, message.Text);
+                    
                     var ex = message.ExceptionInfo;
-                    if (ShowStacktrace && ex != null)
-                        content = $"{content}{Environment.NewLine}{ex}";
-                    var lineText = $"{(message.Module != null ? $"[{message.Module}]: " : string.Empty)}{message.Type}:{content}{Environment.NewLine}";
+                    if (ex != null)
+                    {
+                        if (ShowStacktrace)
+                        {
+                            sb.AppendFormat("{0}{1}{0}", Environment.NewLine, ex);
+                        }
+                        else
+                        {
+                            sb.Append(" (...)");
+                        }
+                    }
+
+                    sb.AppendLine();
+
+                    var lineText = sb.ToString();
 
                     var logColor = GetLogColor(message.Type);
                     if (string.IsNullOrEmpty(searchToken))

--- a/sources/presentation/Stride.Core.Presentation/Themes/ThemeSelector.xaml
+++ b/sources/presentation/Stride.Core.Presentation/Themes/ThemeSelector.xaml
@@ -4550,7 +4550,7 @@
                   <Path Width="12" Height="12" Stretch="Uniform" Fill="{DynamicResource TextBrush}" Data="{StaticResource GeometryFatalMessage}"/>
                 </ToggleButton>
                 <ToggleButton IsChecked="{Binding ShowStacktrace, RelativeSource={RelativeSource Mode=TemplatedParent}}">
-                  <Label Content="..." Width="12" Height="12" HorizontalContentAlignment="Center" />
+                  <Label Content="(...)" Width="16" Height="12" FontSize="10" HorizontalContentAlignment="Center" />
                 </ToggleButton>
               </ToolBar>
               <ToolBar ToolBarTray.IsLocked="True" Header="Search:" Visibility="{Binding CanSearchLog, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={cvt:VisibleOrCollapsed}}">


### PR DESCRIPTION
# PR Details
Hopefully this should make the logger less obtuse for users.

## Description
Adds a ``(...)`` at the end of exceptions to hint to users that they can use a similar button to show the rest. 
Changes ``ExceptionInfo``'s formatting to reflect how dot net does it by default, i.e.: 
``Type: Message\n{innerExceptions.ToString}\n{Stacktrace}``
instead of ours which was
``Message\n{Stacktrace}\n{innerException.ToString}``
this leads to the first stacktrace line being the line that actually created the exception instead of one of the many catch the exception climbed back through.

## Related Issue

## Motivation and Context
See PR Details.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.