### PR TITLE
[Shader] Expose point+spot attenuation and fix celshading

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Lights/DirectLightGroup.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/DirectLightGroup.sdsl
@@ -47,7 +47,7 @@ namespace Stride.Rendering.Lights
             streams.shadowColor = ComputeShadow(streams.PositionWS.xyz, lightIndex);
 
             // Compute the final color with NdotL
-            streams.lightColorNdotL = streams.lightColor * streams.shadowColor * streams.NdotL * streams.lightDirectAmbientOcclusion;
+            streams.lightColorNdotL = streams.lightColor * streams.lightAttenuation * streams.shadowColor * streams.NdotL * streams.lightDirectAmbientOcclusion;
             streams.lightSpecularColorNdotL = streams.lightColorNdotL;
 
             // Mask the light by the color of the projected texture:

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightPoint.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightPoint.sdsl
@@ -30,6 +30,7 @@ namespace Stride.Rendering.Lights
 
             streams.lightPositionWS = light.PositionWS;
             streams.lightColor = light.Color * attenuation;
+            streams.lightAttenuation = attenuation;
             streams.lightDirectionWS = lightVectorNorm;
         }
 

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightPoint.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightPoint.sdsl
@@ -29,7 +29,7 @@ namespace Stride.Rendering.Lights
             float attenuation = ComputeAttenuation(light, streams.PositionWS.xyz, lightVectorNorm);
 
             streams.lightPositionWS = light.PositionWS;
-            streams.lightColor = light.Color * attenuation;
+            streams.lightColor = light.Color;
             streams.lightAttenuation = attenuation;
             streams.lightDirectionWS = lightVectorNorm;
         }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSpot.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSpot.sdsl
@@ -30,6 +30,7 @@ namespace Stride.Rendering.Lights
                                                    streams.PositionWS.xyz, lightVectorNorm);
 
             streams.lightColor = light.Color * attenuation;
+            streams.lightAttenuation = attenuation;
             streams.lightDirectionWS = lightVectorNorm;
         }
     };

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSpot.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSpot.sdsl
@@ -29,7 +29,7 @@ namespace Stride.Rendering.Lights
                                                    light.DirectionWS,
                                                    streams.PositionWS.xyz, lightVectorNorm);
 
-            streams.lightColor = light.Color * attenuation;
+            streams.lightColor = light.Color;
             streams.lightAttenuation = attenuation;
             streams.lightDirectionWS = lightVectorNorm;
         }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightStream.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightStream.sdsl
@@ -12,6 +12,7 @@ namespace Stride.Rendering.Lights
         stage stream float3 lightColor;
         stage stream float3 lightColorNdotL;
         stage stream float3 lightSpecularColorNdotL;
+        stage stream float lightAttenuation;
         stage stream float3 envLightDiffuseColor;
         stage stream float3 envLightSpecularColor;
 
@@ -27,6 +28,7 @@ namespace Stride.Rendering.Lights
             streams.lightColor = 0;
             streams.lightColorNdotL = 0;
             streams.lightSpecularColorNdotL = 0;
+            streams.lightAttenuation = 1.0f;
             streams.envLightDiffuseColor = 0;
             streams.envLightSpecularColor = 0;
             streams.lightDirectAmbientOcclusion = 1.0f;

--- a/sources/engine/Stride.Rendering/Rendering/Materials/CelShading/MaterialSurfaceShadingDiffuseCelShading.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/CelShading/MaterialSurfaceShadingDiffuseCelShading.sdsl
@@ -11,27 +11,18 @@ namespace Stride.Rendering.Materials
 
         override float3 ComputeDirectLightContribution()
         {
-            float oldLightColorNdotL = streams.lightColorNdotL;
-            float3 celLight = float3(1, 1, 1);
-
+            float3 celLight = streams.NdotL * streams.lightAttenuation;
+            
             if (FakeNDotL > 0)
             {
-                // Fake - this gradient depends on light intensity as well
-                //streams.lightColorNdotL = celLightFunction.Compute(streams.lightColorNdotL).rgb;
-				celLight = celLightFunction.Compute(streams.lightColorNdotL * FakeNDotL);
+				celLight = celLightFunction.Compute(celLight * FakeNDotL);
             }
             else
             {
-				// Correct
-				celLight = celLightFunction.Compute(streams.NdotL);          
+				celLight = celLightFunction.Compute(celLight);
             }
             
-            // Point and spotlight include attenuation in their lightColor, remove it and re-apply it based on light function
-            float3 lc = streams.lightAttenuation;
-            lc = lc == 0 ? 0 : streams.lightColor / lc;
-            lc *= celLightFunction.Compute(streams.lightAttenuation);
-            
-			streams.lightColorNdotL = lc * streams.shadowColor * streams.lightDirectAmbientOcclusion;      
+			float3 lighting = celLight * streams.lightColor * streams.shadowColor * streams.lightDirectAmbientOcclusion;      
 
             var diffuseColor = streams.matDiffuseVisible;
             if (TIsEnergyConservative)
@@ -40,10 +31,8 @@ namespace Stride.Rendering.Materials
                 diffuseColor *= (1 - streams.matSpecularVisible);
             }
 
