### PR TITLE
Fix CompilerApp to not load invalid assemblies

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/PackageBuilder.cs
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/PackageBuilder.cs
@@ -148,7 +148,7 @@ namespace Stride.Core.Assets.CompilerApp
                 // Add runtime identifier (if any) to avoid clash when building multiple at the same time (this happens when using ExtrasBuildEachRuntimeIdentifier feature of MSBuild.Sdk.Extras)
                 if (builderOptions.Properties.TryGetValue("RuntimeIdentifier", out var runtimeIdentifier))
                     indexName += $".{runtimeIdentifier}";
-                if (builderOptions.ExtraCompileProperties.TryGetValue("StrideGraphicsApi", out var graphicsApi))
+                if (builderOptions.ExtraCompileProperties != null && builderOptions.ExtraCompileProperties.TryGetValue("StrideGraphicsApi", out var graphicsApi))
                     indexName += $".{graphicsApi}";
 
                 // Create the builder

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -407,13 +407,19 @@ namespace Stride.Core.Assets
                                 // Build list of assemblies
                                 foreach (var a in targetLibrary.RuntimeAssemblies)
                                 {
-                                    var assemblyFile = Path.Combine(libraryPath, a.Path.Replace('/', Path.DirectorySeparatorChar));
-                                    projectDependency.Assemblies.Add(assemblyFile);
+                                    if (!a.Path.EndsWith("_._"))
+                                    {
+                                        var assemblyFile = Path.Combine(libraryPath, a.Path.Replace('/', Path.DirectorySeparatorChar));
+                                        projectDependency.Assemblies.Add(assemblyFile);
+                                    }
                                 }
                                 foreach (var a in targetLibrary.RuntimeTargets)
                                 {
-                                    var assemblyFile = Path.Combine(libraryPath, a.Path.Replace('/', Path.DirectorySeparatorChar));
-                                    projectDependency.Assemblies.Add(assemblyFile);
+                                    if (!a.Path.EndsWith("_._"))
+                                    {
+                                        var assemblyFile = Path.Combine(libraryPath, a.Path.Replace('/', Path.DirectorySeparatorChar));
+                                        projectDependency.Assemblies.Add(assemblyFile);
+                                    }
                                 }
                             }
                         }
@@ -519,7 +525,7 @@ namespace Stride.Core.Assets
             else
             {
                 // External references were passed, but the top level project wasn't found.
-                // This is always due to an internal issue and typically caused by errors 
+                // This is always due to an internal issue and typically caused by errors
                 // building the project closure.
                 throw new InvalidOperationException($"Missing external reference metadata for {_request.Project.Name}");
             }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix some CompilerApp issues so it can build/load the game projects.

## Description

<!--- Describe your changes in detail -->
`builderOptions.ExtraCompileProperties` is nullable so needs to guarded before calling `TryGetValue`.

Sometimes nuget generates paths with "\_.\_", eg. my `[GAME].Windows\obj\project.assets.json` contains
```
{
  "version": 3,
  "targets": {
    ".NETFramework,Version=v4.7.2": {
// ...omitted
      "Stride.SpriteStudio.Offline/4.0.0.1-beta03": {
        "type": "package",
        "dependencies": {
          "Stride.Assets": "4.0.0.1-beta03",
          "Stride.SpriteStudio.Runtime": "4.0.0.1-beta03"
        },
        "compile": {
          "lib/net472/_._": {}
        },
        "runtime": {
          "lib/net472/_._": {}
        }
      },
// ...other stuff
```

According to [this thread](https://github.com/dotnet/aspnetcore/issues/744), nuget sometimes emits empty directories.
I have changed it so these paths are ignored, so it's not added into the `projectDependency.Assemblies` since later in the code it tries to load these paths which do not exist since they are not a real assembly paths, though I don't know if that's the proper fix or not.

@xen2 I know you're the expert in this area, so feel free to implement the proper fix :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.