### PR TITLE
Fallback to net472 AssetCompiler first

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -117,8 +117,8 @@
       <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net472\Stride.Core.Assets.CompilerApp.exe') And $(TargetFramework.StartsWith('net4'))">net472</StrideCompileAssetTargetFramework>
 
       <!-- Otherwise, fallback to whichever framework is available -->
-      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\netcoreapp3.1\Stride.Core.Assets.CompilerApp.exe')">netcoreapp3.1</StrideCompileAssetTargetFramework>
       <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net472\Stride.Core.Assets.CompilerApp.exe')">net472</StrideCompileAssetTargetFramework>
+      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\netcoreapp3.1\Stride.Core.Assets.CompilerApp.exe')">netcoreapp3.1</StrideCompileAssetTargetFramework>
 
       <StrideCompileAssetCommand Condition="'$(StrideCompileAssetCommand)' == ''">$(StrideCompileAssetCommandPath)\$(StrideCompileAssetTargetFramework)\Stride.Core.Assets.CompilerApp.exe</StrideCompileAssetCommand>
     </PropertyGroup>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

When choosing AssetCompiler version for projects that don't target .NET Framework or .NET Core, choose .NET Framework so that MSBuild tools are used.

## Related Issue
Fixes #904 
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Mobile projects don't target .NET Framework or .NET Core, but require MSBuild tools to be used rather than dotnet build tool.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.