### PR TITLE
Allow absolute paths in $(IntermediateOutputPath)

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -45,7 +45,7 @@
     <!--asset OutputPath for other platforms. Note: this is overridden for UnitTests projects. -->
     <StrideCompileAssetOutputPath Condition="'$(StrideCompileAssetOutputPath)' == ''">$(TargetDir)data</StrideCompileAssetOutputPath>
 
-    <StrideCompileAssetUpToDateCheckFileBase>$(ProjectDir)$(IntermediateOutputPath)stride\assetcompiler-uptodatecheck</StrideCompileAssetUpToDateCheckFileBase>
+    <StrideCompileAssetUpToDateCheckFileBase>$(IntermediateOutputPath)stride\assetcompiler-uptodatecheck</StrideCompileAssetUpToDateCheckFileBase>
   </PropertyGroup>
 
   <!-- Prepare path to be able to copy Task dll to temp directory (otherwise MSBuild lock the task file and we can't reinstall package in dev mode) -->

--- a/sources/assets/Stride.Core.Assets/Compiler/AssetCompilerRegistry.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/AssetCompilerRegistry.cs
@@ -180,8 +180,20 @@ namespace Stride.Core.Assets.Compiler
 
         private void RegisterCompilersFromAssembly(Assembly assembly)
         {
+            Type[] assemblyTypes;
+
+            try
+            {
+                assemblyTypes = assembly.GetTypes();
+            }
+            catch(Exception ex)
+            {
+                log.Warning($"Failed to Register Compilers from Assembly: [{assembly.FullName}].  Getting types threw exception.", ex);
+                return;
+            }
+
             // Process Asset types.
-            foreach (var type in assembly.GetTypes())
+            foreach (var type in assemblyTypes)
             {
                 // Only process Asset types
                 if (!typeof(IAssetCompiler).IsAssignableFrom(type) || !type.IsClass)


### PR DESCRIPTION
# PR Details

## Description

Remove $(ProjectDir), only rely on naked $(IntermediateOutputPath) which is typically relative, but this change allows IntermediateOutputPath to be an absolute path.
May require current working directory is set correctly for the typical case. 

## Related Issue

#952  

## Motivation and Context

I moved my IntermediateOutputPath to a ramdisk on a different drive, and so $(ProjectDir)$(IntermediateOutputPath) results in two absolute paths crammed into one which breaks the build.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.