### PR TITLE
[Editor] Fix autohide taskbar

### DIFF
--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml.cs
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml.cs
@@ -215,6 +215,8 @@ namespace Stride.GameStudio
             var wasWindowMaximized = GameStudioInternalSettings.WindowMaximized.GetValue();
             var workArea = this.GetWorkArea();
 
+            AdjustMaxSizeWithTaskbar();
+            
             if (wasWindowMaximized || previousWorkAreaWidth > (int)workArea.Width || previousWorkAreaHeight > (int)workArea.Height)
             {
                 // Resolution has changed (and is now smaller), let's make the window fill all available space.
@@ -456,6 +458,23 @@ namespace Stride.GameStudio
         private void EditorWindowPreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             ((EditorViewModel)DataContext).Status.DiscardStatus();
+        }
+
+        protected override void OnStateChanged(EventArgs e)
+        {
+            base.OnStateChanged(e);
+            // To handle window changing screen
+            AdjustMaxSizeWithTaskbar();
+        }
+
+        void AdjustMaxSizeWithTaskbar()
+        {
+            // There's an issue were auto-hide taskbars cannot be focused while WPF windows are maximized
+            // decreasing, even slightly, the maximum size fixes that issue
+            var v = this.GetWorkArea();
+            MaxWidth = v.Width;
+            // Yes, works even when the taskbar is on the left and right of the screen, somehow
+            MaxHeight = v.Height - 0.1d;
         }
     }
 }


### PR DESCRIPTION
# PR Details
A taskbar set to auto-hide cannot be interacted with while the gamestudio window is maximized, this PR fixes that.

## Description
See changes.

## Related Issue
None

## Motivation and Context
Fix bug

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.