### PR TITLE
[Build] Fix project files without extensions preventing loading

### DIFF
--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -1272,7 +1272,7 @@ namespace Stride.Core.Assets
             // Adjust extensions for Stride rename
             foreach (var loadingAsset in listFiles)
             {
-                var originalExt = loadingAsset.FilePath.GetFileExtension();
+                var originalExt = loadingAsset.FilePath.GetFileExtension() ?? "";
                 var ext = originalExt.Replace(".xk", ".sd");
                 if (ext != originalExt)
                 {
@@ -1301,7 +1301,7 @@ namespace Stride.Core.Assets
                 // Test both Stride and Xenko extensions
                 .Where(x =>
                     AssetRegistry.IsProjectAssetFileExtension(x.FilePath.GetFileExtension())
-                    || AssetRegistry.IsProjectAssetFileExtension(x.FilePath.GetFileExtension().Replace(".xk", ".sd")))
+                    || AssetRegistry.IsProjectAssetFileExtension(x.FilePath.GetFileExtension()?.Replace(".xk", ".sd")))
                 // avoid duplicates otherwise it might save a single file as separte file with renaming
                 // had issues with case such as Effect.sdsl being registered twice (with glob pattern) and being saved as Effect.sdsl and Effect (2).sdsl
                 .Distinct()


### PR DESCRIPTION
# PR Details
As the title says, having a file without an extension (like a github license file for example) prevents the whole project from being loaded in the game studio.
The first change might not be required, not sure, you'll probably know better than I do @xen2 

## Related Issue
None

## Motivation and Context
Bug

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (extremely unlikely to test negative, so ticked it anyway)