### PR TITLE
[Editor] Fix GameStudio IDE selection crash, fix launching with Default IDE and update Q&A link

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
@@ -81,7 +81,8 @@ namespace Stride.Core.Assets.Editor.Services
             }
             else
             {
-                startInfo.FileName = session.SolutionPath;
+                startInfo.FileName = session.SolutionPath.ToWindowsPath();
+                startInfo.UseShellExecute = true;
             }
             try
             {

--- a/sources/editor/Stride.GameStudio/StrideGameStudio.cs
+++ b/sources/editor/Stride.GameStudio/StrideGameStudio.cs
@@ -29,7 +29,7 @@ namespace Stride.GameStudio
         public static string EditorVersionMajor => new System.Version(StrideVersion.PublicVersion).ToString(2);
 
         [NotNull]
-        public static string AnswersUrl => "http://answers.stride3d.net/";
+        public static string AnswersUrl => "https://gamedev.stackexchange.com/tags/stride"; // #706
 
         [NotNull]
         public static string DocumentationUrl => $"https://doc.stride3d.net/{EditorVersionMajor}/";

--- a/sources/presentation/Stride.Core.Presentation.Quantum/Presenters/MemberNodePresenter.cs
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/Presenters/MemberNodePresenter.cs
@@ -73,6 +73,11 @@ namespace Stride.Core.Presentation.Quantum.Presenters
 
         public override void UpdateValue(object newValue)
         {
+            // Do not update member node presenter value to null if it does not
+            // allow null values (related to issue #668)
+            if ((newValue == null) && (memberAttributes.Any(x => x is NotNullAttribute)))
+                return;
+
             try
             {
                 Member.Update(newValue);


### PR DESCRIPTION
# PR Details

Multiple improvements:
* Fixed crash that occurred when the IDE was changed in the settings (see #668 for more details)
* Fixed opening the solution with the Visual Studio `Default IDE` (see #1002 for more details)
* Changed the Q&A menu link to use the new `gamedev.stackexchange.com` URL (related to #706 changes)

## Description

The IDE (combobox) control from the settings window attempted to execute the value setter twice before the events were fully processed the first time. This was resulting in `OnPropertyChanging called twice for property 'NodeValue' without invoking OnPropertyChanged between calls.` exception. Second setter was called with a `null` value. The change now ignores it if the `NotNullAttribute` is set.

Furthermore, launching of the `Default IDE` from the toolbar was fixed (it needs to use shell, and the paths should have been in the Windows format - `\` instead of `/`).

And lastly, the Q&A link that originally pointed to `http://answers.stride3d.net/` was updated to point to `https://gamedev.stackexchange.com/tags/stride`.

## Related Issue

Fixes #668 (crash was fixed)
Fixes #1002 (`Default IDE` can be launched)
Fixes #911 (same as above)
Relates to #706 (Q&A menu linked to the old Q&A link; changed to `gamedev.stackexchange.com`)

## Motivation and Context

Improvement of usability and stability. Making the GameStudio more user-friendly.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.