### PR TITLE
Allow components to have required members and report warning/error if they're null

### DIFF
--- a/sources/core/Stride.Core/Annotations/MemberRequiredAttribute.cs
+++ b/sources/core/Stride.Core/Annotations/MemberRequiredAttribute.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Stride.Core.Annotations
+{
+    /// <summary>
+    /// This attribute signals the asset compiler that the field/property
+    /// is required to have a value (i.e. not null) when compiling assets.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class MemberRequiredAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets or sets the reporting level (warning/error) of the notification that the field/property is null.
+        /// </summary>
+        public MemberRequiredReportType ReportAs { get; set; } = MemberRequiredReportType.Warning;
+    }
+
+    /// <summary>
+    /// Specifies the reporting level for a missing value of a field/property with a <see cref="MemberRequiredAttribute"/>.
+    /// </summary>
+    public enum MemberRequiredReportType
+    {
+        /// <summary>
+        /// Report missing required member as a warning.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Report missing required member as an error.
+        /// </summary>
+        Error,
+    }
+}

--- a/sources/engine/Stride.Assets.Tests/Stride.Assets.Tests.csproj
+++ b/sources/engine/Stride.Assets.Tests/Stride.Assets.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\..\assets\Stride.Core.Assets.Tests\Helpers\GuidGenerator.cs">
       <Link>GuidGenerator.cs</Link>
     </Compile>
+    <Compile Include="TestMemberRequiredComponentChecks.cs" />
     <Compile Include="XunitAttributes.cs" />
     <Compile Include="TestMaterialGenerator.cs" />
     <Compile Include="AssetImportTests.cs" />

--- a/sources/engine/Stride.Assets.Tests/TestMemberRequiredComponentChecks.cs
+++ b/sources/engine/Stride.Assets.Tests/TestMemberRequiredComponentChecks.cs
@@ -1,0 +1,138 @@
+using Stride.Assets.Entities.ComponentChecks;
+using Stride.Core;
+using Stride.Core.Annotations;
+using Stride.Core.Assets.Compiler;
+using Stride.Engine;
+using Xunit;
+
+namespace Stride.Assets.Tests
+{
+    /// <summary>
+    /// Tests the behaviour of <see cref="RequiredMembersCheck"/>.
+    /// </summary>
+    public class TestMemberRequiredComponentChecks
+    {
+        /// <summary>
+        /// Test component that has <see cref="MemberRequiredAttribute"/> on serializable members.
+        /// </summary>
+        [DataContract]
+        public class MemberRequiredComponent : EntityComponent
+        {
+            // We won't test the (ReportAs = Error) case
+            // it would duplicate tests and it's more important to assert
+            // that presence of the attribute gives a warning
+            [MemberRequired] public object PublicField;
+            [MemberRequired] public object PublicProp { get; set; }
+            [MemberRequired] private object PrivateProp { get; set; }
+            [MemberRequired] protected object ProtectedProp { get; set; }
+            public MemberRequiredComponent(object privateData, object protectedData)
+            {
+                PrivateProp = privateData;
+                ProtectedProp = protectedData;
+            }
+        }
+
+        [Fact]
+        void EntityIsNotMissingRequiredMembers()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(new object(), new object())
+            {
+                PublicProp = new object(),
+                PublicField = new object(),
+            };
+            var entity = new Entity("test");
+            entity.Add(memberRequiredComponent);
+
+            var check = new RequiredMembersCheck();
+            var result = new AssetCompilerResult();
+
+            Assert.True(check.AppliesTo(memberRequiredComponent.GetType()));
+            check.Check(memberRequiredComponent, entity, null, "", result);
+            Assert.Empty(result.Messages);
+        }
+
+        [Fact]
+        void EntityIsMissingRequiredMember_PublicField()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(new object(), new object())
+            {
+                PublicProp = new object(),
+                PublicField = null,
+            };
+            var memberName = nameof(memberRequiredComponent.PublicField);
+            TestSingle(memberRequiredComponent, memberName);
+        }
+
+        [Fact]
+        void EntityIsMissingRequiredMember_PublicProp()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(new object(), new object())
+            {
+                PublicProp = null,
+                PublicField = new object(),
+            };
+            var memberName = nameof(memberRequiredComponent.PublicProp);
+            TestSingle(memberRequiredComponent, memberName);
+        }
+
+        [Fact]
+        void EntityIsMissingRequiredMember_PrivateProp()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(null, new object())
+            {
+                PublicProp = new object(),
+                PublicField = new object(),
+            };
+            var memberName = "PrivateProp";
+            TestSingle(memberRequiredComponent, memberName);
+        }
+
+        [Fact]
+        void EntityIsMissingRequiredMember_ProtectedProp()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(new object(), null)
+            {
+                PublicProp = new object(),
+                PublicField = new object(),
+            };
+            var memberName = "ProtectedProp";
+            TestSingle(memberRequiredComponent, memberName);
+        }
+
+        [Fact]
+        void EntityIsMissingAllRequiredMembers()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(null, null)
+            {
+                PublicProp = null,
+                PublicField = null,
+            };
+            var entity = new Entity("test");
+            entity.Add(memberRequiredComponent);
+
+            var check = new RequiredMembersCheck();
+            var result = new AssetCompilerResult();
+
+            Assert.True(check.AppliesTo(memberRequiredComponent.GetType()));
+            check.Check(memberRequiredComponent, entity, null, "", result);
+            Assert.Equal(4, result.Messages.Count);
+        }
+
+        private static void TestSingle(MemberRequiredComponent memberRequiredComponent, string memberName)
+        {
+            var entity = new Entity("Test");
+            entity.Add(memberRequiredComponent);
+
+            var check = new RequiredMembersCheck();
+            var result = new AssetCompilerResult();
+
+            Assert.True(check.AppliesTo(memberRequiredComponent.GetType()));
+            check.Check(memberRequiredComponent, entity, null, "", result);
+            Assert.Collection(result.Messages, (msg) =>
+            {
+                Assert.Equal(Core.Diagnostics.LogMessageType.Warning, msg.Type);
+                Assert.Contains(memberName, msg.Text);
+            });
+        }
+    }
+}

