### PR TITLE
[Rendering] Instancing: fix instance back to scene

### DIFF
--- a/sources/engine/Stride.Engine/Engine/InstanceComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/InstanceComponent.cs
@@ -58,16 +58,16 @@ namespace Stride.Engine
             ConnectInstancing();
         }
 
-        private void ConnectInstancing()
+        internal void ConnectInstancing()
         {
-            if (master != null && master.Type is InstancingEntityTransform instancing)
+            if (connectedInstancing == null && master != null && master.Type is InstancingEntityTransform instancing)
             {
                 instancing.AddInstance(this);
                 connectedInstancing = instancing;
             }
         }
 
-        public void DisconnectInstancing()
+        internal void DisconnectInstancing()
         {
             if (connectedInstancing != null)
             {

--- a/sources/engine/Stride.Engine/Engine/Processors/InstanceProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/Processors/InstanceProcessor.cs
@@ -19,6 +19,10 @@ namespace Stride.Engine.Processors
             {
                 component.Master = FindMasterInParents(component.Entity);
             }
+            else
+            {
+                component.ConnectInstancing();
+            }
         }
 
         protected override void OnEntityComponentRemoved(Entity entity, [NotNull] InstanceComponent component, [NotNull] InstanceComponent data)

--- a/sources/engine/Stride.Engine/Engine/Processors/InstancingProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/Processors/InstancingProcessor.cs
@@ -179,7 +179,10 @@ namespace Stride.Engine.Processors
 
         protected override void OnEntityComponentRemoved(Entity entity, [NotNull] InstancingComponent component, [NotNull] InstancingData data)
         {
-            modelInstancingMap.Remove(data.RenderModel);
+            if (data.RenderModel != null)
+            {
+                modelInstancingMap.Remove(data.RenderModel);
+            }
 
             if (component.Type is InstancingUserArray)
             {


### PR DESCRIPTION
# PR Details
Small fix to keep state valid for an instance that was removed from the scene and added right back. (previously didn't end up rendering the instance after this operation)

## Related Issue
None reported

## Motivation and Context
Fix bug

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


@tebjan note the modifier changes from ``public``->``internal``, seemed more fitting, was there a specific reason to keep it public ? 
On that note, ``OnEntityComponentAdding`` calling ``FindMasterInParents`` seems to me like unexpected or unwanted behavior, should we keep it ?