### PR TITLE
[Core] Added IReadOnlyList<T> base interface to core collections

### DIFF
--- a/sources/assets/Stride.Core.Assets/AssetFolderCollection.cs
+++ b/sources/assets/Stride.Core.Assets/AssetFolderCollection.cs
@@ -17,7 +17,7 @@ namespace Stride.Core.Assets
     [DataContract("AssetFolderCollection")]
     [DebuggerTypeProxy(typeof(CollectionDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    public sealed class AssetFolderCollection : IList<AssetFolder>
+    public sealed class AssetFolderCollection : IList<AssetFolder>, IReadOnlyList<AssetFolder>
     {
         private readonly List<AssetFolder> folders;
 
@@ -108,6 +108,8 @@ namespace Stride.Core.Assets
                 return false;
             }
         }
+
+        public AssetFolder this[int index] => folders[index];
 
         /// <inheritdoc/>
         public IEnumerator<AssetFolder> GetEnumerator()

--- a/sources/core/Stride.Core/Collections/ConstrainedList.cs
+++ b/sources/core/Stride.Core/Collections/ConstrainedList.cs
@@ -13,7 +13,7 @@ namespace Stride.Core.Collections
     /// If the test fails, the item can either be discarded, or an exception can be thrown. The desired behavior can be defined with <see cref="ThrowException"/>.
     /// </summary>
     [DataSerializer(typeof(ListAllSerializer<,>), Mode = DataSerializerGenericMode.TypeAndGenericArguments)]
-    public class ConstrainedList<T> : IList<T>
+    public class ConstrainedList<T> : IList<T>, IReadOnlyList<T>
     {
         private readonly List<T> innerList = new List<T>();
 

--- a/sources/core/Stride.Core/Collections/SortedList.cs
+++ b/sources/core/Stride.Core/Collections/SortedList.cs
@@ -181,7 +181,7 @@ namespace Stride.Core.Collections
                     this.table = newTable;
                 }
 #if NET_1_0
-				else if (current > defaultCapacity && value < current) {
+                else if (current > defaultCapacity && value < current) {
                                         KeyValuePair<TKey, TValue> [] newTable = new KeyValuePair<TKey, TValue> [defaultCapacity];
                                         Array.Copy (table, newTable, inUse);
                                         this.table = newTable;
@@ -941,7 +941,7 @@ namespace Stride.Core.Collections
             object IEnumerator.Current => Current;
         }
 
-        private class ListKeys : IList<TKey>, ICollection, IEnumerable
+        private class ListKeys : IList<TKey>, IReadOnlyList<TKey>, ICollection, IEnumerable
         {
 
             private readonly SortedList<TKey, TValue> host;
@@ -1062,7 +1062,7 @@ namespace Stride.Core.Collections
             }
         }
 
-        private class ListValues : IList<TValue>, ICollection, IEnumerable
+        private class ListValues : IList<TValue>, IReadOnlyList<TValue>, ICollection, IEnumerable
         {
 
             private readonly SortedList<TKey, TValue> host;

--- a/sources/engine/Stride.Games/IGameSystemCollection.cs
+++ b/sources/engine/Stride.Games/IGameSystemCollection.cs
@@ -7,7 +7,7 @@ namespace Stride.Games
     /// <summary>
     /// A list of game systems.
     /// </summary>
-    public interface IGameSystemCollection : IList<IGameSystemBase>
+    public interface IGameSystemCollection : IList<IGameSystemBase>, IReadOnlyList<IGameSystemBase>
     {
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/GraphicsRendererCollectionBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/GraphicsRendererCollectionBase.cs
@@ -18,7 +18,7 @@ namespace Stride.Rendering
     /// </summary>
     /// <typeparam name="T">Type of the <see cref="IGraphicsRenderer"/></typeparam>.
     [DataSerializer(typeof(ListAllSerializer<,>), Mode = DataSerializerGenericMode.TypeAndGenericArguments)]
-    public abstract class GraphicsRendererCollectionBase<T> : RendererCoreBase, IGraphicsRenderer, IList<T> where T : class, IGraphicsRendererCore
+    public abstract class GraphicsRendererCollectionBase<T> : RendererCoreBase, IGraphicsRenderer, IList<T>, IReadOnlyList<T> where T : class, IGraphicsRendererCore
     {
         private readonly HashSet<T> tempRenderers;
 


### PR DESCRIPTION
# PR Details

Added `IReadOnlyList<T>` base interface to the core collections, where it was missing.

## Description

Unfortunately, `IList<T>` doesn't inherit from `IReadOnlyList<T>`, so one has to add it manually. Most Stride collections had it already, but a few were missing.

## Motivation and Context

This makes the collection compatible with generic operations that expect an `IReadOnlyList<T>`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.