### PR TITLE
AssetMemberNode.ContentChanged only generates missing ids if needed

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetMemberNode.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetMemberNode.cs
@@ -74,12 +74,12 @@ namespace Stride.Core.Assets.Quantum.Internal
 
         private void ContentChanged(object sender, [NotNull] MemberNodeChangeEventArgs e)
         {
-            // Make sure that we have item ids everywhere we're supposed to.
-            AssetCollectionItemIdHelper.GenerateMissingItemIds(e.Member.Retrieve());
-
             var node = (AssetMemberNode)e.Member;
             if (node.IsNonIdentifiableCollectionContent)
                 return;
+
+            // Make sure that we have item ids everywhere we're supposed to.
+            AssetCollectionItemIdHelper.GenerateMissingItemIds(e.Member.Retrieve());
 
             // Don't update override if propagation from base is disabled.
             if (PropertyGraph?.Container == null || PropertyGraph?.Container?.PropagateChangesFromBase == false)


### PR DESCRIPTION
# PR Details

## Description
No longer generate item ids for collections that are not supposed to have them. 

## Motivation and Context

It improves performance but not generating item ids when they are not needed.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

All directly related tests seems to pass. Quite a few tests fail, but this seems to be the case even without this change.

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.