### PR TITLE
Dev/joreg/system pointer

### DIFF
--- a/sources/engine/Stride.Input/PointerDeviceState.cs
+++ b/sources/engine/Stride.Input/PointerDeviceState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
@@ -91,6 +91,7 @@ namespace Stride.Input
         public void UpdatePointerState(PointerEvent evt, bool updateDelta = true)
         {
             var data = GetPointerData(evt.PointerId);
+            data.Id = evt.PointerId;
 
             if (updateDelta)
             {

--- a/sources/engine/Stride.Input/PointerDeviceState.cs
+++ b/sources/engine/Stride.Input/PointerDeviceState.cs
@@ -78,6 +78,7 @@ namespace Stride.Input
             var pointerEvent = InputEventPool<PointerEvent>.GetOrCreate(SourceDevice);
             pointerEvent.Position = evt.Position;
             pointerEvent.PointerId = evt.Id;
+            pointerEvent.SystemPointerId = evt.SystemId;
             pointerEvent.EventType = evt.Type;
             UpdatePointerState(pointerEvent);
 
@@ -92,6 +93,7 @@ namespace Stride.Input
         {
             var data = GetPointerData(evt.PointerId);
             data.Id = evt.PointerId;
+            data.SystemId = evt.SystemPointerId;
 
             if (updateDelta)
             {
@@ -174,6 +176,7 @@ namespace Stride.Input
             public Vector2 Position;
             public Vector2 Delta;
             public int Id;
+            public uint SystemId;
         }
     }
 }

--- a/sources/engine/Stride.Input/PointerEvent.cs
+++ b/sources/engine/Stride.Input/PointerEvent.cs
@@ -20,6 +20,13 @@ namespace Stride.Input
         public int PointerId { get; internal set; }
 
         /// <summary>
+        /// The original, unmodified id as provided by the OS. See remarks.
+        /// </summary>
+        /// <value>The system pointer id.</value>
+        /// <remarks>On Windows this is a unique id, endlessly counting up from 0, never reusing id's that became free when a touch was removed.</remarks>
+        public uint SystemPointerId { get; internal set; }
+
+        /// <summary>
         /// Gets the absolute screen position of the pointer.
         /// </summary>
         /// <value>The absolute delta position.</value>
@@ -67,7 +74,7 @@ namespace Stride.Input
 
         public override string ToString()
         {
-            return $"Pointer {PointerId} {EventType}, {AbsolutePosition}, Delta: {AbsoluteDeltaPosition}, DT: {DeltaTime}, {nameof(IsDown)}: {IsDown}, {nameof(Pointer)}: {Pointer.Name}";
+            return $"Pointer {PointerId} {EventType}, {AbsolutePosition}, Delta: {AbsoluteDeltaPosition}, DT: {DeltaTime}, {nameof(IsDown)}: {IsDown}, {nameof(Pointer)}: {Pointer.Name}, {nameof(SystemPointerId)}: {SystemPointerId}";
         }
 
         /// <summary>
@@ -80,6 +87,7 @@ namespace Stride.Input
             {
                 Device = Device,
                 PointerId = PointerId,
+                SystemPointerId = SystemPointerId,
                 Position = Position,
                 DeltaPosition = DeltaPosition,
                 DeltaTime = DeltaTime,

--- a/sources/engine/Stride.Input/PointerPoint.cs
+++ b/sources/engine/Stride.Input/PointerPoint.cs
@@ -31,13 +31,18 @@ namespace Stride.Input
         public int Id;
 
         /// <summary>
+        /// The original, unmodified pointer ID as provided by the OS
+        /// </summary>
+        public uint SystemId;
+
+        /// <summary>
         /// The device to which this pointer belongs
         /// </summary>
         public IPointerDevice Pointer;
 
         public override string ToString()
         {
-            return $"Pointer [{Id}] {nameof(Position)}: {Position}, {nameof(Delta)}: {Delta}, {nameof(IsDown)}: {IsDown}, {nameof(Pointer)}: {Pointer}";
+            return $"Pointer [{Id}] {nameof(Position)}: {Position}, {nameof(Delta)}: {Delta}, {nameof(IsDown)}: {IsDown}, {nameof(Pointer)}: {Pointer}, {nameof(SystemId)}: {SystemId}";
         }
     }
 }

--- a/sources/engine/Stride.Input/SDL/PointerSDL.cs
+++ b/sources/engine/Stride.Input/SDL/PointerSDL.cs
@@ -95,7 +95,7 @@ namespace Stride.Input
         {
             var newPosition = new Vector2(e.x, e.y);
             var id = GetFingerId(e.fingerId, type);
-            PointerState.PointerInputEvents.Add(new PointerDeviceState.InputEvent { Type = type, Position = newPosition, Id = id });
+            PointerState.PointerInputEvents.Add(new PointerDeviceState.InputEvent { Type = type, Position = newPosition, Id = id, SystemId = (uint) e.fingerId});
         }
 
         private void OnFingerMoveEvent(SDL.SDL_TouchFingerEvent e)


### PR DESCRIPTION
# PR Details

Introduces a SystemPointerId property which is different from the already existing PointerId in that it passes through the original, unmodified pointer Id provided by the OS.

## Description

Adds a SystemPointerId to PointerEvent and a SystemId to PointerPoint allowing the different framework implementations to pass through the original, unmodified Ids as provided by the OS. 

# Questions
* For now, I only implemented this for SDL. How would I do this for the other backends which I cannot test?
* Looking at the implementations of how the existing PointerId is generated in the different backends [iOS](https://github.com/stride3d/stride/blob/7e836297cb5930c01e6dfa0183e7f3cc64748fb6/sources/engine/Stride.Input/iOS/PointeriOS.cs#L120), [Android](https://github.com/stride3d/stride/blob/7e836297cb5930c01e6dfa0183e7f3cc64748fb6/sources/engine/Stride.Input/Android/PointerAndroid.cs#L89), [SDL](https://github.com/stride3d/stride/blob/7e836297cb5930c01e6dfa0183e7f3cc64748fb6/sources/engine/Stride.Input/SDL/PointerSDL.cs#L97) and [UWP](https://github.com/stride3d/stride/blob/7e836297cb5930c01e6dfa0183e7f3cc64748fb6/sources/engine/Stride.Input/UWP/PointerUWP.cs#L82), it is obvious that iOS and SDL work the same. Android might be the same, hard to understand without testing (the Android docs are not really vocal about the nature of the Id). And UWP, doesn't seem to modify the Id, ie may already currently be working differently than the others.. So how to deal with that?

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Under Windows, this solves the issue that we can now use an API like [InteractionContext](https://docs.microsoft.com/en-us/windows/win32/api/_input_intcontext/), which relies on those original Ids.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.