### PR TITLE
[Doc] More troubleshooting guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If building failed:
 * Visual Studio might have issues properly building if an outdated version of 2017 is present alongside 2019. If you want to keep VS 2017 make sure that it is up to date and that you are building Stride through VS 2019.
 * Some changes might require a system reboot, try that if you haven't yet.
 * Make sure that git and visual studio can access the internet.
-* Close VS, clear the nuget cache (in your cmd ``dotnet nuget locals all --clear``), delete the hidden ``.vs`` folder inside ``\build``, build the whole solution then build and run GameStudio.
+* Close VS, clear the nuget cache (in your cmd ``dotnet nuget locals all --clear``), delete the hidden ``.vs`` folder inside ``\build`` and the files inside ``bin\packages``, kill any msbuild and other vs processes, build the whole solution then build and run GameStudio.
 
 Do note that test solutions might fail but it should not prevent you from building `Stride.GameStudio`.
 

--- a/README.md
+++ b/README.md
@@ -59,14 +59,22 @@ Ask for help or report issues:
 1. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
 2. Open `<StrideDir>\build\Stride.sln` with Visual Studio 2019 and build `Stride.GameStudio` (it should be the default startup project) or run it from VS's toolbar.
 * Optionally, open and build `Stride.Android.sln`, `Stride.iOS.sln`, etc.
-* For .Net 5.0 make sure that you have the latest SDK and runtime, navigate to ``\sources\targets\Stride.Core.TargetFrameworks.Editor.props`` and change ``net472`` to ``net5.0-windows``
+
+### Build Stride without Visual Studio
+
+1. Install VS build tools with the same prerequisites listed above
+2. Add MSBuild's directory to your system's *PATH*
+3. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
+4. Navigate to `/Build` with the command prompt, input `dotnet restore Stride.sln` then `compile`
+
+For .Net 5.0 make sure that you have the latest SDK and runtime, navigate to `\sources\targets\Stride.Core.TargetFrameworks.Editor.props` and change `net472` to `net5.0-windows`
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.
 * Visual Studio might have issues properly building if an outdated version of 2017 is present alongside 2019. If you want to keep VS 2017 make sure that it is up to date and that you are building Stride through VS 2019.
 * Some changes might require a system reboot, try that if you haven't yet.
 * Make sure that git and visual studio can access the internet.
-* Close VS, clear the nuget cache (in your cmd ``dotnet nuget locals all --clear``), delete the hidden ``.vs`` folder inside ``\build`` and the files inside ``bin\packages``, kill any msbuild and other vs processes, build the whole solution then build and run GameStudio.
+* Close VS, clear the nuget cache (in your cmd `dotnet nuget locals all --clear`), delete the hidden `.vs` folder inside `\build` and the files inside `bin\packages`, kill any msbuild and other vs processes, build the whole solution then build and run GameStudio.
 
 Do note that test solutions might fail but it should not prevent you from building `Stride.GameStudio`.
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ Ask for help or report issues:
 1. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
 2. Open `<StrideDir>\build\Stride.sln` with Visual Studio 2019 and build `Stride.GameStudio` (it should be the default startup project) or run it from VS's toolbar.
 * Optionally, open and build `Stride.Android.sln`, `Stride.iOS.sln`, etc.
+* For .Net 5.0 make sure that you have the latest SDK and runtime, navigate to ``\sources\targets\Stride.Core.TargetFrameworks.Editor.props`` and change ``net472`` to ``net5.0-windows``
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.
 * Visual Studio might have issues properly building if an outdated version of 2017 is present alongside 2019. If you want to keep VS 2017 make sure that it is up to date and that you are building Stride through VS 2019.
 * Some changes might require a system reboot, try that if you haven't yet.
+* Make sure that git and visual studio can access the internet.
+* Close VS, clear the nuget cache (in your cmd ``dotnet nuget locals all --clear``), delete the hidden ``.vs`` folder inside ``\build``, build the whole solution then build and run GameStudio.
 
 Do note that test solutions might fail but it should not prevent you from building `Stride.GameStudio`.
 


### PR DESCRIPTION
# PR Details
Not exactly sure how we're supposed to build for net5.0 but this worked for me inside VS **only in debug**.
Release fails with a couple of projects outputting 
```
Your project does not reference ".NETCoreApp,Version=v5.0" framework. Add a reference to ".NETCoreApp,Version=v5.0" in the "TargetFrameworks" property of your project file and then re-run NuGet restore.
```
See [Output.txt](https://github.com/stride3d/stride/files/5742103/Output.txt) for vs output.

Using the command line with dotnet + msbuild seems to work pretty well for both debug and release though.


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.