### PR TITLE
[Core] Improve AppSettings usability

### DIFF
--- a/sources/core/Stride.Core/Settings/AppSettings.cs
+++ b/sources/core/Stride.Core/Settings/AppSettings.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Stride.Core.Collections;
 
 namespace Stride.Core.Settings
@@ -9,7 +10,18 @@ namespace Stride.Core.Settings
         /// Application specific settings.
         /// </summary>
         [DataMember]
-        private FastList<object> Settings { get; set; }
+        public IReadOnlyCollection<object> Settings { get; private set; }
+
+        /// <summary>
+        /// Default constructor, used for deserialization.
+        /// </summary>
+        public AppSettings() { }
+
+        /// <summary>
+        /// Creates a new <see cref="AppSettings"/> instance with a settings collection.
+        /// </summary>
+        /// <param name="settings">Settings collection.</param>
+        public AppSettings(IEnumerable<object> settings) => Settings = new FastList<object>(settings);
 
         /// <summary>
         /// Finds a settings object of the specified type in the settings collection.

--- a/sources/core/Stride.Core/Settings/AppSettings.cs
+++ b/sources/core/Stride.Core/Settings/AppSettings.cs
@@ -4,6 +4,9 @@ using Stride.Core.Collections;
 
 namespace Stride.Core.Settings
 {
+    /// <summary>
+    /// Collection of runtime loaded application settings. See also <seealso cref="AppSettingsManager"/>.
+    /// </summary>
     [DataContract("AppSettings")]
     public sealed class AppSettings : IEnumerable<object>
     {
@@ -40,6 +43,10 @@ namespace Stride.Core.Settings
             return null;
         }
 
+        /// <summary>
+        /// Inline Enumerator used by foreach.
+        /// </summary>
+        /// <returns>Enumerator of the underlying settings collection.</returns>
         public FastCollection<object>.Enumerator GetEnumerator() => Settings.GetEnumerator();
 
         IEnumerator<object> IEnumerable<object>.GetEnumerator() => ((IEnumerable<object>)Settings).GetEnumerator();

--- a/sources/core/Stride.Core/Settings/AppSettings.cs
+++ b/sources/core/Stride.Core/Settings/AppSettings.cs
@@ -1,16 +1,17 @@
+using System.Collections;
 using System.Collections.Generic;
 using Stride.Core.Collections;
 
 namespace Stride.Core.Settings
 {
     [DataContract("AppSettings")]
-    public sealed class AppSettings
+    public sealed class AppSettings : IEnumerable<object>
     {
         /// <summary>
         /// Application specific settings.
         /// </summary>
         [DataMember]
-        public IReadOnlyCollection<object> Settings { get; private set; }
+        private FastCollection<object> Settings { get; set; }
 
         /// <summary>
         /// Default constructor, used for deserialization.
@@ -21,7 +22,7 @@ namespace Stride.Core.Settings
         /// Creates a new <see cref="AppSettings"/> instance with a settings collection.
         /// </summary>
         /// <param name="settings">Settings collection.</param>
-        public AppSettings(IEnumerable<object> settings) => Settings = new FastList<object>(settings);
+        public AppSettings(IEnumerable<object> settings) => Settings = new FastCollection<object>(settings);
 
         /// <summary>
         /// Finds a settings object of the specified type in the settings collection.
@@ -38,5 +39,11 @@ namespace Stride.Core.Settings
 
             return null;
         }
+
+        public FastCollection<object>.Enumerator GetEnumerator() => Settings.GetEnumerator();
+
+        IEnumerator<object> IEnumerable<object>.GetEnumerator() => ((IEnumerable<object>)Settings).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Settings).GetEnumerator();
     }
 }

--- a/sources/core/Stride.Core/Settings/AppSettingsManager.cs
+++ b/sources/core/Stride.Core/Settings/AppSettingsManager.cs
@@ -8,6 +8,9 @@ namespace Stride.Core.Settings
     /// </summary>
     public static class AppSettingsManager
     {
+        private static AppSettings settings;
+        private static IAppSettingsProvider provider;
+
         /// <summary>
         /// Gets <see cref="AppSettings"/> instance for the application.
         /// </summary>
@@ -30,8 +33,8 @@ namespace Stride.Core.Settings
         /// Gets or sets an <see cref="IAppSettingsProvider"/> for the application.
         /// </summary>
         /// <remarks>
-        /// If provider is not set, getter of this property will attempt to find an implementation among the registered assemblies.
-        /// 
+        /// If provider is not set, getter of this property will attempt to find an implementation
+        /// among the registered assemblies and cache it.
         /// </remarks>
         public static IAppSettingsProvider SettingsProvider
         {
@@ -78,8 +81,5 @@ namespace Stride.Core.Settings
                 settings = new AppSettings();
             }
         }
-
-        private static AppSettings settings;
-        private static IAppSettingsProvider provider;
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

In #878 I have introduced a class called `AppSettings` for loading settings at runtime (defined outside of compilation as opposed to design time defined `Configuration`). While the previous implementation was usable within the context of `Stride.Core.Design` (based on YAML), when using the `AppSettings` in my game I saw a lot of things were missing for future users of this class.

As such I modified it a bit to allow for creating instances outside of reflection based serialization and provided a way to override the `IAppSettingsProvider` in the `AppSettingsManager` in case there's more than one implementation available.

Here in [RoamingAppSettingsProvider.cs](https://github.com/manio143/RiseOfTheUndeaf/blob/bd013dccdd8228757f5285e3a2109880fed101ab/RiseOfTheUndeaf.Game/Core/Configuration/RoamingAppSettingsProvider.cs) you can see a custom implementation of a settings provider which uses a `config.ini` file (a popular choice for user settings in games).

## Related Issue

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I performed manual testing of existing and new use cases.