### PR TITLE
Fix namespace generator for new project to use Namespace parameter in…

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
@@ -112,6 +112,7 @@ namespace Stride.Assets.Presentation.Templates
             var logger = parameters.Logger;
             var platforms = parameters.GetTag(PlatformsKey);
             var name = parameters.Name;
+            var nameSpace = parameters.Namespace ?? parameters.Name;
             var outputDirectory = parameters.OutputDirectory;
             var orientation = parameters.GetTag(OrientationKey);
 
@@ -121,7 +122,7 @@ namespace Stride.Assets.Presentation.Templates
             // Generate projects for this package
             var session = parameters.Session;
 
-            var projectGameName = Utilities.BuildValidNamespaceName(name);
+            var projectGameName = Utilities.BuildValidNamespaceName(nameSpace);
 
             var stepIndex = 0;
             var stepCount = platforms.Count + 1;


### PR DESCRIPTION
# PR Details

Fix issue while creating a new project with different namespace then name project that caused namespace starting with number if Project Name started with numer

## Description

Added variable `nameSpace` in `NewGameTemplateGenerator` to build namespace from instead of name if namespace isn't null

## Related Issue

[Issue #547 ](https://github.com/stride3d/stride/issues/547)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.