### PR TITLE
[Samples] Fix missing sub-scenes in CSharpBeginner tutorial

### DIFF
--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/CSharpBeginner.Game.sdpkg
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/CSharpBeginner.Game.sdpkg
@@ -27,6 +27,9 @@ RootAssets:
     - 9e1b53ff-dc0c-410a-8972-14f949f83a01:Scenes/Basics/Child entities
     - ba8ed57d-74b9-4121-baf0-6a92463b600a:Scenes/Basics/Getting a component
     - c00aec52-d6b8-4eab-80c2-460ac8109da6:Scenes/Basics/Mouse input
+    - ca777fe9-5471-4137-a42d-fa87b6c20c91:Scenes/Basics/Loading content
+    - d625592d-d7c2-4151-bd8e-09ff90120d9e:Scenes/Basics/Linear Interpolation
     - d8597439-175b-42b3-81ca-d6553655e38f:Scenes/Basics/Removing entities
     - dbb3b809-4ff0-41da-b125-78a5ea1ec89c:Scenes/Basics/TransformPosition
+    - deb8b6f8-1da6-4ad7-8499-ebd34e1d423b:Scenes/Basics/Instantiating prefabs
     - ee2eb459-7847-42b5-bd69-fc43a6625fd5:Scenes/Basics/Keyboard input

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Windows/CSharpBeginner.Windows.sdpkg
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Windows/CSharpBeginner.Windows.sdpkg
@@ -14,7 +14,4 @@ OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []
 TemplateFolders: []
-RootAssets:
-    - ca777fe9-5471-4137-a42d-fa87b6c20c91:Scenes/Basics/Loading content
-    - d625592d-d7c2-4151-bd8e-09ff90120d9e:Scenes/Basics/Linear Interpolation
-    - deb8b6f8-1da6-4ad7-8499-ebd34e1d423b:Scenes/Basics/Instantiating prefabs
+RootAssets: []


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
This commit should fix the missing sub-scenes in the beginner tutorial, however I am not aware if there are any additional things required to ensure it gets packaged in the final build (I'm assuming the sub-scenes being in the correct sdpkg is the only thing required).

## Description

<!--- Describe your changes in detail -->
Moved the missing sub-scenes that were declared in the Windows sdpkg into the Game sdpkg.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #821


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.