### PR TITLE
#1063 GameSettingsAssetCompiler dynamically detecs runtime content types

### DIFF
--- a/sources/engine/Stride.Assets/GameSettingsAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/GameSettingsAssetCompiler.cs
@@ -35,9 +35,8 @@ namespace Stride.Assets
 
         public override IEnumerable<Type> GetRuntimeTypes(AssetItem assetItem)
         {
-            yield return typeof(Scene);
-            yield return typeof(GraphicsCompositor);
-            yield return typeof(Texture);
+            var runtimeTypesCollector = new RuntimeTypesCollector();
+            return runtimeTypesCollector.GetRuntimeTypes(assetItem.Asset);
         }
 
         private class GameSettingsCompileCommand : AssetCommand<GameSettingsAsset>

--- a/sources/engine/Stride.Assets/RuntimeTypesCollector.cs
+++ b/sources/engine/Stride.Assets/RuntimeTypesCollector.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Visitors;
+using Stride.Core.Reflection;
+
+namespace Stride.Assets
+{
+    /// <summary>
+    /// Dynamically detects runtime content types in a given object
+    /// </summary>
+    public class RuntimeTypesCollector : AssetVisitorBase
+    {
+        private readonly HashSet<Type> runtimeTypes = new();
+
+        public IEnumerable<Type> GetRuntimeTypes(object obj)
+        {
+            Visit(obj);
+            return runtimeTypes;
+        }
+
+        public override void VisitObject(object obj, ObjectDescriptor descriptor, bool visitMembers)
+        {
+            if (AssetRegistry.IsContentType(obj.GetType()))
+            {
+                // Asset compiler will sort out any dependencies so we dont need to visit any content types
+                runtimeTypes.Add(obj.GetType());
+            }
+            else
+            {
+                base.VisitObject(obj, descriptor, visitMembers);
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Assets/RuntimeTypesCollector.cs
+++ b/sources/engine/Stride.Assets/RuntimeTypesCollector.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
# PR Details

Adds dynamic runtime type detection to the game settings asset compiler.

## Description

This change allows the game settings to dynamically detect referenced runtime content types and allowing custom configuration implementation to properly reference assets in a project. 

## Related Issue

Closes #1063 

## Motivation and Context

This solves the issue where assets references in custom configurations where not properly included in the build. Note that its preferable to only use `UrlReference<T>` and loading the assets when required as stride is not fully initialized when the game settings are loaded.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.