### PR TITLE
[Rendering] Instancing: Changed Buffer<Matrix> to Buffer

### DIFF
--- a/sources/engine/Stride.Engine/Engine/InstancingUserBuffer.cs
+++ b/sources/engine/Stride.Engine/Engine/InstancingUserBuffer.cs
@@ -27,10 +27,10 @@ namespace Stride.Engine
         public virtual BoundingBox BoundingBox { get; set; } = BoundingBox.Empty;
 
         [DataMemberIgnore]
-        public Buffer<Matrix> InstanceWorldBuffer;
+        public Buffer InstanceWorldBuffer;
 
         [DataMemberIgnore]
-        public Buffer<Matrix> InstanceWorldInverseBuffer;
+        public Buffer InstanceWorldInverseBuffer;
 
         public void Update()
         {

--- a/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
@@ -21,8 +21,8 @@ namespace Stride.Rendering
 
         // GPU buffers
         public bool BuffersManagedByUser;
-        public Buffer<Matrix> InstanceWorldBuffer;
-        public Buffer<Matrix> InstanceWorldInverseBuffer;
+        public Buffer InstanceWorldBuffer;
+        public Buffer InstanceWorldInverseBuffer;
     }
 
     public class InstancingRenderFeature : SubRenderFeature

--- a/sources/engine/Stride.Rendering/Rendering/RenderInstancing.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RenderInstancing.cs
@@ -19,7 +19,7 @@ namespace Stride.Rendering
 
         // GPU buffers
         public bool BuffersManagedByUser;
-        public Buffer<Matrix> InstanceWorldBuffer;
-        public Buffer<Matrix> InstanceWorldInverseBuffer;
+        public Buffer InstanceWorldBuffer;
+        public Buffer InstanceWorldInverseBuffer;
     }
 }


### PR DESCRIPTION
This constraint was restricting the user buffer setup

(cherry picked from commit 78e74a7fa5576f2f6efe178b31ee5a27ef14e083)

# PR Details

Minor fix to allow more buffer types.

## Related Issue

PR #340 

## Motivation and Context

Providing matrix buffers with compute shaders.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.