### PR TITLE
Game Systems to use Services instead of Game object

### DIFF
--- a/sources/engine/Stride.Physics/Bullet2PhysicsSystem.cs
+++ b/sources/engine/Stride.Physics/Bullet2PhysicsSystem.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Stride.Core;
 using Stride.Engine;
+using Stride.Engine.Design;
 using Stride.Games;
 
 namespace Stride.Physics
@@ -37,7 +38,8 @@ namespace Stride.Physics
 
         public override void Initialize()
         {
-            physicsConfiguration = Game?.Settings != null ? Game.Settings.Configurations.Get<PhysicsSettings>() : new PhysicsSettings();
+            var gameSettings = Services.GetService<IGameSettingsService>()?.Settings;
+            physicsConfiguration = gameSettings?.Configurations?.Get<PhysicsSettings>() ?? new PhysicsSettings();
         }
 
         protected override void Destroy()
@@ -88,7 +90,7 @@ namespace Stride.Physics
 
                     //read skinned meshes bone positions and write them to the physics engine
                     physicsScene.Processor.UpdateBones();
-                    
+
                     //simulate physics
                     physicsScene.Simulation.Simulate((float)gameTime.Elapsed.TotalSeconds);
 
@@ -97,7 +99,7 @@ namespace Stride.Physics
 
                     //Perform clean ups before test contacts in this frame
                     physicsScene.Simulation.BeginContactTesting();
-                   
+
                     //handle frame contacts
                     physicsScene.Processor.UpdateContacts();
 
@@ -105,7 +107,7 @@ namespace Stride.Physics
                     physicsScene.Simulation.EndContactTesting();
 
                     //send contact events
-                    physicsScene.Simulation.SendEvents();                   
+                    physicsScene.Simulation.SendEvents();
                 }
             }
         }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Bullet2PhysicsSystem and DynamicNavigationMeshSystem to use services to retrieve GameSettings and game systems to remove dependency on Game object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Ideally Game object should have a 'headless server' mode, but this is a lot of effort.
In the mean time, this change makes it easier to make a "game" class that doesn't inherit the Game class.
eg. consider the following HeadlessGame, but we want to load the physics settings from the asset, or include DynamicNavigationMeshSystem.
https://github.com/xen2/Xenko.ClientServerSample/blob/master/Xenko.ClientServerSample.Server/HeadlessGame.cs

Note I haven't really tested if DynamicNavigationMeshSystem could work in a headless mode, so could be excluded from this commit if it's a bit iffy to change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.