### PR TITLE
[POC] Async entity processors

### DIFF
--- a/sources/core/Stride.Core/Collections/OrderedCollection.cs
+++ b/sources/core/Stride.Core/Collections/OrderedCollection.cs
@@ -146,7 +146,7 @@ namespace Stride.Core.Collections
         public void RemoveAt(int index)
         {
             if (index < 0 || index >= size) throw new ArgumentOutOfRangeException(nameof(index));
-            RemoteItem(index);
+            RemoveItem(index);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Stride.Core.Collections
             size++;
         }
 
-        protected virtual void RemoteItem(int index)
+        protected virtual void RemoveItem(int index)
         {
             size--;
             if (index < size)

--- a/sources/engine/Stride.Engine.Tests/TestEntityManager.cs
+++ b/sources/engine/Stride.Engine.Tests/TestEntityManager.cs
@@ -146,7 +146,7 @@ namespace Stride.Engine.Tests
             Assert.Empty(entityManager.Processors);
 
             // ================================================================
-            // 1) Add an entity with the CustomEntityComponent to the Entity Manager
+            // 1) Add an entity with the AsyncEntityComponent to the Entity Manager
             // ================================================================
             var events = new List<CustomEntityComponentEventArgs>();
             var entity = new Entity
@@ -184,9 +184,6 @@ namespace Stride.Engine.Tests
             var processorListForAsyncEntityComponentType = entityManager.MapComponentTypeToProcessors[typeof(AsyncEntityComponent).GetTypeInfo()];
             Assert.Single(processorListForAsyncEntityComponentType);
             Assert.True(processorListForAsyncEntityComponentType[0] is AsyncEntityComponentProcessor);
-
-            // TODO: Test calling execute asynchronously. How to test async is happening?
-            // TODO: How to test the microthreads are working correctly? Are there asyncscript tests anywhere?
 
             // clear events collector
             componentTypes.Clear();

--- a/sources/engine/Stride.Engine/Engine/AsyncEntityProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/AsyncEntityProcessor.cs
@@ -1,16 +1,19 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Stride.Core;
 using Stride.Core.Annotations;
+using Stride.Core.Collections;
 using Stride.Core.Diagnostics;
 using Stride.Core.MicroThreading;
 
 namespace Stride.Engine
 {
-    public abstract class AsyncEntityProcessor : EntityProcessor
+    public abstract class AsyncEntityProcessor : EntityProcessorBase
     {
         public static readonly ProfilingKey ScriptGlobalProfilingKey = new ProfilingKey("AsyncProcessor");
 
@@ -65,6 +68,7 @@ namespace Stride.Engine
         /// </summary>
         public CancellationToken CancellationToken => MicroThread.CancellationToken;
 
+
         protected AsyncEntityProcessor([NotNull] Type mainComponentType, [NotNull] Type[] additionalTypes)
             : base(mainComponentType, additionalTypes)
         {
@@ -74,7 +78,10 @@ namespace Stride.Engine
         /// Called once, as a microthread
         /// </summary>
         /// <returns></returns>
-        public abstract Task Execute();
+        public virtual Task Execute()
+        {
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Internal helper function called when <see cref="Priority"/> is changed.
@@ -87,15 +94,183 @@ namespace Stride.Engine
         }
     }
 
+    public abstract class AsyncEntityProcessor<TComponent> : AsyncEntityProcessor<TComponent, TComponent> where TComponent : EntityComponent
+    {
+        protected AsyncEntityProcessor([NotNull] params Type[] requiredAdditionalTypes)
+            : base(requiredAdditionalTypes)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override TComponent GenerateComponentData(Entity entity, TComponent component)
+        {
+            return component;
+        }
+
+        /// <inheritdoc />
+        protected override bool IsAssociatedDataValid(Entity entity, TComponent component, TComponent associatedData)
+        {
+            return component == associatedData;
+        }
+    }
+
     public abstract class AsyncEntityProcessor<TComponent, TData> : AsyncEntityProcessor where TData : class where TComponent : EntityComponent
     {
+        protected readonly ConcurrentDictionary<TComponent, TData> ComponentDatas = new ConcurrentDictionary<TComponent, TData>();
+        private readonly HashSet<Entity> reentrancyCheck = new HashSet<Entity>();
+        private readonly FastList<TypeInfo> checkRequiredTypes = new FastList<TypeInfo>();
+
         protected AsyncEntityProcessor([NotNull] params Type[] requiredAdditionalTypes)
             : base(typeof(TComponent), requiredAdditionalTypes)
         {
         }
-    }
 
-    public abstract class AsyncEntityProcessor<TComponent> : AsyncEntityProcessor<TComponent, TComponent> where TComponent : EntityComponent
-    {
+        /// <inheritdoc/>
+        protected internal override void OnSystemAdd()
+        {
+        }
+
+        /// <inheritdoc/>
+        protected internal override void OnSystemRemove()
+        {
+        }
+
+        /// <inheritdoc/>
+        protected internal override void RemoveAllEntities()
+        {
+            // Keep removing until empty
+            while (ComponentDatas.Count > 0)
+            {
+                foreach (var component in ComponentDatas)
+                {
+                    ProcessEntityComponent(component.Key.Entity, component.Key, true);
+                    break; // break right after since we remove from iterator
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected internal override void ProcessEntityComponent(Entity entity, EntityComponent entityComponentArg, bool forceRemove)
+        {
+            // TODO: Entity component processing is currently synchronous, but can it be made fully asynchronous?
+            var entityComponent = (TComponent)entityComponentArg;
+            // If forceRemove is true, no need to check if entity matches.
+            var entityMatch = !forceRemove && EntityMatch(entity);
+            var entityAdded = ComponentDatas.TryGetValue(entityComponent, out var entityData);
+
+            if (entityMatch && !entityAdded)
+            {
+                // Adding entity is not reentrant, so let's skip if already being called for current entity
+                // (could happen if either GenerateComponentData, OnEntityPrepare or OnEntityAdd changes
+                // any Entity components
+                lock (reentrancyCheck)
+                {
+                    if (!reentrancyCheck.Add(entity))
+                        return;
+                }
+
+                // Generate associated data
+                var data = GenerateComponentData(entity, entityComponent);
+
+                // Notify component being added
+                OnEntityComponentAdding(entity, entityComponent, data);
+
+                // Associate the component to its data
+                ComponentDatas.TryAdd(entityComponent, data);
+
+                lock (reentrancyCheck)
+                {
+                    reentrancyCheck.Remove(entity);
+                }
+            }
+            else if (entityAdded && !entityMatch)
+            {
+                // Notify component being removed
+                OnEntityComponentRemoved(entity, entityComponent, entityData);
+
+                // Removes it from the component => data map
+                ComponentDatas.TryRemove(entityComponent, out _);
+            }
+            else if (entityMatch) // && entityMatch
+            {
+                if (!IsAssociatedDataValid(entity, entityComponent, entityData))
+                {
+                    OnEntityComponentRemoved(entity, entityComponent, entityData);
+                    entityData = GenerateComponentData(entity, entityComponent);
+                    OnEntityComponentAdding(entity, entityComponent, entityData);
+                    ComponentDatas.TryUpdate(entityComponent, entityData, ComponentDatas[entityComponent]);
+                }
+            }
+        }
+
+        /// <summary>Generates associated data to the given entity.</summary>
+        /// Called right before <see cref="OnEntityComponentAdding"/>.
+        /// <param name="entity">The entity.</param>
+        /// <param name="component"></param>
+        /// <returns>The associated data.</returns>
+        [NotNull]
+        protected abstract TData GenerateComponentData([NotNull] Entity entity, [NotNull] TComponent component);
+
+        /// <summary>Checks if the current associated data is valid, or if readding the entity is required.</summary>
+        /// <param name="entity">The entity.</param>
+        /// <param name="component"></param>
+        /// <param name="associatedData">The associated data.</param>
+        /// <returns>True if the change in associated data requires the entity to be readded, false otherwise.</returns>
+        protected virtual bool IsAssociatedDataValid([NotNull] Entity entity, [NotNull] TComponent component, [NotNull] TData associatedData)
+        {
+            return GenerateComponentData(entity, component).Equals(associatedData);
+        }
+
+        /// <summary>Run when a matching entity is added to this entity processor.</summary>
+        /// <param name="entity">The entity.</param>
+        /// <param name="component"></param>
+        /// <param name="data">  The associated data.</param>
+        protected virtual void OnEntityComponentAdding(Entity entity, [NotNull] TComponent component, [NotNull] TData data)
+        {
+        }
+
+        /// <summary>Run when a matching entity is removed from this entity processor.</summary>
+        /// <param name="entity">The entity.</param>
+        /// <param name="component"></param>
+        /// <param name="data">  The associated data.</param>
+        protected virtual void OnEntityComponentRemoved(Entity entity, [NotNull] TComponent component, [NotNull] TData data)
+        {
+        }
+
+        private bool EntityMatch(Entity entity)
+        {
+            // When a processor has no requirement components, it always match with at least the component of entity
+            if (!HasRequiredComponents)
+            {
+                return true;
+            }
+
+            checkRequiredTypes.Clear();
+            for (var i = 0; i < RequiredTypes.Length; i++)
+            {
+                checkRequiredTypes.Add(RequiredTypes[i]);
+            }
+
+            var components = entity.Components;
+            for (var i = 0; i < components.Count; i++)
+            {
+                var componentType = components[i].GetType().GetTypeInfo();
+                for (var j = checkRequiredTypes.Count - 1; j >= 0; j--)
+                {
+                    if (checkRequiredTypes.Items[j].IsAssignableFrom(componentType))
+                    {
+                        checkRequiredTypes.RemoveAt(j);
+
+                        if (checkRequiredTypes.Count == 0)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            // If we are here, it means that required types were not found, so return false
+            return false;
+        }
     }
 }

--- a/sources/engine/Stride.Engine/Engine/AsyncEntityProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/AsyncEntityProcessor.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Stride.Core;
+using Stride.Core.Annotations;
+using Stride.Core.Diagnostics;
+using Stride.Core.MicroThreading;
+
+namespace Stride.Engine
+{
+    public abstract class AsyncEntityProcessor : EntityProcessor
+    {
+        public static readonly ProfilingKey ScriptGlobalProfilingKey = new ProfilingKey("AsyncProcessor");
+
+        private static readonly Dictionary<Type, ProfilingKey> ProcessorToProfilingKey = new Dictionary<Type, ProfilingKey>();
+
+        private ProfilingKey profilingKey;
+
+        /// <summary>
+        /// Gets the profiling key to activate/deactivate profiling for the current script class.
+        /// </summary>
+        [DataMemberIgnore]
+        public ProfilingKey ProfilingKey
+        {
+            get
+            {
+                if (profilingKey != null)
+                    return profilingKey;
+
+                var processorType = GetType();
+                if (!ProcessorToProfilingKey.TryGetValue(processorType, out profilingKey))
+                {
+                    profilingKey = new ProfilingKey(ScriptGlobalProfilingKey, processorType.FullName);
+                    ProcessorToProfilingKey[processorType] = profilingKey;
+                }
+
+                return profilingKey;
+            }
+        }
+
+        private int priority;
+
+        /// <summary>
+        /// The priority this processor will be scheduled with (compared to other processors).
+        /// </summary>
+        /// <userdoc>The execution priority for this processor. Lower values mean earlier execution.</userdoc>
+        [DefaultValue(0)]
+        [DataMember(10000)]
+        public int Priority
+        {
+            get { return priority; }
+            set { priority = value; PriorityUpdated(); }
+        }
+
+        [DataMemberIgnore]
+        internal MicroThread MicroThread;
+
+        [DataMemberIgnore]
+        internal CancellationTokenSource CancellationTokenSource;
+
+        /// <summary>
+        /// Gets a token indicating if the script execution was canceled.
+        /// </summary>
+        public CancellationToken CancellationToken => MicroThread.CancellationToken;
+
+        protected AsyncEntityProcessor([NotNull] Type mainComponentType, [NotNull] Type[] additionalTypes)
+            : base(mainComponentType, additionalTypes)
+        {
+        }
+
+        /// <summary>
+        /// Called once, as a microthread
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task Execute();
+
+        /// <summary>
+        /// Internal helper function called when <see cref="Priority"/> is changed.
+        /// </summary>
+        protected internal virtual void PriorityUpdated()
+        {
+            // Update micro thread priority
+            if (MicroThread != null)
+                MicroThread.Priority = Priority;
+        }
+    }
+
+    public abstract class AsyncEntityProcessor<TComponent, TData> : AsyncEntityProcessor where TData : class where TComponent : EntityComponent
+    {
+        protected AsyncEntityProcessor([NotNull] params Type[] requiredAdditionalTypes)
+            : base(typeof(TComponent), requiredAdditionalTypes)
+        {
+        }
+    }
+
+    public abstract class AsyncEntityProcessor<TComponent> : AsyncEntityProcessor<TComponent, TComponent> where TComponent : EntityComponent
+    {
+    }
+}

--- a/sources/engine/Stride.Engine/Engine/Design/DefaultEntityComponentProcessorAttribute.cs
+++ b/sources/engine/Stride.Engine/Engine/Design/DefaultEntityComponentProcessorAttribute.cs
@@ -7,7 +7,7 @@ using Stride.Core.Annotations;
 namespace Stride.Engine.Design
 {
     /// <summary>
-    /// An attribute used to associate a default <see cref="EntityProcessor"/> to an entity component.
+    /// An attribute used to associate a default <see cref="EntityProcessorBase"/> to an entity component.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class DefaultEntityComponentProcessorAttribute : DynamicTypeAttributeBase
@@ -15,7 +15,7 @@ namespace Stride.Engine.Design
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultEntityComponentProcessorAttribute"/> class.
         /// </summary>
-        /// <param name="type">The type must derived from <see cref="EntityProcessor"/>.</param>
+        /// <param name="type">The type must derived from <see cref="EntityProcessorBase"/>.</param>
         public DefaultEntityComponentProcessorAttribute(Type type) : base(type)
         {
         }

--- a/sources/engine/Stride.Engine/Engine/EntityProcessorCollection.cs
+++ b/sources/engine/Stride.Engine/Engine/EntityProcessorCollection.cs
@@ -8,10 +8,10 @@ using Stride.Core.Collections;
 namespace Stride.Engine
 {
     /// <summary>
-    /// Ordered collection of <see cref="EntityProcessor"/> based on the <see cref="EntityProcessor.Order"/> property.
+    /// Ordered collection of <see cref="EntityProcessorBase"/> based on the <see cref="EntityProcessorBase.Order"/> property.
     /// </summary>
     /// <seealso cref="Stride.Core.Collections.OrderedCollection{Stride.Engine.EntityProcessor}" />
-    public class EntityProcessorCollection : OrderedCollection<EntityProcessor>
+    public class EntityProcessorCollection : OrderedCollection<EntityProcessorBase>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityProcessorCollection"/> class.
@@ -34,7 +34,7 @@ namespace Stride.Engine
         /// <typeparam name="T">Type of the processor</typeparam>
         /// <returns>The first processor of type T or <c>null</c> if not found.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T Get<T>() where T : EntityProcessor
+        public T Get<T>() where T : EntityProcessorBase
         {
             for (int i = 0; i < this.Count; i++)
             {
@@ -47,13 +47,13 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Internal comparer for <see cref="EntityProcessor"/>
+        /// Internal comparer for <see cref="EntityProcessorBase"/>
         /// </summary>
-        private class EntityProcessorComparer : Comparer<EntityProcessor>
+        private class EntityProcessorComparer : Comparer<EntityProcessorBase>
         {
             public static new readonly EntityProcessorComparer Default = new EntityProcessorComparer();
 
-            public override int Compare(EntityProcessor x, EntityProcessor y)
+            public override int Compare(EntityProcessorBase x, EntityProcessorBase y)
             {
                 return x.Order.CompareTo(y.Order);
             }


### PR DESCRIPTION
# PR Details

This PR provides a base processor for async entity processing and modifies the entity manager to support it in the same way that the `ScriptSystem` does for `AsyncScript`. 

## Description

Moving towards an asynchronous, ECS type system, we need to be able to support asynchronous component processing.  The `EntityProcessor` class was built to support synchronous operations only. Specifically, it was doing Update and Draw operations which do need to be performed on time. Stride supports asynchronous scripting through it's `ScriptSystem` and the `AsyncScript` base type, but the `EntityManager` had no concept of microthreads or async entity processors. There were bits of code in the `EntityManager` that suggested it may have been intended at some point (see `Scheduler` property) and was never fully implemented.  

## Related Issue

https://github.com/stride3d/stride/issues/20
https://github.com/stride3d/stride/issues/803

## Motivation and Context

Entity component processing can only happen synchronously. We allow asynchronous scripting through the AsyncScript, but no async entity processor if the developer would like to follow a pattern closer to ECS. 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.