### PR TITLE
Fix InstancingProcessor dependency on ModelRenderProcessor

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Processors/InstancingProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/Processors/InstancingProcessor.cs
@@ -23,8 +23,8 @@ namespace Stride.Engine.Processors
             public RenderInstancing RenderInstancing = new RenderInstancing();
         }
 
-        public InstancingProcessor() 
-            : base (typeof(TransformComponent), typeof(ModelComponent)) // Requires TransformComponent and ModelComponent
+        public InstancingProcessor()
+            : base(typeof(TransformComponent), typeof(ModelComponent)) // Requires TransformComponent and ModelComponent
         {
             // After TransformProcessor but before ModelRenderProcessor
             Order = -100;
@@ -73,7 +73,7 @@ namespace Stride.Engine.Processors
                     renderInstancing.BuffersManagedByUser = true;
                     renderInstancing.InstanceWorldBuffer = instancingUserBuffer.InstanceWorldBuffer;
                     renderInstancing.InstanceWorldInverseBuffer = instancingUserBuffer.InstanceWorldInverseBuffer;
-                } 
+                }
             }
         }
 
@@ -148,7 +148,6 @@ namespace Stride.Engine.Processors
 
         private static void BoundingBoxPreMultiplyWorld(InstancingData instancingData, IInstancing instancing, ModelComponent.MeshInfo meshInfo, Mesh mesh)
         {
-            
             var ibb = instancing.BoundingBox;
 
             var center = meshInfo.BoundingBox.Center;
@@ -208,6 +207,11 @@ namespace Stride.Engine.Processors
             VisibilityGroup.Tags.Set(InstancingRenderFeature.ModelToInstancingMap, modelInstancingMap);
 
             modelRenderProcessor = EntityManager.GetProcessor<ModelRenderProcessor>();
+            if (modelRenderProcessor == null)
+            {
+                modelRenderProcessor = new ModelRenderProcessor();
+                EntityManager.Processors.Add(modelRenderProcessor);
+            }
         }
 
         protected internal override void OnSystemRemove()


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Create and add `ModelRenderProcessor` if it doesn't exist in `InstancingProcessor`.

## Related Issue
Fixes #813

## Motivation and Context
`InstancingProcessor` has a hard dependency on `ModelRenderProcessor` which it stores in a field.
A subtle bug can occur (usually in the Game Studio) where a user adds an `InstancingComponent` before adding any `ModelComponent`s in a scene. In this scenario, `InstancingProcessor` will be created first, on its own, and null will be stored in the field, so the fix is to create the processor immediately.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.