### PR TITLE
minor improvements to the viewport grid

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyEditorViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyEditorViewModel.cs
@@ -313,8 +313,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             Transform.LoadSettings(settings);
             EntityGizmos.LoadSettings(settings);
             DisplaySelectionMask = settings.SelectionMaskVisible;
-            Grid.IsVisible = settings.GridVisible;
-            Grid.Color = settings.GridColor;
+            Grid.LoadSettings(settings);
             Lighting.LightProbeWireframeVisible = settings.LightProbeWireframe;
             Lighting.LightProbeBounces = settings.LightProbeBounces;
             MaterialSelectionMode = false;
@@ -327,8 +326,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             Camera.SaveSettings(settings);
             Transform.SaveSettings(settings);
             settings.SelectionMaskVisible = DisplaySelectionMask;
-            settings.GridVisible = Grid.IsVisible;
-            settings.GridColor = Grid.Color;
+            Grid.SaveSettings(settings);
             settings.LightProbeWireframe = Lighting.LightProbeWireframeVisible;
             settings.LightProbeBounces = Lighting.LightProbeBounces;
             Navigation.SaveSettings(settings);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
@@ -472,6 +472,30 @@
         <Border Background="{StaticResource BackgroundBrush}" DockPanel.Dock="Top" Padding="8,2">
           <DockPanel>
             <WrapPanel HorizontalAlignment="Right" DockPanel.Dock="Right">
+              <!-- Grid -->
+              <ToggleButton x:Name="ToggleGrid" Content="{sd:Image {StaticResource ImageGrid}, 16, 16, NearestNeighbor}"
+                            ToolTip="{sd:Localize Viewport grid settings..., Context=ToolTip}" sd:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
+                            Width="28" Height="28" Background="Transparent" >
+              </ToggleButton>
+              <Popup IsOpen="{Binding ElementName=ToggleGrid, Path=IsChecked}" StaysOpen="False" PlacementTarget="{Binding ElementName=ToggleGrid}">
+                <Grid Background="{StaticResource BackgroundBrush}" MinWidth="130" MinHeight="100">
+                  <StackPanel>
+                    <CheckBox Content="Show Grid" Margin="8" IsChecked="{Binding Grid.IsVisible}"/>
+                    <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
+                      <TextBlock Text="{sd:Localize Grid axis}" FontWeight="Bold"/>
+                    </Border>
+                    <DockPanel Margin="8">
+                      <RadioButton Content="{sd:Localize X, Context=Button}" IsChecked="{Binding Grid.AxisIndex, Converter={sd:IntToBool}, ConverterParameter=0}" Margin="4"/>
+                      <RadioButton Content="{sd:Localize Y, Context=Button}" IsChecked="{Binding Grid.AxisIndex, Converter={sd:IntToBool}, ConverterParameter=1}" Margin="4"/>
+                      <RadioButton Content="{sd:Localize Z, Context=Button}" IsChecked="{Binding Grid.AxisIndex, Converter={sd:IntToBool}, ConverterParameter=2}" Margin="4"/>
+                    </DockPanel>
+                    <Border Padding="8,2" Background="{StaticResource NormalBrush}" HorizontalAlignment="Stretch">
+                      <TextBlock Text="{sd:Localize Grid opacity}" FontWeight="Bold"/>
+                    </Border>
+                    <sd:NumericTextBox Value="{Binding Grid.Alpha}" SmallChange="0.1"  Minimum="0" Maximum="1" DecimalPlaces="3" Margin="8"/>
+                  </StackPanel>
+                </Grid>
+              </Popup>
               <!-- Lighting -->
               <ToggleButton x:Name="ToggleLighting" Content="{sd:Image {StaticResource ImageLighting}, 16, 16, NearestNeighbor}"
                             ToolTip="{sd:Localize Light probes and cubemaps..., Context=ToolTip}" sd:ToolTipHelper.Status="{Binding Session.Editor.Status}" ToolTipService.ShowOnDisabled="True"
