### PR TITLE
Remove packages which are no longer referenced by any GameStudio package after uninstall or update

### DIFF
--- a/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Microsoft.Win32;
 
 using Stride.Core.Extensions;
-using Stride.PrivacyPolicy;
 using Stride.LauncherApp.Resources;
 using Stride.LauncherApp.Services;
 using Stride.Core.Packages;
@@ -23,6 +22,7 @@ using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.ViewModel;
 using Stride.Metrics;
 using Stride.Core.VisualStudio;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Stride.LauncherApp.ViewModels
 {
@@ -206,6 +206,52 @@ namespace Stride.LauncherApp.ViewModels
             Dispatcher.Invoke(() => IsSynchronizing = false);
         }
 
+        private class ReferencedPackageEqualityComparer : IEqualityComparer<NugetLocalPackage>
+        {
+            public static readonly ReferencedPackageEqualityComparer Instance = new ReferencedPackageEqualityComparer();
+
+            private ReferencedPackageEqualityComparer() { }
+
+            public bool Equals(NugetLocalPackage x, NugetLocalPackage y)
+                => (ReferenceEquals(x, y)) || ((!ReferenceEquals(x, null)) && (!ReferenceEquals(y, null)) && (x.Id == y.Id) && (x.Version.ToString() == y.Version.ToString()));
+
+            public int GetHashCode([DisallowNull] NugetLocalPackage obj)
+                => (obj.Id.GetHashCode() ^ obj.Version.ToString().GetHashCode());
+        }
+
+        private HashSet<NugetLocalPackage> referencedPackages = new HashSet<NugetLocalPackage>(ReferencedPackageEqualityComparer.Instance);
+
+        private async Task RemoveUnusedPackages(IEnumerable<NugetLocalPackage> mainPackages)
+        {
+            var previousReferencedPackages = referencedPackages;
+            referencedPackages = new HashSet<NugetLocalPackage>(ReferencedPackageEqualityComparer.Instance);
+            foreach (var mainPackage in mainPackages)
+            {
+                await FindReferencedPackages(mainPackage);
+            }
+            foreach (var package in previousReferencedPackages.Where(package => !referencedPackages.Contains(package)))
+            {
+                await store.UninstallPackage(package, null);
+            }
+        }
+
+        private async Task FindReferencedPackages(NugetLocalPackage package)
+        {
+            foreach (var dependency in package.Dependencies)
+            {
+                string prefix = dependency.Item1.Split('.', 2)[0];
+                if ((prefix == "Stride") || (prefix == "Xenko"))
+                {
+                    NugetLocalPackage dependencyPackage = store.FindLocalPackage(dependency.Item1, dependency.Item2);
+                    if ((dependencyPackage != null) && (!referencedPackages.Contains(dependencyPackage)))
+                    {
+                        referencedPackages.Add(dependencyPackage);
+                        await FindReferencedPackages(dependencyPackage);
+                    }
+                }
+            }
+        }
+
         public async Task RetrieveLocalStrideVersions()
         {
             List<RecentProjectViewModel> currentRecentProjects;
@@ -218,6 +264,22 @@ namespace Stride.LauncherApp.ViewModels
                 var localPackages = await RunLockTask(() => store.GetPackagesInstalled(store.MainPackageIds).FilterStrideMainPackages().OrderByDescending(p => p.Version).ToList());
                 lock (objectLock)
                 {
+                    // Try to remove unused Stride/Xenko packages after uninstall or update
+                    try
+                    {
+                        Task.WaitAll(RemoveUnusedPackages(localPackages));
+                    }
+                    catch (Exception e)
+                    {
+                        var message = $@"**Failed to remove unused NuGet package(s).**
+
+### Exception
+```
+{e.FormatSummary(false).TrimEnd(Environment.NewLine.ToCharArray())}
+```";
+                        Task.WaitAll(ServiceProvider.Get<IDialogService>().MessageBox(message, MessageBoxButton.OK, MessageBoxImage.Warning));
+                    }
+
                     // Retrieve all local packages
                     var packages = localPackages.Where(p => !store.IsDevRedirectPackage(p)).GroupBy(p => $"{p.Version.Version.Major}.{p.Version.Version.Minor}", p => p);
                     var updatedLocalPackages = new HashSet<StrideStoreVersionViewModel>();

--- a/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Threading.Tasks;
-using Stride.Core;
 using Stride.Core.Extensions;
 using Stride.LauncherApp.Resources;
 using Stride.Core.Packages;
@@ -10,7 +9,6 @@ using Stride.LauncherApp.Services;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.ViewModel;
-using System.Linq;
 
 namespace Stride.LauncherApp.ViewModels
 {
@@ -190,7 +188,7 @@ namespace Stride.LauncherApp.ViewModels
                         {
                             progressReport.ProgressChanged += (action, progress) => { Dispatcher.InvokeAsync(() => { UpdateProgress(action, progress); }).Forget(); };
                             progressReport.UpdateProgress(ProgressAction.Delete, -1);
-                            await UninstallPackage(Store, LocalPackage, progressReport);
+                            await Store.UninstallPackage(LocalPackage, progressReport);
                             CurrentProcessStatus = null;
                         }
                     }
@@ -237,7 +235,7 @@ namespace Stride.LauncherApp.ViewModels
                         var localPackage = Store.FindLocalPackage(ServerPackage.Id, ServerPackage.Version);
                         if (localPackage != null)
                         {
-                            await UninstallPackage(Store, localPackage, null);
+                            await Store.UninstallPackage(localPackage, null);
                         }
                     }
                     catch
@@ -296,7 +294,7 @@ namespace Stride.LauncherApp.ViewModels
                     progressReport.ProgressChanged += (action, progress) => { Dispatcher.InvokeAsync(() => { UpdateProgress(action, progress); }).Forget(); };
                     progressReport.UpdateProgress(ProgressAction.Delete, -1);
                     CurrentProcessStatus = string.Format(Strings.ReportDeletingVersion, FullName);
-                    await UninstallPackage(Store, LocalPackage, progressReport);
+                    await Store.UninstallPackage(LocalPackage, progressReport);
                     CurrentProcessStatus = null;
                 }
             }
