### PR TITLE
Correct Stride Visual Studio extension GUID

### DIFF
--- a/sources/tools/Stride.VisualStudio.Package/Guids.cs
+++ b/sources/tools/Stride.VisualStudio.Package/Guids.cs
@@ -6,7 +6,7 @@ namespace Stride.VisualStudio
 {
     internal static class GuidList
     {
-        public const string guidStride_VisualStudio_PackagePkgString = "b0b8feb1-7b83-43fc-9fc0-70065ddb80a1";
+        public const string guidStride_VisualStudio_PackagePkgString = "248ff1ce-dacd-4404-947a-85e999d3c3ea";
         public const string guidStride_VisualStudio_PackageCmdSetString = "9428db93-bfea-4115-8d4a-40b047166e61";
         public const string guidToolWindowPersistanceString = "ddd10155-9f63-4694-95ce-c7ba2d74ad46";
 

--- a/sources/tools/Stride.VisualStudio.Package/StridePackage.vsct
+++ b/sources/tools/Stride.VisualStudio.Package/StridePackage.vsct
@@ -119,7 +119,7 @@
 
   <Symbols>
     <!-- This is the package guid. -->
-    <GuidSymbol name="guidStride_VisualStudio_PackagePkg" value="{b0b8feb1-7b83-43fc-9fc0-70065ddb80a1}" />
+    <GuidSymbol name="guidStride_VisualStudio_PackagePkg" value="{248ff1ce-dacd-4404-947a-85e999d3c3ea}" />
     
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidStride_VisualStudio_PackageCmdSet" value="{9428db93-bfea-4115-8d4a-40b047166e61}">

--- a/sources/tools/Stride.VisualStudio.PackageInstall/Program.cs
+++ b/sources/tools/Stride.VisualStudio.PackageInstall/Program.cs
@@ -45,7 +45,7 @@ namespace Stride.VisualStudio.PackageInstall
                     case "/uninstall":
                     {
                         // Note: we allow uninstall to fail (i.e. VSIX was not installed for that specific VIsual Studio version)
-                        RunVsixInstaller(visualStudioVersion.VsixInstallerPath, "/uninstall:b0b8feb1-7b83-43fc-9fc0-70065ddb80a1");
+                        RunVsixInstaller(visualStudioVersion.VsixInstallerPath, "/uninstall:248ff1ce-dacd-4404-947a-85e999d3c3ea");
                         break;
                     }
                 }


### PR DESCRIPTION
# PR Details

Incorrect Stride Visual Studio extension GUID is specified when uninstalling the extension through the launcher. This causes reinstall to fail every time.

## Description

Visual Studio extension GUID was changed for Stride only in the VSIX manifest file `/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest`, however there are 3 additional places where the GUID is used:
* `/sources/tools/Stride.VisualStudio.Package/Guids.cs`
* `/sources/tools/Stride.VisualStudio.Package/StridePackage.vsct`
* `/sources/tools/Stride.VisualStudio.PackageInstall/Program.cs`

It needs to be changed there as well, or else the reinstall (from the Launcher) will attempt to remove Xenko Visual Studio extension instead of Stride Visual Studio extension, which causes reinstall to fail.

Xenko GUID: `b0b8feb1-7b83-43fc-9fc0-70065ddb80a1`
Stride GUID: `248ff1ce-dacd-4404-947a-85e999d3c3ea`

## Related Issue

Fixes #989.
Possibly related to #672.

## Motivation and Context

This is a very annoying bug that needs to be fixed.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.