@@ -589,8 +613,6 @@
                               Maximum="{Binding Length, Source={x:Static sd:Utils.ZoomFactors}, Converter={sd:SumNum}, ConverterParameter=-1}"
                               Value="{Binding EntityGizmos.GizmoSize, Converter={sd:ItemToIndex}, ConverterParameter={x:Static sd:Utils.ZoomFactors}}"/>
                       <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                        <CheckBox Content="Grid" Margin="5" IsChecked="{Binding Grid.IsVisible}"/>
-                        <Separator Margin="5" Height="0" Width="5"/>
                         <CheckBox Content="{sd:Localize Camera preview, Context=Button}" Margin="5" IsChecked="{Binding DisplayCameraPreview}"/>
                         <CheckBox Content="{sd:Localize Light probe volumes, Context=Button}" Margin="5" IsChecked="{Binding Lighting.LightProbeWireframeVisible}"/>
                       </StackPanel>

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameGridService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameGridService.cs
@@ -27,6 +27,8 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Game
 
         public float Alpha { get; set; } = 0.35f;
 
+        public int AxisIndex { get; set; } = 1;
+
         public override IEnumerable<Type> Dependencies { get { yield return typeof(IEditorGameCameraService); } }
 
         protected override Task<bool> Initialize(EditorServiceGame editorGame)
@@ -61,7 +63,7 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Game
             while (!IsDisposed)
             {
                 grid.IsEnabled = IsActive;
-                grid.Update(Color, game.EditorServices.Get<IEditorGameCameraService>().SceneUnit);
+                grid.Update(Color, Alpha, AxisIndex, game.EditorServices.Get<IEditorGameCameraService>().SceneUnit);
                 await game.Script.NextFrame();
             }
         }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Services/IEditorGameGridViewModelService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Services/IEditorGameGridViewModelService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Stride.Assets.Presentation.SceneEditor;
 using Stride.Core.Mathematics;
 using Stride.Editor.EditorGame.ViewModels;
 
@@ -24,5 +25,10 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Services
         /// Gets or sets the alpha level of the grid.
         /// </summary>
         float Alpha { get; set; }
+
+        /// <summary>
+        /// Gets or sets the axis of the grid.
+        /// </summary>
+        int AxisIndex { get; set; }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/EditorGridViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/EditorGridViewModel.cs
@@ -6,6 +6,7 @@ using Stride.Core.Mathematics;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.ViewModel;
 using Stride.Assets.Presentation.AssetEditors.GameEditor.Services;
+using Stride.Assets.Presentation.SceneEditor;
 
 namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
 {
@@ -45,10 +46,31 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
         public float Alpha { get { return Service.Alpha; } set { SetValue(Math.Abs(Alpha - value) > MathUtil.ZeroTolerance, () => Service.Alpha = value); } }
 
         /// <summary>
+        /// Gets or sets the axis of the grid.
+        /// </summary>
+        public int AxisIndex { get { return Service.AxisIndex; } set { SetValue(AxisIndex != value, () => Service.AxisIndex = value); } }
+
+        /// <summary>
         /// Gets a command that will toggle the visibility of the grid.
         /// </summary>
         public ICommandBase ToggleCommand { get; }
 
         private IEditorGameGridViewModelService Service => controller.GetService<IEditorGameGridViewModelService>();
+
+        public void LoadSettings([NotNull] SceneSettingsData sceneSettings)
+        {
+            IsVisible = sceneSettings.GridVisible;
+            Color = sceneSettings.GridColor;
+            Alpha = sceneSettings.GridOpacity;
+            AxisIndex = sceneSettings.GridAxisIndex;
+        }
+
+        public void SaveSettings([NotNull] SceneSettingsData sceneSettings)
+        {
+            sceneSettings.GridVisible = IsVisible;
+            sceneSettings.GridColor = Color;
+            sceneSettings.GridOpacity = Alpha;
+            sceneSettings.GridAxisIndex = AxisIndex;
+        }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/GridGizmoBase.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/GridGizmoBase.cs
@@ -33,14 +33,14 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         /// </summary>
         protected virtual int GridSize { get; } = 10;
 
-        public void Update(Color3 gridColor, float sceneUnit)
+        public void Update(Color3 gridColor, float alpha, int gridAxisIndex, float sceneUnit)
         {
             if (GraphicsDevice != null)
             {
                 gridColor = gridColor.ToColorSpace(GraphicsDevice.ColorSpace);
             }
 
-            UpdateBase(gridColor, sceneUnit);
+            UpdateBase(gridColor, alpha, gridAxisIndex, sceneUnit);
         }
 
         protected override Entity Create()
@@ -49,6 +49,6 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             return new Entity("Scene grid");
         }
 
