### PR TITLE
[Physics] Send CollisionEnded on entity/component removal

### DIFF
--- a/sources/engine/Stride.Physics.Tests/GameAssets/SendCollisionEndedWhenEntityIsRemovedTest.sdscene
+++ b/sources/engine/Stride.Physics.Tests/GameAssets/SendCollisionEndedWhenEntityIsRemovedTest.sdscene
@@ -1,0 +1,89 @@
+!SceneAsset
+Id: ad1acc09-3637-40e7-b185-3bfdfb77b885
+SerializedVersion: {Stride: 2.1.0.1}
+Tags: []
+ChildrenIds: []
+Offset: {X: 0.0, Y: 0.0, Z: 0.0}
+Hierarchy:
+    RootParts:
+        - ref!! b2be5192-5dfb-4fc1-9cb3-0690ea5171dd
+        - ref!! b5866a46-8ea6-49a9-a46e-a534ce3db87d
+        - ref!! fa2ec94d-e743-4b7f-9b0c-731af5efeac1
+    Parts:
+        -   Entity:
+                Id: b2be5192-5dfb-4fc1-9cb3-0690ea5171dd
+                Name: Camera
+                Components:
+                    54d2b97cfa75fa43958a4db8e83d054b: !TransformComponent
+                        Id: 7cb9d254-75fa-43fa-958a-4db8e83d054b
+                        Position: {X: 0.0, Y: 0.0, Z: 2.215951}
+                        Rotation: {X: 0.0, Y: 0.0, Z: 0.0, W: 1.0}
+                        Scale: {X: 1.0, Y: 1.0, Z: 1.0}
+                        Children: {}
+                    ba901191469d00419a686d5db1a0d8c4: !CameraComponent
+                        Id: 911190ba-9d46-4100-9a68-6d5db1a0d8c4
+                        Name: null
+                        Projection: Perspective
+                        Slot: bdd308f1-d60d-4a59-b0e5-c63d138382bd
+        -   Entity:
+                Id: b5866a46-8ea6-49a9-a46e-a534ce3db87d
+                Name: Cube
+                Components:
+                    77cf0811d90e809e7fe874c63cfabc6c: !TransformComponent
+                        Id: fbfea5b2-8ccf-4939-a657-51c04b77384f
+                        Position: {X: 0.0, Y: 0.0, Z: 0.0}
+                        Rotation: {X: 0.0, Y: 0.0, Z: 0.0, W: 1.0}
+                        Scale: {X: 1.0, Y: 1.0, Z: 1.0}
+                        Children: {}
+                    dfcee9635d5a45349276295027c425fa: !RigidbodyComponent
+                        Id: 52150ee0-6ba5-4042-82e5-50906aa9f11d
+                        CanSleep: false
+                        Restitution: 0.0
+                        Friction: 0.5
+                        RollingFriction: 0.0
+                        CcdMotionThreshold: 0.0
+                        CcdSweptSphereRadius: 0.0
+                        IsTrigger: false
+                        IsKinematic: true
+                        Mass: 1.0
+                        LinearDamping: 0.0
+                        AngularDamping: 0.0
+                        OverrideGravity: false
+                        Gravity: {X: 0.0, Y: 0.0, Z: 0.0}
+                        NodeName: null
+                        ColliderShapes:
+                            3c2d590bd2a5eb30a83488781de5f8a1: !BoxColliderShapeDesc
+                                Is2D: false
+                                Size: {X: 1.0, Y: 1.0, Z: 1.0}
+                                LocalOffset: {X: 0.0, Y: 0.0, Z: 0.0}
+                                LocalRotation: {X: 0.0, Y: 0.0, Z: 0.0, W: 1.0}
+        -   Entity:
+                Id: fa2ec94d-e743-4b7f-9b0c-731af5efeac1
+                Name: Sphere
+                Components:
+                    8095f533a76933465bb4de38278eb96c: !TransformComponent
+                        Id: 424e9105-fa52-499d-bcda-20b1d5427868
+                        Position: {X: 0.0, Y: 0.5, Z: 0.0}
+                        Rotation: {X: 0.0, Y: 0.0, Z: 0.0, W: 1.0}
+                        Scale: {X: 1.0, Y: 1.0, Z: 1.0}
+                        Children: {}
+                    ee6c3578de5e2e5b87f7062ebabe6d0e: !RigidbodyComponent
+                        Id: bfedf50e-2235-416f-85ff-767e11ee4ec2
+                        CanSleep: false
+                        Restitution: 0.0
+                        Friction: 0.5
+                        RollingFriction: 0.0
+                        CcdMotionThreshold: 0.0
+                        CcdSweptSphereRadius: 0.0
+                        IsTrigger: false
+                        IsKinematic: true
+                        Mass: 1.0
+                        LinearDamping: 0.0
+                        AngularDamping: 0.0
+                        OverrideGravity: false
+                        Gravity: {X: 0.0, Y: 0.0, Z: 0.0}
+                        NodeName: null
+                        ColliderShapes:
+                            3c36f2f4115fea563d5429c27f476257: !SphereColliderShapeDesc
+                                Is2D: false
+                                LocalOffset: {X: 0.0, Y: 0.0, Z: 0.0}

