### PR TITLE
[Physics] Fix HeightmapAsset compilation fails with resizing

### DIFF
--- a/sources/engine/Stride.Physics/Engine/HeightmapUtils.cs
+++ b/sources/engine/Stride.Physics/Engine/HeightmapUtils.cs
@@ -76,6 +76,9 @@ namespace Stride.Physics
 
         public static T[] Resize<T>(T[] pixels, Int2 originalSize, Int2 newSize)
         {
+            if (originalSize.X < 1 || originalSize.Y < 1) throw new ArgumentException($"{ nameof(originalSize) }.{ nameof(originalSize.X) } and { nameof(originalSize.Y) } should be greater than 0.");
+            if (newSize.X < 1 || newSize.Y < 1) throw new ArgumentException($"{ nameof(newSize) }.{ nameof(newSize.X) } and { nameof(newSize.Y) } should be greater than 0.");
+
             if (originalSize.Equals(newSize))
             {
                 return pixels.ToArray();
@@ -86,9 +89,12 @@ namespace Stride.Physics
             var newWidth = newSize.X;
             var newLength = newSize.Y;
 
+            var scaleX = (newWidth - 1) == 0 ? 0d : ((double)(originalWidth - 1)) / (newWidth - 1);
+            var scaleY = (newLength - 1) == 0 ? 0d : ((double)(originalLength - 1)) / (newLength - 1);
+
             int GetOriginalIndex(int x, int y) =>
-                (int)Math.Round(MathUtil.Lerp(0, originalLength, MathUtil.InverseLerp(0, newLength, y)), MidpointRounding.AwayFromZero) * originalWidth +
-                (int)Math.Round(MathUtil.Lerp(0, originalWidth, MathUtil.InverseLerp(0, newWidth, x)), MidpointRounding.AwayFromZero);
+                (int)Math.Round(y * scaleY, MidpointRounding.AwayFromZero) * originalWidth +
+                (int)Math.Round(x * scaleX, MidpointRounding.AwayFromZero);
 
             T[] newPixels = new T[newWidth * newLength];
             for (int y = 0; y < newLength; ++y)


### PR DESCRIPTION
# PR Details

Fix array index out of bounds at resizing pixel data.

## Description

HeightmapAsset that enabled Resize fails to compile.

## Related Issue

1. Add HeightmapAsset from a source file(i.e. 256x256).
2. Enable and set Resize to 1024x1024

The asset compilation fails.

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.