### PR TITLE
[Rendering] Allows to use in-memory generated materials as blend layers

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Material.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Material.cs
@@ -49,6 +49,10 @@ namespace Stride.Rendering
         public static Material New(GraphicsDevice device, MaterialDescriptor descriptor)
         {
             if (descriptor == null) throw new ArgumentNullException("descriptor");
+
+            // The descriptor is not assigned to the material because
+            // 1) we don't know whether it will mutate and be used to generate another material
+            // 2) we don't wanna hold on to memory we actually don't need
             var context = new MaterialGeneratorContext(new Material(), device)
             {
                 GraphicsProfile = device.Features.RequestedProfile,

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialBlendLayer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialBlendLayer.cs
@@ -87,7 +87,7 @@ namespace Stride.Rendering.Materials
             }
 
             // Find the material from the reference
-            var material = context.FindAsset(Material) as IMaterialDescriptor;
+            var material = Material.Descriptor ?? context.FindAsset(Material) as IMaterialDescriptor;
             if (material == null)
             {
                 context.Log.Error($"Unable to find material [{Material}]");


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

By querying the `Material.Descriptor` property first an in-memory generated material can be used in blend layers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.