### PR TITLE
[Physics] Render physics debug shapes into any given scene

### DIFF
--- a/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
@@ -27,7 +27,7 @@ namespace Stride.Physics
         private readonly List<CharacterComponent> characters = new List<CharacterComponent>();
 
         private Bullet2PhysicsSystem physicsSystem;
-        private SceneSystem sceneSystem;
+        private Scene parentScene;
         private Scene debugScene;
 
         private bool colliderShapesRendering;
@@ -41,28 +41,28 @@ namespace Stride.Physics
         }
 
         /// <summary>
-        /// Gets or sets the scene system. Assigned with default one on <see cref="OnSystemAdd"/>
+        /// Gets or sets the associated parent scene to render the physics debug shapes. Assigned with default one on <see cref="OnSystemAdd"/>
         /// </summary>
         /// <value>
-        /// The scene system.
+        /// The parent scene.
         /// </value>
-        public SceneSystem SceneSystem
+        public Scene ParentScene
         {
-            get => sceneSystem;
+            get => parentScene;
             set
             {
-                if (value != sceneSystem)
+                if (value != parentScene)
                 {
-                    if (sceneSystem != null && debugShapeRendering.Enabled)
+                    if (parentScene != null && debugShapeRendering.Enabled)
                     {
                         // If debug rendering is running, disable it and re-enable for new scene system
                         RenderColliderShapes(false);
-                        sceneSystem = value;
+                        parentScene = value;
                         RenderColliderShapes(true);
                     }
                     else
                     {
-                        sceneSystem = value;
+                        parentScene = value;
                     }
                 }
             }
@@ -86,8 +86,9 @@ namespace Stride.Physics
                     {
                         element.RemoveDebugEntity(debugScene);
                     }
-
-                    sceneSystem.SceneInstance.RootScene.Children.Remove(debugScene);
+                    
+                    // Remove from parent scene
+                    debugScene.Parent = null;
                 }
             }
             else
@@ -102,7 +103,7 @@ namespace Stride.Physics
                     }
                 }
 
-                sceneSystem.SceneInstance.RootScene.Children.Add(debugScene);
+                debugScene.Parent = parentScene;
             }
         }
 
@@ -211,7 +212,7 @@ namespace Stride.Physics
 
             Simulation = physicsSystem.Create(this);
 
-            sceneSystem = Services.GetSafeServiceAs<SceneSystem>();
+            parentScene = Services.GetSafeServiceAs<SceneSystem>()?.SceneInstance?.RootScene;
         }
 
         protected override void OnSystemRemove()

--- a/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsProcessor.cs
@@ -40,6 +40,34 @@ namespace Stride.Physics
             Order = 0xFFFF;
         }
 
+        /// <summary>
+        /// Gets or sets the scene system. Assigned with default one on <see cref="OnSystemAdd"/>
+        /// </summary>
+        /// <value>
+        /// The scene system.
+        /// </value>
+        public SceneSystem SceneSystem
+        {
+            get => sceneSystem;
+            set
+            {
+                if (value != sceneSystem)
+                {
+                    if (sceneSystem != null && debugShapeRendering.Enabled)
+                    {
+                        // If debug rendering is running, disable it and re-enable for new scene system
+                        RenderColliderShapes(false);
+                        sceneSystem = value;
+                        RenderColliderShapes(true);
+                    }
+                    else
+                    {
+                        sceneSystem = value;
+                    }
+                }
+            }
+        }
+
         public Simulation Simulation { get; private set; }
 
         internal void RenderColliderShapes(bool enabled)


### PR DESCRIPTION
# PR Details

## Description

Instead of placing the debug shapes in the root scene of the game allow to provide the parent scene through a property.

## Motivation and Context

When rendering to multiple windows / multiple scenes at the same time one wants to choose where the debug shapes shall be placed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.