### PR TITLE
Remove dependency of camera processor on scene system

### DIFF
--- a/sources/engine/Stride.Engine.Tests/TestCameraProcessor.cs
+++ b/sources/engine/Stride.Engine.Tests/TestCameraProcessor.cs
@@ -23,7 +23,6 @@ namespace Stride.Engine.Tests
     {
         private CustomEntityManager entityManager;
         private GraphicsCompositor graphicsCompositor;
-        private SceneSystem sceneSystem;
         private RenderContext context;
 
         public TestCameraProcessor()
@@ -35,14 +34,12 @@ namespace Stride.Engine.Tests
 
             // Create graphics compositor
             graphicsCompositor = new GraphicsCompositor();
-            sceneSystem = new SceneSystem(services) { GraphicsCompositor = graphicsCompositor };
-            services.AddService(sceneSystem);
             var graphicsDevice = GraphicsDevice.New(DeviceCreationFlags.Debug);
             services.AddService<IGraphicsDeviceService>(new GraphicsDeviceServiceLocal(graphicsDevice));
             services.AddService(new EffectSystem(services));
             services.AddService(new GraphicsContext(graphicsDevice));
             context = RenderContext.GetShared(services);
-            context.PushTagAndRestore(SceneSystem.Current, sceneSystem);
+            context.PushTagAndRestore(GraphicsCompositor.Current, graphicsCompositor);
         }
 
         private CameraComponent AddCamera(bool enabled, SceneCameraSlotId slot)
@@ -189,7 +186,7 @@ namespace Stride.Engine.Tests
 
             // Change graphics compositor
             var newGraphicsCompositor = new GraphicsCompositor();
-            sceneSystem.GraphicsCompositor = newGraphicsCompositor;
+            context.PushTagAndRestore(GraphicsCompositor.Current, newGraphicsCompositor);
 
             cameraProcessor.Draw(context);
 

--- a/sources/engine/Stride.Engine/Engine/Processors/CameraProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/Processors/CameraProcessor.cs
@@ -27,7 +27,7 @@ namespace Stride.Engine.Processors
 
         public override void Draw(RenderContext context)
         {
-            var graphicsCompositor = context.Tags.Get(SceneSystem.Current)?.GraphicsCompositor;
+            var graphicsCompositor = context.Tags.Get(GraphicsCompositor.Current);
 
             // Monitor changes in the camera slots of the current compositor
             if (graphicsCompositor != currentCompositor)

--- a/sources/engine/Stride.Engine/Rendering/Compositing/GraphicsCompositor.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/GraphicsCompositor.cs
@@ -23,6 +23,11 @@ namespace Stride.Rendering.Compositing
     [DataSerializerGlobal(null, typeof(FastTrackingCollection<RootRenderFeature>))]
     public class GraphicsCompositor : RendererBase
     {
+        /// <summary>
+        /// A property key to get the current graphics compositor from the <see cref="RenderContext.Tags"/>.
+        /// </summary>
+        public static readonly PropertyKey<GraphicsCompositor> Current = new PropertyKey<GraphicsCompositor>("GraphicsCompositor.Current", typeof(GraphicsCompositor));
+
         private readonly List<SceneInstance> initializedSceneInstances = new List<SceneInstance>();
 
         /// <summary>
@@ -139,6 +144,7 @@ namespace Stride.Rendering.Compositing
                 using (context.RenderContext.PushTagAndRestore(SceneInstance.CurrentVisibilityGroup, visibilityGroup))
                 using (context.RenderContext.PushTagAndRestore(SceneInstance.CurrentRenderSystem, RenderSystem))
                 using (context.RenderContext.PushTagAndRestore(SceneCameraSlotCollection.Current, Cameras))
+                using (context.RenderContext.PushTagAndRestore(Current, this))
                 {
                     // Set render system
                     context.RenderContext.RenderSystem = RenderSystem;


### PR DESCRIPTION
# PR Details

## Description
By removing the dependency on the scene system and fetching the camera collection from the used graphics compositor directly, one can render a scene from within a different context than a scene system.

## Motivation and Context
We're dealing with multiple scenes in one game rendered at the same time. The scenes to be rendered can vary from frame to frame. We therefor don't make use of a scene system but use a custom game system scheduling those scene rendering. This PR ensures that a scene using camera slots still works as expected.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.