### PR TITLE
[Physics] Prevent invalid state when component was added right after removal

### DIFF
--- a/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
@@ -103,11 +103,9 @@ namespace Stride.Physics
 
         protected override void OnEntityComponentAdding(Entity entity, PhysicsComponent component, AssociatedData data)
         {
-            if (currentFrameRemovals.Contains(component))
-            {
-                currentFrameRemovals.Remove(component);
+            // Tagged for removal? If yes, cancel it
+            if (currentFrameRemovals.Remove(component))
                 return;
-            }
 
             component.Attach(data);
 
@@ -155,7 +153,7 @@ namespace Stride.Physics
             component.Detach();
         }
 
-        private readonly List<PhysicsComponent> currentFrameRemovals = new List<PhysicsComponent>();
+        private readonly HashSet<PhysicsComponent> currentFrameRemovals = new HashSet<PhysicsComponent>();
 
         protected override void OnEntityComponentRemoved(Entity entity, PhysicsComponent component, AssociatedData data)
         {

--- a/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
@@ -103,6 +103,12 @@ namespace Stride.Physics
 
         protected override void OnEntityComponentAdding(Entity entity, PhysicsComponent component, AssociatedData data)
         {
+            if (currentFrameRemovals.Contains(component))
+            {
+                currentFrameRemovals.Remove(component);
+                return;
+            }
+
             component.Attach(data);
 
             var character = component as CharacterComponent;


### PR DESCRIPTION
# PR Details

Fixes #798 by not removing a component that has been re-added in the same frame.

## Description

When an entity is removed from a scene it is removed from all the component processors. For physics, this removal is delayed till the next frame. So if the same entity is added back in the same frame, it's physics component should not be removed.

Note: This causes the associated data in the `ComponentDatas` to be a different object than in `component.Data`, however, they still have the same _value_ because they pass the `IsAssociatedDataValid` check.

## Related Issue
#798 

## Motivation and Context

Allows removing and adding entities, with a physics component, from the scene without the need to clone them.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.