### PR TITLE
[Input] Fix detecting WinForms right shift key (fixes #754, fixes #929)

### DIFF
--- a/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
@@ -199,7 +199,7 @@ namespace Stride.Input
             {
                 // We need to check the scan code to check which SHIFT key it is.
                 var scanCode = (lParam & 0x00FF0000) >> 16;
-                return (scanCode != 36) ? WinFormsKeys.LShiftKey : WinFormsKeys.RShiftKey;
+                return (scanCode != 0x36) ? WinFormsKeys.LShiftKey : WinFormsKeys.RShiftKey;
             }
 
             if (virtualKey == WinFormsKeys.Menu)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix WinForms right shift key detection using the correct scan code.

## Description

<!--- Describe your changes in detail -->
Scan code used for right shift detection is actually a hex code, ie 0x36 == 54 as pointed out by CharlesWoodhill in #929


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #754
Fixes #929
Also tested on the Touch Input project and saw it says RightShift for pressed & down when pressing right shift.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.