### PR TITLE
Fix C++ compilation with Visual Studio 16.6

### DIFF
--- a/sources/engine/Stride.Graphics/VertexDeclaration.cs
+++ b/sources/engine/Stride.Graphics/VertexDeclaration.cs
@@ -41,7 +41,7 @@ namespace Stride.Graphics
         /// <param name="instanceCount">The instance count.</param>
         /// <param name="vertexStride">The vertex stride.</param>
         /// <exception cref="System.ArgumentNullException">elements</exception>
-        public VertexDeclaration(VertexElement[] elements, int instanceCount = 0, int vertexStride = 0) 
+        public VertexDeclaration(VertexElement[] elements, int instanceCount, int vertexStride) 
         {
             if (elements == null) throw new ArgumentNullException("elements");
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Assimp C++ project fail to compile because of ambiguous method overload resolution.

> C:\Projects\stride\sources\tools\Stride.Importer.Assimp\Stride.Importer.Assimp.cpp(475,1): error C2668: 'Stride::Graphics::VertexDeclaration::VertexDeclaration': ambiguous call to overloaded function

Failing C++:
https://github.com/stride3d/stride/blob/f2730dd2c66ddfec3171ca0a8180ad0fdb2dfe96/sources/tools/Stride.Importer.Assimp/Stride.Importer.Assimp.cpp#L475

Related C# code:
https://github.com/stride3d/stride/blob/f2730dd2c66ddfec3171ca0a8180ad0fdb2dfe96/sources/engine/Stride.Graphics/VertexDeclaration.cs#L32-L33
https://github.com/stride3d/stride/blob/f2730dd2c66ddfec3171ca0a8180ad0fdb2dfe96/sources/engine/Stride.Graphics/VertexDeclaration.cs#L44

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

Fix compilation by making the overloads unambiguous (from C++/CLI point of view).
See [Default argument import in C++/CLI](https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#default-argument-import-in-ccli)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.