--- a/sources/engine/Stride.Physics.Tests/SendCollisionEndedWhenEntityIsRemovedTest.cs
+++ b/sources/engine/Stride.Physics.Tests/SendCollisionEndedWhenEntityIsRemovedTest.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Stride.Engine;
+using Xunit;
+
+namespace Stride.Physics.Tests
+{
+    public class SendCollisionEndedWhenEntityIsRemovedTest : GameTest
+    {
+        public SendCollisionEndedWhenEntityIsRemovedTest() : base(nameof(SendCollisionEndedWhenEntityIsRemovedTest))
+        {
+        }
+
+        [Fact]
+        public void WhenEntityIsRemoved_CollisionEndedIsRaised()
+        {
+            var game = new SendCollisionEndedWhenEntityIsRemovedTest();
+            game.Script.AddTask(async () =>
+            {
+                game.ScreenShotAutomationEnabled = false;
+
+                await game.Script.NextFrame();
+                await game.Script.NextFrame();
+
+                var cube = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Cube");
+                var sphere = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Sphere");
+
+                var cubePhysics = cube.Get<PhysicsComponent>();
+
+                // verify that there is a collision between the sphere and the cube
+                Assert.Single(cubePhysics.Collisions);
+
+                var collisionEndedTask = Task.Run(async () => {
+                    var collision = await cubePhysics.CollisionEnded();
+                    // when we receive the collision it's actually destroyed already
+                    Assert.Null(collision.ColliderA);
+                    Assert.Null(collision.ColliderB);
+                });
+
+                await game.Script.NextFrame();
+
+                // remove sphere from the scene
+                sphere.Scene = null;
+
+                await game.Script.NextFrame();
+
+                Assert.True(collisionEndedTask.IsCompleted);
+
+                game.Exit();
+            });
+            RunGameTest(game);
+        }
+
+        [Fact]
+        public void WhenBothEntitiesAreRemoved_NoExceptionIsThrown()
+        {
+            var game = new SendCollisionEndedWhenEntityIsRemovedTest();
+            game.Script.AddTask(async () =>
+            {
+                game.ScreenShotAutomationEnabled = false;
+
+                await game.Script.NextFrame();
+                await game.Script.NextFrame();
+
+                var cube = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Cube");
+                var sphere = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Sphere");
+
+                var cubePhysics = cube.Get<PhysicsComponent>();
+
+                // verify that there is a collision between the sphere and the cube
+                Assert.Single(cubePhysics.Collisions);
+
+                var collisionEndedTask = Task.Run(async () => {
+                    var collision = await cubePhysics.CollisionEnded();
+                    Assert.Null(collision.ColliderA);
+                    Assert.Null(collision.ColliderB);
+                });
+
+                await game.Script.NextFrame();
+
+                // remove both from the scene
+                sphere.Scene = null;
+                cube.Scene = null;
+
+                await game.Script.NextFrame();
+
+                Assert.True(collisionEndedTask.IsCompleted);
+
+                game.Exit();
+            });
+            RunGameTest(game);
+        }
+    }
+}

--- a/sources/engine/Stride.Physics.Tests/SendCollisionEndedWhenEntityIsRemovedTest.cs
+++ b/sources/engine/Stride.Physics.Tests/SendCollisionEndedWhenEntityIsRemovedTest.cs
@@ -32,9 +32,9 @@ namespace Stride.Physics.Tests
 
                 var collisionEndedTask = Task.Run(async () => {
                     var collision = await cubePhysics.CollisionEnded();
-                    // when we receive the collision it's actually destroyed already
-                    Assert.Null(collision.ColliderA);
-                    Assert.Null(collision.ColliderB);
+                    Assert.True(collision.HasEndedFromComponentRemoval);
+                    Assert.NotNull(collision.ColliderA);
+                    Assert.NotNull(collision.ColliderB);
                 });
 
                 await game.Script.NextFrame();
