### PR TITLE
[Physics] Move libbulletc.dll preloading to module initializer

### DIFF
--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -33,12 +33,6 @@ namespace Stride.Engine
     {
         protected static Logger logger = GlobalLogger.GetLogger("PhysicsComponent");
 
-        static PhysicsComponent()
-        {
-            // Preload proper libbulletc native library (depending on CPU type)
-            NativeLibrary.PreloadLibrary("libbulletc.dll", typeof(PhysicsComponent));
-        }
-
         protected PhysicsComponent()
         {
             CanScaleShape = true;

--- a/sources/engine/Stride.Physics/Module.cs
+++ b/sources/engine/Stride.Physics/Module.cs
@@ -13,6 +13,9 @@ namespace Stride.Engine
         public static void Initialize()
         {
             AssemblyRegistry.Register(typeof(Module).GetTypeInfo().Assembly, AssemblyCommonCategories.Assets);
+
+            // Preload proper libbulletc native library (depending on CPU type)
+            NativeLibrary.PreloadLibrary("libbulletc.dll", typeof(PhysicsComponent));
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves native library preloading to module initializer.

**Question:** Should I also remove the preload call from `Bullet2PhysicsSystem`?

## Related Issue

Fixes #368 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.