### PR TITLE
Add sampling option to UIComponent

### DIFF
--- a/sources/engine/Stride.UI/Engine/UIComponent.cs
+++ b/sources/engine/Stride.UI/Engine/UIComponent.cs
@@ -39,6 +39,17 @@ namespace Stride.Engine
         public UIPage Page { get; set; }
 
         /// <summary>
+        /// Specifies the sampling method to be used for this component
+        /// </summary>
+        /// <userdoc>
+        /// Specifies the sampling method to be used for this component
+        /// </userdoc>
+        [DataMember(15)]
+        [DefaultValue(Sampler.LinearClamp)]
+        [Display("Sampler")]
+        public Sampler Sampler { get; set; } = Sampler.LinearClamp;
+
+        /// <summary>
         /// Gets or sets the value indicating whether the UI should be full screen.
         /// </summary>
         /// <userdoc>Check this checkbox to display UI of this component on full screen. Uncheck it to display UI using standard camera.</userdoc>

--- a/sources/engine/Stride.UI/Rendering/UI/RenderUIElement.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/RenderUIElement.cs
@@ -1,11 +1,21 @@
 // Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Engine;
 using Stride.UI;
 
 namespace Stride.Rendering.UI
 {
+    public enum Sampler
+    {
+        [Display("Point (Nearest)")]
+        PointClamp,
+
+        [Display("Linear")]
+        LinearClamp,
+    }
+
     public class RenderUIElement : RenderObject
     {
         public RenderUIElement()
@@ -16,6 +26,7 @@ namespace Stride.Rendering.UI
 
         // UIComponent values
         public UIPage Page;
+        public Sampler Sampler;
         public bool IsFullScreen;
         public Vector3 Resolution;
         public Vector3 Size;

--- a/sources/engine/Stride.UI/Rendering/UI/RenderUIElement.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/RenderUIElement.cs
@@ -14,6 +14,9 @@ namespace Stride.Rendering.UI
 
         [Display("Linear")]
         LinearClamp,
+
+        [Display("Anisotropic")]
+        AnisotropicClamp,
     }
 
     public class RenderUIElement : RenderObject

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
@@ -263,7 +263,7 @@ namespace Stride.Rendering.UI
                 batch.Begin(context.GraphicsContext, ref uiElementState.WorldViewProjectionMatrix, BlendStates.AlphaBlend, samplerState, null, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
 
                 // Render the UI elements in the final render target
-                RecursiveDrawWithClipping(context, rootElement, ref uiElementState.WorldViewProjectionMatrix);
+                RecursiveDrawWithClipping(context, rootElement, ref uiElementState.WorldViewProjectionMatrix, samplerState);
 
                 // end the image draw session
                 batch.End();
@@ -281,7 +281,7 @@ namespace Stride.Rendering.UI
             }
         }
 
-        private void RecursiveDrawWithClipping(RenderDrawContext context, UIElement element, ref Matrix worldViewProj)
+        private void RecursiveDrawWithClipping(RenderDrawContext context, UIElement element, ref Matrix worldViewProj, SamplerState samplerState)
         {
             // if the element is not visible, we also remove all its children
             if (!element.IsVisible)
@@ -297,13 +297,13 @@ namespace Stride.Rendering.UI
                 batch.End();
 
                 // render the clipping region
-                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.ColorDisabled, uiSystem.IncreaseStencilValueState, renderingContext.StencilTestReferenceValue);
+                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.ColorDisabled, samplerState, null, uiSystem.IncreaseStencilValueState, renderingContext.StencilTestReferenceValue);
                 renderer.RenderClipping(element, renderingContext);
                 batch.End();
 
                 // update context and restart the batch
                 renderingContext.StencilTestReferenceValue += 1;
-                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.AlphaBlend, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
+                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.AlphaBlend, samplerState, null, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
             }
 
             // render the design of the element
@@ -311,7 +311,7 @@ namespace Stride.Rendering.UI
 
             // render the children
             foreach (var child in element.VisualChildrenCollection)
-                RecursiveDrawWithClipping(context, child, ref worldViewProj);
+                RecursiveDrawWithClipping(context, child, ref worldViewProj, samplerState);
 
             // clear the element clipping region from the stencil buffer
             if (element.ClipToBounds)
@@ -322,13 +322,13 @@ namespace Stride.Rendering.UI
                 renderingContext.DepthBias = element.MaxChildrenDepthBias;
 
                 // render the clipping region
-                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.ColorDisabled, uiSystem.DecreaseStencilValueState, renderingContext.StencilTestReferenceValue);
+                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.ColorDisabled, samplerState, null, uiSystem.DecreaseStencilValueState, renderingContext.StencilTestReferenceValue);
                 renderer.RenderClipping(element, renderingContext);
                 batch.End();
 
                 // update context and restart the batch
                 renderingContext.StencilTestReferenceValue -= 1;
-                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.AlphaBlend, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
+                batch.Begin(context.GraphicsContext, ref worldViewProj, BlendStates.AlphaBlend, samplerState, null, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
             }
         }
 

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
@@ -247,9 +247,20 @@ namespace Stride.Rendering.UI
                 }
                 context.CommandList.SetRenderTarget(renderingContext.DepthStencilBuffer, renderingContext.RenderTarget);
 
+                var samplerState = context.GraphicsDevice.SamplerStates.LinearClamp;
+                if (renderObject.Sampler != Sampler.LinearClamp)
+                {
+                    switch (renderObject.Sampler)
+                    {
+                        case Sampler.PointClamp:
+                            samplerState = context.GraphicsDevice.SamplerStates.PointClamp;
+                            break;
+                    }
+                }
+
                 // start the image draw session
                 renderingContext.StencilTestReferenceValue = 0;
-                batch.Begin(context.GraphicsContext, ref uiElementState.WorldViewProjectionMatrix, BlendStates.AlphaBlend, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
+                batch.Begin(context.GraphicsContext, ref uiElementState.WorldViewProjectionMatrix, BlendStates.AlphaBlend, samplerState, null, uiSystem.KeepStencilValueState, renderingContext.StencilTestReferenceValue);
 
                 // Render the UI elements in the final render target
                 RecursiveDrawWithClipping(context, rootElement, ref uiElementState.WorldViewProjectionMatrix);

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderProcessor.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderProcessor.cs
@@ -45,6 +45,7 @@ namespace Stride.Rendering.UI
                     renderUIElement.RenderGroup = uiComponent.RenderGroup;
 
                     renderUIElement.Page = uiComponent.Page;
+                    renderUIElement.Sampler = uiComponent.Sampler;
                     renderUIElement.IsFullScreen = uiComponent.IsFullScreen;
                     renderUIElement.Resolution = uiComponent.Resolution;
                     renderUIElement.Size = uiComponent.Size;


### PR DESCRIPTION
# PR Details
UIComponent sampling option

## Description
I add the sampling option just like in SpriteComponent to UIComponent
Now we can select
- Point  (Nearest)
- Linear
- Anisotropic
![image](https://user-images.githubusercontent.com/14342782/114310422-ee06b400-9b14-11eb-971a-26f99b506585.png)

Comparison between Point(left) and Linear sampler(right)
![image](https://user-images.githubusercontent.com/14342782/114310360-c6175080-9b14-11eb-9de3-214c859b0f11.png)


## Motivation and Context
I see the option is available only in SpriteComponent and at that time I want to have the same thing on UIComponent for my little 2D project
I'm quite new to Stride and maybe this option is available somewhere, but I can't find it so I just implement it.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.