### PR TITLE
Add default RID to Windows, TargetFramework and global.json project template

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>
     <RootNamespace><#= Properties.Namespace #></RootNamespace>

--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework><#= Properties.TargetFramework #></TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>

--- a/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
@@ -136,6 +136,8 @@ namespace Stride.Assets.Presentation.Templates
             //write gitignore
             WriteGitIgnore(parameters);
 
+            WriteGlobalJson(parameters);
+
             // Setup the assets folder
             //Directory.CreateDirectory(UPath.Combine(package.RootDirectory, (UDirectory)"Assets/Shared"));
 

--- a/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
@@ -108,6 +108,8 @@ namespace Stride.Assets.Presentation.Templates
             //write gitignore
             WriteGitIgnore(parameters);
 
+            WriteGlobalJson(parameters);
+
             UFile projectOutputFile = null;
             UFile projectInputFile = null;
 

--- a/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/SessionTemplateGenerator.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/SessionTemplateGenerator.cs
@@ -9,6 +9,9 @@ using Stride.Core.Assets.Templates;
 using Stride.Core.Yaml;
 using System.IO;
 using Stride.Core.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Locator;
+using System.Linq;
 
 namespace Stride.Core.Assets.Editor.Components.TemplateDescriptions
 {
@@ -35,6 +38,8 @@ _ReSharper*
 obj/
 Cache/
 "; //sadly templates and new games are different, the first ones are basically a copy the second is more programatically, so our best bet to have something easy to mantain is this for now.
+
+        private static string GlobalJson(string version) => $"{{ \"sdk\": {{ \"version\": \"{version}\" }} }}";
 
         public sealed override bool Run(SessionTemplateGeneratorParameters parameters)
         {
@@ -124,6 +129,16 @@ Cache/
         {
             var fileName = UFile.Combine(parameters.OutputDirectory, ".gitignore");
             File.WriteAllText(fileName.ToWindowsPath(), GitIgnore);
+        }
+
+        protected void WriteGlobalJson(SessionTemplateGeneratorParameters parameters)
+        {
+            if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Core"))
+                return;
+            var sdkVersion = MSBuildLocator.QueryVisualStudioInstances()
+                .First(vs => vs.DiscoveryType == DiscoveryType.DotNetSdk && vs.Version.Major >= 3).Version;
+            var fileName = UFile.Combine(parameters.OutputDirectory, "global.json");
+            File.WriteAllText(fileName.ToWindowsPath(), GlobalJson(sdkVersion.ToString()));
         }
 
         private void EnsureGraphs(SessionTemplateGeneratorParameters parameters)

--- a/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
+++ b/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
@@ -15,6 +15,7 @@ using Stride.Graphics;
 using Stride.Shaders.Parser.Mixins;
 using Stride.Core.VisualStudio;
 using Stride.Core.Extensions;
+using System.Runtime.InteropServices;
 
 namespace Stride.Assets.Templates
 {
@@ -117,6 +118,12 @@ namespace Stride.Assets.Templates
 
                     // We are going to regenerate this platform, so we are removing it before
                     package.Session.Projects.Remove(existingProject);
+                }
+
+                if (platform.Platform.Type == PlatformType.Windows)
+                {
+                    var isNETCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+                    AddOption(parameters, "TargetFramework", isNETCore ? "netcoreapp3.1" : "net461");
                 }
 
                 var projectDirectory = Path.GetDirectoryName(projectFullPath.ToWindowsPath());
@@ -273,6 +280,12 @@ namespace Stride.Assets.Templates
 
             AddOption(parameters, "ProjectType", projectType);
             AddOption(parameters, "Namespace", parameters.Namespace ?? Utilities.BuildValidNamespaceName(package.Meta.Name));
+
+            if (platformType == PlatformType.Windows)
+            {
+                var isNETCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+                AddOption(parameters, "TargetFramework", isNETCore ? "netcoreapp3.1" : "net461");
+            }
 
             return projectTemplate;
         }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
* Adds the windows RID to executable project template, so that when someone changes target framework to `netcoreapp3.1` they aren't immediately hit with freetype.dll missing exception.
* Setup Windows project to use .NET Core if created from .NET Core GameStudio
* Add global.json when using .NET Core GameStudio

## Related Issue
#911 
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.