### PR TITLE
[Rendering] Instancing: Skip effect validation

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
@@ -121,10 +121,14 @@ namespace Stride.Rendering
                     var staticEffectObjectNode = staticObjectNode * effectSlotCount + i;
                     var renderEffect = renderEffects[staticEffectObjectNode];
 
-                    if (renderEffect != null)
+                    // Skip effects not used during this frame
+                    if (renderEffect == null || !renderEffect.IsUsedDuringThisFrame(RenderSystem))
+                        continue;
+
+                    if (instancingData.InstanceCount > 0)
                     {
                         renderEffect.EffectValidator.ValidateParameter(StrideEffectBaseKeys.ModelTransformUsage, instancingData.ModelTransformUsage);
-                        renderEffect.EffectValidator.ValidateParameter(StrideEffectBaseKeys.HasInstancing, instancingData.InstanceCount > 0);
+                        renderEffect.EffectValidator.ValidateParameter(StrideEffectBaseKeys.HasInstancing, instancingData.InstanceCount > 0); 
                     }
                 }
             });


### PR DESCRIPTION
 If instancing count <= 0

# PR Details

Memory leak bug fix.

## Description

The effect validation doesn't run if instancing count is <= 0. This fixes the bug, but I am not sure whether this is the correct way of doing it.

Questions:

* Does this work if an effect has instancing and then the instancing component is removed?
* Is there a way to not even create the `InstancingData` and also don't run the `InstancingRenderFeature` for a mesh, if no `InstancingComponent` is attached? Here is also the question of whether it works if an effect has instancing and in the next frame not anymore.

## Related Issue

#851 

## Motivation and Context

Reported memory leak

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)