### PR TITLE
[Engine] Scene = null also detaches parent

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Entity.cs
+++ b/sources/engine/Stride.Engine/Engine/Entity.cs
@@ -89,7 +89,8 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// The parent scene.
+        /// The scene this entity is in. <br/>
+        /// Setting this to null will remove the entity from the scene and detach it from its parent if it has one.
         /// </summary>
         [DataMemberIgnore]
         public Scene Scene
@@ -98,11 +99,17 @@ namespace Stride.Engine
             {
                 return this.FindRoot().SceneValue;
             }
-
             set
             {
-                if (this.GetParent() != null)
-                    throw new InvalidOperationException("This entity is another entity's child. Detach it before changing its scene.");
+                if (Transform.Parent != null)
+                {
+                    if (value != null)
+                        throw new InvalidOperationException("This entity is another entity's child. Detach it before changing its scene.");
+                    
+                    Transform.Parent = null;
+                    return;
+                }
+
 
                 var oldScene = SceneValue;
                 if (oldScene == value)


### PR DESCRIPTION
# PR Details
Users want a succinct way to remove entities from the game regardless of their place in the hierarchy, right now they have to set both parent and scene to null when they aren't sure that either of these is set.
Doing this operation should not require more than a single line, it might come more instinctively and will be easier to keep in mind.

In this PR when the value passed to ``Scene`` is null the engine detaches the entity from its parent if it has any or removes it from the scene.

I decided against making a specific function for it to keep it more in line with how we do other operations with transforms and entities and also to avoid having the same issues that unity has with the 'magic' Destroy() function.

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.