### PR TITLE
Fix Android crash due to PlatformFolders.GetApplicationBinaryDirectory call

### DIFF
--- a/sources/core/Stride.Core/PlatformFolders.cs
+++ b/sources/core/Stride.Core/PlatformFolders.cs
@@ -56,9 +56,9 @@ namespace Stride.Core
 
             set
             {
-                if (virtualFileSystemInitialized) 
-                    throw new InvalidOperationException("ApplicationDataSubDirectory cannot be modified after the VirtualFileSystem has been initialized."); 
-                
+                if (virtualFileSystemInitialized)
+                    throw new InvalidOperationException("ApplicationDataSubDirectory cannot be modified after the VirtualFileSystem has been initialized.");
+
                 applicationDataSubDirectory = value;
             }
         }
@@ -152,7 +152,9 @@ namespace Stride.Core
 
         private static string GetApplicationExecutablePath()
         {
-#if STRIDE_PLATFORM_DESKTOP || STRIDE_PLATFORM_MONO_MOBILE
+#if STRIDE_PLATFORM_ANDROID
+            return PlatformAndroid.Context.PackageCodePath;
+#elif STRIDE_PLATFORM_DESKTOP || STRIDE_PLATFORM_MONO_MOBILE
             return Assembly.GetEntryAssembly()?.Location;
 #else
             return null;
@@ -182,10 +184,15 @@ namespace Stride.Core
         [NotNull]
         private static string GetApplicationBinaryDirectory()
         {
-            return FindCoreAssemblyDirectory(GetApplicationExecutableDiretory());
+            var executablePath = GetApplicationExecutableDirectory();
+#if STRIDE_PLATFORM_ANDROID
+            return executablePath;
+#else
+            return FindCoreAssemblyDirectory(executablePath);
+#endif
         }
 
-        private static string GetApplicationExecutableDiretory()
+        private static string GetApplicationExecutableDirectory()
         {
 #if STRIDE_PLATFORM_DESKTOP || STRIDE_PLATFORM_MONO_MOBILE
             var executableName = GetApplicationExecutablePath();


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
The initial assignment to `PlatformFolders.ApplicationBinaryDirectory` crashes the Android app immediately because `GetApplicationBinaryDirectory()` throws an exception (null argument) due to `GetApplicationExecutableDirectory()` returning null leading to the call `FindCoreAssemblyDirectory` -> `Path.Combine(null, "Stride.Core.dll")` where the crash happens.

## Description

<!--- Describe your changes in detail -->
Changed `GetApplicationExecutablePath` to return `PlatformAndroid.Context.PackageCodePath` which is the path of the apk file.
`GetApplicationExecutableDirectory` also avoids `FindCoreAssemblyDirectory` in Android because Android doesn't really have binaries other than the apk.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This bug was introduced due to #599
`GetApplicationBinaryDirectory` had always returned null on Android, but no code in Android actually used this returned value so it avoid any major issues. The change in #599 changed it so it was used immediately but this was null so it threw an exception.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