@@ -314,38 +312,6 @@ namespace Stride.LauncherApp.ViewModels
             {
                 await UpdateVersionsFromStore();
                 IsProcessing = false;
-            }
-        }
-
-        private static async Task UninstallPackage(NugetStore store, NugetPackage package, ProgressReport progressReport)
-        {
-            await store.UninstallPackage(package, progressReport);
-
-            // If package is GameStudio, then recursively delete its Stride/Xenko dependencies to save more disk space
-            if (store.MainPackageIds.Contains(package.Id))
-            {
-                await UninstallDependencies(store, package);
-            }
-        }
-
-        private static async Task UninstallDependencies(NugetStore store, NugetPackage package)
-        {
-            foreach (var dependency in package.Dependencies)
-            {
-                string dependencyId = dependency.Item1;
-                string dependencyIdPrefix = dependencyId.Split('.').First();
-                PackageVersionRange dependencyVersionRange = dependency.Item2;
-
-                // Dependency must be from Stride/Xenko and package version must match exactly
-                if (((dependencyIdPrefix == "Stride") || (dependencyIdPrefix == "Xenko")) && (dependencyVersionRange.Contains(package.Version)))
-                {
-                    NugetPackage dependencyPackage = store.FindLocalPackage(dependencyId, package.Version);
-                    if (dependencyPackage != null)
-                    {
-                        await store.UninstallPackage(dependencyPackage, null);
-                        await UninstallDependencies(store, dependencyPackage);
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
# PR Details

Remove packages which are no longer referenced by any GameStudio package after uninstall or update.

## Description

When a GameStudio package is uninstalled via launcher, a lot of other packages will remain on disk which are no longer referenced by any of the remaining GameStudio packages. This change makes sure that **only** the packages which are not referenced by any GameStudio package are removed.

## Related Issue

#992, #993, #994

## Motivation and Context

Previous solution from #993 was error-prone.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.