### PR TITLE
[Graphics] Back buffer format adjustments based on the device color space

### DIFF
--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -648,26 +648,12 @@ namespace Stride.Games
             if (PreferredColorSpace == ColorSpace.Linear)
             {
                 // If the device support SRgb and ColorSpace is linear, we use automatically a SRgb backbuffer
-                if (preferredParameters.PreferredBackBufferFormat == PixelFormat.R8G8B8A8_UNorm)
-                {
-                    preferredParameters.PreferredBackBufferFormat = PixelFormat.R8G8B8A8_UNorm_SRgb;
-                }
-                else if (preferredParameters.PreferredBackBufferFormat == PixelFormat.B8G8R8A8_UNorm)
-                {
-                    preferredParameters.PreferredBackBufferFormat = PixelFormat.B8G8R8A8_UNorm_SRgb;
-                }
+                preferredParameters.PreferredBackBufferFormat = preferredParameters.PreferredBackBufferFormat.ToSRgb();
             }
             else
             {
                 // If we are looking for gamma and the backbuffer format is SRgb, switch back to non srgb
-                if (preferredParameters.PreferredBackBufferFormat == PixelFormat.R8G8B8A8_UNorm_SRgb)
-                {
-                    preferredParameters.PreferredBackBufferFormat = PixelFormat.R8G8B8A8_UNorm;
-                }
-                else if (preferredParameters.PreferredBackBufferFormat == PixelFormat.B8G8R8A8_UNorm_SRgb)
-                {
-                    preferredParameters.PreferredBackBufferFormat = PixelFormat.B8G8R8A8_UNorm;
-                }
+                preferredParameters.PreferredBackBufferFormat = preferredParameters.PreferredBackBufferFormat.ToNonSRgb();
             }
 
             // Setup resized value if there is a resize pending

--- a/sources/engine/Stride.Graphics/GraphicsPresenter.cs
+++ b/sources/engine/Stride.Graphics/GraphicsPresenter.cs
@@ -55,31 +55,7 @@ namespace Stride.Graphics
             GraphicsDevice = device;
             var description = presentationParameters.Clone();
 
-            // If we are creating a GraphicsPresenter with 
-            if (device.Features.HasSRgb && device.ColorSpace == ColorSpace.Linear)
-            {
-                // If the device support SRgb and ColorSpace is linear, we use automatically a SRgb backbuffer
-                if (description.BackBufferFormat == PixelFormat.R8G8B8A8_UNorm)
-                {
-                    description.BackBufferFormat = PixelFormat.R8G8B8A8_UNorm_SRgb;
-                }
-                else if (description.BackBufferFormat == PixelFormat.B8G8R8A8_UNorm)
-                {
-                    description.BackBufferFormat = PixelFormat.B8G8R8A8_UNorm_SRgb;
-                }
-            }
-            else if (!device.Features.HasSRgb)
-            {
-                // If the device does not support SRgb, but the backbuffer format asked is SRgb, convert it to non SRgb
-                if (description.BackBufferFormat == PixelFormat.R8G8B8A8_UNorm_SRgb)
-                {
-                    description.BackBufferFormat = PixelFormat.R8G8B8A8_UNorm;
-                }
-                else if (description.BackBufferFormat == PixelFormat.B8G8R8A8_UNorm_SRgb)
-                {
-                    description.BackBufferFormat = PixelFormat.B8G8R8A8_UNorm;
-                }
-            }
+            description.BackBufferFormat = NormalizeBackBufferFormat(description.BackBufferFormat);
 
             Description = description;
 
@@ -175,12 +151,27 @@ namespace Stride.Graphics
 
             Description.BackBufferWidth = width;
             Description.BackBufferHeight = height;
-            Description.BackBufferFormat = format;
+            Description.BackBufferFormat = NormalizeBackBufferFormat(format);
 
             ResizeBackBuffer(width, height, format);
             ResizeDepthStencilBuffer(width, height, format);
 
             GraphicsDevice.End();
+        }
+
+        private PixelFormat NormalizeBackBufferFormat(PixelFormat backBufferFormat)
+        {
+            // If we are creating a GraphicsPresenter with 
+            if (GraphicsDevice.Features.HasSRgb && GraphicsDevice.ColorSpace == ColorSpace.Linear)
+            {
+                // If the device support SRgb and ColorSpace is linear, we use automatically a SRgb backbuffer
+                return backBufferFormat.ToSRgb();
+            }
+            else
+            {
+                // If the device does not support SRgb or the ColorSpace is Gamma, but the backbuffer format asked is SRgb, convert it to non SRgb
+                return backBufferFormat.ToNonSRgb();
+            }
         }
 
         protected abstract void ResizeBackBuffer(int width, int height, PixelFormat format);


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Back buffer format adjustments based on the device color space will also be applied on resize. 
It will now also work for all pixel formats by using ToSrgb and ToNonSrgb extension methods.
Also fixes format adjustment not being applied if color space was set to Gamma but device supported Linear space.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.