### PR TITLE
Remove <RestorePackages> from project files to improve build time

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
+++ b/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
@@ -9,7 +9,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/sources/assets/Stride.Core.Assets/Stride.Core.Assets.csproj
+++ b/sources/assets/Stride.Core.Assets/Stride.Core.Assets.csproj
@@ -9,7 +9,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -10,7 +10,6 @@
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">

--- a/sources/core/Stride.Core.Reflection/Stride.Core.Reflection.csproj
+++ b/sources/core/Stride.Core.Reflection/Stride.Core.Reflection.csproj
@@ -9,7 +9,6 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="..\..\targets\Stride.Core.props" />
   <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
   <PropertyGroup>
@@ -11,7 +11,6 @@
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideOutputPath>bin\$(Configuration)\</StrideOutputPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/sources/core/Stride.Core.Translation/Stride.Core.Translation.csproj
+++ b/sources/core/Stride.Core.Translation/Stride.Core.Translation.csproj
@@ -10,7 +10,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Stride.GNU.Gettext" Version="1.0.0.0" />

--- a/sources/core/Stride.Core/Stride.Core.csproj
+++ b/sources/core/Stride.Core/Stride.Core.csproj
@@ -16,7 +16,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StrideBuildTags>*</StrideBuildTags>
-    <RestorePackages>true</RestorePackages>
     <ExtrasUwpMetaPackageVersion>6.2.2</ExtrasUwpMetaPackageVersion>
   </PropertyGroup>
   

--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
@@ -11,7 +11,6 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization --parameter-key</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWPF>true</UseWPF>
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
     <StrideRoslynPadTargetFramework Condition="$(TargetFramework.StartsWith('net4'))">net462</StrideRoslynPadTargetFramework>

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="..\Stride.PrivacyPolicy\Stride.PrivacyPolicy.projitems" Label="Shared" Condition="Exists('..\Stride.PrivacyPolicy\Stride.PrivacyPolicy.projitems')" />
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="..\..\tools\Stride.Core.VisualStudio\Stride.Core.VisualStudio.projitems" Label="Shared" />
@@ -14,7 +14,6 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <AssemblyName>Stride.GameStudio</AssemblyName>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>

--- a/sources/engine/Stride.Assets/Stride.Assets.csproj
+++ b/sources/engine/Stride.Assets/Stride.Assets.csproj
@@ -8,7 +8,6 @@
     <StrideAssemblyProcessorOptions>$(StrideAssemblyProcessorDefaultOptions)</StrideAssemblyProcessorOptions>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition="('$(StridePlatform)' == 'Windows') and ('$(StrideNETRuntime)' != 'CoreCLR')">
     <DefineConstants>STRIDE_VIDEO_FFMPEG;$(DefineConstants)</DefineConstants>

--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -14,7 +14,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>$(StrideAssemblyProcessorDefaultOptions)</StrideAssemblyProcessorOptions>
     <StrideBuildTags>*</StrideBuildTags>
-    <RestorePackages>true</RestorePackages>
     <RootNamespace>Stride</RootNamespace>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
     <StridePackAssets>true</StridePackAssets>

--- a/sources/presentation/Stride.Core.Presentation.Graph/Stride.Core.Presentation.Graph.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Graph/Stride.Core.Presentation.Graph.csproj
@@ -9,7 +9,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWPF>true</UseWPF>
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>

--- a/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <Import Project="..\..\targets\Stride.Core.props" />
   <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
@@ -10,7 +10,6 @@
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StrideLocalized>true</StrideLocalized>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWPF>true</UseWPF>
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>

--- a/sources/presentation/Stride.Core.Translation.Presentation/Stride.Core.Translation.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Translation.Presentation/Stride.Core.Translation.Presentation.csproj
@@ -10,7 +10,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>

--- a/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
+++ b/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
@@ -11,7 +11,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes `<RestorePackages>true</RestorePackages>` from all project files. I believe it is the reason why the projects are rebuilt everytime - Stride.Core.Tasks among others did a force restore which touched its `project.assets.json` and forced all dependants to recompile as well.

The removed tag is from an older version of MSBuild that didn't do automatic NuGet restores (see [link](https://docs.microsoft.com/pl-pl/nuget/consume-packages/package-restore)).

**Please verify that my observations are reproduced.**

## Related Issue

N/A (we talked about it on Discord ([msg](https://discordapp.com/channels/500285081265635328/500290856532574209/743858738561155093)))

## Motivation and Context

Well, after the change I don't have to wait 3 minutes to start GameStudio (event without any changes), but more like 20 seconds.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.