### PR TITLE
[SDL] Drop files and clipboard

### DIFF
--- a/sources/engine/Stride.Graphics/SDL/Application.cs
+++ b/sources/engine/Stride.Graphics/SDL/Application.cs
@@ -190,6 +190,11 @@ namespace Stride.Graphics.SDL
                     // Send these events to all the windows
                     Windows.ForEach(x => x.ProcessEvent(e));
                     break;
+                
+                case SDL.SDL_EventType.SDL_DROPTEXT:
+                case SDL.SDL_EventType.SDL_DROPFILE:
+                    ctrl = WindowFromSdlHandle(SDL.SDL_GetWindowFromID(e.drop.windowID));
+                    break;
             }
             ctrl?.ProcessEvent(e);
         }
@@ -230,6 +235,12 @@ namespace Stride.Graphics.SDL
         /// Backup storage for windows of current application.
         /// </summary>
         private static readonly Dictionary<IntPtr, WeakReference<Window>> InternalWindows;
+    
+        public static string Clipboard
+        {
+            get => SDL.SDL_GetClipboardText();
+            set => SDL.SDL_SetClipboardText( value );
+        }
     }
 }
 #endif

--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -404,6 +404,7 @@ namespace Stride.Graphics.SDL
         public delegate void JoystickDeviceChangedDelegate(int which);
         public delegate void TouchFingerDelegate(SDL.SDL_TouchFingerEvent e);
         public delegate void NotificationDelegate();
+        public delegate void DropEventDelegate(string content);
 
         public event MouseButtonDelegate PointerButtonPressActions;
         public event MouseButtonDelegate PointerButtonReleaseActions;
@@ -430,6 +431,7 @@ namespace Stride.Graphics.SDL
         public event WindowEventDelegate MouseLeaveActions;
         public event WindowEventDelegate FocusGainedActions;
         public event WindowEventDelegate FocusLostActions;
+        public event DropEventDelegate DropFileActions;
 
         /// <summary>
         /// Process events for the current window
@@ -493,6 +495,10 @@ namespace Stride.Graphics.SDL
 
                 case SDL.SDL_EventType.SDL_FINGERUP:
                     FingerReleaseActions?.Invoke(e.tfinger);
+                    break;
+                
+                case SDL.SDL_EventType.SDL_DROPFILE:
+                    DropFileActions?.Invoke( SDL.UTF8_ToManaged(e.drop.file, true) );
                     break;
 
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:


### PR DESCRIPTION
# PR Details
Provides delegate subscription to listen for dropped files and present clipboard IO through SDL Application

## Description
See above.

## Related Issue
None

## Motivation and Context
Those things are useful

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


If @tebjan could take a quick look at this since you have worked around this namespace before, do we want the clipboard to sit within Application.cs ?

Note that I haven't implemented the ``SDL_DROPTEXT`` variant as it doesn't look like it's supported on windows.