### PR TITLE
[Editor] Show property type on hover in property grid

### DIFF
--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
@@ -876,7 +876,16 @@
 
                     <Border Grid.Row="6" Background="{StaticResource ToolBarBackgroundBrush}">
                       <DockPanel>
-                        <TextBlock Margin="4" DockPanel.Dock="Top" FontWeight="Bold" Text="{Binding HoveredItem.DataContext.DisplayName, ElementName=AssetPropertyView}" TextTrimming="CharacterEllipsis"/>
+                        <Grid Margin="4" DockPanel.Dock="Top">
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                          </Grid.ColumnDefinitions>
+                          <TextBlock Grid.Column="0" FontWeight="Bold" FontStyle="Normal" Text="{Binding HoveredItem.DataContext.DisplayName, ElementName=AssetPropertyView}" TextTrimming="CharacterEllipsis"/>
+                          <TextBlock Grid.Column="1" FontWeight="Thin" FontStyle="Italic" TextAlignment="Right" Text="{Binding HoveredItem.DataContext.Type, Converter={sd:TypeToNamespace}, ConverterParameter='$.', ElementName=AssetPropertyView}"/>
+                          <TextBlock Grid.Column="2" FontWeight="Bold" FontStyle="Italic" TextAlignment="Left" Text="{Binding HoveredItem.DataContext.Type, Converter={sd:TypeToTypeName}, ElementName=AssetPropertyView}"/>
+                        </Grid>
                         <TextBlock Margin="4" Text="{Binding HoveredItem.DataContext.Documentation, ElementName=AssetPropertyView}" TextWrapping="Wrap" TextTrimming="WordEllipsis"/>
                       </DockPanel>
                     </Border>

--- a/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
+++ b/sources/editor/Stride.GameStudio/GameStudioWindow.xaml
@@ -879,12 +879,13 @@
                         <Grid Margin="4" DockPanel.Dock="Top">
                           <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="20px"/>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                           </Grid.ColumnDefinitions>
                           <TextBlock Grid.Column="0" FontWeight="Bold" FontStyle="Normal" Text="{Binding HoveredItem.DataContext.DisplayName, ElementName=AssetPropertyView}" TextTrimming="CharacterEllipsis"/>
-                          <TextBlock Grid.Column="1" FontWeight="Thin" FontStyle="Italic" TextAlignment="Right" Text="{Binding HoveredItem.DataContext.Type, Converter={sd:TypeToNamespace}, ConverterParameter='$.', ElementName=AssetPropertyView}"/>
-                          <TextBlock Grid.Column="2" FontWeight="Bold" FontStyle="Italic" TextAlignment="Left" Text="{Binding HoveredItem.DataContext.Type, Converter={sd:TypeToTypeName}, ElementName=AssetPropertyView}"/>
+                          <TextBlock Grid.Column="2" FontWeight="Thin" FontStyle="Italic" TextAlignment="Right" Text="{Binding HoveredItem.DataContext.Type, Converter={sd:TypeToNamespace}, ConverterParameter='$.', ElementName=AssetPropertyView}" TextTrimming="CharacterEllipsis"/>
+                          <TextBlock Grid.Column="3" FontWeight="Bold" FontStyle="Italic" TextAlignment="Left" Text="{Binding HoveredItem.DataContext.Type, Converter={sd:TypeToTypeName}, ElementName=AssetPropertyView}" TextTrimming="CharacterEllipsis"/>
                         </Grid>
                         <TextBlock Margin="4" Text="{Binding HoveredItem.DataContext.Documentation, ElementName=AssetPropertyView}" TextWrapping="Wrap" TextTrimming="WordEllipsis"/>
                       </DockPanel>

--- a/sources/presentation/Stride.Core.Presentation/ValueConverters/TypeToNamespace.cs
+++ b/sources/presentation/Stride.Core.Presentation/ValueConverters/TypeToNamespace.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using Stride.Core.Annotations;
+
+namespace Stride.Core.Presentation.ValueConverters
+{
+    /// <summary>
+    /// Converts the type to its namespace.
+    /// </summary>
+    public class TypeToNamespace : OneWayValueConverter<TypeToNamespace>
+    {
+        /// <inheritdoc/>
+        public override object Convert(object value, [NotNull] Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is null)
+                return null;
+
+            Type type = (Type)value;
+            if (parameter is null)
+                return type.Namespace;
+            return parameter.ToString().Replace("$", type.Namespace);
+        }
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation/ValueConverters/TypeToTypeName.cs
+++ b/sources/presentation/Stride.Core.Presentation/ValueConverters/TypeToTypeName.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using Stride.Core.Annotations;
+
+namespace Stride.Core.Presentation.ValueConverters
+{
+    /// <summary>
+    /// Converts the type to its type name.
+    /// </summary>
+    public class TypeToTypeName : OneWayValueConverter<TypeToTypeName>
+    {
+        /// <inheritdoc/>
+        public override object Convert(object value, [NotNull] Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is null)
+                return null;
+
+            Type type = (Type)value;
+            if (parameter is null)
+                return type.Name;
+            return parameter.ToString().Replace("$", type.Name);
+        }
+    }
+}


### PR DESCRIPTION
# PR Details

Property type should be shown when mouse is hovered over the property in property grid (inspector).

## Description

Property type is now shown when the mouse hovers over the property in property grid (inspector). See example below:

![TypeInfo](https://user-images.githubusercontent.com/60072552/107291742-ee2cf980-6a68-11eb-906a-96673d23f6c4.png)

## Related Issue

Closes #963.

## Motivation and Context

User should be able to tell the data type of the property without having to read the code of the script.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.