### PR TITLE
Add basic F# support

### DIFF
--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -598,7 +598,7 @@ namespace Stride.Core.Assets
 
         public static PackageContainer LoadProject(ILogger log, string filePath)
         {
-            if (Path.GetExtension(filePath).ToLowerInvariant() == ".csproj")
+            if (Path.GetExtension(filePath).ToLowerInvariant() == ".csproj" || Path.GetExtension(filePath).ToLowerInvariant() == ".fsproj")
             {
                 var projectPath = filePath;
                 var packagePath = Path.ChangeExtension(filePath, Package.PackageFileExtension);

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -258,7 +258,8 @@ namespace Stride.Core.Assets
                     switch (projectDependency.Type)
                     {
                         case DependencyType.Project:
-                            if (Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant() == ".csproj")
+                            var fileExtension = Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant();
+                            if (fileExtension == ".csproj" || fileExtension == ".fsproj")
                                 file = UPath.Combine(project.FullPath.GetFullDirectory(), (UFile)projectDependency.MSBuildProject);
                             break;
                         case DependencyType.Package:

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -815,7 +815,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
                         // Note: using ToList() because upgrade from old package system might change Projects list
                         foreach (var vsProject in solution.Projects.ToList())
                         {
-                            if (vsProject.TypeGuid == VisualStudio.KnownProjectTypeGuid.CSharp || vsProject.TypeGuid == VisualStudio.KnownProjectTypeGuid.CSharpNewSystem)
+                            if (vsProject.TypeGuid == VisualStudio.KnownProjectTypeGuid.CSharp || vsProject.TypeGuid == VisualStudio.KnownProjectTypeGuid.CSharpNewSystem || vsProject.TypeGuid == VisualStudio.KnownProjectTypeGuid.FSharpNewSystem)
                             {
                                 var project = (SolutionProject)session.LoadProject(sessionResult, vsProject.FullPath, loadParameters);
                                 project.VSProject = vsProject;

--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -81,12 +81,14 @@ namespace Stride.Core.Assets
             const string MSBUILD_EXE_PATH = nameof(MSBUILD_EXE_PATH);
             const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
             const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
+            const string DOTNET_HOST_PATH = nameof(DOTNET_HOST_PATH);
 
             var variables = new Dictionary<string, string>
             {
                 [MSBUILD_EXE_PATH] = dotNetSdkPath + "MSBuild.dll",
                 [MSBuildExtensionsPath] = dotNetSdkPath,
-                [MSBuildSDKsPath] = dotNetSdkPath + "Sdks"
+                [MSBuildSDKsPath] = dotNetSdkPath + "Sdks",
+                [DOTNET_HOST_PATH] = dotNetSdkPath + "../../dotnet.exe"
             };
 
             foreach (var kvp in variables)

--- a/sources/core/Stride.Core.Design/VisualStudio/KnownProjectTypeGuid.cs
+++ b/sources/core/Stride.Core.Design/VisualStudio/KnownProjectTypeGuid.cs
@@ -38,5 +38,6 @@ namespace Stride.Core.VisualStudio
         public static readonly Guid Setup = new Guid("54435603-DBB4-11D2-8724-00A0C9A8B90C");
         public static readonly Guid WebProject = new Guid("E24C65DC-7377-472B-9ABA-BC803B73C61A");
         public static readonly Guid CSharpNewSystem = new Guid("9A19103F-16F7-4668-BE54-9A1E7A4F7556");
+        public static readonly Guid FSharpNewSystem = new Guid("6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705");
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
@@ -208,6 +208,9 @@ namespace Stride.Assets.Presentation.AssetEditors
                 if (string.Equals(trackedAssembly.LoadedAssembly.Path, changedFile, StringComparison.OrdinalIgnoreCase))
                     return new AssemblyChangedEvent(trackedAssembly.LoadedAssembly, AssemblyChangeType.Binary, changedFile, trackedAssembly.Project);
 
+                if (trackedAssembly.Project == null)
+                    continue;
+
                 var needProjectReload = string.Equals(trackedAssembly.Project.FilePath, changedFile, StringComparison.OrdinalIgnoreCase);
 
                 // Also check for .cs file changes (DefaultItems auto import *.cs, with some excludes such as obj subfolder)
@@ -311,10 +314,11 @@ namespace Stride.Assets.Presentation.AssetEditors
                 directoryWatcher.Track(loadedAssembly.ProjectReference.Location);
 
                 var trackedAssembly = new TrackedAssembly { Package = package, LoadedAssembly = loadedAssembly };
-                
+
                 // Track project source code
-                if (await UpdateProject(trackedAssembly))
-                    trackedAssemblies.Add(trackedAssembly);
+                if (trackedAssembly.LoadedAssembly.ProjectReference.Location.GetFileExtension().Equals("csproj", StringComparison.InvariantCultureIgnoreCase))
+                    await UpdateProject(trackedAssembly);
+                trackedAssemblies.Add(trackedAssembly);
             }
 
             // TODO: Detect changes to loaded assemblies?

--- a/sources/editor/Stride.GameStudio/DebuggingViewModel.cs
+++ b/sources/editor/Stride.GameStudio/DebuggingViewModel.cs
@@ -168,14 +168,14 @@ namespace Stride.GameStudio
                     if (!trackAssemblyChanges || assemblyChange == null)
                         continue;
 
-                    // Ignore Binary changes
-                    if (assemblyChange.ChangeType == AssemblyChangeType.Binary)
+                    if (assemblyChange.Project != null && assemblyChange.ChangeType == AssemblyChangeType.Binary)
                         continue;
 
                     var shouldNotify = !assemblyChangesPending;
                     modifiedAssemblies[assemblyChange.Assembly] = new ModifiedAssembly
                     {
                         LoadedAssembly = assemblyChange.Assembly,
+                        LoadedAssemblyPath = assemblyChange.Assembly.Path,
                         ChangeType = assemblyChange.ChangeType,
                         Project = assemblyChange.Project
                     };

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -17,6 +17,7 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>
     <StrideLocalized>true</StrideLocalized>
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <StrideNuGetResolverUX>true</StrideNuGetResolverUX>
     <StrideSTAThreadOnMain>true</StrideSTAThreadOnMain>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
# PR Details

With these changes F# projects are compiled and included in the solution tree. This allows to have F# projects which are the startup project and automatic recompilation as soon as the source files changed.

Besides, original changes were from @Zeroto, however I had to edit the fork from him to get the F# support up and running again with the latest .NET version. There have been some changes since .NET 5.0.2xx, which required to declare the env var `DOTNET_HOST_PATH`. Without that the F# compilation fails, because the F# targets build on that this env var is existent.

I applied that "fix" based on these insights here.
https://github.com/ionide/proj-info/pull/100
https://github.com/ionide/ionide-vscode-fsharp/issues/1509

## Related Issue

#781

## Motivation and Context

I like to be able to code my game in F# too, with this I have at least minimal engine support for F#.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.