-            float3 result =  diffuseColor / PI * streams.lightColorNdotL * streams.matDiffuseSpecularAlphaBlend.x;
-
-            streams.lightColorNdotL = oldLightColorNdotL;
-            return result * celLight;
+            float3 result =  diffuseColor / PI * lighting * streams.matDiffuseSpecularAlphaBlend.x;
+            return result;
         }
 
         override float3 ComputeEnvironmentLightContribution()

--- a/sources/engine/Stride.Rendering/Rendering/Materials/CelShading/MaterialSurfaceShadingDiffuseCelShading.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/CelShading/MaterialSurfaceShadingDiffuseCelShading.sdsl
@@ -25,8 +25,13 @@ namespace Stride.Rendering.Materials
 				// Correct
 				celLight = celLightFunction.Compute(streams.NdotL);          
             }
-
-			streams.lightColorNdotL = streams.lightColor * streams.shadowColor * streams.lightDirectAmbientOcclusion;      
+            
+            // Point and spotlight include attenuation in their lightColor, remove it and re-apply it based on light function
+            float3 lc = streams.lightAttenuation;
+            lc = lc == 0 ? 0 : streams.lightColor / lc;
+            lc *= celLightFunction.Compute(streams.lightAttenuation);
+            
+			streams.lightColorNdotL = lc * streams.shadowColor * streams.lightDirectAmbientOcclusion;      
 
             var diffuseColor = streams.matDiffuseVisible;
             if (TIsEnergyConservative)

--- a/sources/engine/Stride.Rendering/Rendering/Materials/Hair/MaterialSurfaceShadingDiffuseHair.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/Hair/MaterialSurfaceShadingDiffuseHair.sdsl
@@ -78,7 +78,7 @@ namespace Stride.Rendering.Materials
             }
 
             float3 diffuseLighting = diffuseColor / PI;
-            diffuseLighting *= streams.lightColor;  // Distance-attenuated light color. //diffuseLighting *= streams.lightColorNdotL;  // Distance- & normal-attenuated light color.
+            diffuseLighting *= streams.lightColor * streams.lightAttenuation; //diffuseLighting *= streams.lightColorNdotL;  // Distance- & normal-attenuated light color.
             diffuseLighting *= streams.matDiffuseSpecularAlphaBlend.x;
             diffuseLighting *= hairShadowingFunction.Compute(); // Apply shadowing/scattering.
             diffuseLighting *= streams.lightDirectAmbientOcclusion;

--- a/sources/engine/Stride.Rendering/Rendering/Materials/Hair/MaterialSurfaceShadingSpecularHair.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/Hair/MaterialSurfaceShadingSpecularHair.sdsl
@@ -348,7 +348,7 @@ namespace Stride.Rendering.Materials
             //specular *= saturate(NdotLUnsaturated * 0.5 + 0.5);   // This could be used in combination with hair SSS.
             specular *= HairSpecularAttenuation(NdotLUnsaturated);
             specular *= hairLightAttenuationFunction.Compute();
-            specular *= streams.lightColor * streams.matDiffuseSpecularAlphaBlend.y; // Distance-attenuated light color.
+            specular *= streams.lightColor * streams.lightAttenuation * streams.matDiffuseSpecularAlphaBlend.y;
             //specular *= streams.lightDirectAmbientOcclusion;
             
             // TODO: Multiply by alpha or not?

--- a/sources/engine/Stride.Rendering/Rendering/Materials/SubsurfaceScattering/MaterialSurfaceSubsurfaceScatteringShading.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/SubsurfaceScattering/MaterialSurfaceSubsurfaceScatteringShading.sdsl
@@ -58,7 +58,7 @@ namespace Stride.Rendering.Materials
                                                               ScatteringWidth,
                                                               streams.meshNormalWS,
                                                               streams.lightDirectionWS,
-                                                              streams.lightColor,
+                                                              streams.lightColor * streams.lightAttenuation,
                                                               streams.matDiffuseVisible);
                                                               
             return scatteredLighting;


### PR DESCRIPTION
# PR Details
Point and spotlight attenuation (i.e.: their range) is not readily accessible but instead baked into lightColor, this pr introduces ``lightAttenuation`` and clears the attenuation from the lightColor.
It is then used to enhance celshading to better reflect how that light model works in 2d animation.

Before:![image](https://user-images.githubusercontent.com/5742236/95007171-deaa2980-060c-11eb-86a9-8c4c886c48be.png)After:![image](https://user-images.githubusercontent.com/5742236/95007670-85dd8f80-0612-11eb-9bca-d62198a839f6.png)

## Related Issue
None

## Motivation and Context
See details.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.