### PR TITLE
[Graphics] Disposes the constant buffers allocated by an effect instance

### DIFF
--- a/sources/engine/Stride.Graphics/Rendering/EffectInstance.cs
+++ b/sources/engine/Stride.Graphics/Rendering/EffectInstance.cs
@@ -43,6 +43,8 @@ namespace Stride.Rendering
             RootSignature?.Dispose();
             RootSignature = null;
 
+            bufferUploader.Clear();
+
             base.Destroy();
         }
 
@@ -71,6 +73,7 @@ namespace Stride.Rendering
                 RootSignature?.Dispose();
                 RootSignature = RootSignature.New(graphicsDevice, descriptorReflection);
 
+                bufferUploader.Clear();
                 bufferUploader.Compile(graphicsDevice, descriptorReflection, effect.Bytecode);
 
                 // Create parameter updater

--- a/sources/engine/Stride.Graphics/ResourceGroupBufferUploader.cs
+++ b/sources/engine/Stride.Graphics/ResourceGroupBufferUploader.cs
@@ -89,6 +89,20 @@ namespace Stride.Graphics
             }
         }
 
+        public void Clear()
+        {
+            if (resourceGroupBindings is null)
+                return;
+
+            for (int i = 0; i < resourceGroupBindings.Length; i++)
+            {
+                ref var binding = ref resourceGroupBindings[i];
+                binding.ConstantBufferPreallocated?.Dispose();
+            }
+
+            resourceGroupBindings = null;
+        }
+
         internal struct ResourceGroupBinding
         {
             // Constant buffer


### PR DESCRIPTION
## Description

The buffer uploader of the effect instance allocates constant buffers but doesn't clean them up. Instead it leaves it up to the graphics device to actually dispose them when the device gets disposed. This PR addresses this by simlply cleaning them up directly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.