### PR TITLE
Allow to compile projects on Linux

### DIFF
--- a/sources/core/Stride.Core/build/Stride.Core.targets
+++ b/sources/core/Stride.Core/build/Stride.Core.targets
@@ -57,8 +57,12 @@
     <StrideAssemblyProcessorPath>$(StrideAssemblyProcessorBasePath)Stride.Core.AssemblyProcessor.Packed$(StrideAssemblyProcessorExt)</StrideAssemblyProcessorPath>
     <StrideAssemblyProcessorSerializationHashFile>$(IntermediateOutputPath)$(TargetName).sdserializationhash</StrideAssemblyProcessorSerializationHashFile>
 
+    <TempFolder>$(TEMP)</TempFolder>
+    <TempFolder Condition="'$(TempFolder)' == ''">$(TMPDIR)</TempFolder>
+    <TempFolder Condition="'$(TempFolder)' == ''">/tmp</TempFolder>
+    
     <StrideAssemblyProcessorHash>$([System.IO.File]::ReadAllText('$(StrideAssemblyProcessorPath).hash'))</StrideAssemblyProcessorHash>
-    <StrideAssemblyProcessorTempBasePath>$(TEMP)\Stride\AssemblyProcessor\$(StrideAssemblyProcessorFramework)\$(StrideAssemblyProcessorHash)\</StrideAssemblyProcessorTempBasePath>
+    <StrideAssemblyProcessorTempBasePath>$(TempFolder)\Stride\AssemblyProcessor\$(StrideAssemblyProcessorFramework)\$(StrideAssemblyProcessorHash)\</StrideAssemblyProcessorTempBasePath>
     <StrideAssemblyProcessorTempPath>$(StrideAssemblyProcessorTempBasePath)Stride.Core.AssemblyProcessor.Packed$(StrideAssemblyProcessorExt)</StrideAssemblyProcessorTempPath>
   </PropertyGroup>
   <UsingTask TaskName="AssemblyProcessorTask" AssemblyFile="$(StrideAssemblyProcessorTempPath)" Condition=" '$(StrideAssemblyProcessorTempPath)' != '' And '$(StrideAssemblyProcessorDev)' != 'true' "/>

--- a/sources/engine/Stride.Games/Stride.Games.csproj
+++ b/sources/engine/Stride.Games/Stride.Games.csproj
@@ -11,8 +11,8 @@
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF Condition="'$(StridePlatform)' == 'Windows'">true</UseWPF>
+    <UseWindowsForms Condition="'$(StridePlatform)' == 'Windows'">true</UseWindowsForms>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>
     <StridePlatformDependent>true</StridePlatformDependent>

--- a/sources/engine/Stride.Input/Stride.Input.csproj
+++ b/sources/engine/Stride.Input/Stride.Input.csproj
@@ -8,8 +8,8 @@
   <Import Project="..\..\targets\Stride.props" />
   <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
   <PropertyGroup>
-    <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF Condition="'$(StridePlatform)' == 'Windows'">true</UseWPF>
+    <UseWindowsForms Condition="'$(StridePlatform)' == 'Windows'">true</UseWindowsForms>
     <StridePlatformDependent>true</StridePlatformDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideBuildTags>*</StrideBuildTags>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes two issues with the Stride NuGet packages that made it harder to compile game projects on Linux.

1. On linux there's no `TEMP` variable so the assembly processor was copied to the root directory (which is usually forbidden without root privilages).
2. The Stride.Games and Stride.Input packages were referencing `Microsoft.WindowsDesktop.App` framework which is not present on Linux - when compiling Stride for Linux any code that uses windows stuff is disabled anyways (via `#` directives), so it was just up to the reference.

## Related Issue
Fixes #757 
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

It's much easier for me to test the Linux build if I can compile Stride packages on Windows, expose them as a NuGet source and compile the test project on Linux, rather than deploying the published Linux build from Windows.

Plus, it's now possible to copy compiled assets to Linux and work on the code of the game without a Windows machine.

If you want to test this PR see my [document on building Stride for Linux](https://gist.github.com/manio143/aef62ded55d37fdc684a25209d2b7497).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I haven't run tests, because from the Windows perspective nothing has changed.
I'm not sure how this behaves when compiling for UWP, but should work.