### PR TITLE
Fix using uninitialized CharacterScript in SpaceEscape sample

### DIFF
--- a/samples/Games/SpaceEscape/SpaceEscape.Game/CharacterScript.cs
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/CharacterScript.cs
@@ -73,6 +73,7 @@ namespace SpaceEscape
         }
 
         private bool shouldProcessInput;
+        private bool started;
         private AgentState state; // Current state of the agent
         private PlayingAnimation playingAnimation; // Current active animation
         private float startChangeLanePosX; // Position of X before changing lane
@@ -94,6 +95,8 @@ namespace SpaceEscape
             var modelMinBB = boundingBoxes[BoundingBoxKeys.Normal].Minimum;
             var modelMaxBB = boundingBoxes[BoundingBoxKeys.Normal].Maximum;
             boundingBoxes[BoundingBoxKeys.Slide] = new BoundingBox(modelMinBB, new Vector3(modelMaxBB.X, modelMaxBB.Y - 0.7f, modelMaxBB.Z));
+
+            started = true;
         }
 
         /// <summary>
@@ -139,6 +142,8 @@ namespace SpaceEscape
         /// </summary>
         public void Reset()
         {
+            if (!started)
+                return;
             shouldProcessInput = false;
             State = AgentState.Run;
             CurLane = MiddleLane;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Because of #860 AsyncScript now has a correct update priority, but it's always running after the Start methods of StartupScripts. This lead to an incorrect order of execution of game logic, which I roughly mitigated here. In the future we may consider making an AsyncScript variant with a Start method that gets executed earlier.

## Related Issue

N/A
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Tried running the sample game, got an exception.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.