### PR TITLE
Explicitly pass database to effect compiler

### DIFF
--- a/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
+++ b/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
@@ -142,7 +142,7 @@ namespace Stride.Assets.Effect
                     // Create compiler
                     var effectCompiler = new EffectCompiler(MicrothreadLocalDatabases.DatabaseFileProvider);
                     effectCompiler.SourceDirectories.Add(EffectCompilerBase.DefaultSourceShaderFolder);
-                    compiler = new EffectCompilerCache(effectCompiler) { CurrentCache = EffectBytecodeCacheLoadSource.StartupCache };
+                    compiler = new EffectCompilerCache(effectCompiler, MicrothreadLocalDatabases.DatabaseFileProvider) { CurrentCache = EffectBytecodeCacheLoadSource.StartupCache };
                     context.Properties.Set(CompilerKey, compiler);
 
                     var shaderLocations = context.Properties.Get(EffectShaderAssetCompiler.ShaderLocationsKey);

--- a/sources/engine/Stride.Engine/Shaders.Compiler/EffectCompilerFactory.cs
+++ b/sources/engine/Stride.Engine/Shaders.Compiler/EffectCompilerFactory.cs
@@ -12,7 +12,14 @@ namespace Stride.Shaders.Compiler
 {
     public static class EffectCompilerFactory
     {
-        public static IEffectCompiler CreateEffectCompiler(IVirtualFileProvider fileProvider, EffectSystem effectSystem = null, string packageName = null, EffectCompilationMode effectCompilationMode = EffectCompilationMode.Local, bool recordEffectRequested = false, TaskSchedulerSelector taskSchedulerSelector = null)
+        public static IEffectCompiler CreateEffectCompiler(
+            IVirtualFileProvider fileProvider, 
+            EffectSystem effectSystem = null, 
+            string packageName = null, 
+            EffectCompilationMode effectCompilationMode = EffectCompilationMode.Local, 
+            bool recordEffectRequested = false, 
+            TaskSchedulerSelector taskSchedulerSelector = null,
+            DatabaseFileProvider database = null)
         {
             EffectCompilerBase compiler = null;
 
@@ -24,6 +31,9 @@ namespace Stride.Shaders.Compiler
                     SourceDirectories = { EffectCompilerBase.DefaultSourceShaderFolder },
                 };
             }
+
+            // Select database - needed for caching
+            var selectedDatabase = database ?? fileProvider as DatabaseFileProvider;
 
             // Nothing to do remotely
             bool needRemoteCompiler = (compiler == null && (effectCompilationMode & EffectCompilationMode.Remote) != 0);
@@ -42,7 +52,7 @@ namespace Stride.Shaders.Compiler
                 if (needRemoteCompiler)
                 {
                     // Create a remote compiler
-                    compiler = new RemoteEffectCompiler(fileProvider, shaderCompilerTarget);
+                    compiler = new RemoteEffectCompiler(fileProvider, selectedDatabase, shaderCompilerTarget);
                 }
                 else
                 {
@@ -54,10 +64,10 @@ namespace Stride.Shaders.Compiler
             // Local not possible or allowed, and remote not allowed either => switch back to null compiler
             if (compiler == null)
             {
-                compiler = new NullEffectCompiler(fileProvider);
+                compiler = new NullEffectCompiler(fileProvider, selectedDatabase);
             }
 
-            return new EffectCompilerCache(compiler, taskSchedulerSelector);
+            return new EffectCompilerCache(compiler, selectedDatabase, taskSchedulerSelector);
         }
     }
 }

