### PR TITLE
[Input] Unique input device ids per window as well as for simulated devices

### DIFF
--- a/sources/engine/Stride.Input/SDL/KeyboardSDL.cs
+++ b/sources/engine/Stride.Input/SDL/KeyboardSDL.cs
@@ -23,6 +23,8 @@ namespace Stride.Input
             this.window.KeyUpActions += OnKeyEvent;
             this.window.TextInputActions += OnTextInputActions;
             this.window.TextEditingActions += OnTextEditingActions;
+
+            Id = InputDeviceUtils.DeviceNameToGuid(window.SdlHandle.ToString() + Name);
         }
         
         public void Dispose()
@@ -33,7 +35,7 @@ namespace Stride.Input
 
         public override string Name => "SDL Keyboard";
 
-        public override Guid Id => new Guid("a25469ad-804e-4713-82da-347c6b187323");
+        public override Guid Id { get; }
 
         public override IInputSource Source { get; }
 

--- a/sources/engine/Stride.Input/SDL/MouseSDL.cs
+++ b/sources/engine/Stride.Input/SDL/MouseSDL.cs
@@ -20,18 +20,20 @@ namespace Stride.Input
         {
             Source = source;
             this.uiControl = uiControl;
-            
+
             uiControl.MouseMoveActions += OnMouseMoveEvent;
             uiControl.PointerButtonPressActions += OnMouseInputEvent;
             uiControl.PointerButtonReleaseActions += OnMouseInputEvent;
             uiControl.MouseWheelActions += OnMouseWheelEvent;
             uiControl.ResizeEndActions += OnSizeChanged;
             OnSizeChanged(new SDL.SDL_WindowEvent());
+
+            Id = InputDeviceUtils.DeviceNameToGuid(uiControl.SdlHandle.ToString() + Name);
         }
         
         public override string Name => "SDL Mouse";
 
-        public override Guid Id => new Guid("0ccaf48e-e371-4b34-b6bb-a3720f6742a8");
+        public override Guid Id { get; }
 
         public override bool IsPositionLocked => isMousePositionLocked;
 

--- a/sources/engine/Stride.Input/SDL/PointerSDL.cs
+++ b/sources/engine/Stride.Input/SDL/PointerSDL.cs
@@ -35,11 +35,13 @@ namespace Stride.Input
 
             uiControl.ResizeEndActions += OnSizeChanged;
             OnSizeChanged(new SDL.SDL_WindowEvent());
+
+            Id = InputDeviceUtils.DeviceNameToGuid(uiControl.SdlHandle.ToString() + Name);
         }
 
         public override string Name => "SDL Pointer";
 
-        public override Guid Id => new Guid("f64482a9-dac9-4806-959f-eea7cbb4c609");
+        public override Guid Id { get; }
 
         public override IInputSource Source { get; }
 

--- a/sources/engine/Stride.Input/Simulated/KeyboardSimulated.cs
+++ b/sources/engine/Stride.Input/Simulated/KeyboardSimulated.cs
@@ -11,11 +11,13 @@ namespace Stride.Input
         {
             Priority = -1000;
             Source = source;
+
+            Id = Guid.NewGuid();
         }
 
         public override string Name => "Simulated Keyboard";
 
-        public override Guid Id => new Guid(10, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+        public override Guid Id { get; }
 
         public override IInputSource Source { get; }
 

--- a/sources/engine/Stride.Input/Simulated/MouseSimulated.cs
+++ b/sources/engine/Stride.Input/Simulated/MouseSimulated.cs
@@ -17,11 +17,13 @@ namespace Stride.Input
             Priority = -1000;
             SetSurfaceSize(Vector2.One);
             Source = source;
+
+            Id = Guid.NewGuid();
         }
 
         public override string Name => "Simulated Mouse";
 
-        public override Guid Id => new Guid("B6B2EE26-23F2-4B8B-8431-529DBCF9AC83");
+        public override Guid Id { get; }
 
         public override bool IsPositionLocked => positionLocked;
 

--- a/sources/engine/Stride.Input/Simulated/PointerSimulated.cs
+++ b/sources/engine/Stride.Input/Simulated/PointerSimulated.cs
@@ -17,11 +17,13 @@ namespace Stride.Input
             Priority = -1000;
             SetSurfaceSize(Vector2.One);
             Source = source;
+
+            Id = Guid.NewGuid();
         }
 
         public override string Name => "Simulated Pointer";
 
-        public override Guid Id => new Guid("8D527970-EB53-4392-AFBB-CB08CFF95143");
+        public override Guid Id { get; }
 
         public override IInputSource Source { get; }
 

--- a/sources/engine/Stride.Input/Windows/KeyboardWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/KeyboardWinforms.cs
@@ -42,6 +42,8 @@ namespace Stride.Input
             wndProcDelegate = WndProc;
             var windowProc = Marshal.GetFunctionPointerForDelegate(wndProcDelegate);
             oldWndProc = Win32Native.SetWindowLong(richTextBox.Handle, Win32Native.WindowLongType.WndProc, windowProc);
+
+            Id = InputDeviceUtils.DeviceNameToGuid(uiControl.Handle.ToString() + Name);
         }
 
         public void Dispose()
@@ -51,7 +53,7 @@ namespace Stride.Input
          
         public override string Name => "Windows Keyboard";
 
-        public override Guid Id => new Guid("027cf994-681f-4ed5-b38f-ce34fc295b8f");
+        public override Guid Id { get; }
 
         public override IInputSource Source { get; }
 

--- a/sources/engine/Stride.Input/Windows/MouseWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/MouseWinforms.cs
@@ -40,6 +40,8 @@ namespace Stride.Input
             OnSizeChanged(this, null);
 
             BindRawInput();
+
+            Id = InputDeviceUtils.DeviceNameToGuid(uiControl.Handle.ToString() + Name);
         }
 
         public override IInputSource Source { get; }
@@ -61,7 +63,7 @@ namespace Stride.Input
         }
 
         public override string Name => "Windows Mouse";
-        public override Guid Id => new Guid("699e35c5-c363-4bb0-8e8b-0474ea1a5cf1");
+        public override Guid Id { get; }
         public override bool IsPositionLocked => isPositionLocked;
 
         public override void Update(List<InputEvent> inputEvents)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Each window comes with its own mouse and keyboard device. Therefor the generated ids must be unique per window. Further simulated devices must always have a unique id.

## Related Issue

#919 

## Motivation and Context

Creating a second input source for a second render window leads currently to a crash due to the shared id. The changes in this PR can be seen as part of #919.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.