### PR TITLE
[Editor] Allow adding default configurations to GameSettings

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GameSettingsAssetNodeUpdater.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GameSettingsAssetNodeUpdater.cs
@@ -27,7 +27,7 @@ namespace Stride.Assets.Presentation.NodePresenters.Updaters
                     item.Order = node.Order + item.Index.Int;
                     item.AttachedProperties.Add(CategoryData.Key, true);
                 }
-                node.BypassNode();
+                node.Commands.Add(new AddNewItemCommand());
             }
 
             if (typeof(Configuration).IsAssignableFrom(node.Type))

--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GameSettingsAssetNodeUpdater.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GameSettingsAssetNodeUpdater.cs
@@ -27,7 +27,8 @@ namespace Stride.Assets.Presentation.NodePresenters.Updaters
                     item.Order = node.Order + item.Index.Int;
                     item.AttachedProperties.Add(CategoryData.Key, true);
                 }
-                node.Commands.Add(new AddNewItemCommand());
+                if (!node.Commands.Any(cmd => cmd.Name == AddNewItemCommand.CommandName))
+                    node.Commands.Add(new AddNewItemCommand());
             }
 
             if (typeof(Configuration).IsAssignableFrom(node.Type))

--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GameSettingsAssetNodeUpdater.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GameSettingsAssetNodeUpdater.cs
@@ -29,6 +29,8 @@ namespace Stride.Assets.Presentation.NodePresenters.Updaters
                 }
                 if (!node.Commands.Any(cmd => cmd.Name == AddNewItemCommand.CommandName))
                     node.Commands.Add(new AddNewItemCommand());
+                if (!node.Commands.Any(cmd => cmd.Name == RemoveItemCommand.CommandName))
+                    node.Commands.Add(new RemoveItemCommand());
             }
 
             if (typeof(Configuration).IsAssignableFrom(node.Type))

--- a/sources/editor/Stride.Assets.Presentation/TemplateProviders/GameSettingAddConfigurationTemplateProvider.cs
+++ b/sources/editor/Stride.Assets.Presentation/TemplateProviders/GameSettingAddConfigurationTemplateProvider.cs
@@ -6,7 +6,7 @@ using Stride.Core.Presentation.Quantum.ViewModels;
 namespace Stride.Assets.Presentation.TemplateProviders
 {
     /// <summary>
-    /// Removes the standard collection header/expander of <see cref="GameSettingsAsset.Defaults"/>.
+    /// Removes the standard collection header/expander of <see cref="GameSettingsAsset.Defaults"/> and provides a custom footer.
     /// For XAML part see <see href="../View/EntityPropertyTemplates.xaml"/>.
     /// </summary>
     public class GameSettingAddConfigurationTemplateProvider : NodeViewModelTemplateProvider
@@ -15,7 +15,9 @@ namespace Stride.Assets.Presentation.TemplateProviders
 
         public override bool MatchNode(NodeViewModel node)
         {
-            return node.Type == typeof(List<Configuration>) && node.Name == nameof(GameSettingsAsset.Defaults);
+            return node.Parent?.Type == typeof(GameSettingsAsset)
+                && node.Type == typeof(List<Configuration>) 
+                && node.Name == nameof(GameSettingsAsset.Defaults);
         }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/TemplateProviders/GameSettingAddConfigurationTemplateProvider.cs
+++ b/sources/editor/Stride.Assets.Presentation/TemplateProviders/GameSettingAddConfigurationTemplateProvider.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Stride.Data;
+using Stride.Core.Presentation.Quantum.View;
+using Stride.Core.Presentation.Quantum.ViewModels;
+
+namespace Stride.Assets.Presentation.TemplateProviders
+{
+    /// <summary>
+    /// Removes the standard collection header/expander of <see cref="GameSettingsAsset.Defaults"/>.
+    /// For XAML part see <see href="../View/EntityPropertyTemplates.xaml"/>.
+    /// </summary>
+    public class GameSettingAddConfigurationTemplateProvider : NodeViewModelTemplateProvider
+    {
+        public override string Name => nameof(GameSettingAddConfigurationTemplateProvider);
+
+        public override bool MatchNode(NodeViewModel node)
+        {
+            return node.Type == typeof(List<Configuration>) && node.Name == nameof(GameSettingsAsset.Defaults);
+        }
+    }
+}

--- a/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
+++ b/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
@@ -254,5 +254,30 @@
           Visibility="{Binding IsVisible, Converter={sd:VisibleOrCollapsed}}" />
     </DataTemplate>
   </tp:GameSettingAddConfigurationTemplateProvider>
+
+  <tp:GameSettingAddConfigurationTemplateProvider x:Key="" OverrideRule="All" sd:PropertyViewHelper.TemplateCategory="PropertyFooter">
+    <DataTemplate>
+      <Grid>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="10"/>
+          <ColumnDefinition Width="125"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <Grid Grid.Column="1" Margin="0,2,5,2" VerticalAlignment="Center">
+          <DockPanel>
+            <Button DockPanel.Dock="Right" Style="{StaticResource AddNewItemButtonStyle}"/>
+            <ComboBox DockPanel.Dock="Right" x:Name="InstanceTypeSelectionComboBox" Style="{StaticResource AddItemComboBox}"
+                          ItemsSource="{Binding AbstractNodeMatchingEntries}" Margin="2,0">
+              <i:Interaction.Behaviors>
+                <behaviors:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewItem}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
+              </i:Interaction.Behaviors>
+            </ComboBox>
+            <TextBlock Text="{sd:Localize Add configuration}" TextTrimming="CharacterEllipsis" FontStyle="Italic"/>
+          </DockPanel>
+        </Grid>
+      </Grid>
+    </DataTemplate>
+  </tp:GameSettingAddConfigurationTemplateProvider>
 </ResourceDictionary>
 