--- a/sources/engine/Stride.Assets.Tests/TestMemberRequiredComponentChecks.cs
+++ b/sources/engine/Stride.Assets.Tests/TestMemberRequiredComponentChecks.cs
@@ -23,8 +23,10 @@ namespace Stride.Assets.Tests
             // that presence of the attribute gives a warning
             [MemberRequired] public object PublicField;
             [MemberRequired] public object PublicProp { get; set; }
-            [MemberRequired] private object PrivateProp { get; set; }
-            [MemberRequired] protected object ProtectedProp { get; set; }
+            [MemberRequired]
+            [DataMember] private object PrivateProp { get; set; }
+            [MemberRequired]
+            [DataMember] protected object ProtectedProp { get; set; }
             public MemberRequiredComponent(object privateData, object protectedData)
             {
                 PrivateProp = privateData;

--- a/sources/engine/Stride.Assets/Entities/ComponentChecks/IEntityComponentCheck.cs
+++ b/sources/engine/Stride.Assets/Entities/ComponentChecks/IEntityComponentCheck.cs
@@ -1,0 +1,30 @@
+using System;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Compiler;
+using Stride.Engine;
+
+namespace Stride.Assets.Entities.ComponentChecks
+{
+    /// <summary>
+    /// Interface for component checks executed during asset compilation.
+    /// </summary>
+    public interface IEntityComponentCheck
+    {
+        /// <summary>
+        /// A predicate determining if a component can be passed to <see cref="Check(EntityComponent)"/>.
+        /// </summary>
+        /// <param name="componentType">Type of the component to be checked.</param>
+        /// <returns>Returns <c>true</c> if the component of <paramref name="componentType"/> can be passed to <see cref="Check(EntityComponent)"/>.</returns>
+        bool AppliesTo(Type componentType);
+
+        /// <summary>
+        /// Checks if the component state is valid and reports appropriate errors/warnings.
+        /// </summary>
+        /// <param name="component">Component to check.</param>
+        /// <param name="entity">Entity the <paramref name="component"/> is associated with.</param>
+        /// <param name="assetItem">Asset item the <paramref name="entity"/> belongs to.</param>
+        /// <param name="targetUrlInStorage">URL of the <paramref name="assetItem"/>.</param>
+        /// <param name="result">Logger result to write information to.</param>
+        void Check(EntityComponent component, Entity entity, AssetItem assetItem, string targetUrlInStorage, AssetCompilerResult result);
+    }
+}

--- a/sources/engine/Stride.Assets/Entities/ComponentChecks/ModelComponentCheck.cs
+++ b/sources/engine/Stride.Assets/Entities/ComponentChecks/ModelComponentCheck.cs
@@ -1,0 +1,42 @@
+using System;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Compiler;
+using Stride.Core.Serialization;
+using Stride.Engine;
+
+namespace Stride.Assets.Entities.ComponentChecks
+{
+    /// <summary>
+    /// Checks if the <see cref="ModelComponent"/> has a Model associated with it and that this Model has a reachable asset.
+    /// </summary>
+    public class ModelComponentCheck : IEntityComponentCheck
+    {
+        /// <inheritdoc/>
+        public bool AppliesTo(Type componentType)
+        {
+            return componentType == typeof(ModelComponent);
+        }
+
+        /// <inheritdoc/>
+        public void Check(EntityComponent component, Entity entity, AssetItem assetItem, string targetUrlInStorage, AssetCompilerResult result)
+        {
+            var modelComponent = component as ModelComponent;
+            if (modelComponent.Model == null)
+            {
+                result.Warning($"The entity [{targetUrlInStorage}:{entity.Name}] has a model component that does not reference any model.");
+            }
+            else
+            {
+                var modelAttachedReference = AttachedReferenceManager.GetAttachedReference(modelComponent.Model);
+                var modelId = modelAttachedReference.Id;
+
+                // compute the full path to the source asset.
+                var modelAssetItem = assetItem.Package.Session.FindAsset(modelId);
+                if (modelAssetItem == null)
+                {
+                    result.Error($"The entity [{targetUrlInStorage}:{entity.Name}] is referencing an unreachable model.");
+                }
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Assets/Entities/ComponentChecks/ModelNodeLinkComponentCheck.cs
+++ b/sources/engine/Stride.Assets/Entities/ComponentChecks/ModelNodeLinkComponentCheck.cs
@@ -1,0 +1,31 @@
+using System;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Compiler;
+using Stride.Engine;
+
+namespace Stride.Assets.Entities.ComponentChecks
+{
+    /// <summary>
+    /// Checks the validity of a <see cref="ModelNodeLinkComponent"/>.
+    /// </summary>
+    public class ModelNodeLinkComponentCheck : IEntityComponentCheck
+    {
+        /// <inheritdoc/>
+        public bool AppliesTo(Type componentType)
+        {
+            return componentType == typeof(ModelNodeLinkComponent);
+        }
+
+        /// <inheritdoc/>
+        public void Check(EntityComponent component, Entity entity, AssetItem assetItem, string targetUrlInStorage, AssetCompilerResult result)
+        {
+            var nodeLinkComponent = component as ModelNodeLinkComponent;
+            nodeLinkComponent.ValidityCheck();
+            if (!nodeLinkComponent.IsValid)
+            {
+                result.Warning($"The Model Node Link between {entity.Name} and {nodeLinkComponent.Target?.Entity.Name} is invalid.");
+                nodeLinkComponent.Target = null;
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Assets/Entities/ComponentChecks/RequiredMembersCheck.cs
+++ b/sources/engine/Stride.Assets/Entities/ComponentChecks/RequiredMembersCheck.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Reflection;
+using Stride.Core.Annotations;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Compiler;
+using Stride.Engine;
+
+namespace Stride.Assets.Entities.ComponentChecks
+{
+    /// <summary>
+    /// Checks if all members of a component with a <see cref="MemberRequiredAttribute"/> are assigned a value.
+    /// </summary>
+    public class RequiredMembersCheck : IEntityComponentCheck
+    {
+        /// <inheritdoc/>
+        public bool AppliesTo(Type componentType)
+        {
+            return true; // applies to any component
+        }
+
+        /// <inheritdoc/>
+        public void Check(EntityComponent component, Entity entity, AssetItem assetItem, string targetUrlInStorage, AssetCompilerResult result)
+        {
+            var type = component.GetType();
+            var componentName = type.Name; // QUESTION: Should we check attributes for another name?
+
+            var fields = type.GetFields(); // public fields, only those can be serialized?
+            var properties = type.GetRuntimeProperties(); // all properties may have a DataMember attribute
+
+            foreach (var field in fields)
+            {
+                if (field.FieldType.IsValueType)
+                    continue; // value types cannot be null, and must always have a proper default value
+
+                MemberRequiredAttribute memberRequired;
+                if ((memberRequired = field.GetCustomAttribute<MemberRequiredAttribute>()) != null)
+                {
+                    if (field.GetValue(component) == null)
+                        WriteResult(result, componentName, targetUrlInStorage, entity.Name, field.Name, memberRequired.ReportAs);
+                }
+            }
+
+            foreach (var prop in properties)
+            {
+                if (prop.PropertyType.IsValueType)
+                    continue; // value types cannot be null, and must always have a proper default value
+
+                MemberRequiredAttribute memberRequired;
+                if ((memberRequired = prop.GetCustomAttribute<MemberRequiredAttribute>()) != null)
+                {
+                    if (prop.GetValue(component) == null)
+                        WriteResult(result, componentName, targetUrlInStorage, entity.Name, prop.Name, memberRequired.ReportAs);
+                }
+            }
+        }
+
+        private void WriteResult(AssetCompilerResult result, string componentName, string targetUrlInStorage, string entityName, string memberName, MemberRequiredReportType reportType)
+        {
+            var logMsg = $"The component {componentName} on entity [{targetUrlInStorage}:{entityName}] is missing a value on a required field '{memberName}'.";
+            switch (reportType)
+            {
+                case MemberRequiredReportType.Warning:
+                    result.Warning(logMsg);
+                    break;
+                case MemberRequiredReportType.Error:
+                    result.Error(logMsg);
+                    break;
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Assets/Entities/ComponentChecks/RequiredMembersCheck.cs
+++ b/sources/engine/Stride.Assets/Entities/ComponentChecks/RequiredMembersCheck.cs
@@ -34,7 +34,7 @@ namespace Stride.Assets.Entities.ComponentChecks
                     continue; // value types cannot be null, and must always have a proper default value
 
                 MemberRequiredAttribute memberRequired;
-                if ((memberRequired = member.GetCustomAttributes<MemberRequiredAttribute>(false).FirstOrDefault()) != null)
+                if ((memberRequired = member.GetCustomAttributes<MemberRequiredAttribute>(true).FirstOrDefault()) != null)
                 {
                     if (member.Get(component) == null)
                         WriteResult(result, componentName, targetUrlInStorage, entity.Name, member.Name, memberRequired.ReportAs);

--- a/sources/engine/Stride.Assets/Entities/EntityHierarchyCompilerBase.cs
+++ b/sources/engine/Stride.Assets/Entities/EntityHierarchyCompilerBase.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using Stride.Core.Annotations;
+using Stride.Assets.Entities.ComponentChecks;
 using Stride.Core.Assets;
 using Stride.Core.Assets.Compiler;
-using Stride.Core.Serialization;
 using Stride.Engine;
 
 namespace Stride.Assets.Entities
@@ -25,90 +22,12 @@ namespace Stride.Assets.Entities
             var asset = (T)assetItem.Asset;
             foreach (var entityData in asset.Hierarchy.Parts.Values)
             {
-                // TODO: How to make this code pluggable?
-                var modelComponent = entityData.Entity.Components.Get<ModelComponent>();                
-                if (modelComponent != null)
-                {
-                    if (modelComponent.Model == null)
-                    {
-                        result.Warning($"The entity [{targetUrlInStorage}:{entityData.Entity.Name}] has a model component that does not reference any model.");
-                    }
-                    else
-                    {
-                        var modelAttachedReference = AttachedReferenceManager.GetAttachedReference(modelComponent.Model);
-                        var modelId = modelAttachedReference.Id;
-
-                        // compute the full path to the source asset.
-                        var modelAssetItem = assetItem.Package.Session.FindAsset(modelId);
-                        if (modelAssetItem == null)
-                        {
-                            result.Error($"The entity [{targetUrlInStorage}:{entityData.Entity.Name}] is referencing an unreachable model.");
-                        }
-                    }
-                }
-
-                var nodeLinkComponent = entityData.Entity.Components.Get<ModelNodeLinkComponent>();
-                if (nodeLinkComponent != null)
-                {
-                    nodeLinkComponent.ValidityCheck();
-                    if (!nodeLinkComponent.IsValid)
-                    {
-                        result.Warning($"The Model Node Link between {entityData.Entity.Name} and {nodeLinkComponent.Target?.Entity.Name} is invalid.");
-                        nodeLinkComponent.Target = null;
-                    }
-                }
-
                 foreach (var component in entityData.Entity.Components)
                 {
-                    var type = component.GetType();
-                    var componentName = type.Name; // QUESTION: Should we check attributes for another name?
-                    var fields = type.GetFields(); // public fields, only those appear in GS?
-                    var properties = type.GetRuntimeProperties(); // all properties may have a DataMember attribute
-                    foreach(var field in fields)
+                    foreach(var check in componentChecks)
                     {
-                        if (field.FieldType.IsValueType)
-                            continue; // value types cannot be null, and must always have a proper default value
-                        
-                        MemberRequiredAttribute memberRequired;
-                        if ((memberRequired = field.GetCustomAttribute<MemberRequiredAttribute>()) != null)
-                        {
-                            if(field.GetValue(component) == null)
-                            {
-                                var logMsg = $"The component {componentName} on entity [{targetUrlInStorage}:{entityData.Entity.Name}] is missing a value on a required field '{field.Name}'.";
-                                switch (memberRequired.ReportAs)
-                                {
-                                    case MemberRequiredReportType.Warning:
-                                        result.Warning(logMsg);
-                                        break;
-                                    case MemberRequiredReportType.Error:
-                                        result.Error(logMsg);
-                                        break;
-                                }
-                            }
-                        }
-                    }
-                    foreach (var prop in properties)
-                    {
-                        if (prop.PropertyType.IsValueType)
-                            continue; // value types cannot be null, and must always have a proper default value
-
-                        MemberRequiredAttribute memberRequired;
-                        if ((memberRequired = prop.GetCustomAttribute<MemberRequiredAttribute>()) != null)
-                        {
-                            if (prop.GetValue(component) == null)
-                            {
-                                var logMsg = $"The component {componentName} on entity [{targetUrlInStorage}:{entityData.Entity.Name}] is missing a value on a required field '{prop.Name}'.";
-                                switch (memberRequired.ReportAs)
-                                {
-                                    case MemberRequiredReportType.Warning:
-                                        result.Warning(logMsg);
-                                        break;
-                                    case MemberRequiredReportType.Error:
-                                        result.Error(logMsg);
-                                        break;
-                                }
-                            }
-                        }
+                        if (check.AppliesTo(component.GetType()))
+                            check.Check(component, entityData.Entity, assetItem, targetUrlInStorage, result);
                     }
                 }
             }
@@ -116,6 +35,14 @@ namespace Stride.Assets.Entities
             result.BuildSteps = new AssetBuildStep(assetItem);
             result.BuildSteps.Add(Create(targetUrlInStorage, asset, assetItem.Package));
         }
+
+        private static List<IEntityComponentCheck> componentChecks = new List<IEntityComponentCheck>
+        {
+            // TODO: How to make this code pluggable?
+            new ModelComponentCheck(),
+            new ModelNodeLinkComponentCheck(),
+            new RequiredMembersCheck(),
+        };
 
         protected abstract AssetCommand<T> Create(string url, T assetParameters, Package package);
     }

--- a/sources/engine/Stride.Assets/Entities/EntityHierarchyCompilerBase.cs
+++ b/sources/engine/Stride.Assets/Entities/EntityHierarchyCompilerBase.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Stride.Core.Annotations;
 using Stride.Core.Assets;
 using Stride.Core.Assets.Compiler;
 using Stride.Core.Serialization;
@@ -52,6 +55,60 @@ namespace Stride.Assets.Entities
                     {
                         result.Warning($"The Model Node Link between {entityData.Entity.Name} and {nodeLinkComponent.Target?.Entity.Name} is invalid.");
                         nodeLinkComponent.Target = null;
+                    }
+                }
+
+                foreach (var component in entityData.Entity.Components)
+                {
+                    var type = component.GetType();
+                    var componentName = type.Name; // QUESTION: Should we check attributes for another name?
+                    var fields = type.GetFields(); // public fields, only those appear in GS?
+                    var properties = type.GetRuntimeProperties(); // all properties may have a DataMember attribute
+                    foreach(var field in fields)
+                    {
+                        if (field.FieldType.IsValueType)
+                            continue; // value types cannot be null, and must always have a proper default value
+                        
+                        MemberRequiredAttribute memberRequired;
+                        if ((memberRequired = field.GetCustomAttribute<MemberRequiredAttribute>()) != null)
+                        {
+                            if(field.GetValue(component) == null)
+                            {
+                                var logMsg = $"The component {componentName} on entity [{targetUrlInStorage}:{entityData.Entity.Name}] is missing a value on a required field '{field.Name}'.";
+                                switch (memberRequired.ReportAs)
+                                {
+                                    case MemberRequiredReportType.Warning:
+                                        result.Warning(logMsg);
+                                        break;
+                                    case MemberRequiredReportType.Error:
+                                        result.Error(logMsg);
+                                        break;
+                                }
+                            }
+                        }
+                    }
+                    foreach (var prop in properties)
+                    {
+                        if (prop.PropertyType.IsValueType)
+                            continue; // value types cannot be null, and must always have a proper default value
+
+                        MemberRequiredAttribute memberRequired;
+                        if ((memberRequired = prop.GetCustomAttribute<MemberRequiredAttribute>()) != null)
+                        {
+                            if (prop.GetValue(component) == null)
+                            {
+                                var logMsg = $"The component {componentName} on entity [{targetUrlInStorage}:{entityData.Entity.Name}] is missing a value on a required field '{prop.Name}'.";
+                                switch (memberRequired.ReportAs)
+                                {
+                                    case MemberRequiredReportType.Warning:
+                                        result.Warning(logMsg);
+                                        break;
+                                    case MemberRequiredReportType.Error:
+                                        result.Error(logMsg);
+                                        break;
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a `[MemberRequired]` attribute that can be placed on fields and properties of components. If during the asset compilation a field/property with that attribute is `null`, a warning/error is issued.

Additionally, component checks in the `EntityHierarchyCompilerBase` have been abstracted into an interface `IEntityComponentCheck` to allow better maintenance and future expansion of such checks.

## Related Issue

Resolves #778 

## Motivation and Context

It's often very easy to forget to set a value for a component in Game Studio and you would only find that out with an exception. With this change, you can mark properties as required and get a warning during compilation which is more visible.

![asset_compiler_null_warning_2](https://user-images.githubusercontent.com/10709060/88173840-8e354980-cc23-11ea-9ba3-f65b26116a5e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The docs would need to be updated to include information about a possibility of marking properties with the added attribute.
All tests should be passing (I had some errors but they seemed to be completely unconnected).