### PR TITLE
[Rendering] Fixes null pointer after switching to an empty scene

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -615,6 +615,10 @@ namespace Stride.Rendering.Lights
                 // Find lights
                 var lightCollection = activeRenderer.LightGroup.FindLightCollectionByGroup(group);
 
+                // Light collections aren't cleared (see ClearCache). Can be null after switching to empty scenes.
+                if (lightCollection is null)
+                    continue;
+
                 // Indices of lights in lightCollection that need processing
                 lightIndicesToProcess.Clear();
                 for (int i = 0; i < lightCollection.Count; i++)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a null pointer when switching to an empty scene.

## Related Issue

https://github.com/vvvv/VL.Stride/issues/411

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.