### PR TITLE
[Rendering] Added NumOfTexCoords property to Procedural Models

### DIFF
--- a/sources/engine/Stride.Graphics/VertexHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexHelper.cs
@@ -108,7 +108,7 @@ namespace Stride.Graphics
         /// or
         /// vertexStride;vertexStride must be >= 0
         /// or
-        /// maxTexcoord;maxTexcoord must be > 0
+        /// maxTexcoord;maxTexcoord must be >= 0
         /// </exception>
         /// <exception cref="System.InvalidOperationException">The vertex buffer must contain at least the TEXCOORD</exception>
         /// <remarks>

--- a/sources/engine/Stride.Graphics/VertexHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexHelper.cs
@@ -121,7 +121,7 @@ namespace Stride.Graphics
             if (vertexBufferData == IntPtr.Zero) throw new ArgumentNullException("vertexBufferData");
             if (vertexCount <= 0) throw new ArgumentOutOfRangeException("vertexCount", "vertexCount must be > 0");
             if (vertexStride < 0) throw new ArgumentOutOfRangeException("vertexStride", "vertexStride must be >= 0");
-            if (maxTexcoord < 0) throw new ArgumentOutOfRangeException("maxTexcoord", "maxTexcoord must be > 0");
+            if (maxTexcoord < 0) throw new ArgumentOutOfRangeException("maxTexcoord", "maxTexcoord must be >= 0");
 
             // Get the stride from the vertex declaration if necessary
             if (vertexStride == 0)

--- a/sources/engine/Stride.Rendering/Rendering/ProceduralModels/PrimitiveProceduralModelBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/ProceduralModels/PrimitiveProceduralModelBase.cs
@@ -52,6 +52,16 @@ namespace Stride.Rendering.ProceduralModels
         public Vector3 LocalOffset { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of texture coordinates to generate. A value between 1 and 10, inclusive.
+        /// </summary>
+        /// <value>
+        /// The number of texure coordinates.
+        /// </value>
+        [DataMember(540)]
+        [DataMemberRange(1, 10)]
+        public int NumOfTexCoords { get; set; } = 10;
+
+        /// <summary>
         /// Gets the material instance.
         /// </summary>
         /// <value>The material instance.</value>
@@ -121,7 +131,8 @@ namespace Stride.Rendering.ProceduralModels
             var resultWithTangentBiNormal = VertexHelper.GenerateTangentBinormal(originalLayout, data.Vertices, data.Indices);
 
             // Generate Multitexcoords
-            var result = VertexHelper.GenerateMultiTextureCoordinates(resultWithTangentBiNormal);
+            var maxTexCoords = MathUtil.Clamp(NumOfTexCoords, 1, 10) - 1;
+            var result = VertexHelper.GenerateMultiTextureCoordinates(resultWithTangentBiNormal, vertexStride: 0, maxTexCoords);
 
             var meshDraw = new MeshDraw();
 

--- a/sources/engine/Stride.Rendering/Rendering/ProceduralModels/PrimitiveProceduralModelBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/ProceduralModels/PrimitiveProceduralModelBase.cs
@@ -52,14 +52,15 @@ namespace Stride.Rendering.ProceduralModels
         public Vector3 LocalOffset { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of texture coordinates to generate. A value between 1 and 10, inclusive.
+        /// Gets or sets the number of texture coordinate channels to generate. A value between 1 and 10, inclusive.
         /// </summary>
         /// <value>
-        /// The number of texure coordinates.
+        /// The number of texure coordinate channels.
         /// </value>
         [DataMember(540)]
         [DataMemberRange(1, 10)]
-        public int NumOfTexCoords { get; set; } = 10;
+        [Display("Number of texture coordinate channels")]
+        public int NumberOfTextureCoordinates  { get; set; } = 10;
 
         /// <summary>
         /// Gets the material instance.
@@ -131,7 +132,7 @@ namespace Stride.Rendering.ProceduralModels
             var resultWithTangentBiNormal = VertexHelper.GenerateTangentBinormal(originalLayout, data.Vertices, data.Indices);
 
             // Generate Multitexcoords
-            var maxTexCoords = MathUtil.Clamp(NumOfTexCoords, 1, 10) - 1;
+            var maxTexCoords = MathUtil.Clamp(NumberOfTextureCoordinates, 1, 10) - 1;
             var result = VertexHelper.GenerateMultiTextureCoordinates(resultWithTangentBiNormal, vertexStride: 0, maxTexCoords);
 
             var meshDraw = new MeshDraw();


### PR DESCRIPTION
# PR Details

Made the property to adjust the number of generated texture coordinates visible to the user.

## Motivation and Context

The vertex buffers generated by the procedural models are quite huge since they contain 10 channels of texture coordinates. This property allows the user to reduce them if needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.