### PR TITLE
Template validation

### DIFF
--- a/sources/core/Stride.Core.AssemblyProcessor/Utilities.cs
+++ b/sources/core/Stride.Core.AssemblyProcessor/Utilities.cs
@@ -37,6 +37,10 @@ namespace Stride
         [NotNull]
         public static string BuildValidClassName([NotNull] string originalName, IEnumerable<string> additionalReservedWords, char replacementCharacter = '_')
         {
+            // C# identifiers must start with a letter or underscore
+            if (char.IsLetter(originalName[0]) == false && originalName[0] != '_')
+                originalName = "_" + originalName;
+            
             if (ReservedNames.Contains(originalName))
                 return originalName + replacementCharacter;
 
@@ -70,6 +74,10 @@ namespace Stride
         [NotNull]
         public static string BuildValidNamespaceName([NotNull] string originalName, IEnumerable<string> additionalReservedWords, char replacementCharacter = '_')
         {
+            // C# identifiers must start with a letter or underscore
+            if (char.IsLetter(originalName[0]) == false && originalName[0] != '_')
+                originalName = "_" + originalName;
+
             if (ReservedNames.Contains(originalName))
                 return originalName + replacementCharacter;
 

--- a/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
@@ -156,6 +156,7 @@ namespace Stride.Assets.Presentation.Templates
                 Description = parameters.Description,
                 Package = package,
                 Logger = parameters.Logger,
+                Namespace = parameters.Namespace
             };
 
             // Generate executable projects for each platform

--- a/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
+++ b/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
@@ -61,6 +61,7 @@ namespace Stride.Assets.Templates
                 OutputDirectory = package.FullPath.GetFullDirectory().GetParent(),
                 Session = package.Session,
                 Description = packageParameters.Description,
+                Namespace = packageParameters.Namespace
             };
 
             // Setup the ProjectGameGuid to be accessible from exec (in order to be able to link to the game project.

--- a/sources/tools/Stride.ProjectGenerator/Program.cs
+++ b/sources/tools/Stride.ProjectGenerator/Program.cs
@@ -147,6 +147,7 @@ namespace Stride.ProjectGenerator
             templateGeneratorParameters.Logger = result;
             templateGeneratorParameters.Description = new TemplateDescription();
             templateGeneratorParameters.Id = assetId;
+            templateGeneratorParameters.Namespace = projectNamespace;
 
             if (!PackageUnitTestGenerator.Default.PrepareForRun(templateGeneratorParameters).Result)
             {


### PR DESCRIPTION
# PR Details
Namespace changes within the namespace validation window weren't being carried over to generated project source files, this PR fixes that.

## Description
See above.

## Related Issue
#547 

## Motivation and Context
Fix a bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


This PR supersedes #753 , see my comment over there for more info.

Do note that the generated ``*App.cs`` class name is based on the project name and gets auto-corrected through ``BuildValidClassName()``, it is not based on the namespace, they won't match if users change the namespace, it works fine but I'm not sure that that's expected behavior for you @xen2, I'll leave that to you.