### PR TITLE
[WIP] Workaround in ScrollingText to avoid endless loop

### DIFF
--- a/sources/engine/Stride.UI/Controls/ScrollingText.cs
+++ b/sources/engine/Stride.UI/Controls/ScrollingText.cs
@@ -168,6 +168,11 @@ namespace Stride.UI.Controls
         {
             if (string.IsNullOrEmpty(Text))
                 return;
+            // todo: better handling of while loop below,
+            // if for any reason CalculateTextToDisplayWidth() returns 0, its endlessLoop
+            // making entire gamestudio unresponsible
+            if (Font is null)
+                return;
 
             var elapsedSeconds = time != null ? (float)time.Elapsed.TotalSeconds : 0f;
 
@@ -190,6 +195,10 @@ namespace Stride.UI.Controls
                     nextLetterIndex = 0;
 
                 textToDisplayWidth += addedCharacterWidth;
+
+                // workaround to avoid endless loop
+                if (addedCharacterWidth <= 0.0f)
+                    break;
             }
 
             // Check if all the string has finished to scroll, if clear the message


### PR DESCRIPTION
# PR Details

Workaround in ScrollingText to avoid endless loop (when measuring text)

## Description
added bailout for while loop when measuredText = 0

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

gameStudio hangup when using scrollingtext

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.