### PR TITLE
[Games] Fixed SDL window resize initiated by GraphicsDeviceManager

### DIFF
--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -75,7 +75,7 @@ namespace Stride.Games
                 }
 
             }
-            else if (isFullScreenMaximized) //fullscreen to windowed
+            else //fullscreen to windowed or window resize
             {
                 isFullScreenMaximized = false;
 


### PR DESCRIPTION
Fixed SDL window resize initiated by GraphicsDeviceManager after back buffer resize

# PR Details

Fixes a regression introduced by #737 

## Description

The case of an automatic window resize after a back buffer resize wasn't handled.

## Related Issue

#737

## Motivation and Context

Get my PR in order :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.