### PR TITLE
[Editor] Fix syntax highliting in .NET Core, by adding missing dependency

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
@@ -20,7 +20,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="AvalonEdit" Version="6.0.0" />
-    <PackageReference Include="System.Reactive.Linq" Version="4.2.0" />
+    <PackageReference Include="System.Reactive.Linq" Version="4.3.1" />
+    <PackageReference Include="System.Reactive" Version="4.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.4.0" />
     <Reference Include="RoslynPad.Editor.Windows">


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds missing dependency on `System.Reactive` - this is an indirect dependency, introduced by RoslynPad. On .NET Framework it was pulled from the GAC, but in .NET Core it was missing. This resulted in a silent exception being swallowed because it occurred on a background thread. The exception message complained about version 4.3.0 (but there's only 4.3.1) so I also upgraded the `System.Reactive.Linq`

## Related Issue

Fixes #786 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.