### PR TITLE
[Profiling] Disable unfocused throttling when profiling

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -50,6 +50,7 @@ namespace Stride.Profiling
         private Color4 textColor = Color.LightGreen;
 
         private PresentInterval userPresentInterval = PresentInterval.Default;
+        private bool userMinimizedState = true;
 
         private int lastFrame = -1;
 
@@ -411,6 +412,12 @@ namespace Stride.Profiling
             Enabled = true;
             Visible = true;
 
+            if (Game != null)
+            {
+                userMinimizedState = Game.TreatNotFocusedLikeMinimized;
+                Game.TreatNotFocusedLikeMinimized = false;
+            }
+
             // Backup current PresentInterval state
             userPresentInterval = GraphicsDevice.Presenter.PresentInterval;
 
@@ -454,6 +461,8 @@ namespace Stride.Profiling
             // Restore previous PresentInterval state
             GraphicsDevice.Presenter.PresentInterval = userPresentInterval;
             userPresentInterval = PresentInterval.Default;
+            if (Game != null)
+                Game.TreatNotFocusedLikeMinimized = userMinimizedState;
 
             Profiler.DisableAll();
             gcProfiler.Disable();


### PR DESCRIPTION
# PR Details
Small change to avoid throttling while the game is being profiled, similar to what we do with vsync in such cases.

## Description
See above and title.

## Related Issue
None

## Motivation and Context
See PR Details.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.