### PR TITLE
Bugfix EffectSystem not using baseClass when accessing graphicsDevice

### DIFF
--- a/sources/engine/Stride.Games/GameSystemBase.cs
+++ b/sources/engine/Stride.Games/GameSystemBase.cs
@@ -137,7 +137,7 @@ namespace Stride.Games
         {
         }
 
-        private void InitGraphicsDeviceService()
+        protected void InitGraphicsDeviceService()
         {
             if (graphicsDeviceService == null)
             {

--- a/sources/engine/Stride.Rendering/Rendering/EffectSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/EffectSystem.cs
@@ -25,7 +25,6 @@ namespace Stride.Rendering
 
         private EffectCompilerParameters effectCompilerParameters = EffectCompilerParameters.Default;
 
-        private IGraphicsDeviceService graphicsDeviceService;
         private EffectCompilerBase compiler;
         private readonly Dictionary<string, List<CompilerResults>> earlyCompilerCache = new Dictionary<string, List<CompilerResults>>();
         private Dictionary<EffectBytecode, Effect> cachedEffects = new Dictionary<EffectBytecode, Effect>();
@@ -64,10 +63,9 @@ namespace Stride.Rendering
         {
             base.Initialize();
 
-            isInitialized = true;
 
             // Get graphics device service
-            graphicsDeviceService = Services.GetSafeServiceAs<IGraphicsDeviceService>();
+            base.InitGraphicsDeviceService();
 
 #if STRIDE_PLATFORM_WINDOWS_DESKTOP
             Enabled = true;
@@ -75,6 +73,8 @@ namespace Stride.Rendering
             directoryWatcher.Modified += FileModifiedEvent;
             // TODO: sdfx too
 #endif
+
+            isInitialized = true;
         }
 
         public void SetCompilationMode(CompilationMode compilationMode)
@@ -210,7 +210,7 @@ namespace Stride.Rendering
 
                 if (!cachedEffects.TryGetValue(bytecode, out effect))
                 {
-                    effect = new Effect(graphicsDeviceService.GraphicsDevice, bytecode) { Name = effectName };
+                    effect = new Effect(GraphicsDevice, bytecode) { Name = effectName };
                     cachedEffects.Add(bytecode, effect);
 
 #if STRIDE_PLATFORM_WINDOWS_DESKTOP


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

removed grahpicsDeviceSerive from EffectSystem (which overwrites the one of baseClass)

<!--- Describe your changes in detail -->
i also made gamesystemBase.InitGraphicdevice protected (from private) to so effectSystem
can init it.
i did it that way becaue didnt want to put the init in the baseclass since i dont know the impact.
but it would be better to do there.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
this crashed with isNullException:GraphicsDevice (in an code only environment)
Effect eff = Game.EffectSystem.LoadEffect("PositionVColorShader").WaitForResult();

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.