### PR TITLE
[Compiler] Register the project's assemblies before loading the asset libraries

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/PackageBuilder.cs
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/PackageBuilder.cs
@@ -80,6 +80,7 @@ namespace Stride.Core.Assets.CompilerApp
                     AutoCompileProjects = !builderOptions.DisableAutoCompileProjects,
                     ExtraCompileProperties = builderOptions.ExtraCompileProperties,
                     RemoveUnloadableObjects = true,
+                    RegisterPackageAssemblies = true,
                     BuildConfiguration = builderOptions.ProjectConfiguration,
                 };
 

--- a/sources/assets/Stride.Core.Assets/PackageLoadParameters.cs
+++ b/sources/assets/Stride.Core.Assets/PackageLoadParameters.cs
@@ -42,6 +42,7 @@ namespace Stride.Core.Assets
         public PackageLoadParameters()
         {
             LoadMissingDependencies = true;
+            RegisterPackageAssemblies = false;
             LoadAssemblyReferences = true;
             AutoCompileProjects = true;
             AutoLoadTemporaryAssets = true;
@@ -54,6 +55,11 @@ namespace Stride.Core.Assets
         /// </summary>
         /// <value><c>true</c> if [load missing dependencies]; otherwise, <c>false</c>.</value>
         public bool LoadMissingDependencies { get; set; }
+
+        /// <summary>
+        /// Register the package's assemblies from the project.
+        /// </summary>
+        public bool RegisterPackageAssemblies { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [load assembly references].
@@ -109,7 +115,7 @@ namespace Stride.Core.Assets
         public CancellationToken? CancelToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the assembly container used to load assemblies referenced by the package. If null, will use the 
+        /// Gets or sets the assembly container used to load assemblies referenced by the package. If null, will use the
         /// <see cref="Stride.Core.Reflection.AssemblyContainer.Default"/>
         /// </summary>
         /// <value>The assembly container.</value>

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -901,6 +901,13 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
         public void LoadMissingReferences(ILogger log, PackageLoadParameters loadParameters = null)
         {
             LoadMissingDependencies(log, loadParameters);
+            if (log != null && (loadParameters?.RegisterPackageAssemblies ?? false))
+            {
+                foreach (var package in Packages.ToList())
+                {
+                    package.LoadAssemblies(log, loadParameters);
+                }
+            }
             LoadMissingAssets(log, Packages.ToList(), loadParameters);
         }
 
@@ -1003,7 +1010,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
                     // Return immediately if there is any error
                     if (loggerResult.HasErrors)
                         return;
-       
+
                     //batch projects
                     var vsProjs = new Dictionary<string, Microsoft.Build.Evaluation.Project>();
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
**Warning:** This is not heavily tested, and I can't say I know what the full implications are of doing this, so probably needs someone more well versed into CompilerApp and probably make a better pull if necessary.
Basically the source of the issue for the Stride.Voxel library is that the asset's "definitions" are defined the optional library (ie. Stride.Voxels). The CompilerApp only registers assemblies that it knows about, ie. only mandatory Stride libraries.
What this does is load the assemblies of the project itself in order to register any missing definitions (eg. the Voxel classes, which are needed for the YAML deserializer).
The part I'm not understanding is the full implications of loading these assemblies. eg. will it conflict with other assemblies, especially if it's same assembly but different versions.

I think at the very least, this should provide pointers in which areas to look at.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #683 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.