### PR TITLE
[Games] Added SetSize to GameWindow to allow resizing the window by code

### DIFF
--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -233,6 +233,20 @@ namespace Stride.Games
 
         internal abstract void Run();
 
+        /// <summary>
+        /// Sets the size of the client area and triggers the <see cref="ClientSizeChanged"/> event.
+        /// This will trigger a backbuffer resize too.
+        /// </summary>
+        public void SetSize(Int2 size)
+        {
+            Resize(size.X, size.Y);
+            OnClientSizeChanged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Only used internally by the device managers when they adapt the window size to the backbuffer size.
+        /// Resizes the window, without sending the resized event.
+        /// </summary>
         internal abstract void Resize(int width, int height);
 
         public virtual IMessageLoop CreateUserManagedMessageLoop()


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows to set the size of a game window in multi-window scenarios. Up to now the API only allowed setting the window size on creation and when switching out of fullscreen.

## Motivation and Context

We need to be able to set the size of a window manually. For example if one wants to arrange multiple windows.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.