### PR TITLE
[Rendering] Fixes engine crash with error in effect files

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
@@ -683,8 +683,8 @@ namespace Stride.Rendering
                     var staticEffectObjectNode = staticObjectNode * effectSlotCount + effectSlots[renderNode.RenderStage.Index].Index;
                     var renderEffect = renderEffects[staticEffectObjectNode];
 
-                    // Not compiled yet?
-                    if (renderEffect.Effect == null)
+                    // Not compiled yet or error?
+                    if (renderEffect.Effect == null || renderEffect.Reflection == null)
                     {
                         renderNode.RenderEffect = renderEffect;
                         renderNode.EffectObjectNode = EffectObjectNodeReference.Invalid;


### PR DESCRIPTION
# PR Details

Fixes engine crash with error in effect files

## Description

When an sdfx file has an error, the engine crashes and closes. This change will take care of just showing the error material when such an error happens.

## Motivation and Context

Crashes when modifying sdfx files at runtime.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
