### PR TITLE
[Rendering] Disabled alpha-to-coverage for Blend and Additive transparency

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/MaterialPass.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MaterialPass.cs
@@ -60,6 +60,11 @@ namespace Stride.Rendering
         public bool HasTransparency { get; set; }
 
         /// <summary>
+        /// Whether or not to use the alpha-to-coverage multisampling technique.
+        /// </summary>
+        public bool? AlphaToCoverage { get; set; }
+
+        /// <summary>
         /// Determines if this material is affected by lighting.
         /// </summary>
         /// <value><c>true</c> if this instance affects lighting; otherwise, <c>false</c>.</value>

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialTransparencyAdditiveFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialTransparencyAdditiveFeature.cs
@@ -62,6 +62,8 @@ namespace Stride.Rendering.Materials
             if (context.MaterialPass.BlendState == null)
                 context.MaterialPass.BlendState = BlendStates.AlphaBlend;
             context.MaterialPass.HasTransparency = true;
+            // Disable alpha-to-coverage. We wanna do alpha blending, not alpha testing.
+            context.MaterialPass.AlphaToCoverage = false;
             // TODO GRAPHICS REFACTOR
             //context.Parameters.SetResourceSlow(Effect.BlendStateKey, BlendState.NewFake(blendDesc));
 

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialTransparencyBlendFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialTransparencyBlendFeature.cs
@@ -63,6 +63,8 @@ namespace Stride.Rendering.Materials
             if (context.MaterialPass.BlendState == null)
                 context.MaterialPass.BlendState = BlendStates.AlphaBlend;
             context.MaterialPass.HasTransparency = true;
+            // Disable alpha-to-coverage. We wanna do alpha blending, not alpha testing.
+            context.MaterialPass.AlphaToCoverage = false;
             // TODO GRAPHICS REFACTOR
             //context.Parameters.SetResourceSlow(Effect.BlendStateKey, BlendState.NewFake(blendDesc));
 

--- a/sources/engine/Stride.Rendering/Rendering/MeshPipelineProcessor.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshPipelineProcessor.cs
@@ -23,7 +23,7 @@ namespace Stride.Rendering
                 pipelineState.BlendState = renderMesh.MaterialPass.BlendState ?? BlendStates.AlphaBlend;
                 pipelineState.DepthStencilState = DepthStencilStates.DepthRead;
                 if (isMultisample)
-                    pipelineState.BlendState.AlphaToCoverageEnable = true;
+                    pipelineState.BlendState.AlphaToCoverageEnable = renderMesh.MaterialPass.AlphaToCoverage ?? true;
             }
 
             var cullMode = pipelineState.RasterizerState.CullMode;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a flag to the material pass to explicitly control the enabled state of the alpha-to-coverage multisample technique. It needs to be disabled for the Blend and Additive transparency features as it uses the alpha channel for alpha testing and not blending.

## Related Issue

#835 

## Motivation and Context

Alpha blending works like expected when MSAA is on.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.