### PR TITLE
[Graphics] New event GraphicsResourceBase.Destroyed

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsResourceBase.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsResourceBase.Direct3D.cs
@@ -57,6 +57,8 @@ namespace Stride.Graphics
         /// </summary>
         protected internal virtual void OnDestroyed()
         {
+            Destroyed?.Invoke(this, EventArgs.Empty);
+
             ReleaseComObject(ref nativeDeviceChild);
             NativeResource = null;
         }

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsResourceBase.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsResourceBase.Direct3D12.cs
@@ -53,6 +53,8 @@ namespace Stride.Graphics
         /// </summary>
         protected internal virtual void OnDestroyed()
         {
+            Destroyed?.Invoke(this, EventArgs.Empty);
+
             if (nativeDeviceChild != null)
             {
                 // Schedule the resource for destruction (as soon as we are done with it)

--- a/sources/engine/Stride.Graphics/GraphicsResourceBase.cs
+++ b/sources/engine/Stride.Graphics/GraphicsResourceBase.cs
@@ -19,6 +19,12 @@ namespace Stride.Graphics
             get;
             private set;
         }
+
+        /// <summary>
+        /// Raised when the internal graphics resource gets destroyed. 
+        /// This event is useful when user allocated handles associated with the internal resource need to be released.
+        /// </summary>
+        public event EventHandler<EventArgs> Destroyed;
         
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphicsResourceBase"/> class.

--- a/sources/engine/Stride.Graphics/Null/GraphicsResourceBase.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/GraphicsResourceBase.Null.cs
@@ -23,6 +23,7 @@ namespace Stride.Graphics
         /// </summary>
         protected internal virtual void OnDestroyed()
         {
+            Destroyed?.Invoke(this, EventArgs.Empty);
             NullHelper.ToImplement();
         }
 

--- a/sources/engine/Stride.Graphics/OpenGL/GraphicsResourceBase.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/GraphicsResourceBase.OpenGL.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 #if STRIDE_GRAPHICS_API_OPENGL 
+using System;
 
 namespace Stride.Graphics
 {
@@ -19,6 +20,7 @@ namespace Stride.Graphics
         /// <inheritdoc/>
         protected internal virtual void OnDestroyed()
         {
+            Destroyed?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsResourceBase.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsResourceBase.Vulkan.cs
@@ -24,6 +24,7 @@ namespace Stride.Graphics
         /// </summary>
         protected internal virtual void OnDestroyed()
         {
+            Destroyed?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows clients to get notified when the internal resource gets destroyed.

## Motivation and Context

We're using `WGL_NV_interop` to register handles for a texture. These handles need to be unregistered in case the internal texture gets destroyed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.