### PR TITLE
[Graphics] When creating the swap chain use the handle as provided by the WindowHandle

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -364,24 +364,17 @@ namespace Stride.Graphics
         }
 #else
         /// <summary>
-        /// Create the SwapChain on Windows. To avoid any hard dependency on a actual windowing system
-        /// we assume that the <c>Description.DeviceWindowHandle.NativeHandle</c> holds
-        /// a window type that exposes the <code>Handle</code> property of type <see cref="IntPtr"/>.
+        /// Create the SwapChain on Windows.
         /// </summary>
         /// <returns></returns>
         private SwapChain CreateSwapChainForWindows()
         {
-            var nativeHandle = Description.DeviceWindowHandle.NativeWindow;
-            var handleProperty = nativeHandle.GetType().GetProperty("Handle", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-            if (handleProperty != null && handleProperty.PropertyType == typeof(IntPtr))
+            var hwndPtr = Description.DeviceWindowHandle.Handle;
+            if (hwndPtr != IntPtr.Zero)
             {
-                var hwndPtr = (IntPtr)handleProperty.GetValue(nativeHandle);
-                if (hwndPtr != IntPtr.Zero)
-                {
-                    return CreateSwapChainForDesktop(hwndPtr);
-                }
+                return CreateSwapChainForDesktop(hwndPtr);
             }
-            throw new NotSupportedException($"Form of type [{Description.DeviceWindowHandle?.GetType().Name ?? "null"}] is not supported. Only System.Windows.Control or SDL2.Window are supported");
+            throw new InvalidOperationException($"The {nameof(WindowHandle)}.{nameof(WindowHandle.Handle)} must not be zero.");
         }
 
         private SwapChain CreateSwapChainForDesktop(IntPtr handle)


### PR DESCRIPTION
# PR Details

Assuming the window has a property called Handle which points to the HWND is not correct. This allows to use the Stride graphics API in other windowing frameworks like for example https://github.com/Ultz/Silk.NET

## Related Issue

https://github.com/Ultz/Silk.NET/issues/347

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.