### PR TITLE
[Editor] Fixed null pointer on startup introduced by 5946194cf738

### DIFF
--- a/sources/editor/Stride.Editor/EditorGame/Game/EditorServiceGame.cs
+++ b/sources/editor/Stride.Editor/EditorGame/Game/EditorServiceGame.cs
@@ -145,6 +145,9 @@ namespace Stride.Editor.EditorGame.Game
         /// <inheritdoc />
         protected override void Initialize()
         {
+            // Database is needed by effect compiler cache
+            MicrothreadLocalDatabases.MountCommonDatabase();
+
             base.Initialize();
 
             // TODO: the physics system should not be registered by default here!


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

My changes in 5946194cf738 caused the preview game to crash on startup. I guess it worked before because the effect compiler created in `Game.Initialize` was replaced with another one after initialization, see `PreviewGame.Initialize` and `EntityHierarchyEditorGame.Initialize`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.