-        protected abstract void UpdateBase(Color3 gridColor, float sceneUnit);
+        protected abstract void UpdateBase(Color3 gridColor, float alpha, int gridAxisIndex, float sceneUnit);
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ViewportGridGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ViewportGridGizmo.cs
@@ -20,13 +20,16 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
     public class ViewportGridGizmo : GridGizmoBase
     {
         private const float MaximumViewAngle = 25f * MathUtil.Pi / 180f;
-        private static readonly Vector3 DefaultUpVector = Vector3.UnitY;
         private const float GridVerticalOffset = 0.0175f;
         private const int GridTextureTopSize = 256;
 
         private List<Entity> originAxes = new List<Entity>();
         private Entity grid;
         private Entity originAxis;
+
+        private readonly Color RedUniformColor = new Color(0xFC, 0x37, 0x37);
+        private readonly Color GreenUniformColor = new Color(0x32, 0xE3, 0x35);
+        private readonly Color BlueUniformColor = new Color(0x2F, 0x6A, 0xE1);
 
         private delegate Image ImageBuilder();
 
@@ -59,9 +62,9 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
             // Create the grid origin
             originAxis = new Entity("The grid origin axes");
-            originAxes.Add(CreateOriginAxis(Color.Red, 0));
-            originAxes.Add(CreateOriginAxis(Color.Green, 1));
-            originAxes.Add(CreateOriginAxis(Color.Blue, 2));
+            originAxes.Add(CreateOriginAxis(RedUniformColor, 0));
+            originAxes.Add(CreateOriginAxis(GreenUniformColor, 1));
+            originAxes.Add(CreateOriginAxis(BlueUniformColor, 2));
             for (int i = 0; i < 3; i++)
                 originAxis.AddChild(originAxes[i]);
 
@@ -100,11 +103,30 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             axisEntity.TransformValue.Scale = new Vector3(GridSize, 1f / GridBase, 1f / GridBase);
             if (axis != 0)
                 axisEntity.TransformValue.Rotation = Quaternion.RotationX(MathUtil.PiOverTwo) * Quaternion.RotationAxis(new Vector3 { [1 + (axis%2)] = 1f}, MathUtil.PiOverTwo);
-
             var axisEntityRoot = new Entity("Scene grid origin axis root");
             axisEntityRoot.AddChild(axisEntity);
 
             return axisEntityRoot;
+        }
+
+        /// <summary>
+        /// Gets the default color associated to the provided axis index.
+        /// </summary>
+        /// <param name="axisIndex">The index of the axis</param>
+        /// <returns>The default color associated</returns>
+        protected Color3 GetAxisDefaultColor(int axisIndex)
+        {
+            switch (axisIndex)
+            {
+                case 0:
+                    return RedUniformColor.ToColor3();
+                case 1:
+                    return GreenUniformColor.ToColor3();
+                case 2:
+                    return BlueUniformColor.ToColor3();
+                default:
+                    throw new ArgumentOutOfRangeException("axisIndex");
+            }
         }
 
         private Texture CreateTexture(ImageBuilder imageBuilder)
@@ -145,20 +167,20 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             });
         }
 
