### PR TITLE
[Editor] Hide buttons that modify archetype reference when it is set to read-only

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -1283,11 +1283,11 @@
     <DockPanel>
       <UniformGrid Rows="1" DockPanel.Dock="Right">
         <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"
-                ToolTip="{sd:Localize Select an asset, Context=ToolTip}">
+                ToolTip="{sd:Localize Select an asset, Context=ToolTip}" Visibility="{Binding IsReadOnly, Converter={sd:VisibleOrCollapsed}, ConverterParameter={sd:False}, Mode=OneWay}">
           <Image Source="{StaticResource ImagePickup}" Width="16" Height="16" Margin="-1"/>
         </Button>
         <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding CreateNewInstance}" CommandParameter="{x:Static assetCommands:AbstractNodeValue.Null}"
-                ToolTip="{sd:Localize Clear the reference, Context=ToolTip}">
+                ToolTip="{sd:Localize Clear the reference, Context=ToolTip}" Visibility="{Binding IsReadOnly, Converter={sd:VisibleOrCollapsed}, ConverterParameter={sd:False}, Mode=OneWay}">
           <Image Source="{StaticResource ImageClear}" Width="16" Height="16" Margin="-1"/>
         </Button>
         <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding FetchAsset}"


### PR DESCRIPTION
# PR Details

Archetype reference presenter in the editor shows buttons to clear the reference and to change the reference, even if the archetype reference is set to read-only (i.e. when the setter is null).

## Description

The archetype reference presenter was fixed. Now the buttons to clear the reference and to change the reference will be collapsed (not-shown) in case where the archetype reference is set to read-only.

![archetype_btns](https://user-images.githubusercontent.com/60072552/108759849-31996480-754d-11eb-9a1a-08dbea9c460b.png)

This addresses #869 where the archetype reference is set to read-only, so it was never intended to be editable in the first place. It makes no sense to show these buttons for read-only properties.

## Related Issue

Fixes #869

## Motivation and Context

This was a bug. Clicking on these buttons did not do anything anyway.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.