### PR TITLE
[Build] Remove unused dependency on Microsoft.WindowsDesktop.App from Stride.Core.Assets

### DIFF
--- a/sources/assets/Stride.Core.Assets/Stride.Core.Assets.csproj
+++ b/sources/assets/Stride.Core.Assets/Stride.Core.Assets.csproj
@@ -10,8 +10,6 @@
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Stride.Core.Assets has no code, nor package dependencies that use WPF or Winforms.
Having those flags set includes a dependency on `Microsoft.WindowsDesktop.App` framework sdk which is not available on non-Windows platforms.
This PR removes this unused dependency to allow future support of non-Windows platforms accessing `Stride.Core.Assets` package.

## Related Issue
N/A

## Motivation and Context

I'm beginning to try to compile my mini Stride.Editor on Linux and got the error
```
The FrameworkReference 'Microsoft.WindowsDesktop.App' was not recognized
```
There's no reason to have the assembly depend on it if no code does.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

My testing (I actually tried running the whole test suite this time to find potential hidden cross project issues):
* GameStudio runs fine
* My game (derived from ThirdPerson platformer) runs fine
* Serialization tests in `Stride.Core.Assets.Test` and `Stride.Core.Assets.Quantum.Test` report error due to different expected and actual new line (`\n` vs `\r\n`)
* Image comparison tests report errors, but I can't see the difference between the checked images
* Sample projects also reported errors, first I got NullReferenceException but cant remember where, and when I restarted it I got `Could not find a MSBuild installation (expected 16.0 or later)` which makes no sense.
Overall running unit tests is a bit of a nightmare (it takes lots of time because if a test fails to compile I need to clean the whole solution and try building it again),