### PR TITLE
Respecting standard XML documentation. Fixes #917

### DIFF
--- a/sources/editor/Stride.GameStudio/DebuggingViewModel.cs
+++ b/sources/editor/Stride.GameStudio/DebuggingViewModel.cs
@@ -254,6 +254,9 @@ namespace Stride.GameStudio
                         var assemblyToReload = modifiedAssembly.Value;
                         assemblyToReload.LoadedAssemblyPath = result.AssemblyPath;
                         assembliesToReload.Add(assemblyToReload);
+
+                        var userDocumentationService = Session.ServiceProvider.Get<UserDocumentationService>();
+                        userDocumentationService.ClearCachedAssemblyDocumentation(assemblyToReload.LoadedAssembly.Assembly);
                     }
                     else
                     {


### PR DESCRIPTION
# PR Details

This changes the way that documentation is cached for the editor to consider the standard XML documentation if available as a fallback when usrdoc is not provided. 

## Description

When first loading a project, the UserDocumentationService caches docs it finds in the `.usrdoc` files. This is a simple key-value format and is not generated automatically by Stride projects. The XML documentation file can be produced easily by including the appropriate directives in a csproj file as laid out in https://docs.microsoft.com/en-us/dotnet/csharp/codedoc. With this change, we will first look for a `.usrdoc` file before falling back to the `.xml` path. A future enhancement could be made to respect the project's specified documentation path. When looking at XML, it only considers the `<userdoc>` element

## Related Issue

https://github.com/stride3d/stride/issues/917

## Motivation and Context

When <userdoc> is added to a public property, game studio should show the text when the mouse is over that property in the Property Grid. The only supported file is a custom key-value doc with the `.userdoc` extension and XML documentation is ignored. The `<userdoc>` element is currently what is being used in the `.usrdoc` file so the convention is continued here. 

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.