### PR TITLE
[Graphics] Lift SetData restriction of Texture

### DIFF
--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -946,8 +946,8 @@ namespace Stride.Graphics
             int sizeOfTextureData = textureDepthStride * depth;
 
             // Check size validity of data to copy to
-            if (fromData.Size != sizeOfTextureData)
-                throw new ArgumentException($"Size of toData ({fromData.Size} bytes) is not compatible expected size ({sizeOfTextureData} bytes) : Width * Height * Depth * sizeof(PixelFormat) size in bytes");
+            if (fromData.Size < sizeOfTextureData)
+                throw new ArgumentException($"Size of fromData ({fromData.Size} bytes) is not compatible expected size must be at least {sizeOfTextureData} bytes : Width * Height * Depth * sizeof(PixelFormat) size in bytes");
 
             // Calculate the subResourceIndex for a Texture
             int subResourceIndex = this.GetSubResourceIndex(arraySlice, mipSlice);


### PR DESCRIPTION
# PR Details

Minor improvement to SetData of Textures.

## Description

The passed DataPointer can now point to a memory area that is bigger than the target area of the texture. Before the size had to match exactly.

## Motivation and Context

Allowing more options on how to set texture data.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.