### PR TITLE
.NET 5

### DIFF
--- a/build/Stride.Launcher.Build.props
+++ b/build/Stride.Launcher.Build.props
@@ -6,6 +6,6 @@
     <!-- Defines the platform used by Stride - Values are Windows/Android/iOS...etc. -->
     <StridePlatform Condition=" '$(StridePlatform)' == '' ">Windows</StridePlatform>
 
-    <StrideEditorTargetFrameworks>netcoreapp3.1</StrideEditorTargetFrameworks>
+    <StrideEditorTargetFrameworks>net5.0-windows</StrideEditorTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/sources/assets/Stride.Core.Assets.CompilerApp/Stride.Core.Assets.CompilerApp.csproj
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/Stride.Core.Assets.CompilerApp.csproj
@@ -9,7 +9,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -48,7 +48,7 @@
   <Import Project="..\..\tools\Stride.Core.VisualStudio\Stride.Core.VisualStudio.projitems" Label="Shared" />
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -113,12 +113,13 @@
       <StrideCompileAssetCommandPath Condition="Exists('$(MSBuildThisFileDirectory)..\Stride.Core.Assets.CompilerApp.csproj')">$(MSBuildThisFileDirectory)..\bin\$(Configuration)</StrideCompileAssetCommandPath>
 
       <!-- Try to guess correct which version of asset compiler to use depending on user TargetFramework -->
-      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\netcoreapp3.1\Stride.Core.Assets.CompilerApp.exe') And $(TargetFramework.StartsWith('netcoreapp'))">netcoreapp3.1</StrideCompileAssetTargetFramework>
+      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net5.0-windows7.0\Stride.Core.Assets.CompilerApp.exe') And $(TargetFramework.StartsWith('net5'))">net5.0-windows7.0</StrideCompileAssetTargetFramework>
+      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net5.0-windows7.0\Stride.Core.Assets.CompilerApp.exe') And $(TargetFramework.StartsWith('netcoreapp'))">net5.0-windows7.0</StrideCompileAssetTargetFramework>
       <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net472\Stride.Core.Assets.CompilerApp.exe') And $(TargetFramework.StartsWith('net4'))">net472</StrideCompileAssetTargetFramework>
 
       <!-- Otherwise, fallback to whichever framework is available -->
       <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net472\Stride.Core.Assets.CompilerApp.exe')">net472</StrideCompileAssetTargetFramework>
-      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\netcoreapp3.1\Stride.Core.Assets.CompilerApp.exe')">netcoreapp3.1</StrideCompileAssetTargetFramework>
+      <StrideCompileAssetTargetFramework Condition="'$(StrideCompileAssetTargetFramework)' == '' And Exists('$(StrideCompileAssetCommandPath)\net5.0-windows7.0\Stride.Core.Assets.CompilerApp.exe')">net5.0-windows7.0</StrideCompileAssetTargetFramework>
 
       <StrideCompileAssetCommand Condition="'$(StrideCompileAssetCommand)' == ''">$(StrideCompileAssetCommandPath)\$(StrideCompileAssetTargetFramework)\Stride.Core.Assets.CompilerApp.exe</StrideCompileAssetCommand>
     </PropertyGroup>

--- a/sources/assets/Stride.Core.Assets.CompilerApp/global.json
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "5.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
+++ b/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -34,5 +34,5 @@
     <ProjectReference Include="..\Stride.Core.Assets\Stride.Core.Assets.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -33,7 +33,7 @@ namespace Stride.Core.Assets
             if (MSBuildInstance == null && Interlocked.Increment(ref MSBuildLocatorCount) == 1)
             {
                 // Detect either .NET Core SDK or Visual Studio depending on current runtime
-                var isNETCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+                var isNETCore = !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
                 MSBuildInstance = MSBuildLocator.QueryVisualStudioInstances().FirstOrDefault(x => isNETCore
                     ? x.DiscoveryType == DiscoveryType.DotNetSdk && x.Version.Major >= 3
                     : (x.DiscoveryType == DiscoveryType.VisualStudioSetup || x.DiscoveryType == DiscoveryType.DeveloperConsole) && x.Version.Major >= 16);

--- a/sources/assets/Stride.Core.Assets/Stride.Core.Assets.csproj
+++ b/sources/assets/Stride.Core.Assets/Stride.Core.Assets.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -49,5 +49,5 @@
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="..\Stride.Core.Assets.Yaml\Stride.Core.Assets.Yaml.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -85,23 +85,6 @@ namespace Stride.Core.Packages
             sourceRepositoryProvider = new NugetSourceRepositoryProvider(packageSourceProvider, this);
         }
 
