### PR TITLE
Uninstalling GameStudio should not remove Stride.Samples.Templates package

### DIFF
--- a/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
@@ -328,16 +328,21 @@ namespace Stride.LauncherApp.ViewModels
             }
         }
 
+        // These packages will not be uninstalled with GameStudio
+        private static readonly string[] fixedDependencies = { "Samples.Templates" };
+
         private static async Task UninstallDependencies(NugetStore store, NugetPackage package)
         {
             foreach (var dependency in package.Dependencies)
             {
                 string dependencyId = dependency.Item1;
-                string dependencyIdPrefix = dependencyId.Split('.').First();
+                string[] dependencyIdParts = dependencyId.Split('.', 2);
                 PackageVersionRange dependencyVersionRange = dependency.Item2;
 
-                // Dependency must be from Stride/Xenko and package version must match exactly
-                if (((dependencyIdPrefix == "Stride") || (dependencyIdPrefix == "Xenko")) && (dependencyVersionRange.Contains(package.Version)))
+                // Dependency must be from Stride/Xenko, it must not be a fixed dependency and package version must match exactly
+                if (((dependencyIdParts[0] == "Stride") || (dependencyIdParts[0] == "Xenko"))
+                    && ((dependencyIdParts.Length < 2) || (!fixedDependencies.Contains(dependencyIdParts[1])))
+                    && (dependencyVersionRange.Contains(package.Version)))
                 {
                     NugetPackage dependencyPackage = store.FindLocalPackage(dependencyId, package.Version);
                     if (dependencyPackage != null)


### PR DESCRIPTION
# PR Details

Uninstalling `Stride.GameStudio`/`Xenko.GameStudio` should not remove `Stride.Samples.Templates`/`Xenko.Samples.Templates` package.

## Description

PR #993 added a functionality where removing `Stride.GameStudio`/`Xenko.GameStudio` via the launcher would also remove all of its dependencies with package IDs like `Stride.*`/`Xenko.*`. However, it was recently brought to my attention by @xen2 that there exists a shared package (`Stride.Samples.Templates`/`Xenko.Samples.Templates`) which does not get released for every released build, but rather some of the newer builds reference the past builds of this package. This package should not be removed because there is a chance that it is also referenced by a build newer than the build that is being uninstalled.

## Related Issue

#992

## Motivation and Context

Preventing a possible bug in the future. See [comment](https://github.com/stride3d/stride/pull/993#discussion_r556267309) for more details.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.