### PR TITLE
[Rendering] Fixed null pointer in ImageEffectShader in case no input texture is set on a slot

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Images/ImageEffectShader.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/ImageEffectShader.cs
@@ -117,10 +117,11 @@ namespace Stride.Rendering.Images
                 var texture = GetInput(i);
                 if (i < TexturingKeys.DefaultTextures.Count)
                 {
-                    var texturingKeys = texture.ViewDimension == TextureDimension.TextureCube ? TexturingKeys.TextureCubes : TexturingKeys.DefaultTextures;
+                    var texturingKeys = texture != null && texture.ViewDimension == TextureDimension.TextureCube ? TexturingKeys.TextureCubes : TexturingKeys.DefaultTextures;
+                    var texelSize = texture != null ? new Vector2(1.0f / texture.ViewWidth, 1.0f / texture.ViewHeight) : default;
                     // TODO GRAPHICS REFACTOR Do not use slow version
                     Parameters.Set(texturingKeys[i], texture);
-                    Parameters.Set(TexturingKeys.TexturesTexelSize[i], new Vector2(1.0f / texture.ViewWidth, 1.0f / texture.ViewHeight));
+                    Parameters.Set(TexturingKeys.TexturesTexelSize[i], texelSize);
                 }
                 else
                 {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed null pointer in ImageEffectShader in case no input texture is set on a slot.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.