### PR TITLE
Correction Color[index]

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Color.cs
+++ b/sources/core/Stride.Core.Mathematics/Color.cs
@@ -199,7 +199,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Color"/> struct.
         /// </summary>
-        /// <param name="values">The values to assign to the alpha, red, green, and blue components of the color. This must be an array with four elements.</param>
+        /// <param name="values">The values to assign to the red, green, blue, or alpha components of the color. This must be an array with four elements.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than four elements.</exception>
         public Color(byte[] values)
@@ -218,7 +218,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Gets or sets the component at the specified index.
         /// </summary>
-        /// <value>The value of the alpha, red, green, or blue component, depending on the index.</value>
+        /// <value>The value of the red, green, blue, or alpha component, depending on the index.</value>
         /// <param name="index">The index of the component to access. Use 0 for the red(R) component, 1 for the green(G) component, 2 for the blue(B) component, and 3 for the alpha(A) component.</param>
         /// <returns>The value of the component at the specified index.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 3].</exception>

--- a/sources/core/Stride.Core.Mathematics/Color.cs
+++ b/sources/core/Stride.Core.Mathematics/Color.cs
@@ -219,7 +219,7 @@ namespace Stride.Core.Mathematics
         /// Gets or sets the component at the specified index.
         /// </summary>
         /// <value>The value of the alpha, red, green, or blue component, depending on the index.</value>
-        /// <param name="index">The index of the component to access. Use 0 for the alpha component, 1 for the red component, 2 for the green component, and 3 for the blue component.</param>
+        /// <param name="index">The index of the component to access. Use 0 for the red(R) component, 1 for the green(G) component, 2 for the blue(B) component, and 3 for the alpha(A) component.</param>
         /// <returns>The value of the component at the specified index.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 3].</exception>
         public byte this[int index]


### PR DESCRIPTION
Corrected the param documentations for Color[index].

# PR Details

Params for color indexes were incorrect as described in [Issue #693](https://github.com/stride3d/stride/issues/693) and so were corrected to:
 - 0: Red
 - 1: Green
 - 2: Blue
 - 3: Alpha

## Description

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/stride3d/stride/issues/693

## Motivation and Context

Change is good for readability and to avoid confusion.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.