### PR TITLE
Couple of fixes to the shader compiler

### DIFF
--- a/sources/engine/Stride.Shaders.Parser/Mixins/ShaderCompilationContext.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/ShaderCompilationContext.cs
@@ -107,6 +107,14 @@ namespace Stride.Shaders.Parser.Mixins
 
             lock (AnalysisLock)
             {
+                // reset error status of mixins so we get the same error messages for each compilation
+                foreach (var mixinInfo in mixinInfos)
+                {
+                    var mixin = mixinInfo.Mixin;
+                    if (mixin.DependenciesStatus == AnalysisStatus.Error || mixin.DependenciesStatus == AnalysisStatus.Cyclic)
+                        mixin.DependenciesStatus = AnalysisStatus.None;
+                }
+
                 foreach (var mixinInfo in mixinInfos)
                     BuildMixinDependencies(mixinInfo);
 

--- a/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
@@ -185,13 +185,12 @@ namespace Stride.Shaders.Parser.Mixins
             if (mixinInfo == null)
             {
                 mixinInfo = BuildMixinInfo(shaderSource, macros);
+                mixinInfo.MinimalContext.Add(mixinInfo);
 
                 if (mixinInfo.Instanciated)
                 {
                     MixinInfos.Add(mixinInfo);
-                    mapMacrosToMixins[macrosString].Add(mixinInfo);
-
-                    mixinInfo.MinimalContext.Add(mixinInfo);
+                    context.Add(mixinInfo);
 
                     if (!mixinInfo.Log.HasErrors)
                     {

--- a/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
@@ -196,7 +196,6 @@ namespace Stride.Shaders.Parser.Mixins
                     {
                         LoadNecessaryShaders(mixinInfo, macros, macrosString);
                     }
-                    mixinInfo.MinimalContext = new HashSet<ModuleMixinInfo>(mixinInfo.MinimalContext.Distinct());
                 }
             }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses two issues we ran into when loading a broken shader:
1) It was impossible to reload it due to some internal dependency not being tracked and therefor a cache not being invalidated by ResetCache calls.
2) The compiler result was not deterministic when invoked a second time - a mixin was marked with error flag but the result log had no error which lead to subsequent code paths crashing as they only checked the result log.

## Related Issue

https://github.com/vvvv/VL.Stride/issues/221

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.