### PR TITLE
[Rendering] InstancingRenderFeature: null check for VisibilityGroup

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
@@ -48,7 +48,7 @@ namespace Stride.Rendering
         /// <inheritdoc/>
         public override void Extract()
         {
-            if (!Context.VisibilityGroup.Tags.TryGetValue(ModelToInstancingMap, out var modelToInstancingMap))
+            if ((Context.VisibilityGroup == null) || (!Context.VisibilityGroup.Tags.TryGetValue(ModelToInstancingMap, out var modelToInstancingMap)))
                 return;
 
             var renderObjectInstancingData = RootRenderFeature.RenderData.GetData(renderObjectInstancingDataInfoKey);


### PR DESCRIPTION
# PR Details

`CustomEffect` sample crashes when `InstancingRenderFeature` is enabled in the graphics compositor.

## Description

`InstancingRenderFeature.Extract()` does not check if `VisibilityGroup` is null, so the game crashes with `NullReferenceException`.

## Related Issue

Fixes #987.

## Motivation and Context

Improvement of stability.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.