--- a/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
+++ b/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
@@ -255,28 +255,18 @@
     </DataTemplate>
   </tp:GameSettingAddConfigurationTemplateProvider>
 
-  <tp:GameSettingAddConfigurationTemplateProvider x:Key="" OverrideRule="All" sd:PropertyViewHelper.TemplateCategory="PropertyFooter">
+  <tp:GameSettingAddConfigurationTemplateProvider x:Key="GameSettingAddConfigurationTemplateProviderFooter" OverrideRule="All" sd:PropertyViewHelper.TemplateCategory="PropertyFooter">
     <DataTemplate>
-      <Grid>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="10"/>
-          <ColumnDefinition Width="125"/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-
-        <Grid Grid.Column="1" Margin="0,2,5,2" VerticalAlignment="Center">
-          <DockPanel>
-            <Button DockPanel.Dock="Right" Style="{StaticResource AddNewItemButtonStyle}"/>
-            <ComboBox DockPanel.Dock="Right" x:Name="InstanceTypeSelectionComboBox" Style="{StaticResource AddItemComboBox}"
-                          ItemsSource="{Binding AbstractNodeMatchingEntries}" Margin="2,0">
-              <i:Interaction.Behaviors>
-                <behaviors:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewItem}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
-              </i:Interaction.Behaviors>
-            </ComboBox>
-            <TextBlock Text="{sd:Localize Add configuration}" TextTrimming="CharacterEllipsis" FontStyle="Italic"/>
-          </DockPanel>
-        </Grid>
-      </Grid>
+      <StackPanel Margin="10,2,5,2" Orientation="Horizontal">
+        <TextBlock Text="{sd:Localize Add configuration}" TextTrimming="CharacterEllipsis" FontStyle="Italic" Margin="0,0,2,0"/>
+        <Button Style="{StaticResource AddNewItemButtonStyle}"/>
+        <ComboBox x:Name="InstanceTypeSelectionComboBox" Style="{StaticResource AddItemComboBox}"
+            ItemsSource="{Binding AbstractNodeMatchingEntries}" Margin="2,0">
+          <i:Interaction.Behaviors>
+            <behaviors:OnComboBoxClosedWithSelectionBehavior Command="{Binding AddNewItem}" CommandParameter="{Binding SelectedItem, ElementName=InstanceTypeSelectionComboBox}"/>
+          </i:Interaction.Behaviors>
+        </ComboBox>
+      </StackPanel>
     </DataTemplate>
   </tp:GameSettingAddConfigurationTemplateProvider>
 </ResourceDictionary>

--- a/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
+++ b/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
@@ -246,5 +246,13 @@
       </DockPanel>
     </DataTemplate>
   </tp:GameSettingsFiltersTemplateProvider>
+
+  <tp:GameSettingAddConfigurationTemplateProvider x:Key="GameSettingAddConfigurationTemplateProvider" OverrideRule="All"
+   sd:PropertyViewHelper.TemplateCategory="PropertyHeader">
+    <DataTemplate>
+      <Border sd:PropertyViewHelper.Increment="0" sd:PropertyViewHelper.IsExpanded="True"
+          Visibility="{Binding IsVisible, Converter={sd:VisibleOrCollapsed}}" />
+    </DataTemplate>
+  </tp:GameSettingAddConfigurationTemplateProvider>
 </ResourceDictionary>
 

--- a/sources/engine/Stride.Assets/GameSettingsAsset.cs
+++ b/sources/engine/Stride.Assets/GameSettingsAsset.cs
@@ -78,7 +78,7 @@ namespace Stride.Assets
         public bool DoubleViewSplashScreen { get; set; } = false;
 
         [DataMember(2000)]
-        [MemberCollection(ReadOnly = true, NotNullItems = true)]
+        [MemberCollection(ReadOnly = false, NotNullItems = true)]
         public List<Configuration> Defaults { get; } = new List<Configuration>();
 
         [DataMember(3000)]


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR modifies the presentation of `GameSettingsAsset.Defaults` in such way, that the Quantum nodes with default configurations are no longer spilled into the root node for the asset, but kept as a collection which allows to use the existing templates to display an add button that provides a way to add custom configurations.

Comparison between old and new look:
![stride_gamesettings_add_configuration_change](https://user-images.githubusercontent.com/10709060/98464412-a0c79480-21ba-11eb-92db-20f2cb2edcfd.png)

I tried to add a button without modifying the way it looks now, but it seems that might not be possible. In particular, after the items in `Defaults` are spilled into the root, any modifications to the collection won't properly update the view without opening a different asset in the property grid and forcing a full refresh.

## Related Issue

Closes #844 

## Motivation and Context

We need a quick way to add settings for non-default packages (e.g. Physics or Navigation). It can also be used for adding custom configurations created by the user. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.