### PR TITLE
Little cleanup to previous PR regarding shader reflection

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/LogicalGroup.cs
+++ b/sources/engine/Stride.Rendering/Rendering/LogicalGroup.cs
@@ -6,7 +6,7 @@ namespace Stride.Rendering
 {
     /// <summary>
     /// Defines a group of descriptors and cbuffer range that are updated together.
-    /// It can be declared in shader using the syntax <c>cbuffer PerView_LogicalGroupName</c> (also works with <c>rgroup</c>).
+    /// It can be declared in shader using the syntax <c>cbuffer PerView.LogicalGroupName</c> (also works with <c>rgroup</c>).
     /// </summary>
     public struct LogicalGroup
     {

--- a/sources/engine/Stride.Shaders.Compiler/EffectCompiler.cs
+++ b/sources/engine/Stride.Shaders.Compiler/EffectCompiler.cs
@@ -280,11 +280,8 @@ namespace Stride.Shaders.Compiler
                     break;
             }
 
-            if (effectParameters.OptimizationLevel > 0)
-            {
-                // Remove unused reflection data, as it is entirely resolved at compile time.
-                CleanupReflection(bytecode.Reflection);
-            }
+            // Remove unused reflection data, as it is entirely resolved at compile time.
+            CleanupReflection(bytecode.Reflection);
 
             bytecode.Stages = shaderStageBytecodes.ToArray();
 


### PR DESCRIPTION
## Description
Reverts change from previous commit that reflection wasn't cleaned up in debug.

## Related Issue
#765 

## Motivation and Context
The shader reflection should be the same in debug and release builds. My change in the last PR was a little too quick. It would've required user code to filter the reflection on its own.
It would still be nice to tell the compiler not to remove parameters, but that's for another day.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.