### PR TITLE
Increase UIRenderFeature SortKey to always render UI on top of Sprites

### DIFF
--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
@@ -43,6 +43,11 @@ namespace Stride.Rendering.UI
         /// </summary>
         public UIElement UIElementUnderMouseCursor { get; private set; }
 
+        public UIRenderFeature()
+        {
+            SortKey = 192;
+        }
+
         protected override void InitializeCore()
         {
             base.InitializeCore();


### PR DESCRIPTION
# PR Details

This change prevents UI elements from being rendered underneath Sprites.
Previous value is `128` - the default, same as `SpriteRenderFeature`, which meant that during sorting the UI could potentially end up rendered before the sprites (or not).

The value `192` was chosen to match the `SortKey` of `BackgroundRenderFeature`.

## Motivation and Context

I was playing around with JumpyJet and noticed that for some combinations of entity order in the scene the UI was not rendered on top of everything else as it should be.

![JumpyUIOverlayIssue](https://user-images.githubusercontent.com/10709060/86256675-e5ae3f80-bbb8-11ea-979c-1c43579dd19c.png)

After I applied the change I played a bit with the order of entities as previously but now UI was always on top.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

_I'm not sure about changes to the documentation or in-code comments for this change._

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.