### PR TITLE
Catch type load exceptions when trying to load asset compilers from an assembly

### DIFF
--- a/sources/assets/Stride.Core.Assets/Compiler/AssetCompilerRegistry.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/AssetCompilerRegistry.cs
@@ -181,26 +181,33 @@ namespace Stride.Core.Assets.Compiler
         private void RegisterCompilersFromAssembly(Assembly assembly)
         {
             // Process Asset types.
-            foreach (var type in assembly.GetTypes())
+            try
             {
-                // Only process Asset types
-                if (!typeof(IAssetCompiler).IsAssignableFrom(type) || !type.IsClass)
-                    continue;
-
-                // Asset compiler
-                var compilerAttribute = type.GetCustomAttribute<AssetCompilerAttribute>();
-
-                if (compilerAttribute == null) // no compiler attribute in this asset
-                    continue;
-
-                try
+                foreach (var type in assembly.GetTypes())
                 {
-                    ProcessAttribute(compilerAttribute, type);
+                    // Only process Asset types
+                    if (!typeof(IAssetCompiler).IsAssignableFrom(type) || !type.IsClass)
+                        continue;
+
+                    // Asset compiler
+                    var compilerAttribute = type.GetCustomAttribute<AssetCompilerAttribute>();
+
+                    if (compilerAttribute == null) // no compiler attribute in this asset
+                        continue;
+
+                    try
+                    {
+                        ProcessAttribute(compilerAttribute, type);
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Error($"Unable to instantiate compiler [{compilerAttribute.TypeName}]", ex);
+                    }
                 }
-                catch (Exception ex)
-                {
-                    log.Error($"Unable to instantiate compiler [{compilerAttribute.TypeName}]", ex);
-                }
+            }
+            catch (Exception e)
+            {
+                log.Warning($"Unable to register asset compilers from assembly [{assembly}]", e);
             }
         }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR simply turns a compiler error into a warning. I had the asset compiler app crashing while it was processing an unrelated assembly. So instead of crashing completely a warning that it skipped the assembly was a nice way out.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.