### PR TITLE
ENH: Update to latest Vortice.Vulkan (target 1.2.167 vulkan SDK).

### DIFF
--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'UWP'" />
     <PackageReference Include="SharpDX.Direct3D12" Version="4.2.0" Condition="'$(StridePlatform)' == 'Windows'" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'UWP'" />
-    <PackageReference Include="Vortice.Vulkan" Version="1.2.141-alpha-001" Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'Linux' Or '$(StridePlatform)' == 'macOS'" />
+    <PackageReference Include="Vortice.Vulkan" Version="1.2.167" Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'Linux' Or '$(StridePlatform)' == 'macOS'" />
     <PackageReference Include="Stride.OpenTK" Version="1.0.3" Condition="'$(StridePlatform)' == 'Windows' Or '$(StridePlatform)' == 'Linux' Or '$(StridePlatform)' == 'iOS' Or '$(StridePlatform)' == 'Android'" />
     <PackageReference Include="Stride.SharpFont" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Updates to latest Vortice.Vulkan (target 1.2.167 vulkan SDK).
- This adds support for latest raytracing support and variable rate shading in vulkan bindings.