### PR TITLE
[Launcher] Distinguish between dev updates and official updates

### DIFF
--- a/sources/launcher/Stride.Launcher/Resources/Strings.Designer.cs
+++ b/sources/launcher/Stride.Launcher/Resources/Strings.Designer.cs
@@ -722,6 +722,15 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (local update available).
+        /// </summary>
+        public static string VersionButtonLocalUpdateAvailable {
+            get {
+                return ResourceManager.GetString("VersionButtonLocalUpdateAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Visual Studio plugin.
         /// </summary>
         public static string VisualStudioPlugin {

--- a/sources/launcher/Stride.Launcher/Resources/Strings.resx
+++ b/sources/launcher/Stride.Launcher/Resources/Strings.resx
@@ -313,6 +313,10 @@
     <value>(update available)</value>
     <comment>Additional message stating that an update is available for the version. It is displayed right after the VersionButton text (with a space)</comment>
   </data>
+  <data name="VersionButtonLocalUpdateAvailable" xml:space="preserve">
+    <value>(local update available)</value>
+    <comment>Additional message stating that a local update is available for the version. It is displayed right after the VersionButton text (with a space)</comment>
+  </data>
   <data name="VisualStudioPlugin" xml:space="preserve">
     <value>Visual Studio plugin</value>
     <comment>Title of this category</comment>

--- a/sources/launcher/Stride.Launcher/ViewModels/StrideStoreVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/StrideStoreVersionViewModel.cs
@@ -43,6 +43,28 @@ namespace Stride.LauncherApp.ViewModels
         }
 
         /// <summary>
+        /// Checks whether the latest available package is from a remote repository (i.e. NuGet).
+        /// </summary>
+        public bool IsLatestPackageRemote
+        {
+            get
+            {
+                return (LatestServerPackage?.Source != null) && (Uri.IsWellFormedUriString(LatestServerPackage.Source, UriKind.Absolute));
+            }
+        }
+
+        /// <summary>
+        /// Checks whether the latest available package is from a local repository (i.e. disk).
+        /// </summary>
+        public bool IsLatestPackageLocal
+        {
+            get
+            {
+                return (LatestServerPackage?.Source != null) && (Directory.Exists(LatestServerPackage.Source));
+            }
+        }
+
+        /// <summary>
         /// Gets the full name of this version, including revision number and special revision string.
         /// </summary>
         /// <remarks>If this version is installed, it will use the name of the installed version. Otherwise, it will use the name of the latest version available on the server.</remarks>
@@ -118,7 +140,11 @@ namespace Stride.LauncherApp.ViewModels
 
             // Always keep track of highest version
             if (ServerPackage != null && (LatestServerPackage == null || LatestServerPackage.Version < ServerPackage.Version))
+            {
+                OnPropertyChanging(nameof(IsLatestPackageRemote), nameof(IsLatestPackageLocal));
                 LatestServerPackage = ServerPackage;
+                OnPropertyChanged(nameof(IsLatestPackageRemote), nameof(IsLatestPackageLocal));
+            }
 
             Dispatcher.Invoke(UpdateStatus);
             if (alternateVersions != null)

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -196,8 +196,10 @@
                   <Run Text="{Binding DisplayName, StringFormat={x:Static r:Strings.VersionButton}, Mode=OneWay}"/>
                   <!-- Careful here, there must not be any space or line-break between the next two Run tags! -->
                   <Run Text="{Binding CanDelete, Converter={sskk:Chained {sskk:InvertBool}, {sskk:BoolToParam}, Parameter2={x:Static r:Strings.VersionButtonUninstalled}},
-                       Mode=OneWay}"/><Run Text="{sskk:MultiBinding {Binding CanDelete}, {Binding CanBeDownloaded}, Converter={sskk:MultiChained {sskk:AndMultiConverter},
-                       {sskk:BoolToParam}, Parameter1={x:Static r:Strings.VersionButtonUpdateAvailable}}, Mode=OneWay}"/>
+                       Mode=OneWay}"/><Run Text="{sskk:MultiBinding {Binding CanDelete}, {Binding CanBeDownloaded}, {Binding IsLatestPackageRemote}, Converter={sskk:MultiChained
+                       {sskk:AndMultiConverter}, {sskk:BoolToParam}, Parameter1={x:Static r:Strings.VersionButtonUpdateAvailable}}, Mode=OneWay}"/><Run Text="{sskk:MultiBinding
+                       {Binding CanDelete}, {Binding CanBeDownloaded}, {Binding IsLatestPackageLocal}, Converter={sskk:MultiChained {sskk:AndMultiConverter}, {sskk:BoolToParam},
+                       Parameter1={x:Static r:Strings.VersionButtonLocalUpdateAvailable}}, Mode=OneWay}"/>
               </TextBlock>
             </Grid>
           </Grid>
@@ -290,7 +292,7 @@
           </Grid.RowDefinitions>
 
           <!-- FIRST COLUMN -->
-          <DockPanel Grid.Row="0" Grid.Column="0" Width="380">
+          <DockPanel Grid.Row="0" Grid.Column="0" Width="400">
             <Border DockPanel.Dock="Bottom" BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}"
                   Background="{StaticResource TileAlphaBackgroundBrush}">
               <DockPanel Margin="10">


### PR DESCRIPTION
# PR Details

When the Launcher shows that a GameStudio package update is available, it will now show "(local update available)" in case if it is a local build (from disk, with location such as `%LocalAppData%\Stride\NugetDev`).

## Description

Previously it was not possible to distinguish between locally built dev packages and official packages from NuGet. This PR changes that by showing "(local update available)" instead of "(update available)" for locally built packages. See the screenshot below (`4.0.*.*` versions are official, whereas `4.1.*.*` versions were built locally).

![launcher_example](https://user-images.githubusercontent.com/60072552/108415500-eb32c580-722d-11eb-885a-d23c42e1f84d.PNG)

## Related Issue

Closes #719 (proposed solution not implemented exactly as suggested, but instead just the local build indication was implemented - in my opinion, if the package was supposed to get its own separate version section entry, the actual version identifier should be changed in `/sources/shared/SharedAssemblyInfo.cs` file - for example, by appending `-dev` suffix).

## Motivation and Context

First time that I built Stride locally I was confused by this and actually thought that a new version was released in the meantime. It took me a bit to realize that building the solution will make the packages available to the officially installed launcher as well. It would be a good idea to merge this change to remove further confusion for newcomers.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.