--- a/sources/engine/Stride.Engine/Shaders.Compiler/RemoteEffectCompiler.cs
+++ b/sources/engine/Stride.Engine/Shaders.Compiler/RemoteEffectCompiler.cs
@@ -17,14 +17,16 @@ namespace Stride.Shaders.Compiler
     /// </summary>
     internal class RemoteEffectCompiler : EffectCompilerBase
     {
-        private RemoteEffectCompilerClient remoteEffectCompilerClient;
+        private readonly DatabaseFileProvider database;
+        private readonly RemoteEffectCompilerClient remoteEffectCompilerClient;
 
         /// <inheritdoc/>
         public override IVirtualFileProvider FileProvider { get; set; }
 
-        public RemoteEffectCompiler(IVirtualFileProvider fileProvider, RemoteEffectCompilerClient remoteEffectCompilerClient)
+        public RemoteEffectCompiler(IVirtualFileProvider fileProvider, DatabaseFileProvider database, RemoteEffectCompilerClient remoteEffectCompilerClient)
         {
             FileProvider = fileProvider;
+            this.database = database;
             this.remoteEffectCompilerClient = remoteEffectCompilerClient;
         }
 
@@ -39,7 +41,7 @@ namespace Stride.Shaders.Compiler
         public override ObjectId GetShaderSourceHash(string type)
         {
             var url = GetStoragePathFromShaderType(type);
-            ((DatabaseFileProvider)FileProvider).ContentIndexMap.TryGetValue(url, out var shaderSourceId);
+            database.ContentIndexMap.TryGetValue(url, out var shaderSourceId);
             return shaderSourceId;
         }
 

--- a/sources/engine/Stride.Rendering/Rendering/EffectSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/EffectSystem.cs
@@ -217,11 +217,15 @@ namespace Stride.Rendering
                     foreach (var type in bytecode.HashSources.Keys)
                     {
                         // TODO: the "/path" is hardcoded, used in ImportStreamCommand and ShaderSourceManager. Find a place to share this correctly.
-                        using (var pathStream = FileProvider.OpenStream(EffectCompilerBase.GetStoragePathFromShaderType(type) + "/path", VirtualFileMode.Open, VirtualFileAccess.Read))
-                        using (var reader = new StreamReader(pathStream))
+                        var pathUrl = EffectCompilerBase.GetStoragePathFromShaderType(type) + "/path";
+                        if (FileProvider.FileExists(pathUrl))
                         {
-                            var path = reader.ReadToEnd();
-                            directoryWatcher.Track(path);
+                            using (var pathStream = FileProvider.OpenStream(pathUrl, VirtualFileMode.Open, VirtualFileAccess.Read))
+                            using (var reader = new StreamReader(pathStream))
+                            {
+                                var path = reader.ReadToEnd();
+                                directoryWatcher.Track(path);
+                            }
                         }
                     }
 #endif

--- a/sources/engine/Stride.Rendering/Rendering/EffectSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/EffectSystem.cs
@@ -216,17 +216,22 @@ namespace Stride.Rendering
 #if STRIDE_PLATFORM_WINDOWS_DESKTOP
                     foreach (var type in bytecode.HashSources.Keys)
                     {
-                        // TODO: the "/path" is hardcoded, used in ImportStreamCommand and ShaderSourceManager. Find a place to share this correctly.
-                        var pathUrl = EffectCompilerBase.GetStoragePathFromShaderType(type) + "/path";
-                        if (FileProvider.FileExists(pathUrl))
+                        var storagePath = EffectCompilerBase.GetStoragePathFromShaderType(type);
+                        if (!FileProvider.TryGetFileLocation(storagePath, out var filePath, out _, out _))
                         {
-                            using (var pathStream = FileProvider.OpenStream(pathUrl, VirtualFileMode.Open, VirtualFileAccess.Read))
-                            using (var reader = new StreamReader(pathStream))
+                            // TODO: the "/path" is hardcoded, used in ImportStreamCommand and ShaderSourceManager. Find a place to share this correctly.
+                            var pathUrl = storagePath + "/path";
+                            if (FileProvider.FileExists(pathUrl))
                             {
-                                var path = reader.ReadToEnd();
-                                directoryWatcher.Track(path);
-                            }
+                                using (var pathStream = FileProvider.OpenStream(pathUrl, VirtualFileMode.Open, VirtualFileAccess.Read))
+                                using (var reader = new StreamReader(pathStream))
+                                {
+                                    filePath = reader.ReadToEnd();
+                                }
+                            }                            
                         }
+                        if (filePath != null)
+                            directoryWatcher.Track(filePath);
                     }
 #endif
                 }

