### PR TITLE
Correct VS workload name and fix VS installer arguments

### DIFF
--- a/sources/tools/Stride.PackageInstall/Program.cs
+++ b/sources/tools/Stride.PackageInstall/Program.cs
@@ -22,7 +22,7 @@ namespace Stride.PackageInstall
         {
             ("Microsoft.VisualStudio.Workload.ManagedDesktop", ".NET desktop development"),
             ("Microsoft.VisualStudio.Workload.NetCoreTools", ".NET core cross-platform development"),
-            ("Microsoft.NetCore.ComponentGroup.DevelopmentTools.2.1", ".NET Core 2.1 Runtime (LTS) (inside .NET core cross-platform development)"),
+            ("Microsoft.NetCore.ComponentGroup.DevelopmentTools.2.1", "Development Tools plus .NET Core 2.1"),
         };
         private static readonly new(string Id, string Name)[] NecessaryBuildTools2019Workloads = new[]
         {
@@ -195,7 +195,7 @@ namespace Stride.PackageInstall
 
                     // Second, check workloads
                     {
-                        var vsInstallerExitCode = RunProgramAndAskUntilSuccess("Visual Studio", vsInstallerPath, $"modify --noUpdateInstaller --passive --norestart --installPath \"{existingVisualStudio2019Install.InstallationPath}\" {string.Join(" ", NecessaryVS2019Workloads.Select(x => $"--add {x}"))}", DialogBoxTryAgainVS);
+                        var vsInstallerExitCode = RunProgramAndAskUntilSuccess("Visual Studio", vsInstallerPath, $"modify --noUpdateInstaller --passive --norestart --installPath \"{existingVisualStudio2019Install.InstallationPath}\" {string.Join(" ", NecessaryVS2019Workloads.Select(x => $"--add {x.Id}"))}", DialogBoxTryAgainVS);
                         if (vsInstallerExitCode != 0)
                         {
                             var errorMessage = $"Visual Studio 2019 install failed with error {vsInstallerExitCode}\r\n\r\nPlease manually install the following workloads/components using \"Visual Studio Installer\":\r\n  - {string.Join("\r\n  - ", NecessaryVS2019Workloads.Where(workload => !existingVisualStudio2019Install.PackageVersions.ContainsKey(workload.Id)).Select(workload => workload.Name))}";
@@ -222,12 +222,12 @@ namespace Stride.PackageInstall
                         if (buildTools.Count > 0)
                         {
                             // Incomplete installation
-                            buildToolsCommandLine = $"modify --wait --passive --norestart --installPath \"{buildTools.First().InstallationPath}\" {string.Join(" ", NecessaryBuildTools2019Workloads.Select(x => $"--add {x}"))}";
+                            buildToolsCommandLine = $"modify --wait --passive --norestart --installPath \"{buildTools.First().InstallationPath}\" {string.Join(" ", NecessaryBuildTools2019Workloads.Select(x => $"--add {x.Id}"))}";
                         }
                         else
                         {
                             // Not installed yet
-                            buildToolsCommandLine = $"--wait --passive --norestart {string.Join(" ", NecessaryBuildTools2019Workloads.Select(x => $"--add {x}"))}";
+                            buildToolsCommandLine = $"--wait --passive --norestart {string.Join(" ", NecessaryBuildTools2019Workloads.Select(x => $"--add {x.Id}"))}";
                         }
                     }
 


### PR DESCRIPTION
# PR Details

This fixes a problem where Stride installation always fails for the machines which do not have the `Development Tools plus .NET Core 2.1` workload installed and then shows an incorrect error message telling the user to install the incorrect workload `.NET Core 2.1 Runtime (LTS) (inside .NET core cross-platform development)` manually.

## Description

This problem was introduced with b73b2a956422171c4173cecc7d5433d2d9c67d36 - the VS installer is invoked incorrectly due to invalid generated arguments. The commit changes the array type containing necessary VS workloads from string to tuple. However, not all places that referred to the tuple were updated to access the appropriate tuple item, which in turn resulted in the tuple being consumed directly by its `ToString()` method instead of the actual workload ID. This PR changes the code in the remaining places.

Furthermore, VS installer workload `Microsoft.NetCore.ComponentGroup.DevelopmentTools.2.1` was incorrectly labeled as `.NET Core 2.1 Runtime (LTS) (inside .NET core cross-platform development)`. This PR changes it to `Development Tools plus .NET Core 2.1` (as seen in the official documentation [here](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2019)).

## Related Issue

#653, #985

## Motivation and Context

The motivation is to fix the installation problem and the incorrect error message, so that the newcomers do not have to waste their time trying to figure out why the installation is constantly failing for their machine.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.