### PR TITLE
[Core] Customize minimum log level for GlobalLogger by introducing AppSettings

### DIFF
--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -1172,7 +1172,7 @@ namespace Stride.Core.Assets
                             continue;
                         }
 
-                        var templateDescription = YamlSerializer.Default.Load<TemplateDescription>(file.FullName);
+                        var templateDescription = YamlSerializer.Load<TemplateDescription>(file.FullName);
                         templateDescription.FullPath = file.FullName;
                         Templates.Add(templateDescription);
                     }

--- a/sources/core/Stride.Core.Design/Settings/AppSettingsProvider.cs
+++ b/sources/core/Stride.Core.Design/Settings/AppSettingsProvider.cs
@@ -14,7 +14,11 @@ namespace Stride.Core.Settings
         /// <inheritdoc/>
         public AppSettings LoadAppSettings()
         {
-            var execFilePath = Assembly.GetEntryAssembly().Location;
+            var execFilePath = Assembly.GetEntryAssembly()?.Location;
+
+            if (execFilePath == null)
+                return new AppSettings();
+
             var settingsFilePath = Path.ChangeExtension(execFilePath, SettingsExtension);
             try
             {

--- a/sources/core/Stride.Core.Design/Settings/AppSettingsProvider.cs
+++ b/sources/core/Stride.Core.Design/Settings/AppSettingsProvider.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Reflection;
+using Stride.Core.Yaml;
+
+namespace Stride.Core.Settings
+{
+    /// <summary>
+    /// Implementation of <see cref="IAppSettingsProvider"/> which uses YAML deserializer to read the settings file.
+    /// </summary>
+    internal class AppSettingsProvider : IAppSettingsProvider
+    {
+        const string SettingsExtension = ".appsettings";
+
+        /// <inheritdoc/>
+        public AppSettings LoadAppSettings()
+        {
+            var execFilePath = Assembly.GetEntryAssembly().Location;
+            var settingsFilePath = Path.ChangeExtension(execFilePath, SettingsExtension);
+            try
+            {
+                return YamlSerializer.Load<AppSettings>(settingsFilePath);
+            }
+            catch (FileNotFoundException)
+            {
+                return new AppSettings();
+            }
+        }
+    }
+}

--- a/sources/core/Stride.Core.Design/Yaml/YamlSerializer.cs
+++ b/sources/core/Stride.Core.Design/Yaml/YamlSerializer.cs
@@ -19,7 +19,7 @@ namespace Stride.Core.Yaml
 
         public static YamlSerializer Default { get; set; } = new YamlSerializer();
 
-        public T Load<T>([NotNull] string filePath, ILogger log = null)
+        public static T Load<T>([NotNull] string filePath, ILogger log = null)
         {
             if (filePath == null) throw new ArgumentNullException(nameof(filePath));
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))

--- a/sources/core/Stride.Core/Diagnostics/GlobalLogger.cs
+++ b/sources/core/Stride.Core/Diagnostics/GlobalLogger.cs
@@ -118,6 +118,18 @@ namespace Stride.Core.Diagnostics
         /// <returns>An instance of a <see cref="Logger"/></returns>
         public static Logger GetLogger([NotNull] string module)
         {
+            return GetLogger(module, MinimumLevelEnabled);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="GlobalLogger"/> associated to the specified module.
+        /// </summary>
+        /// <param name="module">The module name.</param>
+        /// <param name="minimumLevel">Minimum log level (only applied if new logger instance is created)</param>
+        /// <exception cref="ArgumentNullException">If module name is null</exception>
+        /// <returns>An instance of a <see cref="Logger"/></returns>
+        public static Logger GetLogger([NotNull] string module, LogMessageType minimumLevel)
+        {
             if (module == null)
                 throw new ArgumentNullException(nameof(module));
 
@@ -127,7 +139,7 @@ namespace Stride.Core.Diagnostics
                 if (!MapModuleNameToLogger.TryGetValue(module, out logger))
                 {
                     logger = new GlobalLogger(module);
-                    logger.ActivateLog(MinimumLevelEnabled);
+                    logger.ActivateLog(minimumLevel);
                     MapModuleNameToLogger.Add(module, logger);
                 }
             }

--- a/sources/core/Stride.Core/Diagnostics/GlobalLogger.cs
+++ b/sources/core/Stride.Core/Diagnostics/GlobalLogger.cs
@@ -15,11 +15,6 @@ namespace Stride.Core.Diagnostics
         #region Constants and Fields
 
         /// <summary>
-        /// By default, the minimum level for a GlobalLogger is info.
-        /// </summary>
-        public const LogMessageType MinimumLevel = LogMessageType.Info;
-
-        /// <summary>
         /// Map for all instantiated loggers. Map a module name to a logger.
         /// </summary>
         private static readonly Dictionary<string, Logger> MapModuleNameToLogger = new Dictionary<string, Logger>();
@@ -132,7 +127,7 @@ namespace Stride.Core.Diagnostics
                 if (!MapModuleNameToLogger.TryGetValue(module, out logger))
                 {
                     logger = new GlobalLogger(module);
-                    logger.ActivateLog(MinimumLevel);
+                    logger.ActivateLog(MinimumLevelEnabled);
                     MapModuleNameToLogger.Add(module, logger);
                 }
             }

--- a/sources/core/Stride.Core/Diagnostics/Logger.cs
+++ b/sources/core/Stride.Core/Diagnostics/Logger.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using Stride.Core.Annotations;
+using Stride.Core.Settings;
 
 namespace Stride.Core.Diagnostics
 {
@@ -11,6 +12,7 @@ namespace Stride.Core.Diagnostics
     public abstract partial class Logger : ILogger
     {
         private static object _lock = new object();
+        private static LogMessageType? minimumLevelEnabled;
         protected readonly bool[] EnableTypes;
 
         /// <summary>
@@ -27,9 +29,21 @@ namespace Stride.Core.Diagnostics
         }
 
         /// <summary>
-        /// Gets the minimum level enabled from the config file.
+        /// Gets the minimum level enabled from the config file. Can be overridden by the user.
         /// </summary>
-        public static readonly LogMessageType MinimumLevelEnabled = LogMessageType.Info; // AppConfig.GetConfiguration<LoggerConfig>("Logger").Level;
+        public static LogMessageType MinimumLevelEnabled
+        {
+            get
+            {
+                if (minimumLevelEnabled.HasValue)
+                    return minimumLevelEnabled.Value;
+
+                var loggerConfig = AppSettingsManager.Settings.GetSettings<LoggerConfig>();
+                minimumLevelEnabled = loggerConfig?.Level ?? LogMessageType.Info; // default value
+                return minimumLevelEnabled.Value;
+            }
+            set => minimumLevelEnabled = value;
+        }
 
         /// <summary>
         /// True if the debug level is enabled at a global level

--- a/sources/core/Stride.Core/Diagnostics/LoggerConfig.cs
+++ b/sources/core/Stride.Core/Diagnostics/LoggerConfig.cs
@@ -5,6 +5,7 @@ namespace Stride.Core.Diagnostics
     /// <summary>
     /// Configuration for <see cref="GlobalLogger"/>.
     /// </summary>
+    [DataContract("GlobalLoggerConfig")]
     public class LoggerConfig
     {
         /// <summary>

--- a/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
+++ b/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
@@ -15,10 +15,7 @@ namespace Stride.Core.Reflection
     /// </summary>
     public static class AssemblyRegistry
     {
-        // Log has to be constructed lazily, because AssemblyRegistry is used in static Logger property used to construct GlobalLogger
-        public static Logger Log
-        { get { log = log ?? GlobalLogger.GetLogger("AssemblyRegistry"); return log; } }
-        private static Logger log;
+        private static readonly Lazy<Logger> Log = new Lazy<Logger>(() => GlobalLogger.GetLogger("AssemblyRegistry"));
         private static readonly object Lock = new object();
         private static readonly Dictionary<string, HashSet<Assembly>> MapCategoryToAssemblies = new Dictionary<string, HashSet<Assembly>>();
         private static readonly Dictionary<Assembly, HashSet<string>> MapAssemblyToCategories = new Dictionary<Assembly, HashSet<string>>();
@@ -211,7 +208,7 @@ namespace Stride.Core.Reflection
                 {
                     if (string.IsNullOrWhiteSpace(category))
                     {
-                        Log.Error($"Invalid empty category for assembly [{assembly}]");
+                        Log.Value.Error($"Invalid empty category for assembly [{assembly}]");
                         continue;
                     }
 

--- a/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
+++ b/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
@@ -15,12 +15,20 @@ namespace Stride.Core.Reflection
     /// </summary>
     public static class AssemblyRegistry
     {
-        private static readonly Logger Log = GlobalLogger.GetLogger("AssemblyRegistry");
+        // Log has to be constructed lazily, because AssemblyRegistry is used in static Logger property used to construct GlobalLogger
+        public static Logger Log
+        { get { log = log ?? GlobalLogger.GetLogger("AssemblyRegistry"); return log; } }
+        private static Logger log;
         private static readonly object Lock = new object();
         private static readonly Dictionary<string, HashSet<Assembly>> MapCategoryToAssemblies = new Dictionary<string, HashSet<Assembly>>();
         private static readonly Dictionary<Assembly, HashSet<string>> MapAssemblyToCategories = new Dictionary<Assembly, HashSet<string>>();
         private static readonly Dictionary<Assembly, ScanTypes> AssemblyToScanTypes = new Dictionary<Assembly, ScanTypes>();
         private static readonly Dictionary<string, Assembly> AssemblyNameToAssembly = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+
+        static AssemblyRegistry()
+        {
+            Register(typeof(AssemblyRegistry).Assembly, "core"); // to be included in FindAll()
+        }
 
         /// <summary>
         /// Occurs when an assembly is registered.

--- a/sources/core/Stride.Core/Settings/AppSettings.cs
+++ b/sources/core/Stride.Core/Settings/AppSettings.cs
@@ -1,0 +1,30 @@
+using Stride.Core.Collections;
+
+namespace Stride.Core.Settings
+{
+    [DataContract("AppSettings")]
+    public sealed class AppSettings
+    {
+        /// <summary>
+        /// Application specific settings.
+        /// </summary>
+        [DataMember]
+        private FastList<object> Settings { get; set; }
+
+        /// <summary>
+        /// Finds a settings object of the specified type in the settings collection.
+        /// </summary>
+        /// <returns>Found object, or null if not found.</returns>
+        public T GetSettings<T>() where T : class
+        {
+            if (Settings == null)
+                return null;
+
+            foreach (var obj in Settings)
+                if (obj is T setting)
+                    return setting;
+
+            return null;
+        }
+    }
+}

--- a/sources/core/Stride.Core/Settings/AppSettingsManager.cs
+++ b/sources/core/Stride.Core/Settings/AppSettingsManager.cs
@@ -1,0 +1,44 @@
+using System;
+using Stride.Core.Reflection;
+
+namespace Stride.Core.Settings
+{
+    /// <summary>
+    /// Manages the loading of application settings with <see cref="IAppSettingsProvider"/>.
+    /// </summary>
+    public static class AppSettingsManager
+    {
+        /// <summary>
+        /// <see cref="AppSettings"/> instance for the application.
+        /// </summary>
+        /// <note>
+        /// Loaded with an <see cref="IAppSettingsProvider"/>. If no provider implementation is found, returns empty <see cref="AppSettings"/> instance.
+        /// </note>
+        public static AppSettings Settings
+        {
+            get
+            {
+                if (settings != null)
+                    return settings;
+
+                foreach (var assembly in AssemblyRegistry.FindAll())
+                    foreach (var type in assembly.GetTypes())
+                        if (typeof(IAppSettingsProvider).IsAssignableFrom(type))
+                        {
+                            var ctor = type.GetConstructor(new Type[0]);
+                            if (ctor != null)
+                            {
+                                var instance = (IAppSettingsProvider)ctor.Invoke(new object[0]);
+                                settings = instance.LoadAppSettings();
+                                return settings;
+                            }
+                        }
+
+                settings = new AppSettings();
+                return settings;
+            }
+        }
+
+        private static AppSettings settings;
+    }
+}

--- a/sources/core/Stride.Core/Settings/IAppSettingsProvider.cs
+++ b/sources/core/Stride.Core/Settings/IAppSettingsProvider.cs
@@ -1,0 +1,17 @@
+namespace Stride.Core.Settings
+{
+    /// <summary>
+    /// A custom loader of the application settings. Implementation is required to have a parameterless constructor.
+    /// </summary>
+    /// <note>
+    /// We don't want a dependency on complex parsing libraries in Stride.Core,
+    /// so the reading of the AppSettings file is left to the implementation of this interface.
+    /// </note>
+    public interface IAppSettingsProvider
+    {
+        /// <summary>
+        /// Loads <see cref="AppSettings"/> for the application.
+        /// </summary>
+        AppSettings LoadAppSettings();
+    }
+}

--- a/sources/core/Stride.Core/Settings/IAppSettingsProvider.cs
+++ b/sources/core/Stride.Core/Settings/IAppSettingsProvider.cs
@@ -1,3 +1,5 @@
+using Stride.Core.Reflection;
+
 namespace Stride.Core.Settings
 {
     /// <summary>
@@ -7,6 +9,7 @@ namespace Stride.Core.Settings
     /// We don't want a dependency on complex parsing libraries in Stride.Core,
     /// so the reading of the AppSettings file is left to the implementation of this interface.
     /// </note>
+    [AssemblyScan]
     public interface IAppSettingsProvider
     {
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a new way to define application level settings and uses it to allow user to override the minimum log level, which is currently hardcoded to Info.

* `Stride.Core.Settings.AppSettings` is the settings container - a collection of objects which should differ by type (otherwise the first object of the given type is returned).
* `Stride.Core.Settings.IAppSettingsProvider` is an interface that abstracts how we obtain the AppSettings. This is because we don't want to add any dependencies to `Stride.Core`.
* `Stride.Core.Settings.AppSettingsManager` is a static class that uses `AssemblyRegistry` to find a type which implements the above interface, loads the settings and caches them.
* `Stride.Core.Settings.AppSettingsProvider` (in `Stride.Core.Design`) provides a way to load Yaml based `.appsettings` file. Note: `.settings` is special for Visual Studio, so couldn't be used.
* `Stride.Core.Diagnostics.Logger` has been modified to try loading the user provided override from `AppSettings` to determine the `MinimumLevelEnabled`. Moreover, the property can be overridden from code.
* `Stride.Core.Diagnostics.GlobalLogger` now uses the above property when creating new loggers. It also got an overload which can specify the minimum log level per instance (when created).
* `AssemblyRegistry` got a static constructor in which we register `Stride.Core` assembly - this is so that we can use the default `YamlSerializer` which only allows deserializing registered types. Moreover, the static logger is initialized lazily because otherwise there's a static initializer dependency cycle.
* I also included a small change to the `YamlSerializer` making `Load<T>` static as it just called a static field.

### Usage
To override the default log level create a file called "_YourExecutable_.appsettings" and mark it in VS to copy to output directory, or include the following in your project file:

```xml
  <ItemGroup>
    <None Update="MyProject.appsettings">
      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
    </None>
  </ItemGroup>
```

Edit the file contents to look like this:

```yaml
!AppSettings
Settings:
    - !GlobalLoggerConfig
        Level: Debug
```
You can set the log level to one of those: `Debug`, `Verbose`, `Info`, `Warning`, `Error`, `Fatal` (but usually only the first three make sense).

## Related Issue

Closes #876 
I haven't waited long for comments under my issue, so I'll gladly take any criticism here.

## Motivation and Context

When creating `static Logger Logger = GlobalLogger.GetLogger(nameof(Class));` for many classes I want to be able to change one setting to have them all logging more or less information. I could not use the `GlobalLogger.ActivateLog` because I would have to call it after my loggers are created and that's not easy.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Note:** This is a binary interface breaking change, but a non-breaking change with regard to usage and behavior.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.