--- a/sources/engine/Stride.Shaders.Tests/TestMixinCompiler.cs
+++ b/sources/engine/Stride.Shaders.Tests/TestMixinCompiler.cs
@@ -223,7 +223,7 @@ namespace Stride.Shaders.Tests
 
                 var compiler = new EffectCompiler(database);
                 compiler.SourceDirectories.Add("assets/shaders");
-                var compilerCache = new EffectCompilerCache(compiler);
+                var compilerCache = new EffectCompilerCache(compiler, database);
 
                 var compilerParameters = new CompilerParameters { EffectParameters = { Platform = GraphicsPlatform.Direct3D11 } };
 

--- a/sources/engine/Stride.Shaders/Compiler/EffectCompilerCache.cs
+++ b/sources/engine/Stride.Shaders/Compiler/EffectCompilerCache.cs
@@ -32,6 +32,7 @@ namespace Stride.Shaders.Compiler
         private const string CompiledShadersKey = "__shaders_bytecode__";
 
         private readonly Dictionary<ObjectId, Task<EffectBytecodeCompilerResult>> compilingShaders = new Dictionary<ObjectId, Task<EffectBytecodeCompilerResult>>();
+        private readonly DatabaseFileProvider database;
         private readonly TaskSchedulerSelector taskSchedulerSelector;
 
         private int effectCompileCount;
@@ -43,9 +44,10 @@ namespace Stride.Shaders.Compiler
         /// </summary>
         public EffectBytecodeCacheLoadSource CurrentCache { get; set; } = EffectBytecodeCacheLoadSource.DynamicCache;
 
-        public EffectCompilerCache(EffectCompilerBase compiler, TaskSchedulerSelector taskSchedulerSelector = null) : base(compiler)
+        public EffectCompilerCache(EffectCompilerBase compiler, DatabaseFileProvider database, TaskSchedulerSelector taskSchedulerSelector = null) : base(compiler)
         {
             CompileEffectAsynchronously = true;
+            this.database = database ?? throw new ArgumentNullException(nameof(database), "Using the cache requires a database.");
             this.taskSchedulerSelector = taskSchedulerSelector;
         }
 
@@ -61,8 +63,6 @@ namespace Stride.Shaders.Compiler
 
         public override TaskOrResult<EffectBytecodeCompilerResult> Compile(ShaderMixinSource mixin, EffectCompilerParameters effectParameters, CompilerParameters compilerParameters)
         {
-            var database = FileProvider as DatabaseFileProvider ?? throw new NotSupportedException("Using the cache requires to ContentManager.FileProvider to be valid.");
-
             var usedParameters = compilerParameters;
             var mixinObjectId = ShaderMixinObjectId.Compute(mixin, usedParameters.EffectParameters);
 

--- a/sources/engine/Stride.Shaders/Compiler/NullEffectCompiler.cs
+++ b/sources/engine/Stride.Shaders/Compiler/NullEffectCompiler.cs
@@ -11,16 +11,19 @@ namespace Stride.Shaders.Compiler
 {
     public class NullEffectCompiler : EffectCompilerBase
     {
-        public NullEffectCompiler(IVirtualFileProvider fileProvider)
+        private readonly DatabaseFileProvider database;
+
+        public NullEffectCompiler(IVirtualFileProvider fileProvider, DatabaseFileProvider database)
         {
             FileProvider = fileProvider;
+            this.database = database;
         }
 
         public override ObjectId GetShaderSourceHash(string type)
         {
             var url = GetStoragePathFromShaderType(type);
             var shaderSourceId = ObjectId.Empty;
-            (FileProvider as DatabaseFileProvider)?.ContentIndexMap.TryGetValue(url, out shaderSourceId);
+            database?.ContentIndexMap.TryGetValue(url, out shaderSourceId);
             return shaderSourceId;
         }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

The effect compiler uses the virtual file provider to lookup shader source code and the database to cache compiled shaders. Allowing to pass both services explicitly (and not assuming they're implemented by the same instance) one can highly customize the shader source code lookup without affecting the caching mechanism.

## Motivation and Context

We need to be able to load shaders at runtime. These changes allow us to use a custom file provider for shader source code lookup.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.