### PR TITLE
Fix to stop the visual studio installer exiting with code -1 during prerequisites install

### DIFF
--- a/sources/tools/Stride.PackageInstall/Program.cs
+++ b/sources/tools/Stride.PackageInstall/Program.cs
@@ -36,15 +36,15 @@ namespace Stride.PackageInstall
                     case "/install":
                     case "/repair":
                     {
+                        // Make sure we have the proper VS2019/BuildTools prerequisites
+                        CheckVisualStudioAndBuildTools();
+
                         // Run prerequisites installer (if it exists)
                         var prerequisitesInstallerPath = @"install-prerequisites.exe";
                         if (File.Exists(prerequisitesInstallerPath))
                         {
                             RunProgramAndAskUntilSuccess("prerequisites", prerequisitesInstallerPath, string.Empty, DialogBoxTryAgain);
                         }
-
-                        // Make sure we have the proper VS2019/BuildTools prerequisites
-                        CheckVisualStudioAndBuildTools();
 
                         break;
                     }


### PR DESCRIPTION
# PR Details

Moved vs prerequisite install before the other prerequisite installs.

## Description

The prerequisites installer somehow keeps the msiexec service in an installing state even though the installer is already finished and closed. This causes the visual studio installer to refuse to install because it thinks there is still an other installer running.

By installing the visual studio prerequisite before installing the other prequisites this problem is avoided. This is a hack because the windows installer state will still be wrong after this, but this will at least allow people to install stride properly without encountering an error that they can't easily solve. The windows installer being in a wrong state will most likely not cause any other problems for the user, because the next windows installer will detect the wrong state and fix it, or in the case of the visual studio installer it will fix it after hitting retry or restarting the visual studio installer(this will not happen when it is run in passive mode such as during the prerequisite install).

The proper solution for not ending up in this state would be in the advanced installer script/version. However, I could not find any online solutions for this or other people with the same problem.

## Related Issue

#653

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.