### PR TITLE
[Mathematics] Fixes RectangleF.Contains method

### DIFF
--- a/sources/core/Stride.Core.Mathematics/RectangleF.cs
+++ b/sources/core/Stride.Core.Mathematics/RectangleF.cs
@@ -269,7 +269,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">[OutAttribute] true if the specified Point is contained within this rectangle; false otherwise.</param>
         public void Contains(ref Vector2 value, out bool result)
         {
-            result = (X <= value.X) && (value.X < Right) && (Y <= value.Y) && (value.Y < Bottom);
+            result = value.X >= this.X && value.X <= Right && value.Y >= this.Y && value.Y <= Bottom;
         }
 
         /// <summary>Determines whether this rectangle entirely contains a specified rectangle.</summary>
@@ -295,7 +295,7 @@ namespace Stride.Core.Mathematics
         /// <returns><c>true</c> if point is inside <see cref="RectangleF"/>, otherwise <c>false</c>.</returns>
         public bool Contains(float x, float y)
         {
-            return (x >= this.X && x <= Right && y >= this.Y && y <= Bottom);
+            return x >= this.X && x <= Right && y >= this.Y && y <= Bottom;
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

The `RectangleF.Contains` method for `Vector2` is now exactly the same as for individual x and y values.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.