### PR TITLE
[Build] Fixes Stride.Assimp.dll not found during package build

### DIFF
--- a/sources/engine/Stride.Assets.Models/Stride.Assets.Models.csproj
+++ b/sources/engine/Stride.Assets.Models/Stride.Assets.Models.csproj
@@ -14,6 +14,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\tools\Stride.Assimp\Stride.Assimp.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\..\tools\Stride.Assimp.Translation\Stride.Assimp.Translation.vcxproj" PrivateAssets="All" />
     <ProjectReference Include="..\..\tools\Stride.Importer.Assimp\Stride.Importer.Assimp.vcxproj" PrivateAssets="All" />
     <ProjectReference Include="..\..\tools\Stride.Importer.Common\Stride.Importer.Common.vcxproj" PrivateAssets="All" />
     <ProjectReference Include="..\..\tools\Stride.Importer.FBX\Stride.Importer.FBX.vcxproj" PrivateAssets="All" />


### PR DESCRIPTION
# PR Details
## Description

Seems like something changed in msbuild with the net5 update that the dll isn't copied anymore. I guess in the past it came through the `Stride.Importer.Assimp.vcxproj` reference even though there it's marked as `CopyLocal = false`

Referencing the project directly ensures that the assembly gets copied to the build output folder of `Stride.Assets.Models` - it's needed by the `IncludeExtraAssemblies` target (`<BuildOutputInPackage Include="$(OutputPath)Stride.Assimp.dll" />`).

For reference, this is my build invocation:
`msbuild Stride.build /t:Package /m /v:m /restore /nr:false /p:StridePlatforms="Windows" /p:StrideGraphicsApiDependentBuildAll=false /p:StrideBuildPrerequisitesInstaller=false /p:StrideSign=false /p:StrideOfficialBuild=false`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.