### PR TITLE
[Graphics] Adds toSRgb parameter to CreateTextureFromNative

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/SharpDXInterop.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SharpDXInterop.cs
@@ -71,13 +71,14 @@ namespace Stride.Graphics
         /// <param name="device">The GraphicsDevice in use</param>
         /// <param name="dxTexture2D">The DX11 texture</param>
         /// <param name="takeOwnership">If false AddRef will be called on the texture, if true will not, effectively taking ownership</param>
+        /// <param name="isSRgb">Set the format to SRgb</param>
         /// <returns></returns>
-        public static Texture CreateTextureFromNative(GraphicsDevice device, object dxTexture2D, bool takeOwnership)
+        public static Texture CreateTextureFromNative(GraphicsDevice device, object dxTexture2D, bool takeOwnership, bool isSRgb = false)
         {
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-            return CreateTextureFromNativeImpl(device, (Texture2D)dxTexture2D, takeOwnership);
+            return CreateTextureFromNativeImpl(device, (Texture2D)dxTexture2D, takeOwnership, isSRgb);
 #elif STRIDE_GRAPHICS_API_DIRECT3D12
-            return CreateTextureFromNativeImpl(device, (Resource)dxTexture2D, takeOwnership);
+            return CreateTextureFromNativeImpl(device, (Resource)dxTexture2D, takeOwnership, isSRgb);
 #endif
         }
 
@@ -129,8 +130,9 @@ namespace Stride.Graphics
         /// <param name="device">The GraphicsDevice in use</param>
         /// <param name="dxTexture2D">The DX11 texture</param>
         /// <param name="takeOwnership">If false AddRef will be called on the texture, if true will not, effectively taking ownership</param>
+        /// <param name="isSRgb">Set the format to SRgb</param>
         /// <returns></returns>
-        private static Texture CreateTextureFromNativeImpl(GraphicsDevice device, Texture2D dxTexture2D, bool takeOwnership)
+        private static Texture CreateTextureFromNativeImpl(GraphicsDevice device, Texture2D dxTexture2D, bool takeOwnership, bool isSRgb = false)
         {
             var tex = new Texture(device);
 
@@ -140,7 +142,7 @@ namespace Stride.Graphics
                 unknown.AddReference();
             }
 
-            tex.InitializeFromImpl(dxTexture2D, false);
+            tex.InitializeFromImpl(dxTexture2D, isSRgb);
 
             return tex;
         }


### PR DESCRIPTION
 Allows specifying that a native texture is in gamma space.

# PR Details

Adds a new optional parameter toSRgb.

## Motivation and Context

When receiving or loading a native SharpDX texture, it is often in gamma space. This PR adds a parameter to specify the color space. The parameter already existed in the method that gets called to create the texture.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.