### PR TITLE
Make Directional Light arrow always visible

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightDirectionalGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightDirectionalGizmo.cs
@@ -49,6 +49,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             bodyEntity.Transform.Rotation = Quaternion.RotationX(-MathUtil.PiOverTwo);
             lightRay.AddChild(bodyEntity);
 
+            root.AddChild(lightRay);
+
             return root;
         }
 
@@ -58,23 +60,6 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
             // update the color of the ray
             GizmoUniformColorMaterial.UpdateColor(GraphicsDevice, rayMaterial, (Color)new Color4(GetLightColor(GraphicsDevice), 1f));
-        }
-
-        public override bool IsSelected
-        {
-            set
-            {
-                bool hasChanged = IsSelected != value;
-                base.IsSelected = value;
-
-                if (hasChanged)
-                {
-                    if (IsSelected)
-                        GizmoRootEntity.AddChild(lightRay);
-                    else
-                        GizmoRootEntity.RemoveChild(lightRay);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
# PR Details

Makes the directional light's direction indicator always visible instead of just when the light is selected.

## Related Issue

https://github.com/stride3d/stride/issues/909

## Motivation and Context

I agreed with the linked issue that it's annoying needing to select the directional light to see its direction, and how the transform gizmo can cover the direction indicator.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)