### PR TITLE
[GameStudio] Prefabs and scene loading optimization

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
@@ -566,11 +566,11 @@ namespace Stride.Core.Assets.Quantum
 
         private void LinkBaseNode([NotNull] IGraphNode currentNode, IGraphNode baseNode)
         {
-            var assetNode = (IAssetNode)currentNode;
-            ((IAssetNodeInternal)assetNode).SetPropertyGraph(this);
-            ((IAssetNodeInternal)assetNode).SetBaseNode(baseNode);
+            var assetNode = (IAssetNodeInternal)currentNode;
+            assetNode.SetPropertyGraph(this);
+            assetNode.SetBaseNode(baseNode);
 
-            BaseToDerivedRegistry.RegisterBaseToDerived((IAssetNode)baseNode, (IAssetNode)currentNode);
+            BaseToDerivedRegistry.RegisterBaseToDerived((IAssetNode)baseNode, assetNode);
 
             if (!baseLinkedNodes.ContainsKey(assetNode))
             {
@@ -578,14 +578,13 @@ namespace Stride.Core.Assets.Quantum
                 EventHandler<ItemChangeEventArgs> itemChange = null;
                 if (baseNode != null)
                 {
-                    var member = assetNode.BaseNode as IMemberNode;
-                    if (member != null)
+                    if (assetNode.BaseNode is IMemberNode member)
                     {
                         valueChange = (s, e) => OnBaseContentChanged(e, currentNode);
                         member.ValueChanged += valueChange;
                     }
-                    var objectNode = assetNode.BaseNode as IObjectNode;
-                    if (objectNode != null)
+
+                    if (assetNode.BaseNode is IObjectNode objectNode)
                     {
                         itemChange = (s, e) => OnBaseContentChanged(e, currentNode);
                         objectNode.ItemChanged += itemChange;
@@ -601,13 +600,12 @@ namespace Stride.Core.Assets.Quantum
 
             if (baseLinkedNodes.TryGetValue(assetNode, out NodeChangeHandlers linkedNode))
             {
-                var member = assetNode.BaseNode as IMemberNode;
-                if (member != null)
+                if (assetNode.BaseNode is IMemberNode member)
                 {
                     member.ValueChanged -= linkedNode.ValueChange;
                 }
-                var objectNode = assetNode.BaseNode as IObjectNode;
-                if (objectNode != null)
+
+                if (assetNode.BaseNode is IObjectNode objectNode)
                 {
                     objectNode.ItemChanged -= linkedNode.ItemChange;
                 }
@@ -619,13 +617,12 @@ namespace Stride.Core.Assets.Quantum
         {
             foreach (var linkedNode in baseLinkedNodes)
             {
-                var member = linkedNode.Key.BaseNode as IMemberNode;
-                if (member != null)
+                if (linkedNode.Key.BaseNode is IMemberNode member)
                 {
                     member.ValueChanged -= linkedNode.Value.ValueChange;
                 }
-                var objectNode = linkedNode.Key.BaseNode as IObjectNode;
-                if (objectNode != null)
+
+                if (linkedNode.Key.BaseNode is IObjectNode objectNode)
                 {
                     objectNode.ItemChanged -= linkedNode.Value.ItemChange;
                 }

--- a/sources/assets/Stride.Core.Assets.Quantum/AssetToBaseNodeLinker.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetToBaseNodeLinker.cs
@@ -48,7 +48,13 @@ namespace Stride.Core.Assets.Quantum
             var targetIds = CollectionItemIdHelper.GetCollectionItemIds(targetNode.Retrieve());
             var itemId = sourceIds[sourceReference.Index.Value];
             var targetKey = targetIds.GetKey(itemId);
-            return targetReference.FirstOrDefault(x => Equals(x.Index.Value, targetKey));
+            foreach (var targetRef in targetReference)
+            {
+                if (Equals(targetRef.Index.Value, targetKey))
+                    return targetRef;
+            }
+
+            return null;
         }
     }
 }

--- a/sources/assets/Stride.Core.Assets/Reflection/CollectionItemIdentifiers.cs
+++ b/sources/assets/Stride.Core.Assets/Reflection/CollectionItemIdentifiers.cs
@@ -134,7 +134,12 @@ namespace Stride.Core.Reflection
         public object GetKey(ItemId itemId)
         {
             // TODO: add indexing by guid to avoid O(n)
-            return keyToIdMap.SingleOrDefault(x => x.Value == itemId).Key;
+            foreach( var kvp in keyToIdMap )
+            {
+                if( kvp.Value == itemId )
+                    return kvp.Key;
+            }
+            return null;
         }
 
         public void CloneInto(CollectionItemIdentifiers target, IReadOnlyDictionary<object, object> referenceTypeClonedKeys)

--- a/sources/assets/Stride.Core.Assets/Reflection/CollectionItemIdentifiers.cs
+++ b/sources/assets/Stride.Core.Assets/Reflection/CollectionItemIdentifiers.cs
@@ -134,9 +134,9 @@ namespace Stride.Core.Reflection
         public object GetKey(ItemId itemId)
         {
             // TODO: add indexing by guid to avoid O(n)
-            foreach( var kvp in keyToIdMap )
+            foreach (var kvp in keyToIdMap)
             {
-                if( kvp.Value == itemId )
+                if (kvp.Value == itemId)
                     return kvp.Key;
             }
             return null;

--- a/sources/assets/Stride.Core.Assets/Reflection/CollectionItemIdentifiers.cs
+++ b/sources/assets/Stride.Core.Assets/Reflection/CollectionItemIdentifiers.cs
@@ -133,13 +133,18 @@ namespace Stride.Core.Reflection
 
         public object GetKey(ItemId itemId)
         {
+            object output = null;
             // TODO: add indexing by guid to avoid O(n)
             foreach (var kvp in keyToIdMap)
             {
                 if (kvp.Value == itemId)
-                    return kvp.Key;
+                {
+                    if(output != null)
+                        throw new InvalidOperationException("Two elements of the collection have the same id");
+                    output = kvp.Key;
+                }
             }
-            return null;
+            return output;
         }
 
         public void CloneInto(CollectionItemIdentifiers target, IReadOnlyDictionary<object, object> referenceTypeClonedKeys)

--- a/sources/core/Stride.Core.Design/AbsoluteId.cs
+++ b/sources/core/Stride.Core.Design/AbsoluteId.cs
@@ -36,13 +36,11 @@ namespace Stride.Core
         /// </summary>
         public Guid ObjectId { get; }
 
-        /// <inheritdoc />
         public static bool operator ==(AbsoluteId left, AbsoluteId right)
         {
             return left.Equals(right);
         }
 
-        /// <inheritdoc />
         public static bool operator !=(AbsoluteId left, AbsoluteId right)
         {
             return !left.Equals(right);
@@ -57,8 +55,7 @@ namespace Stride.Core
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            return obj is AbsoluteId && Equals((AbsoluteId)obj);
+            return obj is AbsoluteId id && Equals(id);
         }
 
         /// <inheritdoc />

--- a/sources/core/Stride.Core.Serialization/Assets/AssetId.cs
+++ b/sources/core/Stride.Core.Serialization/Assets/AssetId.cs
@@ -71,8 +71,7 @@ namespace Stride.Core.Assets
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            return obj is AssetId && Equals((AssetId)obj);
+            return obj is AssetId id && Equals(id);
         }
 
         /// <inheritdoc/>

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/AssetCompositeGameEditor/ViewModels/AssetCompositeHierarchyEditorViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/AssetCompositeGameEditor/ViewModels/AssetCompositeHierarchyEditorViewModel.cs
@@ -137,11 +137,10 @@ namespace Stride.Assets.Presentation.AssetEditors.AssetCompositeGameEditor.ViewM
         [CanBeNull]
         public override IEditorGamePartViewModel FindPartViewModel(AbsoluteId id)
         {
-            var item = RootPart as IEditorGamePartViewModel;
-            if (item != null && id == item.Id)
+            if (RootPart is IEditorGamePartViewModel item && id == item.Id)
                 return item;
-
-            return RootPart?.EnumerateChildren().BreadthFirst(x => x.EnumerateChildren()).OfType<IEditorGamePartViewModel>().FirstOrDefault(part => part.Id == id);
+            
+            return RootPart?.EnumerateChildren().BreadthFirst(x => x.EnumerateChildren()).FirstOrDefault(part => part is IEditorGamePartViewModel viewModel && viewModel.Id == id) as IEditorGamePartViewModel;
         }
 
         /// <summary>

--- a/sources/presentation/Stride.Core.Quantum/GraphNodeLinker.cs
+++ b/sources/presentation/Stride.Core.Quantum/GraphNodeLinker.cs
@@ -46,10 +46,28 @@ namespace Stride.Core.Quantum
             {
                 if (VisitedLinks.TryGetValue(node, out IGraphNode targetNodeParent))
                 {
-                    foreach (var child in node.Members)
+                    var objNode = targetNodeParent as IObjectNode;
+                    var members = node.Members;
+                    if (members is List<IMemberNode> asList)
                     {
-                        string name = child.Name;
-                        VisitedLinks.Add(child, ((IObjectNode)targetNodeParent)?.TryGetChild(name));
+                        foreach (var child in asList)
+                        {
+                            VisitedLinks.Add(child, objNode?.TryGetChild(child.Name));
+                        }
+                    }
+                    else if(members is Dictionary<string, IMemberNode>.ValueCollection asVCol)
+                    {
+                        foreach (var child in asVCol)
+                        {
+                            VisitedLinks.Add(child, objNode?.TryGetChild(child.Name));
+                        }
+                    }
+                    else
+                    {
+                        foreach (var child in members)
+                        {
+                            VisitedLinks.Add(child, objNode?.TryGetChild(child.Name));
+                        }
                     }
                 }
                 base.VisitChildren(node);

--- a/sources/presentation/Stride.Core.Quantum/GraphVisitorBase.cs
+++ b/sources/presentation/Stride.Core.Quantum/GraphVisitorBase.cs
@@ -95,7 +95,7 @@ namespace Stride.Core.Quantum
                     CurrentPath.Pop();
                 }
             }
-            else if(members is Dictionary<string, IMemberNode>.ValueCollection asVCol)
+            else if (members is Dictionary<string, IMemberNode>.ValueCollection asVCol)
             {
                 foreach (var child in asVCol)
                 {

--- a/sources/presentation/Stride.Core.Quantum/GraphVisitorBase.cs
+++ b/sources/presentation/Stride.Core.Quantum/GraphVisitorBase.cs
@@ -64,14 +64,14 @@ namespace Stride.Core.Quantum
             {
                 Visiting?.Invoke(node, CurrentPath);
             }
-            var objectNode = node as IObjectNode;
-            if (objectNode != null)
+
+            if (node is IObjectNode objectNode)
             {
                 VisitChildren(objectNode);
                 VisitItemTargets(objectNode);
             }
-            var memberNode = node as IMemberNode;
-            if (memberNode != null)
+
+            if (node is IMemberNode memberNode)
             {
                 VisitMemberTarget(memberNode);
             }
@@ -85,11 +85,33 @@ namespace Stride.Core.Quantum
         protected virtual void VisitChildren([NotNull] IObjectNode node)
         {
             if (node == null) throw new ArgumentNullException(nameof(node));
-            foreach (var child in node.Members)
+            var members = node.Members;
+            if (members is List<IMemberNode> asList)
             {
-                CurrentPath.PushMember(child.Name);
-                VisitNode(child);
-                CurrentPath.Pop();
+                foreach (var child in asList)
+                {
+                    CurrentPath.PushMember(child.Name);
+                    VisitNode(child);
+                    CurrentPath.Pop();
+                }
+            }
+            else if(members is Dictionary<string, IMemberNode>.ValueCollection asVCol)
+            {
+                foreach (var child in asVCol)
+                {
+                    CurrentPath.PushMember(child.Name);
+                    VisitNode(child);
+                    CurrentPath.Pop();
+                }
+            }
+            else
+            {
+                foreach (var child in members)
+                {
+                    CurrentPath.PushMember(child.Name);
+                    VisitNode(child);
+                    CurrentPath.Pop();
+                }
             }
         }
 

--- a/sources/presentation/Stride.Core.Quantum/References/ReferenceEnumerable.cs
+++ b/sources/presentation/Stride.Core.Quantum/References/ReferenceEnumerable.cs
@@ -153,7 +153,9 @@ namespace Stride.Core.Quantum.References
         }
 
         /// <inheritdoc/>
-        public IEnumerator<ObjectReference> GetEnumerator()
+        public ReferenceEnumerator GetEnumerator() => new ReferenceEnumerator(this);
+        
+        IEnumerator<ObjectReference> IEnumerable<ObjectReference>.GetEnumerator()
         {
             return new ReferenceEnumerator(this);
         }
@@ -237,7 +239,7 @@ namespace Stride.Core.Quantum.References
         /// <summary>
         /// An enumerator for <see cref="ReferenceEnumerable"/> that enumerates in proper item order.
         /// </summary>
-        private class ReferenceEnumerator : IEnumerator<ObjectReference>
+        public struct ReferenceEnumerator : IEnumerator<ObjectReference>
         {
             private readonly IEnumerator<NodeIndex> indexEnumerator;
             private ReferenceEnumerable obj;


### PR DESCRIPTION
# PR Details
Reduce the time taken to add and load prefabs and scenes in the gamestudio.

## Description
Most of the changes made only target the hot path, as I have mentioned on #743 I think that a significant re-write is required before performances are at an acceptable level, this will have to do in the mean time.

The cost associated with allocating are far greater than attempting a couple of casts before hand as those methods are extremely frequently used, so:
- Explicitly tested IReadonlyCollection against common collection implementation to retrieve the alloc-less enum for cases where it made sense.
- Simplified or replaced a couple of linq operations by handwritten loops.
- ``FindSubEntity`` now uses the ``EntityManager.GetEnumerator()`` when it can instead of going through the hierarchy.
- Added another branch in ``CollectionDescriptor`` to handle a couple of functions for ``IDictionary`` and cleaned up unnecessary logic for ``IList``.
- And other minor changes.

## Related Issue
This PR only helps slightly #743, this is still an issue.

## Motivation and Context
Performance issues

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.