### PR TITLE
[Games] Allows to set a custom render target for the GameProfilingSystem

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -11,6 +11,7 @@ using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Games;
 using Stride.Graphics;
+using Stride.Rendering;
 using Color = Stride.Core.Mathematics.Color;
 
 namespace Stride.Profiling
@@ -60,6 +61,11 @@ namespace Stride.Profiling
 
         private uint trianglesCount;
         private uint drawCallsCount;
+
+        /// <summary>
+        /// The render target where the profiling results should be rendered into. If null, the <see cref="Game.GraphicsDevice.Presenter.BackBuffer"/> is used.
+        /// </summary>
+        public Texture RenderTarget { get; set; }
 
         private struct ProfilingResult : IComparer<ProfilingResult>
         {
@@ -343,6 +349,9 @@ namespace Stride.Profiling
         /// <inheritdoc/>
         public override void Draw(GameTime gameTime)
         {
+            // Where to render the result?
+            var renderTarget = RenderTarget ?? Game.GraphicsDevice.Presenter.BackBuffer;
+
             // copy those values before fast text render not to influence the game stats
             drawCallsCount = GraphicsDevice.FrameDrawCalls;
             trianglesCount = GraphicsDevice.FrameTriangleCount;
@@ -351,7 +360,7 @@ namespace Stride.Profiling
             {
                 dumpTiming.Restart();
 
-                renderTargetSize = new Size2(Game.GraphicsContext.CommandList.RenderTarget.Width, Game.GraphicsContext.CommandList.RenderTarget.Height);
+                renderTargetSize = new Size2(renderTarget.Width, renderTarget.Height);
 
                 if (stringBuilderTask == null || stringBuilderTask.IsCompleted)
                 {
@@ -360,46 +369,50 @@ namespace Stride.Profiling
                 }
             }
 
-            viewportHeight = Game.GraphicsContext.CommandList.Viewport.Height;
+            var renderContext = RenderContext.GetShared(Services);
+            var renderDrawContext = renderContext.GetThreadContext();
 
             if (fastTextRenderer == null)
             {
-                fastTextRenderer = new FastTextRenderer(Game.GraphicsContext)
+                fastTextRenderer = new FastTextRenderer(renderDrawContext.GraphicsContext)
                 {
                     DebugSpriteFont = Content.Load<Texture>("StrideDebugSpriteFont"),
                     TextColor = TextColor,
                 };
             }
 
-            // TODO GRAPHICS REFACTOR where to get command list from?
-            Game.GraphicsContext.CommandList.SetRenderTargetAndViewport(null, Game.GraphicsDevice.Presenter.BackBuffer);
-            fastTextRenderer.Begin(Game.GraphicsContext);
-            lock (stringLock)
+            using (renderDrawContext.PushRenderTargetsAndRestore())
             {
-                var currentHeight = textDrawStartOffset.Y;
-                fastTextRenderer.DrawString(Game.GraphicsContext, fpsStatString, textDrawStartOffset.X, currentHeight);
-                currentHeight += TopRowHeight;
-
-                if (FilteringMode == GameProfilingResults.CpuEvents)
+                renderDrawContext.CommandList.SetRenderTargetAndViewport(null, renderTarget);
+                viewportHeight = renderDrawContext.CommandList.Viewport.Height;
+                fastTextRenderer.Begin(renderDrawContext.GraphicsContext);
+                lock (stringLock)
                 {
-                    fastTextRenderer.DrawString(Game.GraphicsContext, gcMemoryString, textDrawStartOffset.X, currentHeight);
+                    var currentHeight = textDrawStartOffset.Y;
+                    fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, fpsStatString, textDrawStartOffset.X, currentHeight);
                     currentHeight += TopRowHeight;
-                    fastTextRenderer.DrawString(Game.GraphicsContext, gcCollectionsString, textDrawStartOffset.X, currentHeight);
-                    currentHeight += TopRowHeight;
-                }
-                else if (FilteringMode == GameProfilingResults.GpuEvents)
-                {
-                    fastTextRenderer.DrawString(Game.GraphicsContext, gpuGeneralInfoString, textDrawStartOffset.X, currentHeight);
-                    currentHeight += TopRowHeight;
-                    fastTextRenderer.DrawString(Game.GraphicsContext, gpuInfoString, textDrawStartOffset.X, currentHeight);
-                    currentHeight += TopRowHeight;
+
+                    if (FilteringMode == GameProfilingResults.CpuEvents)
+                    {
+                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gcMemoryString, textDrawStartOffset.X, currentHeight);
+                        currentHeight += TopRowHeight;
+                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gcCollectionsString, textDrawStartOffset.X, currentHeight);
+                        currentHeight += TopRowHeight;
+                    }
+                    else if (FilteringMode == GameProfilingResults.GpuEvents)
+                    {
+                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gpuGeneralInfoString, textDrawStartOffset.X, currentHeight);
+                        currentHeight += TopRowHeight;
+                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gpuInfoString, textDrawStartOffset.X, currentHeight);
+                        currentHeight += TopRowHeight;
+                    }
+
+                    if (FilteringMode != GameProfilingResults.Fps)
+                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, profilersString, textDrawStartOffset.X, currentHeight);
                 }
 
-                if (FilteringMode != GameProfilingResults.Fps)
-                    fastTextRenderer.DrawString(Game.GraphicsContext, profilersString, textDrawStartOffset.X, currentHeight);
+                fastTextRenderer.End(renderDrawContext.GraphicsContext);
             }
-
-            fastTextRenderer.End(Game.GraphicsContext);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details

## Description

Instead of simply rendering the profiling results into the current presenter, allow to set the render target through a property. If no render target is set the system will still fall back to the current presenter.

## Motivation and Context

When rendering to multiple windows (or even off-screen) it's nice to have the option to choose where the profiling results should be displayed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.