### PR TITLE
Couple of fixes to shader compiler

### DIFF
--- a/sources/engine/Stride.Shaders.Parser/Mixins/ModuleMixinInfo.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/ModuleMixinInfo.cs
@@ -115,6 +115,11 @@ namespace Stride.Shaders.Parser.Mixins
         /// the list of all the necessary MixinInfos to compile the shader
         /// </summary>
         public HashSet<ModuleMixinInfo> MinimalContext = new HashSet<ModuleMixinInfo>();
+
+        /// <summary>
+        /// The referenced shaders. Used to invalidate shaders.
+        /// </summary>
+        public HashSet<string> ReferencedShaders = new HashSet<string>();
         
         #endregion
 

--- a/sources/engine/Stride.Shaders.Parser/Mixins/ShaderCompilationContext.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/ShaderCompilationContext.cs
@@ -107,6 +107,14 @@ namespace Stride.Shaders.Parser.Mixins
 
             lock (AnalysisLock)
             {
+                // reset error status of mixins so we get the same error messages for each compilation
+                foreach (var mixinInfo in mixinInfos)
+                {
+                    var mixin = mixinInfo.Mixin;
+                    if (mixin.DependenciesStatus == AnalysisStatus.Error || mixin.DependenciesStatus == AnalysisStatus.Cyclic)
+                        mixin.DependenciesStatus = AnalysisStatus.None;
+                }
+
                 foreach (var mixinInfo in mixinInfos)
                     BuildMixinDependencies(mixinInfo);
 

--- a/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
@@ -197,7 +197,6 @@ namespace Stride.Shaders.Parser.Mixins
                     {
                         LoadNecessaryShaders(mixinInfo, macros, macrosString);
                     }
-                    mixinInfo.MinimalContext = new HashSet<ModuleMixinInfo>(mixinInfo.MinimalContext.Distinct());
                 }
             }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses two issues we ran into when loading a broken shader:
1) It was impossible to reload it due to some internal dependency not being tracked and therefor a cache not being invalidated by ResetCache calls. I added a `ReferencedShaders` property to keep track of them independent of the `MinimalContext` logic - using that one caused a weired behavior in my previous PR.
2) The compiler result was not deterministic when invoked a second time - a mixin was marked with error flag but the result log had no error which lead to subsequent code paths crashing as they only checked the result log.

## Related Issue

https://github.com/vvvv/VL.Stride/issues/221

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.