### PR TITLE
Register assemblies in the assembly container to ensure later assembly loads succeed

### DIFF
--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -303,6 +303,10 @@ namespace Stride.Core.Assets
             // 1. Load store package
             foreach (var projectDependency in project.FlattenedDependencies)
             {
+                // Make all the assemblies known to the container to ensure that later assembly loads succeed
+                foreach (var assembly in projectDependency.Assemblies)
+                    AssemblyContainer.RegisterDependency(assembly);
+
                 var loadedPackage = packages.Find(projectDependency);
                 if (loadedPackage == null)
                 {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Different approach to what I proposed in https://github.com/stride3d/stride/pull/965. This time all the dependencies as given by the project are registered in the used assembly container to ensure that a later assembly load will work.

## Related Issue

https://github.com/stride3d/stride/pull/965

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.