### PR TITLE
[Engine] Use property key on graphics device to force present interval on all presenters while profiling

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -49,7 +49,7 @@ namespace Stride.Profiling
 
         private Color4 textColor = Color.LightGreen;
 
-        private PresentInterval userPresentInterval = PresentInterval.Default;
+        private PresentInterval? userPresentInterval;
         private bool userMinimizedState = true;
 
         private int lastFrame = -1;
@@ -419,10 +419,10 @@ namespace Stride.Profiling
             }
 
             // Backup current PresentInterval state
-            userPresentInterval = GraphicsDevice.Presenter.PresentInterval;
+            userPresentInterval = GraphicsDevice.Tags.Get(GraphicsPresenter.ForcedPresentInterval);
 
             // Disable VSync (otherwise GPU results might be incorrect)
-            GraphicsDevice.Presenter.PresentInterval = PresentInterval.Immediate;
+            GraphicsDevice.Tags.Set(GraphicsPresenter.ForcedPresentInterval, PresentInterval.Immediate);
 
             if (keys.Length == 0)
             {
@@ -459,8 +459,9 @@ namespace Stride.Profiling
             Visible = false;
 
             // Restore previous PresentInterval state
-            GraphicsDevice.Presenter.PresentInterval = userPresentInterval;
-            userPresentInterval = PresentInterval.Default;
+            GraphicsDevice.Tags.Set(GraphicsPresenter.ForcedPresentInterval, userPresentInterval);
+
+            userPresentInterval = default;
             if (Game != null)
                 Game.TreatNotFocusedLikeMinimized = userMinimizedState;
 

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -151,7 +151,8 @@ namespace Stride.Graphics
         {
             try
             {
-                swapChain.Present((int)PresentInterval, PresentFlags.None);
+                var presentInterval = GraphicsDevice.Tags.Get(ForcedPresentInterval) ?? PresentInterval;
+                swapChain.Present((int)presentInterval, PresentFlags.None);
 #if STRIDE_GRAPHICS_API_DIRECT3D12
                 // Manually swap back buffer
                 backBuffer.NativeResource.Dispose();

--- a/sources/engine/Stride.Graphics/GraphicsPresenter.cs
+++ b/sources/engine/Stride.Graphics/GraphicsPresenter.cs
@@ -35,6 +35,14 @@ namespace Stride.Graphics
     /// </remarks>
     public abstract class GraphicsPresenter : ComponentBase
     {
+        /// <summary>
+        /// If not null the given interval will be used during a <see cref="Present"/> operation. 
+        /// </summary>
+        /// <remarks>
+        /// This is currently only supported by the Direct3D graphics implementation.
+        /// </remarks>
+        internal static readonly PropertyKey<PresentInterval?> ForcedPresentInterval = new PropertyKey<PresentInterval?>(nameof(ForcedPresentInterval), typeof(GraphicsDevice));
+
         private Texture depthStencilBuffer;
 
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is a little bit related to #923 - it removes the assumption that there's only one presenter. Instead it uses an internal property key to override the present interval on all presenters. We talked about it in our review last week.

Will currently only work in the Direct3D implementation. Vulkan would require to re-create the swap chain while in OpenGL the present interval is controlled through the window? It's not even implementing the Present operation. So I wonder whether it ever even worked on those implementations.

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.