-        /// <summary>
-        /// Increase nuget HTTP timeout from 100 sec to something much higher (workaround for https://github.com/NuGet/Home/issues/8120).
-        /// </summary>
-        /// <remarks>
-        /// This needs to be called before any NuGet function is called, otherwise it will lead to a FieldAccessException (HttpSourceRequest already initialized).
-        /// </remarks>
-        public static void RemoveHttpTimeout()
-        {
-            // Workaround for https://github.com/NuGet/Home/issues/8120
-            //  set timeout to something much higher than 100 sec
-            var defaultRequestTimeoutField = typeof(HttpSourceRequest).GetField(nameof(HttpSourceRequest.DefaultRequestTimeout), BindingFlags.Static | BindingFlags.Public);
-            if (defaultRequestTimeoutField != null)
-            {
-                defaultRequestTimeoutField.SetValue(null, TimeSpan.FromMinutes(60));
-            }
-        }
-
         private static void RemoveSources(ISettings settings, string prefixName)
         {
             var packageSources = settings.GetSection("packageSources");

--- a/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
+++ b/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -35,5 +35,5 @@
     </None>
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
+++ b/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
@@ -8,8 +8,8 @@
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="5.5.1" />
-    <PackageReference Include="Stride.NuGet.PackageManagement" Version="5.5.1" />
+    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageReference Include="Stride.NuGet.PackageManagement" Version="5.8.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Stride.Core.BuildEngine.Common.csproj
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Stride.Core.BuildEngine.Common.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -25,5 +25,5 @@
     <ProjectReference Include="..\..\core\Stride.Core.Design\Stride.Core.Design.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/buildengine/Stride.Core.BuildEngine/Stride.Core.BuildEngine.csproj
+++ b/sources/buildengine/Stride.Core.BuildEngine/Stride.Core.BuildEngine.csproj
@@ -3,7 +3,7 @@
     <StridePlatform>Windows</StridePlatform>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -27,5 +27,5 @@
     <ProjectReference Include="..\Stride.Core.BuildEngine.Common\Stride.Core.BuildEngine.Common.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -35,6 +35,6 @@
   </ItemGroup>
   
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="NuGet.Configuration" Version="5.5.1" />
+    <PackageReference Include="NuGet.Configuration" Version="5.8.0" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>

--- a/sources/core/Stride.Core.Design/TypeConverters/Half2Converter.cs
+++ b/sources/core/Stride.Core.Design/TypeConverters/Half2Converter.cs
@@ -52,6 +52,7 @@ using System.Globalization;
 using System.Reflection;
 using Stride.Core.Annotations;
 using Stride.Core.Mathematics;
+using Half = Stride.Core.Mathematics.Half;
 
 namespace Stride.Core.TypeConverters
 {

--- a/sources/core/Stride.Core.Design/TypeConverters/Half3Converter.cs
+++ b/sources/core/Stride.Core.Design/TypeConverters/Half3Converter.cs
@@ -52,6 +52,7 @@ using System.Globalization;
 using System.Reflection;
 using Stride.Core.Annotations;
 using Stride.Core.Mathematics;
+using Half = Stride.Core.Mathematics.Half;
 
 namespace Stride.Core.TypeConverters
 {

--- a/sources/core/Stride.Core.Design/TypeConverters/Half4Converter.cs
+++ b/sources/core/Stride.Core.Design/TypeConverters/Half4Converter.cs
@@ -52,6 +52,7 @@ using System.Globalization;
 using System.Reflection;
 using Stride.Core.Annotations;
 using Stride.Core.Mathematics;
+using Half = Stride.Core.Mathematics.Half;
 
 namespace Stride.Core.TypeConverters
 {

--- a/sources/core/Stride.Core.Design/TypeConverters/HalfConverter.cs
+++ b/sources/core/Stride.Core.Design/TypeConverters/HalfConverter.cs
@@ -50,6 +50,7 @@ using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 
 using Stride.Core.Mathematics;
+using Half = Stride.Core.Mathematics.Half;
 
 namespace Stride.Core.TypeConverters
 {

--- a/sources/core/Stride.Core.IO/Stride.Core.IO.csproj
+++ b/sources/core/Stride.Core.IO/Stride.Core.IO.csproj
@@ -3,7 +3,7 @@
     <StrideRuntime>true</StrideRuntime>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   
   <PropertyGroup>
     <Description>Stride Core IO assembly.</Description>
@@ -33,6 +33,6 @@
   </ItemGroup>
   
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -49,5 +49,5 @@
     <ProjectReference Include="..\..\assets\Stride.Core.Assets\Stride.Core.Assets.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/core/Stride.Core.Translation/Stride.Core.Translation.csproj
+++ b/sources/core/Stride.Core.Translation/Stride.Core.Translation.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -24,5 +24,5 @@
     <ProjectReference Include="..\Stride.Core\Stride.Core.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/core/Stride.Core.Yaml/Stride.Core.Yaml.csproj
+++ b/sources/core/Stride.Core.Yaml/Stride.Core.Yaml.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -18,5 +18,5 @@
     <ProjectReference Include="..\Stride.Core.Reflection\Stride.Core.Reflection.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/core/Stride.Core/Stride.Core.csproj
+++ b/sources/core/Stride.Core/Stride.Core.csproj
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <StrideRuntime>true</StrideRuntime>
+    <StrideRuntimeNet5>true</StrideRuntimeNet5>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.Core.props" />
   <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />

--- a/sources/core/Stride.Core/Stride.Core.csproj
+++ b/sources/core/Stride.Core/Stride.Core.csproj
@@ -3,7 +3,7 @@
     <StrideRuntime>true</StrideRuntime>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   
   <PropertyGroup>
     <Description>Core assembly for all Stride assemblies.</Description>
@@ -122,5 +122,5 @@
   </ItemGroup>
   
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/editor/Stride.Assets.Presentation/Module.cs
+++ b/sources/editor/Stride.Assets.Presentation/Module.cs
@@ -16,7 +16,7 @@ namespace Stride.Assets.Presentation
 {
     internal class Module
     {
-        [ModuleInitializer]
+        [Core.ModuleInitializer]
         public static void Initialize()
         {
             RuntimeHelpers.RunModuleConstructor(typeof(SpriteFontAsset).Module.ModuleHandle);

--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
@@ -117,7 +117,7 @@
     <None Include="Templates\Assets\**" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
@@ -16,6 +16,7 @@
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
     <StrideRoslynPadTargetFramework Condition="$(TargetFramework.StartsWith('net4'))">net462</StrideRoslynPadTargetFramework>
     <StrideRoslynPadTargetFramework Condition="$(TargetFramework.StartsWith('netcoreapp'))">netcoreapp3.1</StrideRoslynPadTargetFramework>
+    <StrideRoslynPadTargetFramework Condition="$(TargetFramework.StartsWith('net5'))">netcoreapp3.1</StrideRoslynPadTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />

--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Linux/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Linux/$ProjectName$.csproj.t4
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>

--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.macOS/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.macOS/$ProjectName$.csproj.t4
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>

--- a/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
+++ b/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -70,7 +70,7 @@
   </ItemGroup>
   <Import Project="..\..\editor\Stride.Core.MostRecentlyUsedFiles\Stride.Core.MostRecentlyUsedFiles.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/editor/Stride.Editor/Stride.Editor.csproj
+++ b/sources/editor/Stride.Editor/Stride.Editor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
@@ -61,5 +61,5 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="..\Stride.PrivacyPolicy\Stride.PrivacyPolicy.projitems" Label="Shared" Condition="Exists('..\Stride.PrivacyPolicy\Stride.PrivacyPolicy.projitems')" />
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="..\..\tools\Stride.Core.VisualStudio\Stride.Core.VisualStudio.projitems" Label="Shared" />
@@ -40,6 +40,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <Reference Include="Stride.Core.AssemblyProcessor" >
       <HintPath Condition="$(TargetFramework.StartsWith('net4'))">..\..\..\deps\AssemblyProcessor\net472\Stride.Core.AssemblyProcessor.exe</HintPath>
+      <HintPath Condition="$(TargetFramework.StartsWith('net5'))">..\..\..\deps\AssemblyProcessor\netstandard2.0\Stride.Core.AssemblyProcessor.dll</HintPath>
       <HintPath Condition="$(TargetFramework.StartsWith('netcoreapp'))">..\..\..\deps\AssemblyProcessor\netstandard2.0\Stride.Core.AssemblyProcessor.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\tools\Stride.Core.VisualStudio\Stride.Core.VisualStudio.projitems" Label="Shared" />
   <Import Project="..\Stride.Editor.CrashReport\Stride.Editor.CrashReport.projitems" Label="Shared" />
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -107,7 +107,7 @@
   </ItemGroup>
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/editor/Stride.GameStudio/global.json
+++ b/sources/editor/Stride.GameStudio/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "5.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/sources/engine/Stride.Assets.Models/Stride.Assets.Models.csproj
+++ b/sources/engine/Stride.Assets.Models/Stride.Assets.Models.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>$(StrideAssemblyProcessorDefaultOptions)</StrideAssemblyProcessorOptions>
@@ -23,7 +23,7 @@
     <Folder Include="Analysis\" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/engine/Stride.Assets/Stride.Assets.csproj
+++ b/sources/engine/Stride.Assets/Stride.Assets.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -115,7 +115,7 @@
   </ItemGroup>
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/engine/Stride.Assets/StrideConfig.cs
+++ b/sources/engine/Stride.Assets/StrideConfig.cs
@@ -135,7 +135,7 @@ namespace Stride.Assets
             {
                 Name = PlatformType.Linux.ToString(),
                 IsAvailable = true,
-                TargetFramework = "netcoreapp2.1",
+                TargetFramework = "net5.0",
                 RuntimeIdentifier = "linux-x64",
                 Type = PlatformType.Linux,
             };
@@ -148,7 +148,7 @@ namespace Stride.Assets
             {
                 Name = PlatformType.macOS.ToString(),
                 IsAvailable = true,
-                TargetFramework = "netcoreapp2.1",
+                TargetFramework = "net5.0",
                 RuntimeIdentifier = "osx-x64",
                 Type = PlatformType.macOS,
             };

--- a/sources/engine/Stride.Audio/Stride.Audio.csproj
+++ b/sources/engine/Stride.Audio/Stride.Audio.csproj
@@ -5,7 +5,7 @@
     <StrideRuntime>true</StrideRuntime>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -48,5 +48,5 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Debugger/Stride.Debugger.csproj
+++ b/sources/engine/Stride.Debugger/Stride.Debugger.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -24,5 +24,5 @@
     <ProjectReference Include="..\Stride.Assets\Stride.Assets.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
@@ -37,7 +37,7 @@
   </ItemGroup>
   <Import Project="..\Stride.Shared\Refactor\Stride.Refactor.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/sources/engine/Stride.FontCompiler/Stride.FontCompiler.csproj
+++ b/sources/engine/Stride.FontCompiler/Stride.FontCompiler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -19,5 +19,5 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Games.Testing/Stride.Games.Testing.csproj
+++ b/sources/engine/Stride.Games.Testing/Stride.Games.Testing.csproj
@@ -3,7 +3,7 @@
     <StrideRuntime>true</StrideRuntime>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePlatformDependent>true</StridePlatformDependent>
@@ -24,5 +24,5 @@
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Games/Stride.Games.csproj
+++ b/sources/engine/Stride.Games/Stride.Games.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <StrideRuntime>true</StrideRuntime>
     <StrideRuntimeWindowsDotNet>true</StrideRuntimeWindowsDotNet>
-    <StrideRuntimeWindowsNetCoreApp3>true</StrideRuntimeWindowsNetCoreApp3>
+    <StrideRuntimeWindowsNet5>true</StrideRuntimeWindowsNet5>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <UseWindowsForms Condition="$(StrideUI.Contains('WINFORMS')) OR $(StrideUI.Contains('WPF'))">true</UseWindowsForms>
   </PropertyGroup>

--- a/sources/engine/Stride.Games/Stride.Games.csproj
+++ b/sources/engine/Stride.Games/Stride.Games.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms Condition="$(StrideUI.Contains('WINFORMS')) OR $(StrideUI.Contains('WPF'))">true</UseWindowsForms>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -47,5 +47,5 @@
     <ProjectReference Include="..\Stride.Graphics\Stride.Graphics.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Graphics.Regression/Stride.Graphics.Regression.csproj
+++ b/sources/engine/Stride.Graphics.Regression/Stride.Graphics.Regression.csproj
@@ -4,7 +4,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StridePlatformFilter>Windows;Android;iOS;Linux;macOS;UWP</StridePlatformFilter>
     <DefineConstants>$(DefineConstants);XAMCORE_2_0</DefineConstants>
@@ -51,6 +51,6 @@
   </ItemGroup>
 
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -4,7 +4,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -69,7 +69,7 @@
   </ItemGroup>
   <Import Project="..\Stride.Shared\Refactor\Stride.Refactor.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/engine/Stride.Input/GameControllerDeviceBase.cs
+++ b/sources/engine/Stride.Input/GameControllerDeviceBase.cs
@@ -40,9 +40,9 @@ namespace Stride.Input
         public abstract IReadOnlyList<GameControllerAxisInfo> AxisInfos { get; }
         public abstract IReadOnlyList<GameControllerDirectionInfo> DirectionInfos { get; }
 
-        public IReadOnlySet<int> PressedButtons { get; }
-        public IReadOnlySet<int> ReleasedButtons { get; }
-        public IReadOnlySet<int> DownButtons { get; }
+        public Core.Collections.IReadOnlySet<int> PressedButtons { get; }
+        public Core.Collections.IReadOnlySet<int> ReleasedButtons { get; }
+        public Core.Collections.IReadOnlySet<int> DownButtons { get; }
 
         /// <summary>
         /// Creates the correct amount of states based on the amount of object infos that are set

--- a/sources/engine/Stride.Input/GamePadDeviceBase.cs
+++ b/sources/engine/Stride.Input/GamePadDeviceBase.cs
@@ -32,9 +32,9 @@ namespace Stride.Input
             }
         }
 
-        public IReadOnlySet<GamePadButton> PressedButtons { get; }
-        public IReadOnlySet<GamePadButton> ReleasedButtons { get; }
-        public IReadOnlySet<GamePadButton> DownButtons { get; }
+        public Core.Collections.IReadOnlySet<GamePadButton> PressedButtons { get; }
+        public Core.Collections.IReadOnlySet<GamePadButton> ReleasedButtons { get; }
+        public Core.Collections.IReadOnlySet<GamePadButton> DownButtons { get; }
 
         public abstract IInputSource Source { get; }
 

--- a/sources/engine/Stride.Input/IGameControllerDevice.cs
+++ b/sources/engine/Stride.Input/IGameControllerDevice.cs
@@ -35,17 +35,17 @@ namespace Stride.Input
         /// <summary>
         /// The buttons that have been pressed since the last frame
         /// </summary>
-        IReadOnlySet<int> PressedButtons { get; }
+        Core.Collections.IReadOnlySet<int> PressedButtons { get; }
 
         /// <summary>
         /// The buttons that have been released since the last frame
         /// </summary>
-        IReadOnlySet<int> ReleasedButtons { get; }
+        Core.Collections.IReadOnlySet<int> ReleasedButtons { get; }
 
         /// <summary>
         /// The buttons that are down
         /// </summary>
-        IReadOnlySet<int> DownButtons { get; }
+        Core.Collections.IReadOnlySet<int> DownButtons { get; }
         
         /// <summary>
         /// Retrieves the state of a single axis

--- a/sources/engine/Stride.Input/IGamePadDevice.cs
+++ b/sources/engine/Stride.Input/IGamePadDevice.cs
@@ -37,17 +37,17 @@ namespace Stride.Input
         /// <summary>
         /// The gamepad buttons that have been pressed since the last frame
         /// </summary>
-        IReadOnlySet<GamePadButton> PressedButtons { get; }
+        Core.Collections.IReadOnlySet<GamePadButton> PressedButtons { get; }
 
         /// <summary>
         /// The gamepad buttons that have been released since the last frame
         /// </summary>
-        IReadOnlySet<GamePadButton> ReleasedButtons { get; }
+        Core.Collections.IReadOnlySet<GamePadButton> ReleasedButtons { get; }
 
         /// <summary>
         /// The gamepad buttons that are down
         /// </summary>
-        IReadOnlySet<GamePadButton> DownButtons { get; }
+        Core.Collections.IReadOnlySet<GamePadButton> DownButtons { get; }
 
         /// <summary>
         /// Raised if the index assigned to this gamepad changed

--- a/sources/engine/Stride.Input/IGamePadDevice.cs
+++ b/sources/engine/Stride.Input/IGamePadDevice.cs
@@ -2,7 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using Stride.Core.Collections;
+using System.Collections.Generic;
 
 namespace Stride.Input
 {

--- a/sources/engine/Stride.Input/IKeyboardDevice.cs
+++ b/sources/engine/Stride.Input/IKeyboardDevice.cs
@@ -14,16 +14,16 @@ namespace Stride.Input
         /// <summary>
         /// The keys that have been pressed since the last frame
         /// </summary>
-        IReadOnlySet<Keys> PressedKeys { get; }
+        Core.Collections.IReadOnlySet<Keys> PressedKeys { get; }
 
         /// <summary>
         /// The keys that have been released since the last frame
         /// </summary>
-        IReadOnlySet<Keys> ReleasedKeys { get; }
+        Core.Collections.IReadOnlySet<Keys> ReleasedKeys { get; }
 
         /// <summary>
         /// List of keys that are currently down on this keyboard
         /// </summary>
-        IReadOnlySet<Keys> DownKeys { get; }
+        Core.Collections.IReadOnlySet<Keys> DownKeys { get; }
     }
 }

--- a/sources/engine/Stride.Input/IMouseDevice.cs
+++ b/sources/engine/Stride.Input/IMouseDevice.cs
@@ -24,17 +24,17 @@ namespace Stride.Input
         /// <summary>
         /// The mouse buttons that have been pressed since the last frame
         /// </summary>
-        IReadOnlySet<MouseButton> PressedButtons { get; }
+        Core.Collections.IReadOnlySet<MouseButton> PressedButtons { get; }
 
         /// <summary>
         /// The mouse buttons that have been released since the last frame
         /// </summary>
-        IReadOnlySet<MouseButton> ReleasedButtons { get; }
+        Core.Collections.IReadOnlySet<MouseButton> ReleasedButtons { get; }
 
         /// <summary>
         /// The mouse buttons that are down
         /// </summary>
-        IReadOnlySet<MouseButton> DownButtons { get; }
+        Core.Collections.IReadOnlySet<MouseButton> DownButtons { get; }
         
         /// <summary>
         /// Gets or sets if the mouse is locked to the screen

--- a/sources/engine/Stride.Input/IMouseDevice.cs
+++ b/sources/engine/Stride.Input/IMouseDevice.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Stride.Core.Collections;
+using System.Collections.Generic;
 using Stride.Core.Mathematics;
 
 namespace Stride.Input

--- a/sources/engine/Stride.Input/IPointerDevice.cs
+++ b/sources/engine/Stride.Input/IPointerDevice.cs
@@ -26,17 +26,17 @@ namespace Stride.Input
         /// <summary>
         /// The index of the pointers that have been pressed since the last frame
         /// </summary>
-        IReadOnlySet<PointerPoint> PressedPointers { get; }
+        Core.Collections.IReadOnlySet<PointerPoint> PressedPointers { get; }
 
         /// <summary>
         /// The index of the pointers that have been released since the last frame
         /// </summary>
-        IReadOnlySet<PointerPoint> ReleasedPointers { get; }
+        Core.Collections.IReadOnlySet<PointerPoint> ReleasedPointers { get; }
 
         /// <summary>
         /// The index of the pointers that are down
         /// </summary>
-        IReadOnlySet<PointerPoint> DownPointers { get; }
+        Core.Collections.IReadOnlySet<PointerPoint> DownPointers { get; }
 
         /// <summary>
         /// Raised when the surface size of this pointer changed

--- a/sources/engine/Stride.Input/InputManager.State.cs
+++ b/sources/engine/Stride.Input/InputManager.State.cs
@@ -106,7 +106,7 @@ namespace Stride.Input
         /// <summary>
         /// The keys that have been pressed since the last frame
         /// </summary>
-        public IReadOnlySet<Keys> PressedKeys
+        public Core.Collections.IReadOnlySet<Keys> PressedKeys
         {
             get
             {
@@ -118,7 +118,7 @@ namespace Stride.Input
         /// <summary>
         /// The keys that have been released since the last frame
         /// </summary>
-        public IReadOnlySet<Keys> ReleasedKeys
+        public Core.Collections.IReadOnlySet<Keys> ReleasedKeys
         {
             get
             {
@@ -130,7 +130,7 @@ namespace Stride.Input
         /// <summary>
         /// The keys that are down
         /// </summary>
-        public IReadOnlySet<Keys> DownKeys
+        public Core.Collections.IReadOnlySet<Keys> DownKeys
         {
             get
             {
@@ -142,7 +142,7 @@ namespace Stride.Input
         /// <summary>
         /// The mouse buttons that have been pressed since the last frame
         /// </summary>
-        public IReadOnlySet<MouseButton> PressedButtons
+        public Core.Collections.IReadOnlySet<MouseButton> PressedButtons
         {
             get
             {
@@ -154,7 +154,7 @@ namespace Stride.Input
         /// <summary>
         /// The mouse buttons that have been released since the last frame
         /// </summary>
-        public IReadOnlySet<MouseButton> ReleasedButtons
+        public Core.Collections.IReadOnlySet<MouseButton> ReleasedButtons
         {
             get
             {
@@ -166,7 +166,7 @@ namespace Stride.Input
         /// <summary>
         /// The mouse buttons that are down
         /// </summary>
-        public IReadOnlySet<MouseButton> DownButtons
+        public Core.Collections.IReadOnlySet<MouseButton> DownButtons
         {
             get
             {

--- a/sources/engine/Stride.Input/KeyboardDeviceBase.cs
+++ b/sources/engine/Stride.Input/KeyboardDeviceBase.cs
@@ -27,9 +27,9 @@ namespace Stride.Input
             DownKeys = new ReadOnlySet<Keys>(downKeys);
         }
 
-        public IReadOnlySet<Keys> PressedKeys { get; }
-        public IReadOnlySet<Keys> ReleasedKeys { get; }
-        public IReadOnlySet<Keys> DownKeys { get; }
+        public Core.Collections.IReadOnlySet<Keys> PressedKeys { get; }
+        public Core.Collections.IReadOnlySet<Keys> ReleasedKeys { get; }
+        public Core.Collections.IReadOnlySet<Keys> DownKeys { get; }
 
         public abstract string Name { get; }
 

--- a/sources/engine/Stride.Input/MouseDeviceBase.cs
+++ b/sources/engine/Stride.Input/MouseDeviceBase.cs
@@ -21,9 +21,9 @@ namespace Stride.Input
 
         public abstract bool IsPositionLocked { get; }
 
-        public IReadOnlySet<MouseButton> PressedButtons => MouseState.PressedButtons;
-        public IReadOnlySet<MouseButton> ReleasedButtons => MouseState.ReleasedButtons;
-        public IReadOnlySet<MouseButton> DownButtons => MouseState.DownButtons;
+        public Core.Collections.IReadOnlySet<MouseButton> PressedButtons => MouseState.PressedButtons;
+        public Core.Collections.IReadOnlySet<MouseButton> ReleasedButtons => MouseState.ReleasedButtons;
+        public Core.Collections.IReadOnlySet<MouseButton> DownButtons => MouseState.DownButtons;
 
         public Vector2 Position => MouseState.Position;
         public Vector2 Delta => MouseState.Delta;

--- a/sources/engine/Stride.Input/MouseDeviceState.cs
+++ b/sources/engine/Stride.Input/MouseDeviceState.cs
@@ -34,9 +34,9 @@ namespace Stride.Input
             ReleasedButtons = new ReadOnlySet<MouseButton>(releasedButtons);
         }
 
-        public IReadOnlySet<MouseButton> PressedButtons { get; }
-        public IReadOnlySet<MouseButton> ReleasedButtons { get; }
-        public IReadOnlySet<MouseButton> DownButtons { get; }
+        public Core.Collections.IReadOnlySet<MouseButton> PressedButtons { get; }
+        public Core.Collections.IReadOnlySet<MouseButton> ReleasedButtons { get; }
+        public Core.Collections.IReadOnlySet<MouseButton> DownButtons { get; }
         
         public Vector2 Position { get; set; }
         public Vector2 Delta { get; set; }

--- a/sources/engine/Stride.Input/PointerDeviceBase.cs
+++ b/sources/engine/Stride.Input/PointerDeviceBase.cs
@@ -22,9 +22,9 @@ namespace Stride.Input
 
         public Vector2 SurfaceSize => PointerState.SurfaceSize;
         public float SurfaceAspectRatio => PointerState.SurfaceAspectRatio;
-        public IReadOnlySet<PointerPoint> PressedPointers => PointerState.PressedPointers;
-        public IReadOnlySet<PointerPoint> ReleasedPointers => PointerState.ReleasedPointers;
-        public IReadOnlySet<PointerPoint> DownPointers => PointerState.DownPointers;
+        public Core.Collections.IReadOnlySet<PointerPoint> PressedPointers => PointerState.PressedPointers;
+        public Core.Collections.IReadOnlySet<PointerPoint> ReleasedPointers => PointerState.ReleasedPointers;
+        public Core.Collections.IReadOnlySet<PointerPoint> DownPointers => PointerState.DownPointers;
         public event EventHandler<SurfaceSizeChangedEventArgs> SurfaceSizeChanged;
 
         public int Priority { get; set; }

--- a/sources/engine/Stride.Input/PointerDeviceState.cs
+++ b/sources/engine/Stride.Input/PointerDeviceState.cs
@@ -37,9 +37,9 @@ namespace Stride.Input
         public Vector2 InverseSurfaceSize => invSurfaceSize;
         public float SurfaceAspectRatio => aspectRatio;
 
-        public IReadOnlySet<PointerPoint> PressedPointers { get; }
-        public IReadOnlySet<PointerPoint> ReleasedPointers { get; }
-        public IReadOnlySet<PointerPoint> DownPointers { get; }
+        public Core.Collections.IReadOnlySet<PointerPoint> PressedPointers { get; }
+        public Core.Collections.IReadOnlySet<PointerPoint> ReleasedPointers { get; }
+        public Core.Collections.IReadOnlySet<PointerPoint> DownPointers { get; }
 
         public IPointerDevice SourceDevice;
 

--- a/sources/engine/Stride.Input/Stride.Input.csproj
+++ b/sources/engine/Stride.Input/Stride.Input.csproj
@@ -6,7 +6,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <UseWPF Condition="'$(StridePlatform)' == 'Windows'">true</UseWPF>
     <UseWindowsForms Condition="'$(StridePlatform)' == 'Windows'">true</UseWindowsForms>
@@ -30,5 +30,5 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" Condition="'$(StridePlatform)' == 'Windows'" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Input/Stride.Input.csproj
+++ b/sources/engine/Stride.Input/Stride.Input.csproj
@@ -1,8 +1,8 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <StrideRuntime>true</StrideRuntime>
     <StrideRuntimeWindowsDotNet>true</StrideRuntimeWindowsDotNet>
-    <StrideRuntimeWindowsNetCoreApp3>true</StrideRuntimeWindowsNetCoreApp3>
+    <StrideRuntimeWindowsNet5>true</StrideRuntimeWindowsNet5>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButton.Pointer.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButton.Pointer.cs
@@ -121,7 +121,7 @@ namespace Stride.Input
                 return 0f;
             }
 
-            private bool AnyPointerInState(InputManager manager, Func<IPointerDevice, IReadOnlySet<PointerPoint>> stateGetter)
+            private bool AnyPointerInState(InputManager manager, Func<IPointerDevice, Core.Collections.IReadOnlySet<PointerPoint>> stateGetter)
             {
                 foreach (var pointerDevice in manager.Pointers)
                 {
@@ -134,17 +134,17 @@ namespace Stride.Input
                 return false;
             }
 
-            private IReadOnlySet<PointerPoint> GetDownPointers(IPointerDevice device)
+            private Core.Collections.IReadOnlySet<PointerPoint> GetDownPointers(IPointerDevice device)
             {
                 return device.DownPointers;
             }
 
-            private IReadOnlySet<PointerPoint> GetPressedPointers(IPointerDevice device)
+            private Core.Collections.IReadOnlySet<PointerPoint> GetPressedPointers(IPointerDevice device)
             {
                 return device.DownPointers;
             }
 
-            private IReadOnlySet<PointerPoint> GetReleasedPointers(IPointerDevice device)
+            private Core.Collections.IReadOnlySet<PointerPoint> GetReleasedPointers(IPointerDevice device)
             {
                 return device.DownPointers;
             }

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButton.Pointer.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButton.Pointer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
-using Stride.Core.Collections;
+using System.Collections.Generic;
 
 namespace Stride.Input
 {

--- a/sources/engine/Stride.Native/Stride.Native.csproj
+++ b/sources/engine/Stride.Native/Stride.Native.csproj
@@ -5,7 +5,7 @@
     <StrideNativeOutputName>libstride</StrideNativeOutputName>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -35,5 +35,5 @@
     <None Include="Lightprobes\predicates.c" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Navigation/Stride.Navigation.csproj
+++ b/sources/engine/Stride.Navigation/Stride.Navigation.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -43,6 +43,6 @@
   </ItemGroup>
 
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/engine/Stride.Physics/Stride.Physics.csproj
+++ b/sources/engine/Stride.Physics/Stride.Physics.csproj
@@ -4,7 +4,7 @@
     <StrideRuntime>true</StrideRuntime>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/engine/Stride.Shaders.Compiler/Stride.Shaders.Compiler.csproj
+++ b/sources/engine/Stride.Shaders.Compiler/Stride.Shaders.Compiler.csproj
@@ -4,7 +4,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideBuildTags>*</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
@@ -44,5 +44,5 @@
   </ItemGroup>
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.SpriteStudio.Offline/Stride.SpriteStudio.Offline.csproj
+++ b/sources/engine/Stride.SpriteStudio.Offline/Stride.SpriteStudio.Offline.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -26,5 +26,5 @@
     <None Include="Templates\Assets\.sdtpl\SpriteStudioModel.png" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.UI/Stride.UI.csproj
+++ b/sources/engine/Stride.UI/Stride.UI.csproj
@@ -3,7 +3,7 @@
     <StrideRuntime>true</StrideRuntime>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePlatformDependent>true</StridePlatformDependent>
@@ -25,5 +25,5 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.Video/Stride.Video.csproj
+++ b/sources/engine/Stride.Video/Stride.Video.csproj
@@ -4,7 +4,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePlatformDependent>true</StridePlatformDependent>
@@ -51,5 +51,5 @@
     <PackageReference Include="FFmpeg.AutoGen" Version="3.4.0.2" Condition="'$(StridePlatform)' == 'Windows'" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
+++ b/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
@@ -5,7 +5,7 @@
     <StrideNativeOutputName>libstridevr</StrideNativeOutputName>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -66,7 +66,7 @@
     <None Include="Fove\Fove.cpp" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>

--- a/sources/engine/Stride/Stride.csproj
+++ b/sources/engine/Stride/Stride.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
@@ -42,6 +42,6 @@
   </ItemGroup>
 
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/launcher/Stride.Launcher/Launcher.cs
+++ b/sources/launcher/Stride.Launcher/Launcher.cs
@@ -65,8 +65,6 @@ namespace Stride.LauncherApp
         [NotNull]
         internal static NugetStore InitializeNugetStore()
         {
-            NugetStore.RemoveHttpTimeout();
-
             var thisExeDirectory = new UFile(Assembly.GetEntryAssembly().Location).GetFullDirectory().ToWindowsPath();
             var store = new NugetStore(thisExeDirectory);
             return store;

--- a/sources/launcher/Stride.Launcher/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/sources/launcher/Stride.Launcher/Properties/PublishProfiles/FolderProfile.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>bin\Release\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishSingleFile>True</PublishSingleFile>

--- a/sources/launcher/Stride.Launcher/Services/LauncherSettings.cs
+++ b/sources/launcher/Stride.Launcher/Services/LauncherSettings.cs
@@ -15,7 +15,7 @@ namespace Stride.LauncherApp.Services
 
         private static readonly SettingsKey<bool> CloseLauncherAutomaticallyKey = new SettingsKey<bool>("Internal/Launcher/CloseLauncherAutomatically", SettingsContainer, false);
         private static readonly SettingsKey<string> ActiveVersionKey = new SettingsKey<string>("Internal/Launcher/ActiveVersion", SettingsContainer, "");
-        private static readonly SettingsKey<string> PreferredFrameworkKey = new SettingsKey<string>("Internal/Launcher/PreferredFramework", SettingsContainer, "netcoreapp3.1");
+        private static readonly SettingsKey<string> PreferredFrameworkKey = new SettingsKey<string>("Internal/Launcher/PreferredFramework", SettingsContainer, "net5.0");
         private static readonly SettingsKey<int> CurrentTabKey = new SettingsKey<int>("Internal/Launcher/CurrentTabSessions", SettingsContainer, 0);
         private static readonly SettingsKey<List<UDirectory>> DeveloperVersionsKey = new SettingsKey<List<UDirectory>>("Internal/Launcher/DeveloperVersions", SettingsContainer, () => new List<UDirectory>());
 

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.nuspec
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Stride.Launcher</id>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <authors>Stride</authors>
     <owners>Stride</owners>
     <licenseUrl>https://stride3d.net/license.txt</licenseUrl>

--- a/sources/presentation/Stride.Core.Presentation.Dialogs/Stride.Core.Presentation.Dialogs.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Dialogs/Stride.Core.Presentation.Dialogs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\Stride.Core.Presentation\Stride.Core.Presentation.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeExtraAssemblies</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/sources/presentation/Stride.Core.Presentation.Graph/Stride.Core.Presentation.Graph.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Graph/Stride.Core.Presentation.Graph.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -30,5 +30,5 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/presentation/Stride.Core.Presentation.Quantum/Stride.Core.Presentation.Quantum.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/Stride.Core.Presentation.Quantum.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
  
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
@@ -52,5 +52,5 @@
   </ItemGroup>
 
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/presentation/Stride.Core.Quantum/Stride.Core.Quantum.csproj
+++ b/sources/presentation/Stride.Core.Quantum/Stride.Core.Quantum.csproj
@@ -1,7 +1,7 @@
 <Project>
 
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
@@ -20,6 +20,6 @@
   </ItemGroup>
 
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
 </Project>

--- a/sources/presentation/Stride.Core.Translation.Presentation/Stride.Core.Translation.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Translation.Presentation/Stride.Core.Translation.Presentation.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -22,5 +22,5 @@
     <ProjectReference Include="..\..\core\Stride.Core.Translation\Stride.Core.Translation.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/shaders/Irony.GrammarExplorer/030.Irony.GrammarExplorer.2010.csproj
+++ b/sources/shaders/Irony.GrammarExplorer/030.Irony.GrammarExplorer.2010.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.Core.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -74,5 +74,5 @@
     <ProjectReference Include="..\Irony\Irony.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/shared/Stride.NuGetResolver/SplashScreenWindow.xaml.cs
+++ b/sources/shared/Stride.NuGetResolver/SplashScreenWindow.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/sources/shared/Stride.NuGetResolver/Stride.NuGetResolver.projitems
+++ b/sources/shared/Stride.NuGetResolver/Stride.NuGetResolver.projitems
@@ -38,7 +38,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.loaderdata</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <DefineConstants Condition="'$(StrideNuGetResolverUX)' == 'true'">STRIDE_NUGET_RESOLVER_UX;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5'))">
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.loaderdata</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_StridePackageNuGetLoader</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/sources/targets/Stride.Core.Cpp.props
+++ b/sources/targets/Stride.Core.Cpp.props
@@ -9,12 +9,12 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net5'))">
+    <TargetFramework>net5.0</TargetFramework>
     <TargetFrameworkVersion></TargetFrameworkVersion>
     <CLRSupport>NetCore</CLRSupport>
   </PropertyGroup>
-  <!-- Bug: Restore with StrideEditorTargetFrameworks=netcoreapp3.1 fails because Platform is set to Mixed Platforms -->
+  <!-- Bug: Restore with StrideEditorTargetFrameworks=net5.0 fails because Platform is set to Mixed Platforms -->
   <PropertyGroup Condition="'$(Platform)' == 'Mixed Platforms'">
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/sources/targets/Stride.Core.PostSettings.Dependencies.targets
+++ b/sources/targets/Stride.Core.PostSettings.Dependencies.targets
@@ -102,7 +102,10 @@
   <Target Name="_StrideComputePackagePath">
     <PropertyGroup>
       <_StrideAppendRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true'">true</_StrideAppendRuntimeIdentifier>
-      <_StridePackagePathLibrary Condition="'$(_StrideAppendRuntimeIdentifier)' != 'true'">lib\$(TargetFramework)</_StridePackagePathLibrary>
+      <_StridePackageLibraryTargetFramework>$(TargetFramework)</_StridePackageLibraryTargetFramework>
+      <!-- Not sure why, but .NET 5.0 PackTask transforms net5.0-windows to net5.0-windows7.0 behind our back for lib/ paths -->
+      <_StridePackageLibraryTargetFramework Condition="$(TargetFramework.EndsWith('-windows')) And '$(_StrideAppendRuntimeIdentifier)' != 'true'">$(_StridePackageLibraryTargetFramework)7.0</_StridePackageLibraryTargetFramework>
+      <_StridePackagePathLibrary Condition="'$(_StrideAppendRuntimeIdentifier)' != 'true'">lib\$(_StridePackageLibraryTargetFramework)</_StridePackagePathLibrary>
       <_StridePackagePathLibrary Condition="'$(_StrideAppendRuntimeIdentifier)' == 'true'">runtimes\$(RuntimeIdentifier)\lib\$(TargetFramework)</_StridePackagePathLibrary>
     </PropertyGroup>
   </Target>

--- a/sources/targets/Stride.Core.TargetFrameworks.Editor.props
+++ b/sources/targets/Stride.Core.TargetFrameworks.Editor.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <StrideEditorTargetFrameworks Condition="'$(StrideEditorTargetFrameworks)' == ''">net472</StrideEditorTargetFrameworks>
+    <StrideEditorTargetFrameworks Condition="'$(StrideEditorTargetFrameworks)' == ''">net5.0-windows</StrideEditorTargetFrameworks>
     <StrideEditorTargetFramework>$(StrideEditorTargetFrameworks.Split(';', StringSplitOptions.RemoveEmptyEntries)[0])</StrideEditorTargetFramework>
   </PropertyGroup>
 

--- a/sources/targets/Stride.Core.props
+++ b/sources/targets/Stride.Core.props
@@ -55,19 +55,20 @@
     <!-- Add netstandard2.0 no matter what (needed for references) -->
     <StrideRuntimeTargetFrameworks>netstandard2.0</StrideRuntimeTargetFrameworks>
     <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Windows;')) And '$(StrideRuntimeWindowsDotNet)' == 'true'">$(StrideRuntimeTargetFrameworks);net461</StrideRuntimeTargetFrameworks>
-    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Windows;')) And '$(StrideRuntimeWindowsNetCoreApp3)' == 'true'">$(StrideRuntimeTargetFrameworks);netcoreapp3.0</StrideRuntimeTargetFrameworks>
+    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Windows;')) And '$(StrideRuntimeNet5)' == 'true'">$(StrideRuntimeTargetFrameworks);net5.0</StrideRuntimeTargetFrameworks>
+    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Windows;')) And '$(StrideRuntimeWindowsNet5)' == 'true'">$(StrideRuntimeTargetFrameworks);net5.0-windows</StrideRuntimeTargetFrameworks>
     <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';UWP;'))">$(StrideRuntimeTargetFrameworks);uap10.0.16299</StrideRuntimeTargetFrameworks>
     <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Android;'))">$(StrideRuntimeTargetFrameworks);monoandroid81</StrideRuntimeTargetFrameworks>
     <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';iOS;'))">$(StrideRuntimeTargetFrameworks);xamarinios10</StrideRuntimeTargetFrameworks>
 
-    <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And ('$(TargetFramework)' == 'netstandard2.0' Or $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netcoreapp'))) And $(_StridePlatforms.Contains(';Windows;'))">$(StrideRuntimeIdentifiers);win</StrideRuntimeIdentifiers>
+    <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And ('$(TargetFramework)' == 'netstandard2.0' Or $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net5'))) And $(_StridePlatforms.Contains(';Windows;'))">$(StrideRuntimeIdentifiers);win</StrideRuntimeIdentifiers>
     <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And '$(TargetFramework)' == 'netstandard2.0' And $(_StridePlatforms.Contains(';Linux;'))">$(StrideRuntimeIdentifiers);linux</StrideRuntimeIdentifiers>
     <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And '$(TargetFramework)' == 'netstandard2.0' And $(_StridePlatforms.Contains(';macOS;'))">$(StrideRuntimeIdentifiers);osx</StrideRuntimeIdentifiers>
     <!-- Default: at least win (used when compiling only a single platform such as UWP for netstandard assemblies) -->
     <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And '$(TargetFramework)' == 'netstandard2.0' And '$(StrideRuntimeIdentifiers)' == ''">win</StrideRuntimeIdentifiers>
 
     <!-- Need to use a runtime identifier for all other platforms as a workaround https://github.com/NuGet/Home/issues/7661#issuecomment-450040204 -->
-    <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And '$(TargetFramework)' != 'netstandard2.0' And !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcoreapp'))">any</StrideRuntimeIdentifiers>
+    <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeNetStandardNoRuntimeIdentifiers)' != 'true' And '$(TargetFramework)' != 'netstandard2.0' And !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('net5')) And !$(TargetFramework.StartsWith('netcoreapp'))">any</StrideRuntimeIdentifiers>
     
     <StrideRuntimeIdentifiers Condition="'$(StrideRuntimeIdentifiers)' != ''">;$(StrideRuntimeIdentifiers);</StrideRuntimeIdentifiers>
 
@@ -255,7 +256,7 @@
   <!-- 
     Settings StrideNETRuntime specific
   -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5'))">
     <StrideNETRuntimeDefines>STRIDE_RUNTIME_CORECLR</StrideNETRuntimeDefines>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/sources/targets/Stride.GraphicsApi.Dev.targets
+++ b/sources/targets/Stride.GraphicsApi.Dev.targets
@@ -70,7 +70,7 @@
   </Target>
 
   <!-- ==================================================================
-       Target to generate Package with proper layout (built on top of MSBuild.Sdk.Extras 2.0.87)
+       Target to generate Package with proper layout (built on top of MSBuild.Sdk.Extras 2.1.6)
   -->
   <Target Name="_StrideBuildOutputInPackImpl" Condition="'$(ExtrasIncludeDefaultProjectBuildOutputInPack)' != 'false'">
 

--- a/sources/targets/Stride.UnitTests.props
+++ b/sources/targets/Stride.UnitTests.props
@@ -22,5 +22,5 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/targets/Stride.UnitTests.targets
+++ b/sources/targets/Stride.UnitTests.targets
@@ -77,7 +77,7 @@
     <None Update="**\*.sdfx" Generator="StrideEffectCodeGenerator" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <Import Condition="'$(IsCrossTargetingBuild)' == 'true'" Project="$(MSBuildThisFileDirectory)Stride.UnitTests.CrossTargeting.targets"/>
 
   <!-- Add Default targets used by Msbuild for undefined Platforms / or when skipping compilation under a platform -->

--- a/sources/targets/Stride.props
+++ b/sources/targets/Stride.props
@@ -86,7 +86,7 @@
   <PropertyGroup>
     <StrideUI Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'Linux' Or '$(StridePlatform)' == 'macOS'">SDL</StrideUI>
     <StrideUI Condition="'$(StrideGraphicsApi)' == 'OpenGL'">$(StrideUI);OPENTK</StrideUI>
-    <StrideUI Condition="'$(StridePlatform)' == 'Windows' AND ($(TargetFramework.StartsWith('net4')) OR $(TargetFramework.StartsWith('netcoreapp3'))) AND ('$(StrideGraphicsApi)' == 'Direct3D11' Or '$(StrideGraphicsApi)' == 'Direct3D12')">$(StrideUI);WINFORMS;WPF</StrideUI>
+    <StrideUI Condition="'$(StridePlatform)' == 'Windows' AND ($(TargetFramework.StartsWith('net4')) OR $(TargetFramework.StartsWith('net5'))) AND ('$(StrideGraphicsApi)' == 'Direct3D11' Or '$(StrideGraphicsApi)' == 'Direct3D12')">$(StrideUI);WINFORMS;WPF</StrideUI>
 
     <DefineConstants Condition="$(StrideUI.Contains('SDL'))">$(DefineConstants);STRIDE_UI_SDL</DefineConstants>
     <DefineConstants Condition="$(StrideUI.Contains('OPENTK'))">$(DefineConstants);STRIDE_UI_OPENTK</DefineConstants>

--- a/sources/tests/tools/Stride.TextureConverter.Tests/Stride.TextureConverter.Tests.csproj
+++ b/sources/tests/tools/Stride.TextureConverter.Tests/Stride.TextureConverter.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -24,5 +24,5 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tests/xunit.runner.stride/xunit.runner.stride.csproj
+++ b/sources/tests/xunit.runner.stride/xunit.runner.stride.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.87" ToolsVersion="Current">
+<Project Sdk="MSBuild.Sdk.Extras/2.1.6" ToolsVersion="Current">
   <Import Project="..\..\targets\Stride.Core.TargetFrameworks.Editor.props" />
   <PropertyGroup>
     <TargetFrameworks>net461;$(StrideEditorTargetFrameworks)</TargetFrameworks>

--- a/sources/tools/MonoDevelop.Debugger.Soft.Stride/MonoDevelop.Debugger.Soft.Stride.csproj
+++ b/sources/tools/MonoDevelop.Debugger.Soft.Stride/MonoDevelop.Debugger.Soft.Stride.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -35,5 +35,5 @@
     <EmbeddedResource Update="Manifest.addin.xml" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.Assimp/Stride.Assimp.csproj
+++ b/sources/tools/Stride.Assimp/Stride.Assimp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
@@ -10,5 +10,5 @@
     <ProjectReference Include="..\..\core\Stride.Core.Mathematics\Stride.Core.Mathematics.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.Code.Tests/Stride.Code.Tests.csproj
+++ b/sources/tools/Stride.Code.Tests/Stride.Code.Tests.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -18,5 +18,5 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.ConnectionRouter/Stride.ConnectionRouter.csproj
+++ b/sources/tools/Stride.ConnectionRouter/Stride.ConnectionRouter.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -70,5 +70,5 @@
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   </Project>

--- a/sources/tools/Stride.Core.ConfigEditor/Stride.Core.ConfigEditor.csproj
+++ b/sources/tools/Stride.Core.ConfigEditor/Stride.Core.ConfigEditor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -66,5 +66,5 @@
     <ProjectReference Include="..\..\presentation\Stride.Core.Presentation\Stride.Core.Presentation.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.Core.ProjectTemplating/Stride.Core.ProjectTemplating.csproj
+++ b/sources/tools/Stride.Core.ProjectTemplating/Stride.Core.ProjectTemplating.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -12,5 +12,5 @@
     <ProjectReference Include="..\..\core\Stride.Core.Design\Stride.Core.Design.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
+++ b/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -29,5 +29,5 @@
     <ProjectReference Include="..\..\presentation\Stride.Core.Translation.Presentation\Stride.Core.Translation.Presentation.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.DebugTools/Stride.DebugTools.csproj
+++ b/sources/tools/Stride.DebugTools/Stride.DebugTools.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -87,5 +87,5 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.EffectCompilerServer/Stride.EffectCompilerServer.csproj
+++ b/sources/tools/Stride.EffectCompilerServer/Stride.EffectCompilerServer.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -26,5 +26,5 @@
     <ProjectReference Include="..\Stride.ConnectionRouter\Stride.ConnectionRouter.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.FixProjectReferences/Stride.FixProjectReferences.csproj
+++ b/sources/tools/Stride.FixProjectReferences/Stride.FixProjectReferences.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -22,5 +22,5 @@
     <ProjectReference Include="..\..\core\Stride.Core.Design\Stride.Core.Design.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.Graphics.RenderDocPlugin/Stride.Graphics.RenderDocPlugin.csproj
+++ b/sources/tools/Stride.Graphics.RenderDocPlugin/Stride.Graphics.RenderDocPlugin.csproj
@@ -3,7 +3,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
@@ -15,5 +15,5 @@
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'UWP'" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.NuGetLoader/Stride.NuGetLoader.csproj
+++ b/sources/tools/Stride.NuGetLoader/Stride.NuGetLoader.csproj
@@ -1,10 +1,10 @@
-<Project>
+﻿<Project>
   <Import Project="Sdk.props" Condition="'$(StrideNuGetLoaderWindowsDesktop)' != 'true'" Sdk="Microsoft.NET.Sdk" />
   <Import Project="Sdk.props" Condition="'$(StrideNuGetLoaderWindowsDesktop)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" />
 
   <PropertyGroup>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <IntermediateOutputPath>obj\$(Configuration)\$(StrideApplicationName)</IntermediateOutputPath>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stride.NuGet.PackageManagement" Version="5.5.1" />
+    <PackageReference Include="Stride.NuGet.PackageManagement" Version="5.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sources/tools/Stride.ProjectGenerator/Stride.ProjectGenerator.csproj
+++ b/sources/tools/Stride.ProjectGenerator/Stride.ProjectGenerator.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -69,5 +69,5 @@
     <Resource Include="Templates\Stride.UnitTests\Resources\StrideIcon54x54.png" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.RemoteShaderCompiler/Stride.RemoteShaderCompiler.csproj
+++ b/sources/tools/Stride.RemoteShaderCompiler/Stride.RemoteShaderCompiler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -14,5 +14,5 @@
     <ProjectReference Include="..\..\engine\Stride.Graphics\Stride.Graphics.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.SamplesTestServer/Stride.SamplesTestServer.csproj
+++ b/sources/tools/Stride.SamplesTestServer/Stride.SamplesTestServer.csproj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -25,5 +25,5 @@
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.StorageTool/Stride.StorageTool.csproj
+++ b/sources/tools/Stride.StorageTool/Stride.StorageTool.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -21,5 +21,5 @@
     <ProjectReference Include="..\..\core\Stride.Core.Serialization\Stride.Core.Serialization.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.TestRunner/Stride.TestRunner.csproj
+++ b/sources/tools/Stride.TestRunner/Stride.TestRunner.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
@@ -26,7 +26,7 @@
   <Import Project="..\..\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems" Label="Shared" />
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/sources/tools/Stride.TextureConverter/Stride.TextureConverter.csproj
+++ b/sources/tools/Stride.TextureConverter/Stride.TextureConverter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <OutputType>Library</OutputType>
@@ -28,5 +28,5 @@
     <ProjectReference Include="..\..\engine\Stride.Graphics\Stride.Graphics.csproj" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.VisualStudio.Commands/Stride.VisualStudio.Commands.csproj
+++ b/sources/tools/Stride.VisualStudio.Commands/Stride.VisualStudio.Commands.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\..\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetFrameworks>$(StrideEditorTargetFrameworks)</TargetFrameworks>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
@@ -30,5 +30,5 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
 </Project>

--- a/sources/tools/Stride.VisualStudio.Package.Tests/Stride.VisualStudio.Package.Tests.csproj
+++ b/sources/tools/Stride.VisualStudio.Package.Tests/Stride.VisualStudio.Package.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <TargetFramework>net472</TargetFramework>
@@ -58,7 +58,7 @@
   </ItemGroup>
   <Import Project="..\Stride.Core.VisualStudio\Stride.Core.VisualStudio.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <Target Name="LocateDevenv" AfterTargets="PrepareForBuild">
     <!-- Compute and save VisualStudio path to a file so that it can be used when running the test. Note: ideally we should use a Task, but Visual Studio lock the files -->
     <Exec Command="&quot;..\..\core\Stride.Core.Tasks\bin\$(Configuration)\$(StrideEditorTargetFramework)\Stride.Core.Tasks.exe&quot; locate-devenv &quot;$(MSBuildBinPath)&quot;" ConsoleToMsBuild="true">

--- a/sources/tools/Stride.VisualStudio.Package/Commands/StrideCommandsProxy.cs
+++ b/sources/tools/Stride.VisualStudio.Package/Commands/StrideCommandsProxy.cs
@@ -171,9 +171,9 @@ namespace Stride.VisualStudio.Commands
             // Try to find the package with the expected version
             if (packageInfo.ExpectedVersion != null && packageInfo.ExpectedVersion >= MinimumVersion)
             {
-                // Try both netcoreapp3.1 and net472
+                // Try both net5.0 and net472
                 var success = false;
-                foreach (var framework in new[] { ".NETCoreApp,Version=v3.1", ".NETFramework,Version=v4.7.2" })
+                foreach (var framework in new[] { ".NET,Version=v5.0", ".NETFramework,Version=v4.7.2" })
                 {
                     var logger = new Logger();
                     var solutionRoot = Path.GetDirectoryName(solution);

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -6,7 +6,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
-  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <PropertyGroup>
     <TargetVsixContainerName>Stride.vsix</TargetVsixContainerName>
     <TargetVsixContainer>bin\$(TargetVsixContainerName)</TargetVsixContainer>
@@ -176,6 +176,6 @@
   </Target>
   <Import Project="$(StrideSdkTargets)" />
   <!-- Force NET Sdk to be included before VsSDK -->
-  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.0.87" />
+  <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Version="2.1.6" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
 </Project>

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26201" />
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.Commands" Version="5.5.1" />
+    <PackageReference Include="NuGet.Commands" Version="5.8.0" />
 
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />


### PR DESCRIPTION
# PR Details

Switch from .NET Core 3.1 to .NET 5

## Description

Switched MSBuild.Sdk.Extras to latest.
Then various changes so that the new `net5.0` and `net-5.0-windows` TFM is used.

## Related Issue

#912 

## Motivation and Context

We better go straight with .NET 5.0 to avoid another intermediate framework (.NET Core) to keep supporting in the future.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.