### PR TITLE
[Rendering] Fixes crash when changing the LightStreak.IsAnamorphic property during runtime

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Images/LightStreak/LightStreak.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/LightStreak/LightStreak.cs
@@ -31,6 +31,7 @@ namespace Stride.Rendering.Images
         private bool isAnamorphic;
 
         private Vector2[] tapOffsetsWeights;
+        private Vector3[] anamorphicOffsetsWeights;
 
         private readonly List<string> lightStreakDebugStrings = new List<string>();
 
@@ -217,7 +218,22 @@ namespace Stride.Rendering.Images
         /// offset of the original streak, with a certain weight.
         /// </summary>
         [DataMemberIgnore]
-        public Vector3[] AnamorphicOffsetsWeights { get; set; }
+        public Vector3[] AnamorphicOffsetsWeights
+        {
+            get => anamorphicOffsetsWeights;
+            set
+            {
+                if (value != anamorphicOffsetsWeights)
+                {
+                    // Ensure the allocated effect parameters have the same length.
+                    if (value != null && anamorphicOffsetsWeights != null && value.Length != anamorphicOffsetsWeights.Length)
+                    {
+                        lightStreakEffect?.Parameters.Clear();
+                    }
+                    anamorphicOffsetsWeights = value;
+                }
+            }
+        }
 
         protected override void DrawCore(RenderDrawContext contextParameters)
         {

--- a/sources/engine/Stride/Rendering/ParameterCollection.cs
+++ b/sources/engine/Stride/Rendering/ParameterCollection.cs
@@ -510,7 +510,7 @@ namespace Stride.Rendering
         /// </summary>
         public void Clear()
         {
-            DataValues = null;
+            DataValues = EmptyData;
             ObjectValues = null;
             layout = null;
             parameterKeyInfos.Clear();


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

The effect parameters need to be reset when changing the `IsAnamorphic` property so a new parameter with the proper length can be allocated. Not doing so results in a crash when setting the parameter with the different length and in turn crashes the whole application due to constant temporary resource allocations.

## Related Issue

https://github.com/vvvv/VL.Stride/issues/336

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.