### PR TITLE
Support multiple window input sources

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -338,9 +338,10 @@ namespace Stride.Engine
 
             // Add the input manager
             // Add it first so that it can obtained by the UI system
-            Input = new InputManager(Services);
+            var inputSystem = new InputSystem(Services);
+            Input = inputSystem.Manager;
             Services.AddService(Input);
-            GameSystems.Add(Input);
+            GameSystems.Add(inputSystem);
 
             // Initialize the systems
             base.Initialize();

--- a/sources/engine/Stride.Engine/Engine/InputSystem.cs
+++ b/sources/engine/Stride.Engine/Engine/InputSystem.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Stride contributors (https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Stride.Core;
+using Stride.Games;
+using Stride.Input;
+
+namespace Stride.Engine
+{
+    /// <summary>
+    /// The input system updating the input manager exposed by <see cref="Game.Input"/>.
+    /// </summary>
+    sealed class InputSystem : GameSystemBase
+    {
+        public InputSystem(IServiceRegistry registry) : base(registry)
+        {
+            Enabled = true;
+            Manager = new InputManager().DisposeBy(this);
+        }
+
+        public InputManager Manager { get; }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            Manager.Initialize(Game.Context);
+
+            Game.Activated += OnApplicationResumed;
+            Game.Deactivated += OnApplicationPaused;
+        }
+
+        protected override void Destroy()
+        {
+            Game.Activated -= OnApplicationResumed;
+            Game.Deactivated -= OnApplicationPaused;
+
+            // ensure that OnApplicationPaused is called before destruction, when Game.Deactivated event is not triggered.
+            OnApplicationPaused(this, EventArgs.Empty);
+
+            base.Destroy();
+        }
+
+        public override void Update(GameTime gameTime) => Manager.Update(gameTime);
+
+        private void OnApplicationPaused(object sender, EventArgs e) => Manager.Pause();
+
+        private void OnApplicationResumed(object sender, EventArgs e) => Manager.Resume();
+    }
+}

