### PR TITLE
Enable PublishSingleFile scenarios in NativeLibraryHelper

### DIFF
--- a/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
+++ b/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -68,11 +69,12 @@ namespace Stride.Core
                 {
                     foreach (var libraryPath in new[]
                     {
-                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location), $"{platform}-{cpu}"),
-                        Path.Combine(Environment.CurrentDirectory, $"{platform}-{cpu}"),
+                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location) ?? string.Empty, $"{platform}-{cpu}"),
+                        Path.Combine(Environment.CurrentDirectory ?? string.Empty, $"{platform}-{cpu}"),
+                        Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) ?? string.Empty, $"{platform}-{cpu}"),
                         // Also try without platform for Windows-only packages (backward compat for editor packages)
-                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location), $"{cpu}"),
-                        Path.Combine(Environment.CurrentDirectory, $"{cpu}"),
+                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location) ?? string.Empty, $"{cpu}"),
+                        Path.Combine(Environment.CurrentDirectory ?? string.Empty, $"{cpu}"),
                     })
                     {
                         var libraryFilename = Path.Combine(libraryPath, libraryName);


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

With the .NET 6 SDK (I used preview 4) you can use `PublishSingleFile` with your game targeting `net5.0`. They fixed the packaging mechanism of .NET 5 which complains when duplicate paths appear in the list of things to include. This allows us to publish much nicer looking applications.

With project setup

```xml
<PublishSingleFile>true</PublishSingleFile>
<!-- native libs behave a little iffy in single file publish and Stride's NativeLibraryHelper can't find them. -->
<IncludeNativeLibrariesInSingleFile>false</IncludeNativeLibrariesInSingleFile>
<IncludeNativeLibrariesForSelfExtract>false</IncludeNativeLibrariesForSelfExtract>
```

The `owner.GetTypeInfo().Assembly.Location` in the changes is `null` when running the single file which causes an `ArgumentException` in the `Path.Combine`. So I added safe guards to each case, just in case.
That allowed me to run the single file from it's folder.
However, running it from a different folder wasn't working, so I added the `Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName)` and it helped.

![image](https://user-images.githubusercontent.com/10709060/120085925-a1833200-c0dc-11eb-8f13-617be4c20e4b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.