@@ -72,8 +72,9 @@ namespace Stride.Physics.Tests
 
                 var collisionEndedTask = Task.Run(async () => {
                     var collision = await cubePhysics.CollisionEnded();
-                    Assert.Null(collision.ColliderA);
-                    Assert.Null(collision.ColliderB);
+                    Assert.True(collision.HasEndedFromComponentRemoval);
+                    Assert.NotNull(collision.ColliderA);
+                    Assert.NotNull(collision.ColliderB);
                 });
 
                 await game.Script.NextFrame();

--- a/sources/engine/Stride.Physics.Tests/Stride.Physics.Tests.Windows.csproj
+++ b/sources/engine/Stride.Physics.Tests/Stride.Physics.Tests.Windows.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Stride.Graphics.Regression\Stride.Graphics.Regression.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SendCollisionEndedWhenEntityIsRemovedTest.cs" />
     <Compile Include="XunitAttributes.cs" />
     <Compile Include="CharacterTest.cs" />
     <Compile Include="ColliderShapesTest.cs" />

--- a/sources/engine/Stride.Physics.Tests/Stride.Physics.Tests.Windows.sdpkg
+++ b/sources/engine/Stride.Physics.Tests/Stride.Physics.Tests.Windows.sdpkg
@@ -11,3 +11,4 @@ RootAssets:
     - b98408a0-2b2d-4783-a8c2-11b0fe5bbdcc:ColliderShapesTest
     - b98408a0-2b2d-4783-a8c2-11b0fe5bbdcd:SkinnedTest
     - c2b9bd24-3e83-4fff-b963-79f9ff5430ac:CharacterTest
+    - ad1acc09-3637-40e7-b185-3bfdfb77b885:SendCollisionEndedWhenEntityIsRemovedTest

--- a/sources/engine/Stride.Physics/Simulation.cs
+++ b/sources/engine/Stride.Physics/Simulation.cs
@@ -965,6 +965,7 @@ namespace Stride.Physics
 
             foreach (var collision in collisionsRemovedDueToComponentRemoval)
             {
+                collision.HasEndedFromComponentRemoval = true;
                 while (collision.ColliderA.PairEndedChannel.Balance < 0)
                 {
                     collision.ColliderA.PairEndedChannel.Send(collision);

--- a/sources/engine/Stride.Physics/Simulation.cs
+++ b/sources/engine/Stride.Physics/Simulation.cs
@@ -939,10 +939,12 @@ namespace Stride.Physics
         }
 
         private readonly FastList<ContactPoint> currentToRemove = new FastList<ContactPoint>();
+        private readonly HashSet<Collision> collisionsRemovedDueToComponentRemoval = new HashSet<Collision>();
 
         internal void CleanContacts(PhysicsComponent component)
         {
             currentToRemove.Clear(true);
+            collisionsRemovedDueToComponentRemoval.Clear();
 
             foreach (var currentFrameContact in currentFrameContacts)
             {
@@ -951,6 +953,7 @@ namespace Stride.Physics
                 if (component == component0 || component == component1)
                 {
                     currentToRemove.Add(currentFrameContact);
+                    collisionsRemovedDueToComponentRemoval.Add(contactToCollision[currentFrameContact]);
                     ContactRemoval(currentFrameContact, component0, component1);
                 }
             }
@@ -958,6 +961,19 @@ namespace Stride.Physics
             foreach (var contactPoint in currentToRemove)
             {
                 currentFrameContacts.Remove(contactPoint);
+            }
+
+            foreach (var collision in collisionsRemovedDueToComponentRemoval)
+            {
+                while (collision.ColliderA.PairEndedChannel.Balance < 0)
+                {
+                    collision.ColliderA.PairEndedChannel.Send(collision);
+                }
+
+                while (collision.ColliderB.PairEndedChannel.Balance < 0)
+                {
+                    collision.ColliderB.PairEndedChannel.Send(collision);
+                }
             }
         }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Send a message to channels waiting on `physicsComponent.CollisionEnded()` when the collision is removed due to the removal of a physics component. The collision object received by the user will have been _destroyed_, so both `collision.ColliderA` and `collision.ColliderB` will be `null`.

> Note: every collision received from `CollisionEnded` or `NewCollision` is destroyed before the next frame. Here I'm introducing sending of the events in between the last frame scripts and the destroying before the next frame.

## Related Issue

Fixes #788 

## Motivation and Context

Removing an entity/physics component should be valid means of ending a collision (rather than sending into some far away location for a frame). Rather than checking the collisions collection on the physics component we should encourage users to rely on the `CollisionEnded()` awaitable event.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Currently we could assume that each collider of the collision will not be `null` (however, there is no `NotNull` contract on the `Collision` class, so this assumption is purely by convention).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

For some strange reason my test is not being run by default in VS Test explorer.