### PR TITLE
[Input] Fix DirectInput Acquire()

### DIFF
--- a/sources/engine/Stride.Input/Windows/GameControllerDirectInput.cs
+++ b/sources/engine/Stride.Input/Windows/GameControllerDirectInput.cs
@@ -37,6 +37,7 @@ namespace Stride.Input
             Id = instance.InstanceGuid;
             ProductId = instance.ProductGuid;
             joystick = new DirectInputJoystick(directInput, instance.InstanceGuid);
+            joystick.SetCooperativeLevel(IntPtr.Zero, CooperativeLevel.NonExclusive | CooperativeLevel.Foreground);
             var objects = joystick.GetObjects();
 
             int sliderCount = 0;


### PR DESCRIPTION
# PR Details
Calling joystick.Acquire() concurrently with a direct input device connected will hang threads indefinitely.

## Related Issue
It should fix #710, it did fix it on my end but I would still like @jeske to confirm that it works on his end too to be sure.

## Motivation and Context
Fix a bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.