### PR TITLE
[Rendering] Pass the graphics device down to the shader generator context

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Material.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Material.cs
@@ -49,7 +49,7 @@ namespace Stride.Rendering
         public static Material New(GraphicsDevice device, MaterialDescriptor descriptor)
         {
             if (descriptor == null) throw new ArgumentNullException("descriptor");
-            var context = new MaterialGeneratorContext(new Material())
+            var context = new MaterialGeneratorContext(new Material(), device)
             {
                 GraphicsProfile = device.Features.RequestedProfile,
             };

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialGeneratorContext.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialGeneratorContext.cs
@@ -48,7 +48,8 @@ namespace Stride.Rendering.Materials
         /// Initializes a new instance of <see cref="MaterialGeneratorContext"/>.
         /// </summary>
         /// <param name="material"></param>
-        public MaterialGeneratorContext(Material material = null)
+        public MaterialGeneratorContext(Material material = null, GraphicsDevice graphicsDevice = null)
+            : base(graphicsDevice)
         {
             this.Material = material ?? new Material();
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

When creating materials at runtime it's important that the graphics device gets passed down to the `ShaderGeneratorContext` or otherwise the sampler states do not work.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.