### PR TITLE
[Editor] Fix project file not tracked

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
@@ -305,7 +305,7 @@ namespace Stride.Assets.Presentation.AssetEditors
                     directoryWatcher.Track(loadedAssembly.Path);
 
                 // Track the project file
-                if (loadedAssembly.ProjectReference != null)
+                if (loadedAssembly.ProjectReference == null)
                     continue;
 
                 directoryWatcher.Track(loadedAssembly.ProjectReference.Location);


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Code editor and other asset editors would fail to open. It was caused by a *not-null* check which should have been a *null* check.

## Related Issue

Fixes #711

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.