### PR TITLE
Include default values in shader reflection

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Half2.cs
+++ b/sources/core/Stride.Core.Mathematics/Half2.cs
@@ -36,6 +36,32 @@ namespace Stride.Core.Mathematics
     public struct Half2 : IEquatable<Half2>
     {
         /// <summary>
+        /// The size of the <see cref="Stride.Core.Mathematics.Half2"/> type, in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Utilities.SizeOf<Half2>();
+
+
+        /// <summary>
+        /// A <see cref="Stride.Core.Mathematics.Half2"/> with all of its components set to zero.
+        /// </summary>
+        public static readonly Half2 Zero = new Half2();
+
+        /// <summary>
+        /// The X unit <see cref="Stride.Core.Mathematics.Half2"/> (1, 0).
+        /// </summary>
+        public static readonly Half2 UnitX = new Half2(1.0f, 0.0f);
+
+        /// <summary>
+        /// The Y unit <see cref="Stride.Core.Mathematics.Half2"/> (0, 1).
+        /// </summary>
+        public static readonly Half2 UnitY = new Half2(0.0f, 1.0f);
+
+        /// <summary>
+        /// A <see cref="Stride.Core.Mathematics.Half2"/> with all of its components set to one.
+        /// </summary>
+        public static readonly Half2 One = new Half2(1.0f, 1.0f);
+
+        /// <summary>
         /// Gets or sets the X component of the vector.
         /// </summary>
         /// <value>The X component of the vector.</value>
@@ -66,6 +92,23 @@ namespace Stride.Core.Mathematics
         {
             this.X = value;
             this.Y = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Stride.Core.Mathematics.Half2"/> struct.
+        /// </summary>
+        /// <param name="values">The values to assign to the X and Y components of the vector. This must be an array with two elements.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than two elements.</exception>
+        public Half2(Half[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException("values");
+            if (values.Length != 2)
+                throw new ArgumentOutOfRangeException("values", "There must be two and only two input values for Half2.");
+
+            X = values[0];
+            Y = values[1];
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Half3.cs
+++ b/sources/core/Stride.Core.Mathematics/Half3.cs
@@ -36,6 +36,36 @@ namespace Stride.Core.Mathematics
     public struct Half3 : IEquatable<Half3>
     {
         /// <summary>
+        /// The size of the <see cref="Stride.Core.Mathematics.Half3"/> type, in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Utilities.SizeOf<Half3>();
+
+        /// <summary>
+        /// A <see cref="Stride.Core.Mathematics.Half3"/> with all of its components set to zero.
+        /// </summary>
+        public static readonly Half3 Zero = new Half3();
+
+        /// <summary>
+        /// The X unit <see cref="Stride.Core.Mathematics.Half3"/> (1, 0, 0).
+        /// </summary>
+        public static readonly Half3 UnitX = new Half3(1.0f, 0.0f, 0.0f);
+
+        /// <summary>
+        /// The Y unit <see cref="Stride.Core.Mathematics.Half3"/> (0, 1, 0).
+        /// </summary>
+        public static readonly Half3 UnitY = new Half3(0.0f, 1.0f, 0.0f);
+
+        /// <summary>
+        /// The Z unit <see cref="Stride.Core.Mathematics.Half3"/> (0, 0, 1).
+        /// </summary>
+        public static readonly Half3 UnitZ = new Half3(0.0f, 0.0f, 1.0f);
+
+        /// <summary>
+        /// A <see cref="Stride.Core.Mathematics.Half3"/> with all of its components set to one.
+        /// </summary>
+        public static readonly Half3 One = new Half3(1.0f, 1.0f, 1.0f);
+
+        /// <summary>
         /// Gets or sets the X component of the vector.
         /// </summary>
         /// <value>The X component of the vector.</value>
@@ -75,6 +105,24 @@ namespace Stride.Core.Mathematics
             this.X = value;
             this.Y = value;
             this.Z = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Stride.Core.Mathematics.Half3"/> struct.
+        /// </summary>
+        /// <param name="values">The values to assign to the X, Y, and Z components of the vector. This must be an array with three elements.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than three elements.</exception>
+        public Half3(Half[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException("values");
+            if (values.Length != 3)
+                throw new ArgumentOutOfRangeException("values", "There must be three and only three input values for Half3.");
+
+            X = values[0];
+            Y = values[1];
+            Z = values[2];
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Half4.cs
+++ b/sources/core/Stride.Core.Mathematics/Half4.cs
@@ -36,6 +36,41 @@ namespace Stride.Core.Mathematics
     public struct Half4 : IEquatable<Half4>
     {
         /// <summary>
+        /// The size of the <see cref="Stride.Core.Mathematics.Half4"/> type, in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Utilities.SizeOf<Half4>();
+
+        /// <summary>
+        /// A <see cref="Stride.Core.Mathematics.Half4"/> with all of its components set to zero.
+        /// </summary>
+        public static readonly Half4 Zero = new Half4();
+
+        /// <summary>
+        /// The X unit <see cref="Stride.Core.Mathematics.Half4"/> (1, 0, 0, 0).
+        /// </summary>
+        public static readonly Half4 UnitX = new Half4(1.0f, 0.0f, 0.0f, 0.0f);
+
+        /// <summary>
+        /// The Y unit <see cref="Stride.Core.Mathematics.Half4"/> (0, 1, 0, 0).
+        /// </summary>
+        public static readonly Half4 UnitY = new Half4(0.0f, 1.0f, 0.0f, 0.0f);
+
+        /// <summary>
+        /// The Z unit <see cref="Stride.Core.Mathematics.Half4"/> (0, 0, 1, 0).
+        /// </summary>
+        public static readonly Half4 UnitZ = new Half4(0.0f, 0.0f, 1.0f, 0.0f);
+
+        /// <summary>
+        /// The W unit <see cref="Stride.Core.Mathematics.Half4"/> (0, 0, 0, 1).
+        /// </summary>
+        public static readonly Half4 UnitW = new Half4(0.0f, 0.0f, 0.0f, 1.0f);
+
+        /// <summary>
+        /// A <see cref="Stride.Core.Mathematics.Half4"/> with all of its components set to one.
+        /// </summary>
+        public static readonly Half4 One = new Half4(1.0f, 1.0f, 1.0f, 1.0f);
+
+        /// <summary>
         /// Gets or sets the X component of the vector.
         /// </summary>
         /// <value>The X component of the vector.</value>
@@ -84,6 +119,52 @@ namespace Stride.Core.Mathematics
             this.Y = value;
             this.Z = value;
             this.W = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Stride.Core.Mathematics.Half4"/> struct.
+        /// </summary>
+        /// <param name="values">The values to assign to the X, Y, Z, and W components of the vector. This must be an array with four elements.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than four elements.</exception>
+        public Half4(Half[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException("values");
+            if (values.Length != 4)
+                throw new ArgumentOutOfRangeException("values", "There must be four and only four input values for Half4.");
+
+            X = values[0];
+            Y = values[1];
+            Z = values[2];
+            W = values[3];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Half4"/> structure.
+        /// </summary>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        /// <param name="z">The Z component.</param>
+        /// <param name="w">The W component.</param>
+        public Half4(float x, float y, float z, float w)
+        {
+            this.X = (Half)x;
+            this.Y = (Half)y;
+            this.Z = (Half)z;
+            this.W = (Half)w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Half4"/> structure.
+        /// </summary>
+        /// <param name="value">The value to set for the X, Y, Z, and W components.</param>
+        public Half4(float value)
+        {
+            this.X = (Half)value;
+            this.Y = (Half)value;
+            this.Z = (Half)value;
+            this.W = (Half)value;
         }
 
         /// <summary>

--- a/sources/engine/Stride.Shaders.Compiler/EffectCompiler.cs
+++ b/sources/engine/Stride.Shaders.Compiler/EffectCompiler.cs
@@ -280,8 +280,12 @@ namespace Stride.Shaders.Compiler
                     break;
             }
 
-            // Remove unused reflection data, as it is entirely resolved at compile time.
-            CleanupReflection(bytecode.Reflection);
+            if (effectParameters.OptimizationLevel > 0)
+            {
+                // Remove unused reflection data, as it is entirely resolved at compile time.
+                CleanupReflection(bytecode.Reflection);
+            }
+
             bytecode.Stages = shaderStageBytecodes.ToArray();
 
 #if STRIDE_PLATFORM_WINDOWS_DESKTOP

--- a/sources/engine/Stride.Shaders.Parser/ShaderLinker.cs
+++ b/sources/engine/Stride.Shaders.Parser/ShaderLinker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
@@ -351,16 +351,25 @@ namespace Stride.Shaders.Parser
 
             if (variableType is ScalarType)
             {
-                // Uint and int are collapsed to int
-                if (variableType == ScalarType.Int || variableType == ScalarType.UInt)
+                if (variableType == ScalarType.Int)
                 {
                     parameterTypeInfo.Class = EffectParameterClass.Scalar;
-                    parameterTypeInfo.Type = variableType == ScalarType.Int ? EffectParameterType.Int : EffectParameterType.UInt;
+                    parameterTypeInfo.Type = EffectParameterType.Int;
+                }
+                else if (variableType == ScalarType.UInt)
+                {
+                    parameterTypeInfo.Class = EffectParameterClass.Scalar;
+                    parameterTypeInfo.Type = EffectParameterType.UInt;
                 }
                 else if (variableType == ScalarType.Float)
                 {
                     parameterTypeInfo.Class = EffectParameterClass.Scalar;
                     parameterTypeInfo.Type = EffectParameterType.Float;
+                }
+                else if (variableType == ScalarType.Double)
+                {
+                    parameterTypeInfo.Class = EffectParameterClass.Scalar;
+                    parameterTypeInfo.Type = EffectParameterType.Double;
                 }
                 else if (variableType == ScalarType.Bool)
                 {
@@ -371,20 +380,25 @@ namespace Stride.Shaders.Parser
                 parameterTypeInfo.RowCount = 1;
                 parameterTypeInfo.ColumnCount = 1;
             }
-            else if (variableType is VectorType)
+            else if (variableType is VectorType vectorType)
             {
-                if (variableType == VectorType.Float2 || variableType == VectorType.Float3 || variableType == VectorType.Float4)
+                if (vectorType.Type == ScalarType.Float)
                 {
                     bool isColor = attributes.OfType<AttributeDeclaration>().Any(x => x.Name == "Color");
                     parameterTypeInfo.Class = isColor ? EffectParameterClass.Color : EffectParameterClass.Vector;
                     parameterTypeInfo.Type = EffectParameterType.Float;
                 }
-                else if (variableType == VectorType.Int2 || variableType == VectorType.Int3 || variableType == VectorType.Int4)
+                else if (vectorType.Type == ScalarType.Double)
+                {
+                    parameterTypeInfo.Class = EffectParameterClass.Vector;
+                    parameterTypeInfo.Type = EffectParameterType.Double;
+                }
+                else if (vectorType.Type == ScalarType.Int)
                 {
                     parameterTypeInfo.Class = EffectParameterClass.Vector;
                     parameterTypeInfo.Type = EffectParameterType.Int;
                 }
-                else if (variableType == VectorType.UInt2 || variableType == VectorType.UInt3 || variableType == VectorType.UInt4)
+                else if (vectorType.Type == ScalarType.UInt)
                 {
                     parameterTypeInfo.Class = EffectParameterClass.Vector;
                     parameterTypeInfo.Type = EffectParameterType.UInt;
@@ -681,9 +695,70 @@ namespace Stride.Shaders.Parser
                 LogicalGroup = (string)variable.GetTag(StrideTags.LogicalGroup),
                 Type = parameterKey.Type,
                 RawName = variable.Name,
+                DefaultValue = ParseDefaultValue(variable),
             };
             
             members.Add(binding);
+        }
+
+        private object ParseDefaultValue(Variable variable)
+        {
+            var initialValue = variable.InitialValue;
+            if (initialValue is null)
+                return default;
+
+            var parameterType = variable.Type;
+            if (parameterType is ScalarType scalarType)
+            {
+                if (scalarType == ScalarType.Bool)
+                    return ValueParsing.ToScalar<bool>(initialValue);
+                else if (scalarType == ScalarType.Float)
+                    return ValueParsing.ToScalar<float>(initialValue);
+                else if (scalarType == ScalarType.Double)
+                    return ValueParsing.ToScalar<double>(initialValue);
+                else if (scalarType == ScalarType.Half)
+                    return ValueParsing.ToScalar<Half>(initialValue);
+                else if (scalarType == ScalarType.Int)
+                    return ValueParsing.ToScalar<int>(initialValue);
+                else if (scalarType == ScalarType.UInt)
+                    return ValueParsing.ToScalar<uint>(initialValue);
+            }
+            else if (parameterType is VectorType vectorType)
+            {
+                var componentType = vectorType.Type;
+                if (componentType == ScalarType.Float)
+                {
+                    var isColor = variable.Attributes.OfType<AttributeDeclaration>().Any(x => x.Name == "Color");
+                    if (isColor)
+                        return ValueParsing.ToColor(initialValue, vectorType.Dimension);
+                    else
+                        return ValueParsing.ToFloatVector(initialValue, vectorType.Dimension);
+                }
+                else if (componentType == ScalarType.Double)
+                    return ValueParsing.ToDoubleVector(initialValue, vectorType.Dimension);
+                else if (componentType == ScalarType.Half)
+                    return ValueParsing.ToHalfVector(initialValue, vectorType.Dimension);
+                else if (componentType == ScalarType.Int)
+                    return ValueParsing.ToIntVector(initialValue, vectorType.Dimension);
+                else if (componentType == ScalarType.UInt)
+                    return ValueParsing.ToUIntVector(initialValue, vectorType.Dimension);
+            }
+            else if (parameterType is MatrixType matrixType)
+            {
+                var componentType = matrixType.Type;
+                if (componentType == ScalarType.Float)
+                {
+                    if (matrixType.RowCount == 4 && matrixType.ColumnCount == 4)
+                        return ValueParsing.ToVector(initialValue, (float[] args) => new Matrix(args));
+                }
+            }
+            else if (parameterType is ArrayType arrayType)
+            {
+                if (initialValue is ArrayInitializerExpression arrayInitializer)
+                    return ValueParsing.ToArray(arrayInitializer.Items, arrayType.Type);
+            }
+
+            return default;
         }
 
         private class LocalParameterKey
@@ -713,6 +788,220 @@ namespace Stride.Shaders.Parser
 
             public string TypeName;
             public EffectParameterTypeInfo[] Members;*/
+        }
+
+        private static class ValueParsing
+        {
+            public static Array ToArray(List<Expression> v, TypeBase elementType)
+            {
+                if (elementType == ScalarType.Float)
+                    return ToArray<float>(v);
+                if (elementType == ScalarType.Double)
+                    return ToArray<double>(v);
+                if (elementType == ScalarType.Half)
+                    return ToArray<Half>(v);
+                if (elementType == ScalarType.Int)
+                    return ToArray<int>(v);
+                if (elementType == ScalarType.UInt)
+                    return ToArray<uint>(v);
+                if (elementType == ScalarType.Bool)
+                    return ToArray<bool>(v);
+                if (elementType == VectorType.Float2)
+                    return ToArray(v, ToVector2);
+                if (elementType == VectorType.Float3)
+                    return ToArray(v, ToVector3);
+                if (elementType == VectorType.Float4)
+                    return ToArray(v, ToVector4);
+                if (elementType == VectorType.Double2)
+                    return ToArray(v, ToDouble2);
+                if (elementType == VectorType.Double3)
+                    return ToArray(v, ToDouble3);
+                if (elementType == VectorType.Double4)
+                    return ToArray(v, ToDouble4);
+                if (elementType == VectorType.Half2)
+                    return ToArray(v, ToHalf2);
+                if (elementType == VectorType.Half3)
+                    return ToArray(v, ToHalf3);
+                if (elementType == VectorType.Half4)
+                    return ToArray(v, ToHalf4);
+                if (elementType == VectorType.Int2)
+                    return ToArray(v, ToInt2);
+                if (elementType == VectorType.Int3)
+                    return ToArray(v, ToInt3);
+                if (elementType == VectorType.Int4)
+                    return ToArray(v, ToInt4);
+                if (elementType == VectorType.UInt4)
+                    return ToArray(v, ToUInt4);
+                return default;
+            }
+
+            static T[] ToArray<T>(List<Expression> v)
+            {
+                var a = new T[v.Count];
+                for (int i = 0; i < a.Length; i++)
+                    a[i] = ToScalar<T>(v[i]);
+                return a;
+            }
+
+            static T[] ToArray<T>(List<Expression> v, Func<Expression, T> factory)
+            {
+                var a = new T[v.Count];
+                for (int i = 0; i < a.Length; i++)
+                    a[i] = factory(v[i]);
+                return a;
+            }
+
+            public static object ToColor(Expression e, int dimension)
+            {
+                switch (dimension)
+                {
+                    case 3:
+                        return new Color3(ToVector(e, (float[] args) => new Vector3(args)));
+                    case 4:
+                        return new Color4(ToVector(e, (float[] args) => new Vector4(args)));
+                }
+                return null;
+            }
+
+            public static object ToFloatVector(Expression e, int dimension)
+            {
+                switch (dimension)
+                {
+                    case 2:
+                        return ToVector2(e);
+                    case 3:
+                        return ToVector3(e);
+                    case 4:
+                        return ToVector4(e);
+                }
+                return null;
+            }
+
+            public static object ToDoubleVector(Expression e, int dimension)
+            {
+                switch (dimension)
+                {
+                    case 2:
+                        return ToDouble2(e);
+                    case 3:
+                        return ToDouble3(e);
+                    case 4:
+                        return ToDouble4(e);
+                }
+                return null;
+            }
+
+            public static object ToHalfVector(Expression e, int dimension)
+            {
+                switch (dimension)
+                {
+                    case 2:
+                        return ToHalf2(e);
+                    case 3:
+                        return ToHalf3(e);
+                    case 4:
+                        return ToHalf4(e);
+                }
+                return null;
+            }
+
+            public static object ToIntVector(Expression e, int dimension)
+            {
+                switch (dimension)
+                {
+                    case 2:
+                        return ToInt2(e);
+                    case 3:
+                        return ToInt3(e);
+                    case 4:
+                        return ToInt4(e);
+                }
+                return null;
+            }
+
+            public static object ToUIntVector(Expression e, int dimension)
+            {
+                switch (dimension)
+                {
+                    case 4:
+                        return ToUInt4(e);
+                }
+                return null;
+            }
+
+            static Vector2 ToVector2(Expression e) => ToVector(e, (float[] args) => new Vector2(args));
+
+            static Vector3 ToVector3(Expression e) => ToVector(e, (float[] args) => new Vector3(args));
+
+            static Vector4 ToVector4(Expression e) => ToVector(e, (float[] args) => new Vector4(args));
+
+            static Double2 ToDouble2(Expression e) => ToVector(e, (double[] args) => new Double2(args));
+
+            static Double3 ToDouble3(Expression e) => ToVector(e, (double[] args) => new Double3(args));
+
+            static Double4 ToDouble4(Expression e) => ToVector(e, (double[] args) => new Double4(args));
+
+            static Half2 ToHalf2(Expression e) => ToVector(e, (Half[] args) => new Half2(args));
+
+            static Half3 ToHalf3(Expression e) => ToVector(e, (Half[] args) => new Half3(args));
+
+            static Half4 ToHalf4(Expression e) => ToVector(e, (Half[] args) => new Half4(args));
+
+            static Int2 ToInt2(Expression e) => ToVector(e, (int[] args) => new Int2(args));
+
+            static Int3 ToInt3(Expression e) => ToVector(e, (int[] args) => new Int3(args));
+
+            static Int4 ToInt4(Expression e) => ToVector(e, (int[] args) => new Int4(args));
+
+            static UInt4 ToUInt4(Expression e) => ToVector(e, (uint[] args) => new UInt4(args));
+
+            public static TVector ToVector<TVector, TComponent>(Expression e, Func<TComponent[], TVector> factory)
+                where TVector : unmanaged
+                where TComponent : unmanaged
+            {
+                if (e is LiteralExpression l)
+                    return ToVector(new List<Expression>(1) { e }, factory);
+                else if (e is MethodInvocationExpression m)
+                    return ToVector(m.Arguments, factory);
+                else if (e is ArrayInitializerExpression a)
+                    return ToVector(a.Items, factory);
+                return default;
+            }
+
+            static unsafe TVector ToVector<TVector, TComponent>(List<Expression> args, Func<TComponent[], TVector> factory)
+                where TVector : unmanaged
+                where TComponent : unmanaged
+            {
+                var dimension = sizeof(TVector) / sizeof(TComponent);
+                if (args.Count == 1)
+                    return factory(Enumerable.Repeat(ToScalar<TComponent>(args[0]), dimension).ToArray());
+                else if (args.Count == dimension)
+                    return factory(ToArray<TComponent>(args));
+                return default;
+            }
+
+            public static T ToScalar<T>(Expression e)
+            {
+                if (e is LiteralExpression l)
+                    return ToScalar<T>(l.Literal);
+                else
+                    return default;
+            }
+
+            static T ToScalar<T>(Literal l)
+            {
+                if (l.Value is T t)
+                    return t;
+
+                try
+                {
+                    return (T)Convert.ChangeType(l.Value, typeof(T));
+                }
+                catch
+                {
+                    return default;
+                }
+            }
         }
     }
 }

--- a/sources/engine/Stride.Shaders.Parser/ShaderMixinParser.cs
+++ b/sources/engine/Stride.Shaders.Parser/ShaderMixinParser.cs
@@ -180,6 +180,10 @@ namespace Stride.Shaders.Parser
         /// <returns>The combined shader in AST form.</returns>
         public ShaderMixinParsingResult Parse(ShaderMixinSource shaderMixinSource, Stride.Shaders.ShaderMacro[] macros = null)
         {
+            // Make in-memory shader classes known to the source manager
+            foreach (var x in shaderMixinSource.Mixins.OfType<ShaderClassString>())
+                SourceManager.AddShaderSource(x.ClassName, x.ShaderSourceCode, x.ClassName);
+
             // Creates a parsing result
             HashSet<ModuleMixinInfo> mixinsToAnalyze;
             ShaderMixinParsingResult parsingResult;

--- a/sources/engine/Stride.Shaders.Tests/TestShaderReflection.cs
+++ b/sources/engine/Stride.Shaders.Tests/TestShaderReflection.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Xunit;
+
+using Stride.Core.Diagnostics;
+using Stride.Core.IO;
+using Stride.Core.Storage;
+using Stride.Graphics;
+using Stride.Shaders.Compiler;
+using System.Linq;
+using Stride.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Stride.Core.Shaders.Ast;
+using Stride.Core.Mathematics;
+
+namespace Stride.Shaders.Tests
+{
+    public class TestShaderReflection
+    {
+        public EffectCompiler Compiler;
+
+        public LoggerResult ResultLogger;
+
+        public CompilerParameters MixinParameters;
+
+        private void Init()
+        {
+            // Create and mount database file system
+            var objDatabase = ObjectDatabase.CreateDefaultDatabase();
+            var databaseFileProvider = new DatabaseFileProvider(objDatabase);
+
+            Compiler = new EffectCompiler(databaseFileProvider);
+            Compiler.SourceDirectories.Add("shaders");
+            MixinParameters = new CompilerParameters();
+            MixinParameters.EffectParameters.Platform = GraphicsPlatform.Direct3D11;
+            MixinParameters.EffectParameters.Profile = GraphicsProfile.Level_11_0;
+            ResultLogger = new LoggerResult();
+        }
+
+        /// <summary>
+        /// Tests whether default values defined in a shader are present in the shader reflection.
+        /// The shader source code is generated on the fly to ensure that the generated keys haven't been
+        /// created beforehand by the shader key generator tool.
+        /// </summary>
+        [Fact]
+        public void TestDefaultValuesBeingPresentInReflection()
+        {
+            Init();
+
+            var shaderClassName = "DefaultValuesTest";
+
+            var variables = new List<(string name, TypeBase type, string value, object clrValue)>();
+            variables.Add((name: "floatVar", type: ScalarType.Float, value: "1", clrValue: 1f));
+            variables.Add((name: "doubleVar", type: ScalarType.Double, value: "1", clrValue: 1d));
+            variables.Add((name: "intVar", type: ScalarType.Int, value: "1", clrValue: 1));
+            variables.Add((name: "uintVar", type: ScalarType.UInt, value: "1", clrValue: 1u));
+            variables.Add((name: "boolVar", type: ScalarType.Bool, value: "true", clrValue: true));
+            AddVectorVariable(VectorType.Float2, 1f, Vector2.One);
+            AddVectorVariable(VectorType.Float3, 1f, Vector3.One);
+            AddVectorVariable(VectorType.Float4, 1f, Vector4.One);
+            AddVectorVariable(VectorType.Double2, 1d, Double2.One);
+            AddVectorVariable(VectorType.Double3, 1d, Double3.One);
+            AddVectorVariable(VectorType.Double4, 1d, Double4.One);
+            // error X3650: global variables cannot use the 'half' type in vs_5_0. To treat this variable as a float, use the backwards compatibility flag.
+            //AddVectorVariable(VectorType.Half2, (Half)1f, Half2.One);
+            //AddVectorVariable(VectorType.Half3, (Half)1f, Half3.One);
+            //AddVectorVariable(VectorType.Half4, (Half)1f, Half4.One);
+            AddVectorVariable(VectorType.Int2, 1, Int2.One);
+            AddVectorVariable(VectorType.Int3, 1, Int3.One);
+            AddVectorVariable(VectorType.Int4, 1, Int4.One);
+            AddVectorVariable(VectorType.UInt4, 1u, UInt4.One);
+            AddVectorVariable(new MatrixType(ScalarType.Float, 4, 4), 1f, new Matrix(1f));
+
+            var assignments = new StringBuilder();
+            foreach (var v in variables)
+            {
+                assignments.AppendLine($"{v.type} {v.name} = {v.value};");
+            }
+
+            var mixinSource = new ShaderMixinSource() { Name = shaderClassName };
+            mixinSource.Mixins.Add(CreateShaderClassCode(shaderClassName, assignments.ToString()));
+            var byteCodeTask = Compiler.Compile(mixinSource, MixinParameters.EffectParameters, MixinParameters);
+
+            Assert.False(byteCodeTask.Result.CompilationLog.HasErrors);
+
+            var byteCode = byteCodeTask.Result.Bytecode;
+            using (var graphicsDevice = GraphicsDevice.New())
+            {
+                var effect = new Effect(graphicsDevice, byteCode);
+                var effectInstance = new EffectInstance(effect);
+                effectInstance.UpdateEffect(graphicsDevice);
+
+                var parameters = effectInstance.Parameters.Layout.LayoutParameterKeyInfos;
+                foreach (var v in variables)
+                {
+                    var key = parameters.FirstOrDefault(k => k.Key.Name == $"{shaderClassName}.{v.name}").Key;
+                    Assert.NotNull(key);
+
+                    var defaultValue = key.DefaultValueMetadata.GetDefaultValue();
+                    Assert.NotNull(defaultValue);
+
+                    Assert.Equal(v.clrValue, defaultValue);
+                }
+            }
+
+            unsafe void AddVectorVariable<TVector, TComponent>(TypeBase type, TComponent scalarValue, TVector vectorValue)
+                where TVector : unmanaged
+                where TComponent : unmanaged
+            {
+                var name = $"{typeof(TVector).Name}Var";
+                var dimension = sizeof(TVector) / sizeof(TComponent);
+                var components = string.Join(", ", Enumerable.Repeat(scalarValue, dimension));
+                variables.Add((
+                    name: name,
+                    type: type,
+                    value: $"{type}({components})",
+                    clrValue: vectorValue));
+
+                variables.Add((
+                    name: $"{name}_Promoted",
+                    type: type,
+                    value: $"{scalarValue}",
+                    clrValue: vectorValue));
+
+                variables.Add((
+                    name: $"{name}_Array",
+                    type: type,
+                    value: $"{{{components}}}",
+                    clrValue: vectorValue));
+            }
+        }
+
+        /// <summary>
+        /// Tests whether default values defined in a shader are being updated after modifications to the shader.
+        /// </summary>
+        [Fact]
+        public void TestDefaultValuesGettingUpdatedAfterRecompile()
+        {
+            Init();
+
+            var shaderClassName = "DefaultValuesBeingUpdatedTest";
+            var variableName = "floatVar";
+
+            // First register the key as it would've been done by the generator
+            var initialKey = ParameterKeys.NewValue(1f, $"{shaderClassName}.{variableName}");
+            ParameterKeys.Merge(initialKey, null, initialKey.Name);
+
+            GenerateAndCheck("1", 1f);
+
+            Compiler.ResetCache(new HashSet<string>() { shaderClassName });
+
+            GenerateAndCheck("2", 2f);
+
+            void GenerateAndCheck(string stringValue, float value)
+            {
+                var variables = new List<(string name, TypeBase type, string value, object clrValue)>();
+                variables.Add((name: variableName, type: ScalarType.Float, value: stringValue, clrValue: value));
+
+                var assignments = new StringBuilder();
+                foreach (var v in variables)
+                    assignments.AppendLine($"{v.type} {v.name} = {v.value};");
+
+                var mixinSource = new ShaderMixinSource() { Name = shaderClassName };
+                mixinSource.Mixins.Add(CreateShaderClassCode(shaderClassName, assignments.ToString()));
+                var byteCodeTask = Compiler.Compile(mixinSource, MixinParameters.EffectParameters, MixinParameters);
+
+                Assert.False(byteCodeTask.Result.CompilationLog.HasErrors);
+
+                var byteCode = byteCodeTask.Result.Bytecode;
+                using (var graphicsDevice = GraphicsDevice.New())
+                {
+                    var effect = new Effect(graphicsDevice, byteCode);
+                    var effectInstance = new EffectInstance(effect);
+                    effectInstance.UpdateEffect(graphicsDevice);
+
+                    var parameters = effectInstance.Parameters.Layout.LayoutParameterKeyInfos;
+                    foreach (var v in variables)
+                    {
+                        var key = parameters.FirstOrDefault(k => k.Key.Name == $"{shaderClassName}.{v.name}").Key;
+                        Assert.NotNull(key);
+
+                        var defaultValue = key.DefaultValueMetadata.GetDefaultValue();
+                        Assert.NotNull(defaultValue);
+
+                        Assert.Equal(v.clrValue, defaultValue);
+                    }
+                }
+            }
+        }
+
+        static ShaderClassCode CreateShaderClassCode(string className, string initializer)
+        {
+            return new ShaderClassString(className, @"
+shader " + className + @"
+{
+" + initializer + @"
+
+    // Declare Vertex shader main method
+    stage void VSMain() {}
+
+    // Declare Pixel shader main method
+    stage void PSMain() {}
+};
+            ");
+        }
+    }
+}

--- a/sources/engine/Stride.Shaders/EffectValueDescription.cs
+++ b/sources/engine/Stride.Shaders/EffectValueDescription.cs
@@ -41,7 +41,7 @@ namespace Stride.Shaders
         /// <summary>
         /// The default value.
         /// </summary>
-        public byte[] DefaultValue;
+        public object DefaultValue;
 
         /// <summary>
         /// Logical group, used to group related descriptors and variables together.

--- a/sources/engine/Stride/Effects/ParameterKeyValueMetadata.cs
+++ b/sources/engine/Stride/Effects/ParameterKeyValueMetadata.cs
@@ -39,7 +39,7 @@ namespace Stride.Rendering
         /// <summary>
         /// Gets the default value.
         /// </summary>
-        public readonly T DefaultValue;
+        public T DefaultValue { get; internal set; }
 
         public override unsafe bool WriteBuffer(IntPtr dest, int alignment = 1)
         {

--- a/sources/shaders/Stride.Core.Shaders/Ast/VectorType.cs
+++ b/sources/shaders/Stride.Core.Shaders/Ast/VectorType.cs
@@ -73,6 +73,21 @@ namespace Stride.Core.Shaders.Ast
         /// </summary>
         public static readonly VectorType Double4 = new VectorType(ScalarType.Double, 4);
 
+        /// <summary>
+        /// A Half2
+        /// </summary>
+        public static readonly VectorType Half2 = new VectorType(ScalarType.Half, 2);
+
+        /// <summary>
+        /// A Half3
+        /// </summary>
+        public static readonly VectorType Half3 = new VectorType(ScalarType.Half, 3);
+
+        /// <summary>
+        /// A Half4
+        /// </summary>
+        public static readonly VectorType Half4 = new VectorType(ScalarType.Half, 4);
+
 
         #endregion
 

--- a/sources/shaders/Stride.Core.Shaders/Writer/ShaderWriter.cs
+++ b/sources/shaders/Stride.Core.Shaders/Writer/ShaderWriter.cs
@@ -524,6 +524,36 @@ namespace Stride.Core.Shaders.Writer
         }
 
         /// <inheritdoc />
+        public override void Visit(VectorType vectorType)
+        {
+            Write(vectorType.Name).Write("<");
+            for (int i = 0; i < vectorType.Parameters.Count; i++)
+            {
+                var parameter = vectorType.Parameters[i];
+                if (i > 0) Write(",").WriteSpace();
+
+                VisitDynamic(parameter);
+            }
+
+            Write(">");
+        }
+
+        /// <inheritdoc />
+        public override void Visit(MatrixType vectorType)
+        {
+            Write(vectorType.Name).Write("<");
+            for (int i = 0; i < vectorType.Parameters.Count; i++)
+            {
+                var parameter = vectorType.Parameters[i];
+                if (i > 0) Write(",").WriteSpace();
+
+                VisitDynamic(parameter);
+            }
+
+            Write(">");
+        }
+
+        /// <inheritdoc />
         public override void Visit(Literal literal)
         {
             if (literal == null)


### PR DESCRIPTION
## Description
The PR adds the default values as defined in a shader to the shader reflection. This allows to read them during runtime after they have been modified or new ones have been added.

I took the liberty and used the `EffectValueDescription.DefaultValue` property for it, as it wasn't used anywhere before.

I've also added tests to the PR which exposed a few other issues like invalid HLSL being generated when declaring a variable like `vector<float, 2> foo;`, constructors of `Half` vectors not being present or `ShaderClassString` not working.

## Related Issue
None that I know of.

## Motivation and Context
The default values of shader variables are being read at compile time by the shader key generator and stored in static C# fields. This works fine as long as one doesn't change those values during runtime or add new variables to a shader. Having to restart the application and regenerate the keys can be quite cumbersome when working on a shader.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.