-        protected override void UpdateBase(Color3 gridColor, float sceneUnit)
+        protected override void UpdateBase(Color3 gridColor, float alpha, int gridAxisIndex, float sceneUnit)
         {
             var cameraService = Game.EditorServices.Get<IEditorGameCameraService>();
             if (cameraService == null)
                 return;
 
             // update the grid color
-            GridMaterial.Passes[0].Parameters.Set(GridColorKey, Color4.PremultiplyAlpha(new Color4(gridColor, 0.35f)));
-            
+            GridMaterial.Passes[0].Parameters.Set(GridColorKey, Color4.PremultiplyAlpha(new Color4(gridColor, alpha)));
+
             // Determine the up vector depending on view matrix and projection mode
             // -> When orthographic, if we are looking along a coordinate axis, place the grid perpendicular to that axis.
-            // -> Fall back to the default plane otherwise.
-            var viewAxisIndex = 1;
-            var upVector = DefaultUpVector;
+            // -> Place the grid perpendicular to its default axis otherwise.
+            var viewAxisIndex = gridAxisIndex;
+            var upVector = new Vector3(0) { [gridAxisIndex] = 1 };
             var viewInvert = Matrix.Invert(cameraService.ViewMatrix);
             if (cameraService.IsOrthographic)
             {
@@ -192,15 +214,6 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
             // Move the grid origin in slightly in front the grid to have it in the foreground
             originPosition[viewAxisIndex] = snappedPosition[viewAxisIndex] + Math.Sign(viewInvert[3, viewAxisIndex]) * 0.001f * sceneUnit;
-
-            // In orthographic mode, put the grid and origin in the very background of scene
-            if (cameraService.IsOrthographic) 
-            {
-                var dotProduct = Vector3.Dot(viewInvert.Forward, upVector);
-                var cameraOffset = viewInvert.TranslationVector[viewAxisIndex];
-                originPosition[viewAxisIndex] = cameraOffset + Math.Sign(dotProduct) * cameraService.FarPlane * 0.90f;
-                snappedPosition[viewAxisIndex] = cameraOffset + Math.Sign(dotProduct) * cameraService.FarPlane * 0.95f;
-            }
             
             // Determine the intersection point of the center of the vieport with the grid plane
             var ray = EditorGameHelper.CalculateRayFromMousePosition(cameraService.Component, new Vector2(0.5f), viewInvert);
@@ -242,9 +255,16 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             for (var axis = 0; axis < 3; axis++)
                 SetPlaneEntityRotation((axis + 2) % 3, upVector, originAxes[axis]);
 
-            // Hide the vertical axis of the origin 
+            // Update the color of the origin axes and hide the grid axis
             for (int axis = 0; axis < 3; axis++)
+            {
+                // Make the axes alpha higher than the grid alpha so they are visible
+                float axesAlpha = alpha * 4;
+                var color = Color4.PremultiplyAlpha(new Color4(GetAxisDefaultColor(axis), axesAlpha));
+                originAxes[axis].GetChild(0).Get<ModelComponent>().GetMaterial(0).Passes[0].Parameters.Set(GridColorKey, color);
+              
                 originAxes[axis].GetChild(0).Get<ModelComponent>().Enabled = axis != viewAxisIndex;
+            }
         }
 
         private static void SetPlaneEntityRotation(int modelUpAxis, Vector3 upVector, Entity entity)

--- a/sources/editor/Stride.Assets.Presentation/SceneEditor/PackageSceneSettings.cs
+++ b/sources/editor/Stride.Assets.Presentation/SceneEditor/PackageSceneSettings.cs
@@ -44,6 +44,8 @@ namespace Stride.Assets.Presentation.SceneEditor
         public bool SelectionMaskVisible = true;
         public bool GridVisible = true;
         public Color3 GridColor = (Color3)new Color(180, 180, 180);
+        public float GridOpacity = 0.35f;
+        public int GridAxisIndex = 1;
         public bool CameraPreviewVisible = true;
         public RenderMode RenderMode = RenderMode.SingleStream;
         public string ActiveStream = string.Empty;

--- a/sources/editor/Stride.Assets.Presentation/View/ImageDictionary.xaml
+++ b/sources/editor/Stride.Assets.Presentation/View/ImageDictionary.xaml
@@ -676,6 +676,17 @@
     </DrawingImage.Drawing>
   </DrawingImage>
 
+  <DrawingImage x:Key="ImageGrid" >
+    <DrawingImage.Drawing>
+      <DrawingGroup>
+        <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+        <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M14,14L2,14 2,2 14,2z" />
+        <GeometryDrawing Brush="#FF424242" Geometry="F1M12,6L10,6 10,4 12,4z M12,9L10,9 10,7 12,7z M12,12L10,12 10,10 12,10z M9,6L7,6 7,4 9,4z M9,9L7,9 7,7 9,7z M9,12L7,12 7,10 9,10z M6,6L4,6 4,4 6,4z M6,9L4,9 4,7 6,7z M6,12L4,12 4,10 6,10z M3,13L13,13 13,3 3,3z" />
+        <GeometryDrawing Brush="#FFF0EFF1" Geometry="F1M6,10L4,10 4,12 6,12z M6,7L4,7 4,9 6,9z M6,4L4,4 4,6 6,6z M12,4L10,4 10,6 12,6z M12,10L10,10 10,12 12,12z M12,7L10,7 10,9 12,9z M9,4L7,4 7,6 9,6z M9,10L7,10 7,12 9,12z M9,9L7,9 7,7 9,7z" />
+      </DrawingGroup>
+    </DrawingImage.Drawing>
+  </DrawingImage>
+
   <DrawingImage x:Key="ImageLighting" >
     <DrawingImage.Drawing>
       <DrawingGroup>

--- a/sources/presentation/Stride.Core.Presentation/ValueConverters/IntToBool.cs
+++ b/sources/presentation/Stride.Core.Presentation/ValueConverters/IntToBool.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Stride.Core.Presentation.ValueConverters
+{
+    /// <summary>
+    /// This converter will convert an <see cref="int"/> value to a boolean.
+    /// </summary>
+    public class IntToBool : ValueConverterBase<IntToBool>
+    {
+        /// <inheritdoc/>
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return System.Convert.ToInt32(value) == System.Convert.ToInt32(parameter);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ((bool)value) ? parameter : Binding.DoNothing;
+        }
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation/ViewModel/ViewModelBase.cs
+++ b/sources/presentation/Stride.Core.Presentation/ViewModel/ViewModelBase.cs
@@ -184,7 +184,7 @@ namespace Stride.Core.Presentation.ViewModel
 
         /// <summary>
         /// Manages a property modification and its notifications. The first parameter <see cref="hasChanged"/> should indicate whether the property
-        /// should actuallybe updated. If this parameter is <c>True</c>, it will invoke the provided update action. The <see cref="PropertyChanging"/>
+        /// should actually be updated. If this parameter is <c>True</c>, it will invoke the provided update action. The <see cref="PropertyChanging"/>
         /// event will be raised prior to the update action, and the <see cref="PropertyChanged"/> event will be raised after.
         /// </summary>
         /// <param name="hasChanged">A boolean that indicates whether the update must be actually done. If <c>null</c>, the update is always done.</param>


### PR DESCRIPTION
# PR Details
Makes the viewport grid visible in orthographic mode even when not looking along a coordinate axis and adds grid settings to the toolbar (grid axis and opacity)
![Capture3](https://user-images.githubusercontent.com/64394387/125456515-14eda262-cf22-44c5-99de-d1a0ce007844.PNG)
![Capture4](https://user-images.githubusercontent.com/64394387/125456524-890d220d-7316-4941-8cc0-179361cef9f4.PNG)
![Capture2](https://user-images.githubusercontent.com/64394387/125456894-dbd1f0b4-3a3f-4f19-b263-ab7d8737c1d4.PNG)

## Related Issue
Closes #1087 and #158  

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)