### PR TITLE
[Engine] Fixed regression that the camera processor wouldn't find the camera slot anymore

### DIFF
--- a/sources/engine/Stride.Engine/Engine/SceneSystem.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneSystem.cs
@@ -208,9 +208,13 @@ namespace Stride.Engine
             // Update the entities at draw time.
             renderContext.Time = gameTime;
 
-            // Execute Draw step of SceneInstance
-            // This will run entity processors
-            SceneInstance?.Draw(renderContext);
+            // The camera processor needs the graphics compositor
+            using (renderContext.PushTagAndRestore(GraphicsCompositor.Current, GraphicsCompositor))
+            {
+                // Execute Draw step of SceneInstance
+                // This will run entity processors
+                SceneInstance?.Draw(renderContext);
+            }
 
             // Render phase
             // TODO GRAPHICS REFACTOR


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

The graphics compositor needs to be set in the `RenderContext` before calling `Draw` on the entity processors.

## Related Issue

#825 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.