### PR TITLE
[Serialization] Handle component and property access-related exception gracefully

### DIFF
--- a/sources/assets/Stride.Core.Assets/Yaml/CollectionWithIdsSerializerBase.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/CollectionWithIdsSerializerBase.cs
@@ -162,10 +162,7 @@ namespace Stride.Core.Yaml
                     if (objectContext.SerializerContext.AllowErrors)
                     {
                         var logger = objectContext.SerializerContext.Logger;
-                        if(ex.InnerException is DefaultObjectFactory.InstanceCreationException ice)
-                            logger?.Warning($"Ignored dictionary item that could not be deserialized:\n{ice.Message}", ex);
-                        else
-                            logger?.Warning($"Ignored dictionary item that could not be deserialized:\n{ex.Message}", ex);
+                        logger?.Warning($"{ex.Message}, this dictionary item will be ignored", ex);
                         objectContext.Reader.Skip(currentDepth, objectContext.Reader.Parser.Current == startParsingEvent);
                     }
                     else throw;

--- a/sources/assets/Stride.Core.Assets/Yaml/ErrorRecoverySerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/ErrorRecoverySerializer.cs
@@ -49,7 +49,7 @@ namespace Stride.Core.Yaml
                 // Deserialize normally
                 return base.ReadYaml(ref objectContext);
             }
-            catch (YamlException ex) // TODO: Filter only TagTypeSerializer TypeFromTag decoding errors? or more?
+            catch (Exception ex) when (ex is YamlException || ex is DefaultObjectFactory.InstanceCreationException) // TODO: Filter only TagTypeSerializer TypeFromTag decoding errors? or more?
             {
                 // Find the parsing range for this object
                 // Skipping is also important to make sure the depth is properly updated
@@ -105,7 +105,7 @@ namespace Stride.Core.Yaml
                     }
 
                     var log = objectContext.SerializerContext.Logger;
-                    log?.Warning($"Could not deserialize object of type {tag}; replacing it with an object implementing {nameof(IUnloadable)}:\n{ex.Message}", ex);
+                    log?.Warning($"Could not deserialize object of type '{typeName ?? tag}'; replacing it with an object implementing {nameof(IUnloadable)}", ex);
 
                     var unloadableObject = UnloadableObjectInstantiator.CreateUnloadableObject(type, typeName, assemblyName, ex.Message, parsingEvents);
                     objectContext.Instance = unloadableObject;

--- a/sources/core/Stride.Core.Yaml/Serialization/DefaultObjectFactory.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/DefaultObjectFactory.cs
@@ -115,7 +115,6 @@ namespace Stride.Core.Yaml.Serialization
                 }
                 catch (Exception e)
                 {
-                    //return System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type);
                     throw new InstanceCreationException($"'{typeof(Activator)}' failed to create instance of type '{type}', see inner exception.", e);
                 }
             }

--- a/sources/core/Stride.Core.Yaml/Serialization/Serializer.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/Serializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SharpYaml - Alexandre Mutel
+// Copyright (c) 2015 SharpYaml - Alexandre Mutel
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -527,7 +527,7 @@ namespace Stride.Core.Yaml.Serialization
                 catch (Exception ex)
                 {
                     ex = ex.Unwrap();
-                    throw new YamlException(node.Start, node.End, $"Error while deserializing node [{node}]:\n{ex.Message}", ex);
+                    throw new YamlException(node, ex);
                 }
             }
 

--- a/sources/core/Stride.Core.Yaml/Serialization/Serializers/ArraySerializer.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/Serializers/ArraySerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SharpYaml - Alexandre Mutel
+// Copyright (c) 2015 SharpYaml - Alexandre Mutel
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -141,7 +141,7 @@ namespace Stride.Core.Yaml.Serialization.Serializers
             catch (Exception ex)
             {
                 ex = ex.Unwrap();
-                throw new YamlException(node.Start, node.End, $"Error while deserializing node [{node}]:\n{ex.Message}", ex);
+                throw new YamlException(node, ex);
             }
         }
 

--- a/sources/core/Stride.Core.Yaml/Serialization/Serializers/DefaultObjectSerializerBackend.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/Serializers/DefaultObjectSerializerBackend.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SharpYaml - Alexandre Mutel
+// Copyright (c) 2015 SharpYaml - Alexandre Mutel
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -185,7 +185,7 @@ namespace Stride.Core.Yaml.Serialization.Serializers
             catch (Exception ex)
             {
                 ex = ex.Unwrap();
-                throw new YamlException(node.Start, node.End, $"Error while deserializing node [{node}]:\n{ex.Message}", ex);
+                throw new YamlException(node, ex);
             }
         }
 

--- a/sources/core/Stride.Core.Yaml/Serialization/Serializers/DictionarySerializer.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/Serializers/DictionarySerializer.cs
@@ -166,7 +166,7 @@ namespace Stride.Core.Yaml.Serialization.Serializers
                     if (objectContext.SerializerContext.AllowErrors)
                     {
                         var logger = objectContext.SerializerContext.Logger;
-                        logger?.Warning($"Ignored dictionary item that could not be deserialized:\n{ex.Message}", ex);
+                        logger?.Warning($"{ex.Message}, this dictionary item will be ignored", ex);
                         objectContext.Reader.Skip(currentDepth, startParsingEvent == objectContext.Reader.Parser.Current);
                     }
                     else throw;

--- a/sources/core/Stride.Core.Yaml/YamlException.cs
+++ b/sources/core/Stride.Core.Yaml/YamlException.cs
@@ -65,32 +65,16 @@ namespace Stride.Core.Yaml
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        public YamlException()
+        public YamlException(string message = null, Exception inner = null)
+            : base(message, inner)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        /// <param name="message">The message.</param>
-        public YamlException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="YamlException"/> class.
-        /// </summary>
-        public YamlException(Mark start, Mark end, string message)
-            : this(start, end, message, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="YamlException"/> class.
-        /// </summary>
-        public YamlException(Mark start, Mark end, string message, Exception innerException)
-            : base(string.Format("({0}) - ({1}): {2}", start, end, message), innerException)
+        public YamlException(Mark start, Mark end, string message, Exception innerException = null)
+            : base($"{message} (({start.ToString()}) -> ({end.ToString()}))", innerException)
         {
             Start = start;
             End = end;
@@ -99,10 +83,8 @@ namespace Stride.Core.Yaml
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        /// <param name="message">The message.</param>
-        /// <param name="inner">The inner.</param>
-        public YamlException(string message, Exception inner)
-            : base(message, inner)
+        public YamlException(Events.ParsingEvent node, Exception innerException) : 
+            this(node.Start, node.End, $"An exception occured while deserializing node [{node}], see inner exception", innerException)
         {
         }
     }

--- a/sources/core/Stride.Core/Serialization/ClassDataSerializer.cs
+++ b/sources/core/Stride.Core/Serialization/ClassDataSerializer.cs
@@ -9,16 +9,7 @@ namespace Stride.Core.Serialization
         {
             if (mode == ArchiveMode.Deserialize && obj == null)
             {
-                try
-                {
-                    obj = new T();
-                }
-                catch (System.Exception)
-                {
-                    //obj = (T)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(T));
-                    //return;
-                    throw;
-                }
+                obj = new T();
             }
         }
     }


### PR DESCRIPTION
# PR Details
Logs silent fails user component throwing exceptions through their ctor and properties created.
In general most logs are more concise, the rest of the information has been pushed into inner exceptions for the user to unfold through the ``...`` button, keeping the base view readable.

## Related Issue
Fixes #209 
Some changes might not make sense without #687 

## Motivation and Context
Kill an old bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.