### PR TITLE
[Engine] Small fix for time warp

### DIFF
--- a/sources/engine/Stride.Games/GameBase.cs
+++ b/sources/engine/Stride.Games/GameBase.cs
@@ -593,7 +593,7 @@ namespace Stride.Games
 
         /// <summary>
         /// Call this method within your overriden <see cref="RawTickProducer"/> to update and draw the game yourself. <br/>
-        /// As this version is manual, there are a lot of functionallity purposefully skipped: <br/>
+        /// As this version is manual, there are a lot of functionality purposefully skipped: <br/>
         /// clamping elapsed time to a maximum, skipping drawing when the window is minimized, <see cref="ResetElapsedTime"/>, <see cref="SuppressDraw"/>, <see cref="IsFixedTimeStep"/>, <br/>
         /// <see cref="IsDrawDesynchronized"/>, <see cref="MinimizedMinimumUpdateRate"/> / <see cref="WindowMinimumUpdateRate"/> / <see cref="TreatNotFocusedLikeMinimized"/>.
         /// </summary>
@@ -607,8 +607,8 @@ namespace Stride.Games
         /// <param name="drawInterpolationFactor">
         /// See <see cref="DrawInterpolationFactor"/>
         /// </param>
-        /// <param name="skipDrawFrame">
-        /// Do not draw for this tick.
+        /// <param name="drawFrame">
+        /// Draw a frame.
         /// </param>
         protected void RawTick(TimeSpan elapsedTimePerUpdate, int updateCount = 1, float drawInterpolationFactor = 0, bool drawFrame = true)
         {
@@ -632,6 +632,7 @@ namespace Stride.Games
                 if (drawFrame && !IsExiting && GameSystems.IsFirstUpdateDone)
                 {
                     DrawInterpolationFactor = drawInterpolationFactor;
+                    DrawTime.Factor = UpdateTime.Factor;
                     DrawTime.Update(DrawTime.Total + totalElapsedTime, totalElapsedTime, true);
 
                     var profilingDraw = Profiler.Begin(GameProfilingKeys.GameDrawFPS);

--- a/sources/engine/Stride.Games/GameTime.cs
+++ b/sources/engine/Stride.Games/GameTime.cs
@@ -103,10 +103,7 @@ namespace Stride.Games
         /// Gets the amount of time elapsed multiplied by the time factor.
         /// </summary>
         /// <value>The warped elapsed time</value>
-        public TimeSpan WarpElapsed 
-        {
-            get => TimeSpan.FromTicks((long)(Elapsed.Ticks * Factor));
-        }
+        public TimeSpan WarpElapsed { get; private set; }
 
 
         /// <summary>
@@ -125,7 +122,8 @@ namespace Stride.Games
         internal void Update(TimeSpan totalGameTime, TimeSpan elapsedGameTime, bool incrementFrameCount)
         {
             Total = totalGameTime;
-            Elapsed = elapsedGameTime;            
+            Elapsed = elapsedGameTime;
+            WarpElapsed = TimeSpan.FromTicks((long)(Elapsed.Ticks * Factor));
 
             FramePerSecondUpdated = false;
 


### PR DESCRIPTION
# PR Details
I mentioned on the previous PR regarding this topic (#785) that I would look at merging UpdateTime and DrawTime together into a single 'Time' class, it's actually not a good idea to do so for a whole lot of reasons.
So instead of that I'll just fix DrawTime to UpdateTime's factor, see #785 for why that's important. Also, factor should only affect elapsed time after the frame/update is processed otherwise you might have 'one half of the frame' in real time and the other in slow mo when that variable is modified in the middle of its execution.

## Description
See above

## Related Issue
None

## Motivation and Context
See PR details

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.