### PR TITLE
[Editor] Don't skip first level directories for code assets

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/ProjectViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/ProjectViewModel.cs
@@ -109,7 +109,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             DirectoryBaseViewModel result = Code;
             if (!string.IsNullOrEmpty(projectDirectory))
             {
-                var directories = projectDirectory.Split(new[] { DirectoryBaseViewModel.Separator }, StringSplitOptions.RemoveEmptyEntries).Skip(1);
+                var directories = projectDirectory.Split(new[] { DirectoryBaseViewModel.Separator }, StringSplitOptions.RemoveEmptyEntries);
                 result = directories.Aggregate(result, (current, next) => current.SubDirectories.FirstOrDefault(x => x.Name == next) ?? new DirectoryViewModel(next, current, canUndoRedoCreation));
             }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

If you create folders to organize your code, all scripts are visible on the same level in the "Code" folder in GameStudio. That is because the first level folders are skipped in the viewmodel. This PR removes that skip, which means all this organized code is organized in GameStudio as well.

## Related Issue
#663 (I've written more details in the comment there)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.