### PR TITLE
[Input] InputSystem should be public so external users can access it

### DIFF
--- a/sources/engine/Stride.Engine/Engine/InputSystem.cs
+++ b/sources/engine/Stride.Engine/Engine/InputSystem.cs
@@ -11,7 +11,7 @@ namespace Stride.Engine
     /// <summary>
     /// The input system updating the input manager exposed by <see cref="Game.Input"/>.
     /// </summary>
-    sealed class InputSystem : GameSystemBase
+    public sealed class InputSystem : GameSystemBase
     {
         public InputSystem(IServiceRegistry registry) : base(registry)
         {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Makes InputSystem public so users can access it.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
The input's 'system' was changed due to pull #919

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
If you need to change the system settings on the InputSystem (eg. UpdateOrder, Enabled), you need public access to it.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.