### PR TITLE
CameraComponent now can be updated by ignorant third party...

### DIFF
--- a/sources/engine/Stride.Engine/Engine/CameraComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/CameraComponent.cs
@@ -218,8 +218,7 @@ namespace Stride.Engine
             // A helper visualizing the state of the camera will not change it's state.
             if (UseCustomAspectRatio)
                 ActuallyUsedAspectRatio = AspectRatio;
-            else
-            if (screenAspectRatio.HasValue)
+            else if (screenAspectRatio.HasValue)
                 ActuallyUsedAspectRatio = screenAspectRatio.Value;
 
             // Calculates the View

--- a/sources/engine/Stride.Engine/Engine/CameraComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/CameraComponent.cs
@@ -129,15 +129,25 @@ namespace Stride.Engine
         public bool UseCustomAspectRatio { get; set; }
 
         /// <summary>
-        /// Gets or sets the aspect ratio.
+        /// Gets or sets the custom aspect ratio.
         /// </summary>
         /// <value>
-        /// The aspect ratio.
+        /// The custom aspect ratio.
         /// </value>
         /// <userdoc>The aspect ratio for the camera (when the Custom aspect ratio option is selected)</userdoc>
         [DataMember(40)]
         [DefaultValue(DefaultAspectRatio)]
-        public float AspectRatio { get; set; }
+        public float AspectRatio { get; set; }  // TODO: this should be called CustomAspectRatio
+
+        /// <summary>
+        /// Gets the last used aspect ratio.
+        /// </summary>        
+        /// <remarks>
+        /// This value is updated when calling <see cref="Update"/>. 
+        /// It either holds the aspect ratio of the window that called Update or the manually set aspect ratio <see cref="AspectRatio"/> if <see cref="UseCustomAspectRatio"/> is <c>true</c>.
+        /// </remarks>
+        [DataMemberIgnore]
+        public float ActuallyUsedAspectRatio { get; private set; } = 1; // TODO: this should be called AspectRatio
 
         /// <userdoc>The camera slot used in the graphics compositor)</userdoc>
         [DataMember(50)]
@@ -203,8 +213,14 @@ namespace Stride.Engine
         /// <param name="screenAspectRatio">The current screen aspect ratio. If null, use the <see cref="AspectRatio"/> even if <see cref="UseCustomAspectRatio"/> is false.</param>
         public void Update(float? screenAspectRatio)
         {
-            // Calculates the aspect ratio
-            var aspectRatio = (screenAspectRatio.HasValue && !UseCustomAspectRatio) ? screenAspectRatio.Value : AspectRatio;
+            // Calculates the aspect ratio. We only set a new aspect ratio when instructed to. Don't fall back on the custom value, if not instructed to.
+            // By caching the actually used aspect ratio we are now free to call Update(null) at any time. 
+            // A helper visualizing the state of the camera will not change it's state.
+            if (UseCustomAspectRatio)
+                ActuallyUsedAspectRatio = AspectRatio;
+            else
+            if (screenAspectRatio.HasValue)
+                ActuallyUsedAspectRatio = screenAspectRatio.Value;
 
             // Calculates the View
             if (!UseCustomViewMatrix)
@@ -228,10 +244,10 @@ namespace Stride.Engine
             // TODO: Should we throw an error if Projection is not set?
             if (!UseCustomProjectionMatrix)
             {
-                // Calculates the aspect ratio
+                // Calculates the projection matrix
                 ProjectionMatrix = Projection == CameraProjectionMode.Perspective ?
-                    Matrix.PerspectiveFovRH(MathUtil.DegreesToRadians(VerticalFieldOfView), aspectRatio, NearClipPlane, FarClipPlane) :
-                    Matrix.OrthoRH(aspectRatio * OrthographicSize, OrthographicSize, NearClipPlane, FarClipPlane);
+                    Matrix.PerspectiveFovRH(MathUtil.DegreesToRadians(VerticalFieldOfView), ActuallyUsedAspectRatio, NearClipPlane, FarClipPlane) :
+                    Matrix.OrthoRH(ActuallyUsedAspectRatio * OrthographicSize, OrthographicSize, NearClipPlane, FarClipPlane);
             }
 
             // Update ViewProjectionMatrix


### PR DESCRIPTION
... without any harm.

Calling `Update(null)` had the effect that the Custom Aspect Ratio stored in property `AspectRatio` was used, even if `UseCustomAspectRatio` was turned off.

Calling `Update(null)` now will just use the last fed Aspect Ratio.

A helper visualizing the frustum can now just call `Update(null)` without any side effect and visualize the actual frustum with the actually used aspect ratio.

# PR Details

The change shouldn't be problematic, because the `CameraProcessor` was checking 
for the flag `UseCustomAspectRatio` and only called `Update(null)` when true. The behavior in this case will be the same.

## Description

Added a cache for the last used Aspect Ratio.

## Motivation and Context

We now can Update a currently unused Camera and visualize it from another perspective without falling back to the custom aspect ratio that actually isn't used by the `SceneCameraRenderer` when `UseCustomAspectRatio` is turned off (which is the default). 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.