### PR TITLE
Fixed browser not opening when clicking a link in the launcher. Fixes #809

### DIFF
--- a/sources/launcher/Stride.Launcher/ViewModels/DocumentationPageViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/DocumentationPageViewModel.cs
@@ -31,7 +31,7 @@ namespace Stride.LauncherApp.ViewModels
         {
             try
             {
-                Process.Start(Url);
+                Process.Start(new ProcessStartInfo(Url) { UseShellExecute = true });
             }
             catch (Exception)
             {

--- a/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
@@ -550,7 +550,7 @@ namespace Stride.LauncherApp.ViewModels
         {
             try
             {
-                Process.Start(url);
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             }
             // FIXME: catch only specific exceptions?
             catch (Exception)

--- a/sources/launcher/Stride.Launcher/ViewModels/NewsPageViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/NewsPageViewModel.cs
@@ -27,7 +27,7 @@ namespace Stride.LauncherApp.ViewModels
         {
             try
             {
-                Process.Start(Url);
+                Process.Start(new ProcessStartInfo(Url) { UseShellExecute = true });
             }
             catch (Exception)
             {

--- a/sources/launcher/Stride.Launcher/Views/Commands.cs
+++ b/sources/launcher/Stride.Launcher/Views/Commands.cs
@@ -37,7 +37,7 @@ namespace Stride.LauncherApp.Views
             try
             {
                 // Make sure we open proper HTML pages
-                Process.Start(url.ReplaceLast(".md", ".html"));
+                Process.Start(new ProcessStartInfo(url.ReplaceLast(".md", ".html")) { UseShellExecute = true });
             }
             catch (System.ComponentModel.Win32Exception e)
             {

--- a/sources/presentation/Stride.Core.Presentation/Commands/UtilityCommands.cs
+++ b/sources/presentation/Stride.Core.Presentation/Commands/UtilityCommands.cs
@@ -34,7 +34,7 @@ namespace Stride.Core.Presentation.Commands
             // see https://support.microsoft.com/en-us/kb/305703
             try
             {
-                Process.Start(url);
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             }
             catch (System.ComponentModel.Win32Exception e)
             {


### PR DESCRIPTION
# PR Details

## Description
When the launcher switched to .net core the links in the launcher stopped working. This is because UseShellExecute is false by default on .net core. This PR fixes the links by setting UseShellExecute to true for all the Process.Start calls that open an URL.

## Related Issue
#809 

## Motivation and Context

Bug fix for a problem that is causing confusion for new users

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.