--- a/sources/engine/Stride.Input/Android/InputSourceAndroid.cs
+++ b/sources/engine/Stride.Input/Android/InputSourceAndroid.cs
@@ -18,7 +18,7 @@ namespace Stride.Input
     /// </summary>
     internal class InputSourceAndroid : InputSourceBase
     {
-        private AndroidStrideGameView uiControl;
+        private readonly AndroidStrideGameView uiControl;
         
         private KeyboardAndroid keyboard;
         private PointerAndroid pointer;
@@ -39,11 +39,13 @@ namespace Stride.Input
         private float[] quaternionArray = new float[4];
         private float[] rotationVector = new float[3];
 
+        public InputSourceAndroid(AndroidStrideGameView uiControl)
+        {
+            this.uiControl = uiControl ?? throw new ArgumentNullException(nameof(uiControl));
+        }
+
         public override void Initialize(InputManager inputManager)
         {
-            var context = inputManager.Game.Context as GameContextAndroid;
-            uiControl = context.Control;
-
             // Create android pointer and keyboard
             keyboard = new KeyboardAndroid(this, uiControl);
             pointer = new PointerAndroid(this, uiControl);

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -241,9 +241,9 @@ namespace Stride.Input
 
                 if (value)
                 {
-                    if (rawInputSource == null)
+                    if (rawInputSource == null && Game.Context is GameContextWinforms gameContextWinforms)
                     {
-                        rawInputSource = new InputSourceWindowsRawInput();
+                        rawInputSource = new InputSourceWindowsRawInput(gameContextWinforms.Control);
                         Sources.Add(rawInputSource);
                     }
                 }
@@ -580,40 +580,41 @@ namespace Stride.Input
 
         private void AddSources()
         {
-            // Create input sources
-            switch (Game.Context.ContextType)
+            var context = Game.Context;
+
+            // Add window specific input source
+            var windowInputSource = InputSourceFactory.NewWindowInputSource(context);
+            Sources.Add(windowInputSource);
+
+            // Add platform specific input sources
+            switch (context.ContextType)
             {
 #if STRIDE_UI_SDL
                 case AppContextType.DesktopSDL:
-                    Sources.Add(new InputSourceSDL());
                     break;
 #endif
 #if STRIDE_PLATFORM_ANDROID
                 case AppContextType.Android:
-                    Sources.Add(new InputSourceAndroid());
                     break;
 #endif
 #if STRIDE_PLATFORM_IOS
                 case AppContextType.iOS:
-                    Sources.Add(new InputSourceiOS());
                     break;
 #endif
 #if STRIDE_PLATFORM_UWP
                 case AppContextType.UWPXaml:
                 case AppContextType.UWPCoreWindow:
-                    Sources.Add(new InputSourceUWP());
                     break;
 #endif
                 case AppContextType.Desktop:
 #if STRIDE_PLATFORM_WINDOWS && (STRIDE_UI_WINFORMS || STRIDE_UI_WPF)
-                    Sources.Add(new InputSourceWinforms());
                     Sources.Add(new InputSourceWindowsDirectInput());
                     if (InputSourceWindowsXInput.IsSupported())
                         Sources.Add(new InputSourceWindowsXInput());
 #endif
 #if STRIDE_INPUT_RAWINPUT
-                    if (rawInputEnabled)
-                        Sources.Add(new InputSourceWindowsRawInput());
+                    if (rawInputEnabled && context is GameContextWinforms gameContextWinforms)
+                        Sources.Add(new InputSourceWindowsRawInput(gameContextWinforms.Control));
 #endif
                     break;
                 default:

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -16,7 +16,7 @@ namespace Stride.Input
     /// <summary>
     /// Manages collecting input from connected input device in the form of <see cref="IInputDevice"/> objects. Also provides some convenience functions for most commonly used devices
     /// </summary>
-    public partial class InputManager : GameSystemBase
+    public partial class InputManager : ComponentBase
     {
         //this is used in some mobile platform for accelerometer stuff
         internal const float G = 9.81f;
@@ -51,6 +51,8 @@ namespace Stride.Input
 
         private readonly Dictionary<Type, IInputEventRouter> eventRouters = new Dictionary<Type, IInputEventRouter>();
 
+        private GameContext gameContext;
+
         private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs>> devicesCollectionChangedActions = new Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs>>();
 
 #if STRIDE_INPUT_RAWINPUT
@@ -60,10 +62,9 @@ namespace Stride.Input
         /// <summary>
         /// Initializes a new instance of the <see cref="InputManager"/> class.
         /// </summary>
-        internal InputManager(IServiceRegistry registry) : base(registry)
+        /// <param name="gameContext">The game context.</param>
+        public InputManager()
         {
-            Enabled = true;
-            
             Gestures = new TrackingCollection<GestureConfig>();
             Gestures.CollectionChanged += GesturesOnCollectionChanged;
 
@@ -224,7 +225,7 @@ namespace Stride.Input
         /// Gets the collection of connected sensor devices
         /// </summary>
         public IReadOnlyList<ISensorDevice> Sensors => sensors;
-        
+
         /// <summary>
         /// Should raw input be used on windows
         /// </summary>
@@ -241,7 +242,7 @@ namespace Stride.Input
 
                 if (value)
                 {
-                    if (rawInputSource == null && Game.Context is GameContextWinforms gameContextWinforms)
+                    if (rawInputSource == null && gameContext is GameContextWinforms gameContextWinforms)
                     {
                         rawInputSource = new InputSourceWindowsRawInput(gameContextWinforms.Control);
                         Sources.Add(rawInputSource);
@@ -291,19 +292,16 @@ namespace Stride.Input
                 (screenCoordinates.Y * fromSize.Height - destinationRectangle.Y) / destinationRectangle.Height);
         }
 
-        public override void Initialize()
+        public void Initialize(GameContext gameContext)
         {
-            base.Initialize();
-
-            Game.Activated += OnApplicationResumed;
-            Game.Deactivated += OnApplicationPaused;
+            this.gameContext = gameContext ?? throw new ArgumentNullException(nameof(gameContext));
 
             AddSources();
 
             // After adding initial devices, reassign gamepad id's
             // this creates a beter index assignment in the case where you have both an xbox controller and another controller at startup
             var sortedGamePads = GamePads.OrderBy(x => x.CanChangeIndex);
-            
+
             foreach (var gamePad in sortedGamePads)
             {
                 if (gamePad.CanChangeIndex)
@@ -394,7 +392,7 @@ namespace Stride.Input
             }
         }
 
-        public override void Update(GameTime gameTime)
+        public void Update(GameTime gameTime)
         {
             ResetGlobalInputState();
 
@@ -479,25 +477,29 @@ namespace Stride.Input
             virtualButtonValues[configIndex].TryGetValue(bindingName, out value);
             return value;
         }
-        
-        private void OnApplicationPaused(object sender, EventArgs e)
+
+        /// <summary>
+        /// Pause all input sources.
+        /// </summary>
+        public void Pause()
         {
-            // Pause sources
             foreach (var source in Sources)
             {
                 source.Pause();
             }
         }
 
-        private void OnApplicationResumed(object sender, EventArgs e)
+        /// <summary>
+        /// Resume all input sources.
+        /// </summary>
+        public void Resume()
         {
-            // Resume sources
             foreach (var source in Sources)
             {
                 source.Resume();
             }
         }
-        
+
         private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs e)
         {
             var source = (IInputSource)e.Item;
@@ -540,7 +542,7 @@ namespace Stride.Input
         {
             eventRouters[inputEvent.GetType()].PoolEvent(inputEvent);
         }
-
+        
         /// <summary>
         /// Resets the <see cref="Sources"/> collection back to it's default values
         /// </summary>
@@ -580,7 +582,7 @@ namespace Stride.Input
 
         private void AddSources()
         {
-            var context = Game.Context;
+            var context = gameContext;
 
             // Add window specific input source
             var windowInputSource = InputSourceFactory.NewWindowInputSource(context);
@@ -634,12 +636,6 @@ namespace Stride.Input
             {
                 source.Dispose();
             }
-
-            Game.Activated -= OnApplicationResumed;
-            Game.Deactivated -= OnApplicationPaused;
-
-            // ensure that OnApplicationPaused is called before destruction, when Game.Deactivated event is not triggered.
-            OnApplicationPaused(this, EventArgs.Empty);
         }
 
         private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)

--- a/sources/engine/Stride.Input/InputSourceFactory.cs
+++ b/sources/engine/Stride.Input/InputSourceFactory.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Stride contributors (https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Stride.Games;
+
+namespace Stride.Input
+{
+    /// <summary>
+    /// Given a <see cref="GameContext"/> creates the corresponding <see cref="IInputSource"/> for the platform specific window.
+    /// </summary>
+    public static class InputSourceFactory
+    {
+        /// <summary>
+        /// Creates a new input source for the window provided by the <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The context containing the platform specific window.</param>
+        /// <returns>An input source for the window.</returns>
+        public static IInputSource NewWindowInputSource(GameContext context)
+        {
+            switch (context.ContextType)
+            {
+#if STRIDE_UI_SDL
+                case AppContextType.DesktopSDL:
+                    var sdlContext = (GameContextSDL)context;
+                    return new InputSourceSDL(sdlContext.Control);
+#endif
+#if STRIDE_PLATFORM_ANDROID
+                case AppContextType.Android:
+                    var androidContext = (GameContextAndroid)context;
+                    return new InputSourceAndroid(androidContext.Control);
+#endif
+#if STRIDE_PLATFORM_IOS
+                case AppContextType.iOS:
+                    var iosContext = (GameContextiOS)context;
+                    return new InputSourceiOS(iosContext.Control);
+#endif
+#if STRIDE_PLATFORM_UWP
+                case AppContextType.UWPXaml:
+                    var uwpXamlContext = (GameContextUWPXaml)context;
+                    return new InputSourceUWP(Windows.UI.Xaml.Window.Current.CoreWindow);
+                case AppContextType.UWPCoreWindow:
+                    var uwpContext = (GameContextUWPCoreWindow)context;
+                    return new InputSourceUWP(uwpContext.Control);
+#endif
+#if STRIDE_PLATFORM_WINDOWS && (STRIDE_UI_WINFORMS || STRIDE_UI_WPF)
+                case AppContextType.Desktop:
+                    var winformsContext = (GameContextWinforms)context;
+                    return new InputSourceWinforms(winformsContext.Control);
+#endif
+                default:
+                    throw new InvalidOperationException("GameContext type is not supported by the InputManager");
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Input/SDL/InputSourceSDL.cs
+++ b/sources/engine/Stride.Input/SDL/InputSourceSDL.cs
@@ -17,22 +17,24 @@ namespace Stride.Input
     {
         private readonly HashSet<Guid> devicesToRemove = new HashSet<Guid>();
         private readonly Dictionary<int, Guid> joystickInstanceIdToDeviceId = new Dictionary<int, Guid>();
-        private GameContext<Window> context;
-        private Window uiControl;
+        private readonly Window uiControl;
         private MouseSDL mouse;
         private KeyboardSDL keyboard;
         private PointerSDL pointer; // Touch
         private InputManager inputManager;
 
+        public InputSourceSDL(Window uiControl)
+        {
+            this.uiControl = uiControl ?? throw new ArgumentNullException(nameof(uiControl));
+        }
+
         public override void Initialize(InputManager inputManager)
         {
             this.inputManager = inputManager;
-            context = inputManager.Game.Context as GameContext<Window>;
-            uiControl = context.Control;
 
             SDL.SDL_InitSubSystem(SDL.SDL_INIT_JOYSTICK);
 
-            mouse = new MouseSDL(this, inputManager.Game, uiControl);
+            mouse = new MouseSDL(this, uiControl);
             keyboard = new KeyboardSDL(this, uiControl);
             pointer = new PointerSDL(this, uiControl);
 

--- a/sources/engine/Stride.Input/SDL/MouseSDL.cs
+++ b/sources/engine/Stride.Input/SDL/MouseSDL.cs
@@ -5,23 +5,20 @@
 using System;
 using SDL2;
 using Stride.Core.Mathematics;
-using Stride.Games;
 using Stride.Graphics.SDL;
 
 namespace Stride.Input
 {
     internal class MouseSDL : MouseDeviceBase, IDisposable
     {
-        private readonly GameBase game;
         private readonly Window uiControl;
 
         private bool isMousePositionLocked;
         private Point relativeCapturedPosition;
 
-        public MouseSDL(InputSourceSDL source, GameBase game, Window uiControl)
+        public MouseSDL(InputSourceSDL source, Window uiControl)
         {
             Source = source;
-            this.game = game;
             this.uiControl = uiControl;
             
             uiControl.MouseMoveActions += OnMouseMoveEvent;

--- a/sources/engine/Stride.Input/UWP/InputSourceUWP.cs
+++ b/sources/engine/Stride.Input/UWP/InputSourceUWP.cs
@@ -26,6 +26,7 @@ namespace Stride.Input
 
         private readonly Dictionary<Gamepad, GamePadUWP> gamePads = new Dictionary<Gamepad, GamePadUWP>();
 
+        private readonly CoreWindow coreWindow;
         private WindowsAccelerometer windowsAccelerometer;
         private WindowsCompass windowsCompass;
         private WindowsGyroscope windowsGyroscope;
@@ -41,18 +42,13 @@ namespace Stride.Input
         private PointerUWP pointer;
         private KeyboardUWP keyboard;
 
+        public InputSourceUWP(CoreWindow coreWindow)
+        {
+            this.coreWindow = coreWindow ?? throw new ArgumentNullException(nameof(coreWindow));
+        }
+
         public override void Initialize(InputManager inputManager)
         {
-            var nativeWindow = inputManager.Game.Window.NativeWindow;
-            
-            CoreWindow coreWindow;
-            if (nativeWindow.Context == AppContextType.UWPCoreWindow)
-                coreWindow = (CoreWindow)nativeWindow.NativeWindow;
-            else if (nativeWindow.Context == AppContextType.UWPXaml)
-                coreWindow = Window.Current.CoreWindow;
-            else
-                throw new ArgumentException(string.Format("WindowContext [{0}] not supported", nativeWindow.Context));
-
             var mouseCapabilities = new MouseCapabilities();
             if (mouseCapabilities.MousePresent > 0)
             {

--- a/sources/engine/Stride.Input/Windows/InputSourceWindowsRawInput.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWindowsRawInput.cs
@@ -15,14 +15,16 @@ namespace Stride.Input
     /// </summary>
     internal class InputSourceWindowsRawInput : InputSourceBase
     {
+        private readonly Control uiControl;
         private KeyboardWindowsRawInput keyboard;
-        private Control uiControl;
+
+        public InputSourceWindowsRawInput(Control uiControl)
+        {
+            this.uiControl = uiControl ?? throw new ArgumentNullException(nameof(uiControl));
+        }
 
         public override void Initialize(InputManager inputManager)
         {
-            var gameContext = inputManager.Game.Context as GameContext<Control>;
-            uiControl = gameContext.Control;
-
             keyboard = new KeyboardWindowsRawInput(this);
             RegisterDevice(keyboard);
             BindRawInputKeyboard(uiControl);

--- a/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
@@ -30,8 +30,7 @@ namespace Stride.Input
         private Win32Native.WndProc inputWndProc;
 
         // My input devices
-        private GameContext<Control> gameContext;
-        private Control uiControl;
+        private readonly Control uiControl;
         private InputManager input;
 
         /// <summary>
@@ -39,11 +38,15 @@ namespace Stride.Input
         /// </summary>
         public bool IsMousePositionLocked { get; protected set; }
 
+        public InputSourceWinforms(Control uiControl)
+        {
+            this.uiControl = uiControl ?? throw new ArgumentNullException(nameof(uiControl));
+        }
+
         public override void Initialize(InputManager inputManager)
         {
             input = inputManager;
-            gameContext = inputManager.Game.Context as GameContext<Control>;
-            uiControl = gameContext.Control;
+
             uiControl.LostFocus += UIControlOnLostFocus;
             MissingInputHack();
 

--- a/sources/engine/Stride.Input/iOS/InputSourceiOS.cs
+++ b/sources/engine/Stride.Input/iOS/InputSourceiOS.cs
@@ -16,6 +16,7 @@ namespace Stride.Input
     /// </summary>
     internal class InputSourceiOS : InputSourceBase
     {
+        private readonly iOSWindow uiControl;
         private CMMotionManager motionManager;
         private CLLocationManager locationManager;
         private bool locationManagerActivated;
@@ -28,12 +29,15 @@ namespace Stride.Input
         private OrientationSensor orientationSensor;
         private GravitySensor gravitySensor;
         private CompassSensor compassSensor;
+
+        public InputSourceiOS(iOSWindow uiControl)
+        {
+            this.uiControl = uiControl;
+        }
         
         public override void Initialize(InputManager inputManager)
         {
-            var context = inputManager.Game.Context as GameContextiOS;
-            var uiControl = context.Control;
-            var gameController = context.Control.GameViewController;
+            var gameController = uiControl.GameViewController;
 
             pointer = new PointeriOS(this, uiControl, gameController);
             RegisterDevice(pointer);


### PR DESCRIPTION
## Description

Allows to create additional input sources through a new static method called `InputSourceFactory.NewWindowInputSource` as well as decouples the input manager and the game by moving the game system specific logic into a new internal class called `InputSystem`.

## Motivation and Context

In [VL.Stride](https://github.com/vvvv/VL.Stride) we support rendering to multiple windows. The changes in this PR are needed to create input sources for those additional game windows. Further the decoupling of the input manager could be useful in other scenarios where we don't even have a game.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.