### PR TITLE
[Input] fixes PointerPoint.Id always being 0

### DIFF
--- a/sources/engine/Stride.Input/PointerDeviceState.cs
+++ b/sources/engine/Stride.Input/PointerDeviceState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
@@ -91,6 +91,7 @@ namespace Stride.Input
         public void UpdatePointerState(PointerEvent evt, bool updateDelta = true)
         {
             var data = GetPointerData(evt.PointerId);
+            data.Id = evt.PointerId;
 
             if (updateDelta)
             {


### PR DESCRIPTION
# PR Details

The PointerPoints Id property was never set and thus always returning 0 for all pointers.

## Description

It is a one-line fix that takes the pointerId coming from PointerEvent and applying it to the created PointerPoint. 

## Related Issue

N/A

## Motivation and Context

Without pointer Ids multiple touchpoints cannot be distinguished.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.