### PR TITLE
[Graphics] Fixed loading an image as SRgb

### DIFF
--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -137,25 +137,25 @@ namespace Stride.Graphics
         public ImageDescription Description;
 
         /// <summary>
-        /// Converts the format of the description and the pixel buffers to SRgb.
+        /// Converts the format of the description and the pixel buffers to sRGB.
         /// </summary>
-        public void ToSRgb()
+        public void ConvertFormatToSRgb()
         {
             Description.Format = Description.Format.ToSRgb();
             if (PixelBuffers != null)
                 foreach (var pixelBuffer in PixelBuffers)
-                    pixelBuffer.ToSRgb();
+                    pixelBuffer.ConvertFormatToSRgb();
         }
 
         /// <summary>
-        /// Converts the format of the description and the pixel buffers to non SRgb.
+        /// Converts the format of the description and the pixel buffers to non sRGB.
         /// </summary>
-        public void ToNonSRgb()
+        public void ConvertFormatToNonSRgb()
         {
             Description.Format = Description.Format.ToNonSRgb();
             if (PixelBuffers != null)
                 foreach (var pixelBuffer in PixelBuffers)
-                    pixelBuffer.ToNonSRgb();
+                    pixelBuffer.ConvertFormatToNonSRgb();
         }
 
         internal Image()
@@ -686,7 +686,7 @@ namespace Stride.Graphics
                     if (image != null)
                     {
                         if (loadAsSRGB)
-                            image.ToSRgb();                     
+                            image.ConvertFormatToSRgb();                     
 
                         return image;
                     }

--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -136,6 +136,28 @@ namespace Stride.Graphics
         /// </summary>
         public ImageDescription Description;
 
+        /// <summary>
+        /// Converts the format of the description and the pixel buffers to SRgb.
+        /// </summary>
+        public void ToSRgb()
+        {
+            Description.Format = Description.Format.ToSRgb();
+            if (PixelBuffers != null)
+                foreach (var pixelBuffer in PixelBuffers)
+                    pixelBuffer.ToSRgb();
+        }
+
+        /// <summary>
+        /// Converts the format of the description and the pixel buffers to non SRgb.
+        /// </summary>
+        public void ToNonSRgb()
+        {
+            Description.Format = Description.Format.ToNonSRgb();
+            if (PixelBuffers != null)
+                foreach (var pixelBuffer in PixelBuffers)
+                    pixelBuffer.ToNonSRgb();
+        }
+
         internal Image()
         {
         }
@@ -664,7 +686,7 @@ namespace Stride.Graphics
                     if (image != null)
                     {
                         if (loadAsSRGB)
-                            image.Description.Format = image.Description.Format.ToSRgb();
+                            image.ToSRgb();                     
 
                         return image;
                     }

--- a/sources/engine/Stride/Graphics/PixelBuffer.cs
+++ b/sources/engine/Stride/Graphics/PixelBuffer.cs
@@ -93,6 +93,18 @@ namespace Stride.Graphics
         public PixelFormat Format { get { return format; } }
 
         /// <summary>
+        /// Converts the format to srgb.
+        /// </summary>
+        public void ToSRgb()
+            => format = format.ToSRgb();
+
+        /// <summary>
+        /// Converts the format to non srgb.
+        /// </summary>
+        public void ToNonSRgb()
+            => format = format.ToNonSRgb();
+
+        /// <summary>
         /// Gets the pixel size in bytes.
         /// </summary>
         /// <value>The pixel size in bytes.</value>

--- a/sources/engine/Stride/Graphics/PixelBuffer.cs
+++ b/sources/engine/Stride/Graphics/PixelBuffer.cs
@@ -93,15 +93,15 @@ namespace Stride.Graphics
         public PixelFormat Format { get { return format; } }
 
         /// <summary>
-        /// Converts the format to srgb.
+        /// Converts the format to sRGB.
         /// </summary>
-        public void ToSRgb()
+        public void ConvertFormatToSRgb()
             => format = format.ToSRgb();
 
         /// <summary>
-        /// Converts the format to non srgb.
+        /// Converts the format to non sRGB.
         /// </summary>
-        public void ToNonSRgb()
+        public void ConvertFormatToNonSRgb()
             => format = format.ToNonSRgb();
 
         /// <summary>


### PR DESCRIPTION
 will now also convert the format of the pixel buffers.

(cherry picked from commit 659f6eef93e715558ed784eb7870468f32e0b557)

# PR Details

Fixes format to SRgb conversion on image load.

## Related Issue

Copying of pixel buffers failed because the formats did not match.

## Motivation and Context

Loading many images as texture array.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.