### PR TITLE
[Math] Math -> MathF

### DIFF
--- a/sources/core/Stride.Core.Mathematics/AngleSingle.cs
+++ b/sources/core/Stride.Core.Mathematics/AngleSingle.cs
@@ -122,7 +122,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         public void Wrap()
         {
-            float newangle = (float)Math.IEEERemainder(radians, MathUtil.TwoPi);
+            float newangle = MathF.IEEERemainder(radians, MathUtil.TwoPi);
 
             if (newangle <= -MathUtil.Pi)
                 newangle += MathUtil.TwoPi;
@@ -180,19 +180,19 @@ namespace Stride.Core.Mathematics
 
                 if (degrees < 0)
                 {
-                    float degreesfloor = (float)Math.Ceiling(degrees);
+                    float degreesfloor = MathF.Ceiling(degrees);
                     return (degrees - degreesfloor) * 60.0f;
                 }
                 else
                 {
-                    float degreesfloor = (float)Math.Floor(degrees);
+                    float degreesfloor = MathF.Floor(degrees);
                     return (degrees - degreesfloor) * 60.0f;
                 }
             }
             set
             {
                 float degrees = MathUtil.RadiansToDegrees(radians);
-                float degreesfloor = (float)Math.Floor(degrees);
+                float degreesfloor = MathF.Floor(degrees);
 
                 degreesfloor += value / 60.0f;
                 radians = MathUtil.DegreesToRadians(degreesfloor);
@@ -214,19 +214,19 @@ namespace Stride.Core.Mathematics
 
                 if (degrees < 0)
                 {
-                    float degreesfloor = (float)Math.Ceiling(degrees);
+                    float degreesfloor = MathF.Ceiling(degrees);
 
                     float minutes = (degrees - degreesfloor) * 60.0f;
-                    float minutesfloor = (float)Math.Ceiling(minutes);
+                    float minutesfloor = MathF.Ceiling(minutes);
 
                     return (minutes - minutesfloor) * 60.0f;
                 }
                 else
                 {
-                    float degreesfloor = (float)Math.Floor(degrees);
+                    float degreesfloor = MathF.Floor(degrees);
 
                     float minutes = (degrees - degreesfloor) * 60.0f;
-                    float minutesfloor = (float)Math.Floor(minutes);
+                    float minutesfloor = MathF.Floor(minutes);
 
                     return (minutes - minutesfloor) * 60.0f;
                 }
@@ -234,10 +234,10 @@ namespace Stride.Core.Mathematics
             set
             {
                 float degrees = MathUtil.RadiansToDegrees(radians);
-                float degreesfloor = (float)Math.Floor(degrees);
+                float degreesfloor = MathF.Floor(degrees);
 
                 float minutes = (degrees - degreesfloor) * 60.0f;
-                float minutesfloor = (float)Math.Floor(minutes);
+                float minutesfloor = MathF.Floor(minutes);
 
                 minutesfloor += value / 60.0f;
                 degreesfloor += minutesfloor / 60.0f;

--- a/sources/core/Stride.Core.Mathematics/BoundingBoxExt.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingBoxExt.cs
@@ -94,7 +94,7 @@ namespace Stride.Core.Mathematics
                 for (int j = 0; j < 16; ++j)
                 {
                     //*matrixData &= 0x7FFFFFFF;
-                    *matrixData = Math.Abs(*matrixData);
+                    *matrixData = MathF.Abs(*matrixData);
                     ++matrixData;
                 }
             }

--- a/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
@@ -243,7 +243,7 @@ namespace Stride.Core.Mathematics
             }
 
             //Find the real distance from the DistanceSquared.
-            radius = (float)Math.Sqrt(radius);
+            radius = MathF.Sqrt(radius);
 
             //Construct the sphere.
             result.Center = center;
@@ -275,7 +275,7 @@ namespace Stride.Core.Mathematics
             float y = box.Minimum.Y - box.Maximum.Y;
             float z = box.Minimum.Z - box.Maximum.Z;
 
-            float distance = (float)(Math.Sqrt((x * x) + (y * y) + (z * z)));
+            float distance = MathF.Sqrt((x * x) + (y * y) + (z * z));
             result.Radius = distance * 0.5f;
         }
 
@@ -301,12 +301,12 @@ namespace Stride.Core.Mathematics
         {
             Vector3.TransformCoordinate(ref value.Center, ref transform, out result.Center);
 
-            var majorAxisLengthSquared = Math.Max(
-                (transform.M11 * transform.M11) + (transform.M12 * transform.M12) + (transform.M13 * transform.M13), Math.Max(
+            var majorAxisLengthSquared = MathF.Max(
+                (transform.M11 * transform.M11) + (transform.M12 * transform.M12) + (transform.M13 * transform.M13), MathF.Max(
                 (transform.M21 * transform.M21) + (transform.M22 * transform.M22) + (transform.M23 * transform.M23),
                 (transform.M31 * transform.M31) + (transform.M32 * transform.M32) + (transform.M33 * transform.M33)));
 
-            result.Radius = value.Radius * (float)Math.Sqrt(majorAxisLengthSquared);
+            result.Radius = value.Radius * MathF.Sqrt(majorAxisLengthSquared);
         }
 
         /// <summary>
@@ -352,8 +352,8 @@ namespace Stride.Core.Mathematics
             }
 
             Vector3 vector = difference * (1.0f / length);
-            float min = Math.Min(-radius, length - radius2);
-            float max = (Math.Max(radius, length + radius2) - min) * 0.5f;
+            float min = MathF.Min(-radius, length - radius2);
+            float max = (MathF.Max(radius, length + radius2) - min) * 0.5f;
 
             result.Center = value1.Center + vector * (max + min);
             result.Radius = max;

--- a/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
+++ b/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
@@ -270,7 +270,7 @@ namespace Stride.Core.Mathematics
             if (point.Z > box.Maximum.Z)
                 distance += (point.Z - box.Maximum.Z) * (point.Z - box.Maximum.Z);
 
-            return (float)Math.Sqrt(distance);
+            return MathF.Sqrt(distance);
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace Stride.Core.Mathematics
                 distance += delta * delta;
             }
 
-            return (float)Math.Sqrt(distance);
+            return MathF.Sqrt(distance);
         }
 
         /// <summary>
@@ -340,7 +340,7 @@ namespace Stride.Core.Mathematics
             Vector3.Distance(ref sphere.Center, ref point, out distance);
             distance -= sphere.Radius;
 
-            return Math.Max(distance, 0f);
+            return MathF.Max(distance, 0f);
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace Stride.Core.Mathematics
             Vector3.Distance(ref sphere1.Center, ref sphere2.Center, out distance);
             distance -= sphere1.Radius + sphere2.Radius;
 
-            return Math.Max(distance, 0f);
+            return MathF.Max(distance, 0f);
         }
 
         /// <summary>
@@ -420,12 +420,12 @@ namespace Stride.Core.Mathematics
             float denominator = cross.Length();
 
             //Lines are parallel.
-            if (Math.Abs(denominator) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(denominator) < MathUtil.ZeroTolerance)
             {
                 //Lines are parallel and on top of each other.
-                if (Math.Abs(ray2.Position.X - ray1.Position.X) < MathUtil.ZeroTolerance &&
-                    Math.Abs(ray2.Position.Y - ray1.Position.Y) < MathUtil.ZeroTolerance &&
-                    Math.Abs(ray2.Position.Z - ray1.Position.Z) < MathUtil.ZeroTolerance)
+                if (MathF.Abs(ray2.Position.X - ray1.Position.X) < MathUtil.ZeroTolerance &&
+                    MathF.Abs(ray2.Position.Y - ray1.Position.Y) < MathUtil.ZeroTolerance &&
+                    MathF.Abs(ray2.Position.Z - ray1.Position.Z) < MathUtil.ZeroTolerance)
                 {
                     point = Vector3.Zero;
                     return true;
@@ -477,9 +477,9 @@ namespace Stride.Core.Mathematics
             Vector3 point2 = ray2.Position + (t * ray2.Direction);
 
             //If the points are not equal, no intersection has occurred.
-            if (Math.Abs(point2.X - point1.X) > MathUtil.ZeroTolerance ||
-                Math.Abs(point2.Y - point1.Y) > MathUtil.ZeroTolerance ||
-                Math.Abs(point2.Z - point1.Z) > MathUtil.ZeroTolerance)
+            if (MathF.Abs(point2.X - point1.X) > MathUtil.ZeroTolerance ||
+                MathF.Abs(point2.Y - point1.Y) > MathUtil.ZeroTolerance ||
+                MathF.Abs(point2.Z - point1.Z) > MathUtil.ZeroTolerance)
             {
                 point = Vector3.Zero;
                 return false;
@@ -505,7 +505,7 @@ namespace Stride.Core.Mathematics
             float direction;
             Vector3.Dot(ref plane.Normal, ref ray.Direction, out direction);
 
-            if (Math.Abs(direction) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(direction) < MathUtil.ZeroTolerance)
             {
                 distance = 0f;
                 return false;
@@ -733,8 +733,8 @@ namespace Stride.Core.Mathematics
                 rectangleWorldMatrix.M21 == 0 && rectangleWorldMatrix.M23 == 0 &&
                 rectangleWorldMatrix.M31 == 0 && rectangleWorldMatrix.M32 == 0)
             {
-                var halfSize1 = Math.Abs(rectangleWorldMatrix[(testAxis1 << 2) + testAxis1] * rectangleSize[testAxis1] / 2f);
-                var halfSize2 = Math.Abs(rectangleWorldMatrix[(testAxis2 << 2) + testAxis2] * rectangleSize[testAxis2] / 2f);
+                var halfSize1 = MathF.Abs(rectangleWorldMatrix[(testAxis1 << 2) + testAxis1] * rectangleSize[testAxis1] / 2f);
+                var halfSize2 = MathF.Abs(rectangleWorldMatrix[(testAxis2 << 2) + testAxis2] * rectangleSize[testAxis2] / 2f);
 
                 intersects = -halfSize1 <= intersectionInRectangle[testAxis1] && intersectionInRectangle[testAxis1] <= halfSize1 &&
                              -halfSize2 <= intersectionInRectangle[testAxis2] && intersectionInRectangle[testAxis2] <= halfSize2;
@@ -746,10 +746,10 @@ namespace Stride.Core.Mathematics
                 var normalTestIndex = 0;
                 for (int i = 1; i < 3; i++)
                 {
-                    if (Math.Abs(plane.Normal[i]) > Math.Abs(plane.Normal[normalTestIndex]))
+                    if (MathF.Abs(plane.Normal[i]) > MathF.Abs(plane.Normal[normalTestIndex]))
                         normalTestIndex = i;
                 }
-                var normalSign = Math.Sign(plane.Normal[normalTestIndex]);
+                var normalSign = MathF.Sign(plane.Normal[normalTestIndex]);
 
                 // the base vector
                 var base1 = rectangleSize[testAxis1] * new Vector3(rectangleWorldMatrix[(testAxis1 << 2)], rectangleWorldMatrix[(testAxis1 << 2) + 1], rectangleWorldMatrix[(testAxis1 << 2) + 2]) / 2;
@@ -760,9 +760,9 @@ namespace Stride.Core.Mathematics
                 var v2 = +base1 - base2 - intersectionInRectangle;
                 var v3 = +base1 + base2 - intersectionInRectangle;
 
-                intersects = Math.Sign(Vector3.Cross(v1, v2)[normalTestIndex]) == normalSign &&
-                             Math.Sign(Vector3.Cross(v2, v3)[normalTestIndex]) == normalSign &&
-                             Math.Sign(Vector3.Cross(v3, v1)[normalTestIndex]) == normalSign;
+                intersects = MathF.Sign(Vector3.Cross(v1, v2)[normalTestIndex]) == normalSign &&
+                             MathF.Sign(Vector3.Cross(v2, v3)[normalTestIndex]) == normalSign &&
+                             MathF.Sign(Vector3.Cross(v3, v1)[normalTestIndex]) == normalSign;
 
                 // early exit on success
                 if (intersects)
@@ -773,9 +773,9 @@ namespace Stride.Core.Mathematics
                 v2 = +base1 + base2 - intersectionInRectangle;
                 v3 = -base1 + base2 - intersectionInRectangle;
 
-                intersects = Math.Sign(Vector3.Cross(v1, v2)[normalTestIndex]) == normalSign &&
-                             Math.Sign(Vector3.Cross(v2, v3)[normalTestIndex]) == normalSign &&
-                             Math.Sign(Vector3.Cross(v3, v1)[normalTestIndex]) == normalSign;
+                intersects = MathF.Sign(Vector3.Cross(v1, v2)[normalTestIndex]) == normalSign &&
+                             MathF.Sign(Vector3.Cross(v2, v3)[normalTestIndex]) == normalSign &&
+                             MathF.Sign(Vector3.Cross(v3, v1)[normalTestIndex]) == normalSign;
             }
 
             return intersects;
@@ -797,7 +797,7 @@ namespace Stride.Core.Mathematics
             distance = 0f;
             float tmax = float.MaxValue;
 
-            if (Math.Abs(ray.Direction.X) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(ray.Direction.X) < MathUtil.ZeroTolerance)
             {
                 if (ray.Position.X < box.Minimum.X || ray.Position.X > box.Maximum.X)
                 {
@@ -818,8 +818,8 @@ namespace Stride.Core.Mathematics
                     t2 = temp;
                 }
 
-                distance = Math.Max(t1, distance);
-                tmax = Math.Min(t2, tmax);
+                distance = MathF.Max(t1, distance);
+                tmax = MathF.Min(t2, tmax);
 
                 if (distance > tmax)
                 {
@@ -828,7 +828,7 @@ namespace Stride.Core.Mathematics
                 }
             }
 
-            if (Math.Abs(ray.Direction.Y) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(ray.Direction.Y) < MathUtil.ZeroTolerance)
             {
                 if (ray.Position.Y < box.Minimum.Y || ray.Position.Y > box.Maximum.Y)
                 {
@@ -849,8 +849,8 @@ namespace Stride.Core.Mathematics
                     t2 = temp;
                 }
 
-                distance = Math.Max(t1, distance);
-                tmax = Math.Min(t2, tmax);
+                distance = MathF.Max(t1, distance);
+                tmax = MathF.Min(t2, tmax);
 
                 if (distance > tmax)
                 {
@@ -859,7 +859,7 @@ namespace Stride.Core.Mathematics
                 }
             }
 
-            if (Math.Abs(ray.Direction.Z) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(ray.Direction.Z) < MathUtil.ZeroTolerance)
             {
                 if (ray.Position.Z < box.Minimum.Z || ray.Position.Z > box.Maximum.Z)
                 {
@@ -880,8 +880,8 @@ namespace Stride.Core.Mathematics
                     t2 = temp;
                 }
 
-                distance = Math.Max(t1, distance);
-                tmax = Math.Min(t2, tmax);
+                distance = MathF.Max(t1, distance);
+                tmax = MathF.Min(t2, tmax);
 
                 if (distance > tmax)
                 {
@@ -947,7 +947,7 @@ namespace Stride.Core.Mathematics
                 return false;
             }
 
-            distance = -b - (float)Math.Sqrt(discriminant);
+            distance = -b - MathF.Sqrt(discriminant);
 
             if (distance < 0f)
                 distance = 0f;
@@ -1013,7 +1013,7 @@ namespace Stride.Core.Mathematics
             float denominator;
             Vector3.Dot(ref direction, ref direction, out denominator);
 
-            if (Math.Abs(denominator) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(denominator) < MathUtil.ZeroTolerance)
                 return false;
 
             return true;
@@ -1048,7 +1048,7 @@ namespace Stride.Core.Mathematics
             //We assume the planes are normalized, therefore the denominator
             //only serves as a parallel and coincident check. Otherwise we need
             //to deivide the point by the denominator.
-            if (Math.Abs(denominator) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(denominator) < MathUtil.ZeroTolerance)
             {
                 line = new Ray();
                 return false;
@@ -1492,9 +1492,9 @@ namespace Stride.Core.Mathematics
                     {
                         // Previous code:
                         if (Vector3.Dot(boundingBoxExt.Center, plane->Normal)
-                            + boundingBoxExt.Extent.X * Math.Abs(plane->Normal.X)
-                            + boundingBoxExt.Extent.Y * Math.Abs(plane->Normal.Y)
-                            + boundingBoxExt.Extent.Z * Math.Abs(plane->Normal.Z)
+                            + boundingBoxExt.Extent.X * MathF.Abs(plane->Normal.X)
+                            + boundingBoxExt.Extent.Y * MathF.Abs(plane->Normal.Y)
+                            + boundingBoxExt.Extent.Z * MathF.Abs(plane->Normal.Z)
                             <= -plane->D)
                             return false;
                         plane++;

--- a/sources/core/Stride.Core.Mathematics/Color3.cs
+++ b/sources/core/Stride.Core.Mathematics/Color3.cs
@@ -196,9 +196,9 @@ namespace Stride.Core.Mathematics
         /// <param name="exponent">The exponent.</param>
         public void Pow(float exponent)
         {
-            R = (float)Math.Pow(R, exponent);
-            G = (float)Math.Pow(G, exponent);
-            B = (float)Math.Pow(B, exponent);
+            R = MathF.Pow(R, exponent);
+            G = MathF.Pow(G, exponent);
+            B = MathF.Pow(B, exponent);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/ColorHSV.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorHSV.cs
@@ -92,8 +92,8 @@ namespace Stride.Core.Mathematics
         /// <returns>A HSV color</returns>
         public static ColorHSV FromColor(Color4 color)
         {
-            float max = Math.Max(color.R, Math.Max(color.G, color.B));
-            float min = Math.Min(color.R, Math.Min(color.G, color.B));
+            float max = MathF.Max(color.R, MathF.Max(color.G, color.B));
+            float min = MathF.Min(color.R, MathF.Min(color.G, color.B));
 
             float delta = max - min;
             float h = 0.0f;

--- a/sources/core/Stride.Core.Mathematics/Int2.cs
+++ b/sources/core/Stride.Core.Mathematics/Int2.cs
@@ -695,8 +695,8 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Int2 other)
         {
-            return ((float)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance);
+            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Int3.cs
+++ b/sources/core/Stride.Core.Mathematics/Int3.cs
@@ -735,9 +735,9 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Int3 other)
         {
-            return ((float)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Z - Z) < MathUtil.ZeroTolerance);
+            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Z - Z) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/MathUtil.cs
+++ b/sources/core/Stride.Core.Mathematics/MathUtil.cs
@@ -474,7 +474,7 @@ namespace Stride.Core.Mathematics
         /// <returns><value>Log2(x)</value></returns>
         public static float Log2(float x)
         {
-            return (float)Math.Log(x) / 0.6931471805599453f;
+            return MathF.Log(x) / 0.6931471805599453f;
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace Stride.Core.Mathematics
         {
             if (gap == 0)
                 return value;
-            return (float)Math.Round((value / gap), MidpointRounding.AwayFromZero) * gap;
+            return MathF.Round((value / gap), MidpointRounding.AwayFromZero) * gap;
         }
 
         /// <summary>
@@ -615,8 +615,8 @@ namespace Stride.Core.Mathematics
             if (gap == 0)
                 return value;
             return new Vector2(
-                (float)Math.Round((value.X / gap), MidpointRounding.AwayFromZero) * gap,
-                (float)Math.Round((value.Y / gap), MidpointRounding.AwayFromZero) * gap);
+                MathF.Round((value.X / gap), MidpointRounding.AwayFromZero) * gap,
+                MathF.Round((value.Y / gap), MidpointRounding.AwayFromZero) * gap);
         }
 
         /// <summary>
@@ -630,9 +630,9 @@ namespace Stride.Core.Mathematics
             if (gap == 0)
                 return value;
             return new Vector3(
-                (float)Math.Round((value.X / gap), MidpointRounding.AwayFromZero) * gap,
-                (float)Math.Round((value.Y / gap), MidpointRounding.AwayFromZero) * gap,
-                (float)Math.Round((value.Z / gap), MidpointRounding.AwayFromZero) * gap);
+                MathF.Round((value.X / gap), MidpointRounding.AwayFromZero) * gap,
+                MathF.Round((value.Y / gap), MidpointRounding.AwayFromZero) * gap,
+                MathF.Round((value.Z / gap), MidpointRounding.AwayFromZero) * gap);
         }
 
         /// <summary>
@@ -646,10 +646,10 @@ namespace Stride.Core.Mathematics
             if (gap == 0)
                 return value;
             return new Vector4(
-                (float)Math.Round((value.X / gap), MidpointRounding.AwayFromZero) * gap,
-                (float)Math.Round((value.Y / gap), MidpointRounding.AwayFromZero) * gap,
-                (float)Math.Round((value.Z / gap), MidpointRounding.AwayFromZero) * gap,
-                (float)Math.Round((value.W / gap), MidpointRounding.AwayFromZero) * gap);
+                MathF.Round((value.X / gap), MidpointRounding.AwayFromZero) * gap,
+                MathF.Round((value.Y / gap), MidpointRounding.AwayFromZero) * gap,
+                MathF.Round((value.Z / gap), MidpointRounding.AwayFromZero) * gap,
+                MathF.Round((value.W / gap), MidpointRounding.AwayFromZero) * gap);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Matrix.cs
+++ b/sources/core/Stride.Core.Mathematics/Matrix.cs
@@ -620,18 +620,15 @@ namespace Stride.Core.Mathematics
         /// <param name="roll">The roll.</param>
         public void Decompose(out float yaw, out float pitch, out float roll)
         {
-            pitch = (float)Math.Asin(-M32);
-            // Hardcoded constant - burn him, he's a witch
-            // double threshold = 0.001;
-            double test = Math.Cos(pitch);
-            if (test > MathUtil.ZeroTolerance)
+            pitch = MathF.Asin(-M32);
+            if (MathF.Cos(pitch) > MathUtil.ZeroTolerance)
             {
-                roll = (float)Math.Atan2(M12, M22);
-                yaw = (float)Math.Atan2(M31, M33);
+                roll = MathF.Atan2(M12, M22);
+                yaw = MathF.Atan2(M31, M33);
             }
             else
             {
-                roll = (float)Math.Atan2(-M21, M11);
+                roll = MathF.Atan2(-M21, M11);
                 yaw = 0.0f;
             }
         }
@@ -643,16 +640,15 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The vector containing the 3 rotations angles to be applied in order.</param>
         public void DecomposeXYZ(out Vector3 rotation)
         {
-            rotation.Y = (float)Math.Asin(-M13);
-            double test = Math.Cos(rotation.Y);
-            if (test > 1e-6f)
+            rotation.Y = MathF.Asin(-M13);
+            if (MathF.Cos(rotation.Y) > MathUtil.ZeroTolerance)
             {
-                rotation.Z = (float)Math.Atan2(M12, M11);
-                rotation.X = (float)Math.Atan2(M23, M33);
+                rotation.Z = MathF.Atan2(M12, M11);
+                rotation.X = MathF.Atan2(M23, M33);
             }
             else
             {
-                rotation.Z = (float)Math.Atan2(-M21, M31);
+                rotation.Z = MathF.Atan2(-M21, M31);
                 rotation.X = 0.0f;
             }
         }
@@ -675,14 +671,14 @@ namespace Stride.Core.Mathematics
             translation.Z = this.M43;
 
             //Scaling is the length of the rows.
-            scale.X = (float)Math.Sqrt((M11 * M11) + (M12 * M12) + (M13 * M13));
-            scale.Y = (float)Math.Sqrt((M21 * M21) + (M22 * M22) + (M23 * M23));
-            scale.Z = (float)Math.Sqrt((M31 * M31) + (M32 * M32) + (M33 * M33));
+            scale.X = MathF.Sqrt((M11 * M11) + (M12 * M12) + (M13 * M13));
+            scale.Y = MathF.Sqrt((M21 * M21) + (M22 * M22) + (M23 * M23));
+            scale.Z = MathF.Sqrt((M31 * M31) + (M32 * M32) + (M33 * M33));
 
             //If any of the scaling factors are zero, than the rotation matrix can not exist.
-            if (Math.Abs(scale.X) < MathUtil.ZeroTolerance ||
-                Math.Abs(scale.Y) < MathUtil.ZeroTolerance ||
-                Math.Abs(scale.Z) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(scale.X) < MathUtil.ZeroTolerance ||
+                MathF.Abs(scale.Y) < MathUtil.ZeroTolerance ||
+                MathF.Abs(scale.Z) < MathUtil.ZeroTolerance)
             {
                 return false;
             }
@@ -727,14 +723,14 @@ namespace Stride.Core.Mathematics
             translation.Z = this.M43;
 
             //Scaling is the length of the rows.
-            scale.X = (float)Math.Sqrt((M11 * M11) + (M12 * M12) + (M13 * M13));
-            scale.Y = (float)Math.Sqrt((M21 * M21) + (M22 * M22) + (M23 * M23));
-            scale.Z = (float)Math.Sqrt((M31 * M31) + (M32 * M32) + (M33 * M33));
+            scale.X = MathF.Sqrt((M11 * M11) + (M12 * M12) + (M13 * M13));
+            scale.Y = MathF.Sqrt((M21 * M21) + (M22 * M22) + (M23 * M23));
+            scale.Z = MathF.Sqrt((M31 * M31) + (M32 * M32) + (M33 * M33));
 
             //If any of the scaling factors are zero, than the rotation matrix can not exist.
-            if (Math.Abs(scale.X) < MathUtil.ZeroTolerance ||
-                Math.Abs(scale.Y) < MathUtil.ZeroTolerance ||
-                Math.Abs(scale.Z) < MathUtil.ZeroTolerance)
+            if (MathF.Abs(scale.X) < MathUtil.ZeroTolerance ||
+                MathF.Abs(scale.Y) < MathUtil.ZeroTolerance ||
+                MathF.Abs(scale.Z) < MathUtil.ZeroTolerance)
             {
                 rotation = Matrix.Identity;
                 return false;
@@ -1380,7 +1376,7 @@ namespace Stride.Core.Mathematics
             float d14 = value.M21 * b3 + value.M22 * -b1 + value.M23 * b0;
 
             float det = value.M11 * d11 - value.M12 * d12 + value.M13 * d13 - value.M14 * d14;
-            if (Math.Abs(det) == 0.0f)
+            if (MathF.Abs(det) == 0.0f)
             {
                 result = Matrix.Zero;
                 return;
@@ -1602,7 +1598,7 @@ namespace Stride.Core.Mathematics
 
                 int i = r;
 
-                while (Math.Abs(result[i, lead]) < MathUtil.ZeroTolerance)
+                while (MathF.Abs(result[i, lead]) < MathUtil.ZeroTolerance)
                 {
                     i++;
 
@@ -1684,7 +1680,7 @@ namespace Stride.Core.Mathematics
 
                 int i = r;
 
-                while (Math.Abs(result[i, lead]) < MathUtil.ZeroTolerance)
+                while (MathF.Abs(result[i, lead]) < MathUtil.ZeroTolerance)
                 {
                     i++;
 
@@ -1762,7 +1758,7 @@ namespace Stride.Core.Mathematics
 
                 int i = r;
 
-                while (Math.Abs(result[i, lead]) < MathUtil.ZeroTolerance)
+                while (MathF.Abs(result[i, lead]) < MathUtil.ZeroTolerance)
                 {
                     i++;
 
@@ -1957,7 +1953,7 @@ namespace Stride.Core.Mathematics
             if (lengthSq < MathUtil.ZeroTolerance)
                 difference = -cameraForwardVector;
             else
-                difference *= (float)(1.0 / Math.Sqrt(lengthSq));
+                difference *= 1.0f / MathF.Sqrt(lengthSq);
 
             Vector3.Cross(ref cameraUpVector, ref difference, out crossed);
             crossed.Normalize();
@@ -2594,8 +2590,8 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the created rotation matrix.</param>
         public static void RotationX(float angle, out Matrix result)
         {
-            float cos = (float)Math.Cos(angle);
-            float sin = (float)Math.Sin(angle);
+            float cos = MathF.Cos(angle);
+            float sin = MathF.Sin(angle);
 
             result = Matrix.Identity;
             result.M22 = cos;
@@ -2623,8 +2619,8 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the created rotation matrix.</param>
         public static void RotationY(float angle, out Matrix result)
         {
-            float cos = (float)Math.Cos(angle);
-            float sin = (float)Math.Sin(angle);
+            float cos = MathF.Cos(angle);
+            float sin = MathF.Sin(angle);
 
             result = Matrix.Identity;
             result.M11 = cos;
@@ -2652,8 +2648,8 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the created rotation matrix.</param>
         public static void RotationZ(float angle, out Matrix result)
         {
-            float cos = (float)Math.Cos(angle);
-            float sin = (float)Math.Sin(angle);
+            float cos = MathF.Cos(angle);
+            float sin = MathF.Sin(angle);
 
             result = Matrix.Identity;
             result.M11 = cos;
@@ -2685,8 +2681,8 @@ namespace Stride.Core.Mathematics
             float x = axis.X;
             float y = axis.Y;
             float z = axis.Z;
-            float cos = (float)Math.Cos(angle);
-            float sin = (float)Math.Sin(angle);
+            float cos = MathF.Cos(angle);
+            float sin = MathF.Sin(angle);
             float xx = x * x;
             float yy = y * y;
             float zz = z * z;
@@ -3360,25 +3356,25 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Matrix other)
         {
-            return (Math.Abs(other.M11 - M11) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M12 - M12) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M13 - M13) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M14 - M14) < MathUtil.ZeroTolerance &&
+            return (MathF.Abs(other.M11 - M11) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M12 - M12) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M13 - M13) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M14 - M14) < MathUtil.ZeroTolerance &&
 
-                Math.Abs(other.M21 - M21) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M22 - M22) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M23 - M23) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M24 - M24) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M21 - M21) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M22 - M22) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M23 - M23) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M24 - M24) < MathUtil.ZeroTolerance &&
 
-                Math.Abs(other.M31 - M31) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M32 - M32) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M33 - M33) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M34 - M34) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M31 - M31) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M32 - M32) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M33 - M33) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M34 - M34) < MathUtil.ZeroTolerance &&
 
-                Math.Abs(other.M41 - M41) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M42 - M42) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M43 - M43) < MathUtil.ZeroTolerance &&
-                Math.Abs(other.M44 - M44) < MathUtil.ZeroTolerance);
+                MathF.Abs(other.M41 - M41) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M42 - M42) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M43 - M43) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.M44 - M44) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Plane.cs
+++ b/sources/core/Stride.Core.Mathematics/Plane.cs
@@ -112,7 +112,7 @@ namespace Stride.Core.Mathematics
             float yz = (y1 * z2) - (z1 * y2);
             float xz = (z1 * x2) - (x1 * z2);
             float xy = (x1 * y2) - (y1 * x2);
-            float invPyth = 1.0f / (float)(Math.Sqrt((yz * yz) + (xz * xz) + (xy * xy)));
+            float invPyth = 1.0f / MathF.Sqrt((yz * yz) + (xz * xz) + (xy * xy));
 
             Normal.X = yz * invPyth;
             Normal.Y = xz * invPyth;
@@ -190,7 +190,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         public void Normalize()
         {
-            float magnitude = 1.0f / (float)(Math.Sqrt((Normal.X * Normal.X) + (Normal.Y * Normal.Y) + (Normal.Z * Normal.Z)));
+            float magnitude = 1.0f / MathF.Sqrt((Normal.X * Normal.X) + (Normal.Y * Normal.Y) + (Normal.Z * Normal.Z));
 
             Normal.X *= magnitude;
             Normal.Y *= magnitude;
@@ -436,7 +436,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the normalized plane.</param>
         public static void Normalize(float normalX, float normalY, float normalZ, float planeD, out Plane result)
         {
-            float magnitude = 1.0f / (float)(Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ)));
+            float magnitude = 1.0f / MathF.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
 
             result.Normal.X = normalX * magnitude;
             result.Normal.Y = normalY * magnitude;
@@ -451,7 +451,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the normalized plane.</param>
         public static void Normalize(ref Plane plane, out Plane result)
         {
-            float magnitude = 1.0f / (float)(Math.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z)));
+            float magnitude = 1.0f / MathF.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z));
 
             result.Normal.X = plane.Normal.X * magnitude;
             result.Normal.Y = plane.Normal.Y * magnitude;
@@ -466,7 +466,7 @@ namespace Stride.Core.Mathematics
         /// <returns>The normalized plane.</returns>
         public static Plane Normalize(Plane plane)
         {
-            float magnitude = 1.0f / (float)(Math.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z)));
+            float magnitude = 1.0f / MathF.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z));
             return new Plane(plane.Normal.X * magnitude, plane.Normal.Y * magnitude, plane.Normal.Z * magnitude, plane.D * magnitude);
         }
 
@@ -490,7 +490,7 @@ namespace Stride.Core.Mathematics
         /// <returns>The flipped plane.</returns>
         public static Plane Negate(Plane plane)
         {
-            float magnitude = 1.0f / (float)(Math.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z)));
+            float magnitude = 1.0f / MathF.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z));
             return new Plane(plane.Normal.X * magnitude, plane.Normal.Y * magnitude, plane.Normal.Z * magnitude, plane.D * magnitude);
         }
 

--- a/sources/core/Stride.Core.Mathematics/Quaternion.cs
+++ b/sources/core/Stride.Core.Mathematics/Quaternion.cs
@@ -181,7 +181,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         public bool IsNormalized
         {
-            get { return Math.Abs((X * X) + (Y * Y) + (Z * Z) + (W * W) - 1f) < MathUtil.ZeroTolerance; }
+            get { return MathF.Abs((X * X) + (Y * Y) + (Z * Z) + (W * W) - 1f) < MathUtil.ZeroTolerance; }
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Stride.Core.Mathematics
                 if (length < MathUtil.ZeroTolerance)
                     return 0.0f;
 
-                return (float)(2.0 * Math.Acos(W));
+                return 2.0f * MathF.Acos(W);
             }
         }
 
@@ -302,7 +302,7 @@ namespace Stride.Core.Mathematics
         /// </remarks>
         public float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+            return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
         }
 
         /// <summary>
@@ -572,10 +572,10 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the exponentiated quaternion.</param>
         public static void Exponential(ref Quaternion value, out Quaternion result)
         {
-            float angle = (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
-            float sin = (float)Math.Sin(angle);
+            float angle = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
+            float sin = MathF.Sin(angle);
 
-            if (Math.Abs(sin) >= MathUtil.ZeroTolerance)
+            if (MathF.Abs(sin) >= MathUtil.ZeroTolerance)
             {
                 float coeff = sin / angle;
                 result.X = coeff * value.X;
@@ -587,7 +587,7 @@ namespace Stride.Core.Mathematics
                 result = value;
             }
 
-            result.W = (float)Math.Cos(angle);
+            result.W = MathF.Cos(angle);
         }
 
         /// <summary>
@@ -685,12 +685,12 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the natural logarithm of the quaternion.</param>
         public static void Logarithm(ref Quaternion value, out Quaternion result)
         {
-            if (Math.Abs(value.W) < 1.0)
+            if (MathF.Abs(value.W) < 1.0f)
             {
-                float angle = (float)Math.Acos(value.W);
-                float sin = (float)Math.Sin(angle);
+                float angle = MathF.Acos(value.W);
+                float sin = MathF.Sin(angle);
 
-                if (Math.Abs(sin) >= MathUtil.ZeroTolerance)
+                if (MathF.Abs(sin) >= MathUtil.ZeroTolerance)
                 {
                     float coeff = angle / sin;
                     result.X = value.X * coeff;
@@ -771,8 +771,8 @@ namespace Stride.Core.Mathematics
             Vector3.Normalize(ref axis, out normalized);
 
             float half = angle * 0.5f;
-            float sin = (float)Math.Sin(half);
-            float cos = (float)Math.Cos(half);
+            float sin = MathF.Sin(half);
+            float cos = MathF.Cos(half);
 
             result.X = normalized.X * sin;
             result.Y = normalized.Y * sin;
@@ -806,7 +806,7 @@ namespace Stride.Core.Mathematics
 
             if (scale > 0.0f)
             {
-                sqrt = (float)Math.Sqrt(scale + 1.0f);
+                sqrt = MathF.Sqrt(scale + 1.0f);
                 result.W = sqrt * 0.5f;
                 sqrt = 0.5f / sqrt;
 
@@ -816,7 +816,7 @@ namespace Stride.Core.Mathematics
             }
             else if ((matrix.M11 >= matrix.M22) && (matrix.M11 >= matrix.M33))
             {
-                sqrt = (float)Math.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
+                sqrt = MathF.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
                 half = 0.5f / sqrt;
 
                 result.X = 0.5f * sqrt;
@@ -826,7 +826,7 @@ namespace Stride.Core.Mathematics
             }
             else if (matrix.M22 > matrix.M33)
             {
-                sqrt = (float)Math.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
+                sqrt = MathF.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
                 half = 0.5f / sqrt;
 
                 result.X = (matrix.M21 + matrix.M12) * half;
@@ -836,7 +836,7 @@ namespace Stride.Core.Mathematics
             }
             else
             {
-                sqrt = (float)Math.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
+                sqrt = MathF.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
                 half = 0.5f / sqrt;
 
                 result.X = (matrix.M31 + matrix.M13) * half;
@@ -866,7 +866,7 @@ namespace Stride.Core.Mathematics
         public static void RotationX(float angle, out Quaternion result)
         {
             float halfAngle = angle * 0.5f;
-            result = new Quaternion((float)Math.Sin(halfAngle), 0.0f, 0.0f, (float)Math.Cos(halfAngle));
+            result = new Quaternion(MathF.Sin(halfAngle), 0.0f, 0.0f, MathF.Cos(halfAngle));
         }
 
         /// <summary>
@@ -889,7 +889,7 @@ namespace Stride.Core.Mathematics
         public static void RotationY(float angle, out Quaternion result)
         {
             float halfAngle = angle * 0.5f;
-            result = new Quaternion(0.0f, (float)Math.Sin(halfAngle), 0.0f, (float)Math.Cos(halfAngle));
+            result = new Quaternion(0.0f, MathF.Sin(halfAngle), 0.0f, MathF.Cos(halfAngle));
         }
 
         /// <summary>
@@ -912,7 +912,7 @@ namespace Stride.Core.Mathematics
         public static void RotationZ(float angle, out Quaternion result)
         {
             float halfAngle = angle * 0.5f;
-            result = new Quaternion(0.0f, 0.0f, (float)Math.Sin(halfAngle), (float)Math.Cos(halfAngle));
+            result = new Quaternion(0.0f, 0.0f, MathF.Sin(halfAngle), MathF.Cos(halfAngle));
         }
 
         /// <summary>
@@ -951,16 +951,15 @@ namespace Stride.Core.Mathematics
             var yz = rotation.Y * rotation.Z;
             var xw = rotation.X * rotation.W;
 
-            pitch = (float)Math.Asin(2.0f * (xw - yz));
-            double test = Math.Cos(pitch);
-            if (test > MathUtil.ZeroTolerance)
+            pitch = MathF.Asin(2.0f * (xw - yz));
+            if (MathF.Cos(pitch) > MathUtil.ZeroTolerance)
             {
-                roll = (float)Math.Atan2(2.0f * (xy + zw), 1.0f - (2.0f * (zz + xx)));
-                yaw = (float)Math.Atan2(2.0f * (zx + yw), 1.0f - (2.0f * (yy + xx)));
+                roll = MathF.Atan2(2.0f * (xy + zw), 1.0f - (2.0f * (zz + xx)));
+                yaw = MathF.Atan2(2.0f * (zx + yw), 1.0f - (2.0f * (yy + xx)));
             }
             else
             {
-                roll = (float)Math.Atan2(-2.0f * (xy - zw), 1.0f - (2.0f * (yy + zz)));
+                roll = MathF.Atan2(-2.0f * (xy - zw), 1.0f - (2.0f * (yy + zz)));
                 yaw = 0.0f;
             }
         }
@@ -978,12 +977,12 @@ namespace Stride.Core.Mathematics
             var halfPitch = pitch * 0.5f;
             var halfYaw = yaw * 0.5f;
             
-            var sinRoll = (float)Math.Sin(halfRoll);
-            var cosRoll = (float)Math.Cos(halfRoll);
-            var sinPitch = (float)Math.Sin(halfPitch);
-            var cosPitch = (float)Math.Cos(halfPitch);
-            var sinYaw = (float)Math.Sin(halfYaw);
-            var cosYaw = (float)Math.Cos(halfYaw);
+            var sinRoll = MathF.Sin(halfRoll);
+            var cosRoll = MathF.Cos(halfRoll);
+            var sinPitch = MathF.Sin(halfPitch);
+            var cosPitch = MathF.Cos(halfPitch);
+            var sinYaw = MathF.Sin(halfYaw);
+            var cosYaw = MathF.Cos(halfYaw);
 
             var cosYawPitch = cosYaw * cosPitch;
             var sinYawPitch = sinYaw * sinPitch;
@@ -1029,13 +1028,13 @@ namespace Stride.Core.Mathematics
         /// <param name="result">The resulting quaternion corresponding to the transformation of the source vector to the target vector.</param>
         public static void BetweenDirections(ref Vector3 source, ref Vector3 target, out Quaternion result)
         {
-            var norms = (float)Math.Sqrt(source.LengthSquared() * target.LengthSquared());
+            var norms = MathF.Sqrt(source.LengthSquared() * target.LengthSquared());
             var real = norms + Vector3.Dot(source, target);
             if (real < MathUtil.ZeroTolerance * norms)
             {
                 // If source and target are exactly opposite, rotate 180 degrees around an arbitrary orthogonal axis.
                 // Axis normalisation can happen later, when we normalise the quaternion.
-                result = Math.Abs(source.X) > Math.Abs(source.Z)
+                result = MathF.Abs(source.X) > MathF.Abs(source.Z)
                     ? new Quaternion(-source.Y, source.X, 0.0f, 0.0f)
                     : new Quaternion(0.0f, -source.Z, source.Y, 0.0f);
             }
@@ -1061,18 +1060,18 @@ namespace Stride.Core.Mathematics
             float inverse;
             float dot = Dot(start, end);
 
-            if (Math.Abs(dot) > 1.0f - MathUtil.ZeroTolerance)
+            if (MathF.Abs(dot) > 1.0f - MathUtil.ZeroTolerance)
             {
                 inverse = 1.0f - amount;
-                opposite = amount * Math.Sign(dot);
+                opposite = amount * MathF.Sign(dot);
             }
             else
             {
-                float acos = (float)Math.Acos(Math.Abs(dot));
-                float invSin = (float)(1.0 / Math.Sin(acos));
+                float acos = MathF.Acos(MathF.Abs(dot));
+                float invSin = 1.0f / MathF.Sin(acos);
 
-                inverse = (float)Math.Sin((1.0f - amount) * acos) * invSin;
-                opposite = (float)Math.Sin(amount * acos) * invSin * Math.Sign(dot);
+                inverse = MathF.Sin((1.0f - amount) * acos) * invSin;
+                opposite = MathF.Sin(amount * acos) * invSin * MathF.Sign(dot);
             }
 
             result.X = (inverse * start.X) + (opposite * end.X);
@@ -1330,10 +1329,10 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Quaternion other)
         {
-            return ((float)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Z - Z) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.W - W) < MathUtil.ZeroTolerance);
+            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Z - Z) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.W - W) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -121,7 +121,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         public bool IsNormalized
         {
-            get { return Math.Abs((X * X) + (Y * Y) - 1f) < MathUtil.ZeroTolerance; }
+            get { return MathF.Abs((X * X) + (Y * Y) - 1f) < MathUtil.ZeroTolerance; }
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace Stride.Core.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y));
+            return MathF.Sqrt((X * X) + (Y * Y));
         }
 
         /// <summary>
@@ -472,7 +472,7 @@ namespace Stride.Core.Mathematics
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
 
-            result = (float)Math.Sqrt((x * x) + (y * y));
+            result = MathF.Sqrt((x * x) + (y * y));
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace Stride.Core.Mathematics
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
 
-            return (float)Math.Sqrt((x * x) + (y * y));
+            return MathF.Sqrt((x * x) + (y * y));
         }
 
         /// <summary>
@@ -1409,8 +1409,8 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Vector2 other)
         {
-            return ((float)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance);
+            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -148,7 +148,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         public bool IsNormalized
         {
-            get { return Math.Abs((X * X) + (Y * Y) + (Z * Z) - 1f) < MathUtil.ZeroTolerance; }
+            get { return MathF.Abs((X * X) + (Y * Y) + (Z * Z) - 1f) < MathUtil.ZeroTolerance; }
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Stride.Core.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+            return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z));
         }
 
         /// <summary>
@@ -234,9 +234,9 @@ namespace Stride.Core.Mathematics
         /// <param name="exponent">The exponent.</param>
         public void Pow(float exponent)
         {
-            X = (float)Math.Pow(X, exponent);
-            Y = (float)Math.Pow(Y, exponent);
-            Z = (float)Math.Pow(Z, exponent);
+            X = MathF.Pow(X, exponent);
+            Y = MathF.Pow(Y, exponent);
+            Z = MathF.Pow(Z, exponent);
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace Stride.Core.Mathematics
             float y = value1.Y - value2.Y;
             float z = value1.Z - value2.Z;
 
-            result = (float)Math.Sqrt((x * x) + (y * y) + (z * z));
+            result = MathF.Sqrt((x * x) + (y * y) + (z * z));
         }
 
         /// <summary>
@@ -565,7 +565,7 @@ namespace Stride.Core.Mathematics
             float y = value1.Y - value2.Y;
             float z = value1.Z - value2.Z;
 
-            return (float)Math.Sqrt((x * x) + (y * y) + (z * z));
+            return MathF.Sqrt((x * x) + (y * y) + (z * z));
         }
 
         /// <summary>
@@ -1721,9 +1721,9 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Vector3 other)
         {
-            return ((float)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Z - Z) < MathUtil.ZeroTolerance);
+            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Z - Z) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -178,7 +178,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         public bool IsNormalized
         {
-            get { return Math.Abs((X * X) + (Y * Y) + (Z * Z) + (W * W) - 1f) < MathUtil.ZeroTolerance; }
+            get { return MathF.Abs((X * X) + (Y * Y) + (Z * Z) + (W * W) - 1f) < MathUtil.ZeroTolerance; }
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace Stride.Core.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+            return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
         }
 
         /// <summary>
@@ -267,10 +267,10 @@ namespace Stride.Core.Mathematics
         /// <param name="exponent">The exponent.</param>
         public void Pow(float exponent)
         {
-            X = (float)Math.Pow(X, exponent);
-            Y = (float)Math.Pow(Y, exponent);
-            Z = (float)Math.Pow(Z, exponent);
-            W = (float)Math.Pow(W, exponent);
+            X = MathF.Pow(X, exponent);
+            Y = MathF.Pow(Y, exponent);
+            Z = MathF.Pow(Z, exponent);
+            W = MathF.Pow(W, exponent);
         }
 
         /// <summary>
@@ -564,7 +564,7 @@ namespace Stride.Core.Mathematics
             float z = value1.Z - value2.Z;
             float w = value1.W - value2.W;
 
-            result = (float)Math.Sqrt((x * x) + (y * y) + (z * z) + (w * w));
+            result = MathF.Sqrt((x * x) + (y * y) + (z * z) + (w * w));
         }
 
         /// <summary>
@@ -584,7 +584,7 @@ namespace Stride.Core.Mathematics
             float z = value1.Z - value2.Z;
             float w = value1.W - value2.W;
 
-            return (float)Math.Sqrt((x * x) + (y * y) + (z * z) + (w * w));
+            return MathF.Sqrt((x * x) + (y * y) + (z * z) + (w * w));
         }
 
         /// <summary>
@@ -1361,10 +1361,10 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Vector4 other)
         {
-            return ((float)Math.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.Z - Z) < MathUtil.ZeroTolerance &&
-                (float)Math.Abs(other.W - W) < MathUtil.ZeroTolerance);
+            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Z - Z) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.W - W) < MathUtil.ZeroTolerance);
         }
 
         /// <summary>

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameEntityCameraService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameEntityCameraService.cs
@@ -55,10 +55,10 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
         public override void ResetCamera(Vector3 viewDirection)
         {
             var isViewVertical = MathUtil.NearEqual(viewDirection.X, 0) && MathUtil.NearEqual(viewDirection.Z, 0);
-            SetCurrentYaw(isViewVertical ? 0 : (float)Math.Atan2(-viewDirection.X, -viewDirection.Z));
+            SetCurrentYaw(isViewVertical ? 0 : MathF.Atan2(-viewDirection.X, -viewDirection.Z));
 
             var horizontalViewDirection = new Vector2(viewDirection.X, viewDirection.Z);
-            SetCurrentPitch((float)Math.Atan2(viewDirection.Y, horizontalViewDirection.Length()));
+            SetCurrentPitch(MathF.Atan2(viewDirection.Y, horizontalViewDirection.Length()));
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             }
             else
             {
-                distance = 3*(Math.Abs(sphere.Radius) > MathUtil.ZeroTolerance ? sphere.Radius : 0.5f * SceneUnit);
+                distance = 3*(MathF.Abs(sphere.Radius) > MathUtil.ZeroTolerance ? sphere.Radius : 0.5f * SceneUnit);
             }
 
             SetCurrentPosition(targetPos - direction*distance);
@@ -170,7 +170,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             input.isPanning = !isAltDown && mbDown && !rbDown;
             input.isRotating = !isAltDown && !mbDown && rbDown;
             input.isMoving = !isAltDown && mbDown && rbDown;
-            input.isZooming = (isAltDown && !lbDown && !mbDown && rbDown) || (Math.Abs(Game.Input.MouseWheelDelta) > MathUtil.ZeroTolerance);
+            input.isZooming = (isAltDown && !lbDown && !mbDown && rbDown) || (MathF.Abs(Game.Input.MouseWheelDelta) > MathUtil.ZeroTolerance);
             input.isOrbiting = isAltDown && lbDown && !mbDown && !rbDown;
 
             return input;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EntityHierarchyEditorGame.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EntityHierarchyEditorGame.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
@@ -95,7 +95,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             // Ensures a ray angle with projection plane of at least 'limitAngle' to avoid the object to go to infinity.
             var dotProductValue = Vector3.Dot(ray.Direction, plane.Normal);
             var comparisonSign = Math.Sign(Vector3.Dot(ray.Position, plane.Normal) + plane.D);
-            if (comparisonSign * (Math.Acos(dotProductValue) - MathUtil.PiOverTwo) < limitAngle || !plane.Intersects(ref ray, out scenePosition))
+            if (comparisonSign * (MathF.Acos(dotProductValue) - MathUtil.PiOverTwo) < limitAngle || !plane.Intersects(ref ray, out scenePosition))
                 scenePosition = ray.Position + randomDistance * ray.Direction;
 
             return scenePosition;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameCameraService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameCameraService.cs
@@ -160,10 +160,10 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Game
         public virtual void ResetCamera(Vector3 viewDirection)
         {
             var isViewVertical = MathUtil.NearEqual(viewDirection.X, 0) && MathUtil.NearEqual(viewDirection.Z, 0);
-            Yaw = isViewVertical ? 0 : (float)Math.Atan2(-viewDirection.X, -viewDirection.Z);
+            Yaw = isViewVertical ? 0 : MathF.Atan2(-viewDirection.X, -viewDirection.Z);
 
             var horizontalViewDirection = new Vector2(viewDirection.X, viewDirection.Z);
-            Pitch = (float)Math.Atan2(viewDirection.Y, horizontalViewDirection.Length());
+            Pitch = MathF.Atan2(viewDirection.Y, horizontalViewDirection.Length());
         }
 
         public void ResetCamera(CameraOrientation orientation)

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameHelper.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameHelper.cs
@@ -21,7 +21,7 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Game
             {
                 // calculate the ray direction corresponding to the click in the view space
                 var verticalFov = MathUtil.DegreesToRadians(camera.VerticalFieldOfView);
-                var rayDirectionView = Vector3.Normalize(new Vector3(camera.AspectRatio * screenPosition.X, screenPosition.Y, -1 / (float)Math.Tan(verticalFov / 2f)));
+                var rayDirectionView = Vector3.Normalize(new Vector3(camera.AspectRatio * screenPosition.X, screenPosition.Y, -1 / MathF.Tan(verticalFov / 2f)));
 
                 // calculate the direction of the ray in the gizmo space
                 var rayDirectionGizmo = Vector3.Normalize(Vector3.TransformNormal(rayDirectionView, worldView));

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameHelper.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Game/EditorGameHelper.cs
@@ -50,7 +50,7 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Game
             // Ensures a ray angle with projection plane of at least 'limitAngle' to avoid the object to go to infinity.
             var dotProductValue = Vector3.Dot(ray.Direction, projectionPlane.Normal);
             var comparisonSign = Math.Sign(Vector3.Dot(ray.Position, projectionPlane.Normal) + projectionPlane.D);
-            if (comparisonSign * (Math.Acos(dotProductValue) - MathUtil.PiOverTwo) < limitAngle)
+            if (comparisonSign * (MathF.Acos(dotProductValue) - MathUtil.PiOverTwo) < limitAngle)
             {
                 var rotationAxis = Vector3.Normalize(Vector3.Cross(projectionPlane.Normal, ray.Direction));
                 var initialDirection = Vector3.Normalize(Vector3.Cross(rotationAxis, projectionPlane.Normal));

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraGizmo.cs
@@ -180,7 +180,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                     var zDist = i < 4 ? parameters.NearPlane : parameters.FarPlane;
 
                     var y = parameters.ProjectionMode == CameraProjectionMode.Perspective
-                        ? zDist * (float)Math.Tan(MathUtil.DegreesToRadians(parameters.VerticalFov) / 2)
+                        ? zDist * MathF.Tan(MathUtil.DegreesToRadians(parameters.VerticalFov) / 2)
                         : parameters.OrthographicSize / 2f;
 
                     vertex->Position = new Vector3(new Vector2(parameters.AspectRatio*y, y) * offsets[index], -zDist);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraOrientationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraOrientationGizmo.cs
@@ -192,7 +192,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             }
 
             var viewDirection = viewInverse.Forward;
-            IsViewParallelToAxis = MathUtil.WithinEpsilon(Math.Abs(viewDirection.X) + Math.Abs(viewDirection.Y) + Math.Abs(viewDirection.Z), 1.0f, 1e-4f);
+            IsViewParallelToAxis = MathUtil.WithinEpsilon(MathF.Abs(viewDirection.X) + MathF.Abs(viewDirection.Y) + MathF.Abs(viewDirection.Z), 1.0f, 1e-4f);
         }
 
         private static float GetMaximum(int index)

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightPointGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightPointGizmo.cs
@@ -119,18 +119,18 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                     var rotation = Matrix.Identity;
                     if (j == 1)
                     {
-                        rotation = Matrix.RotationX((float)Math.PI / 2);
+                        rotation = Matrix.RotationX(MathF.PI / 2);
                     }
                     else if (j == 2)
                     {
-                        rotation = Matrix.RotationY((float)Math.PI / 2);
+                        rotation = Matrix.RotationY(MathF.PI / 2);
                     }
 
                     for (int i = 0; i <= Tesselation; i++)
                     {
                         var longitude = (float)(i * 2.0 * Math.PI / Tesselation);
-                        var dx = (float)Math.Cos(longitude);
-                        var dy = (float)Math.Sin(longitude);
+                        var dx = MathF.Cos(longitude);
+                        var dy = MathF.Sin(longitude);
 
                         var normal = new Vector3(dx, dy, 0);
                         Vector3.TransformNormal(ref normal, ref rotation, out normal);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightSpotGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightSpotGizmo.cs
@@ -198,9 +198,9 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 {
                     var z = -lightSpot.Range;
                     var theta = 2 * i * MathUtil.Pi / (4 * Tesselation);
-                    var radiusBeam = Math.Abs(z) * (float)Math.Tan(MathUtil.DegreesToRadians(angleOuter / 2));
+                    var radiusBeam = MathF.Abs(z) * MathF.Tan(MathUtil.DegreesToRadians(angleOuter / 2));
 
-                    vertex[i].Position = new Vector3(radiusBeam * (float)Math.Cos(theta), radiusBeam * (float)Math.Sin(theta), z);
+                    vertex[i].Position = new Vector3(radiusBeam * MathF.Cos(theta), radiusBeam * MathF.Sin(theta), z);
                     vertex[i].Normal = new Vector3(0, 0, -1);
                 }
 
@@ -225,8 +225,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
                 // The four corners at the end:
                 float angleOuterInRadians = MathUtil.DegreesToRadians(Math.Max(lightSpot.AngleInner, lightSpot.AngleOuter));
-                float y = (float)Math.Tan(angleOuterInRadians / 2.0f) * lightSpot.Range;  // TODO: Is this correct?
-                //float y = (float)Math.Tan(lightSpot.AngleOuter) * lightSpot.Range * 2.0f;  // TODO: Is this correct?
+                float y = MathF.Tan(angleOuterInRadians / 2.0f) * lightSpot.Range;  // TODO: Is this correct?
+                //float y = MathF.Tan(lightSpot.AngleOuter) * lightSpot.Range * 2.0f;  // TODO: Is this correct?
                 float x = y * lightSpot.AspectRatio;  // TODO: Is this correct?
 
                 vertex[1].Position = new Vector3(-x, -y, -lightSpot.Range);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/RotationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/RotationGizmo.cs
@@ -81,7 +81,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             else
             {
                 var halfFov = MathUtil.DegreesToRadians(cameraService.VerticalFieldOfView/2f);
-                rayDirectionView = Vector3.Normalize(new Vector3(cameraService.AspectRatio*screenPosition.X, screenPosition.Y, -1/(float)Math.Tan(halfFov)));
+                rayDirectionView = Vector3.Normalize(new Vector3(cameraService.AspectRatio*screenPosition.X, screenPosition.Y, -1/MathF.Tan(halfFov)));
             }
 
             // calculate the view to gizmo space matrix 
@@ -92,8 +92,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
             // calculate the length of the box depending to tessellation
             const float Alpha = 2f * MathUtil.Pi / CollisionTessellation;
-            var length = (float)Math.Sqrt(2f * RotationGizmoRadius * RotationGizmoRadius * (1 - (float)Math.Cos(Alpha)));
-            length += ClickThickness * (float)Math.Tan((MathUtil.Pi / 2 - Alpha) / 2f); // avoid small gaps between elements
+            var length = MathF.Sqrt(2f * RotationGizmoRadius * RotationGizmoRadius * (1 - MathF.Cos(Alpha)));
+            length += ClickThickness * MathF.Tan((MathUtil.Pi / 2 - Alpha) / 2f); // avoid small gaps between elements
 
             // calculate the bounding box containing the segment
             var minimum = new Vector3(-ClickThickness);
@@ -102,7 +102,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             maximum[0] = +length / 2;
             var boundingBox = new BoundingBox(minimum, maximum);
 
-            var boxRadius = RotationGizmoRadius * (float)Math.Cos(Alpha);
+            var boxRadius = RotationGizmoRadius * MathF.Cos(Alpha);
             var rotationMatrix = new[] { Matrix.RotationYawPitchRoll(MathUtil.Pi / 2, 0, 0), Matrix.RotationYawPitchRoll(0, MathUtil.Pi / 2, 0), Matrix.Identity };
 
             // select the axis whose intersection is the closest

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
@@ -24,7 +24,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
             public int Compare(EntitySortInfo x, EntitySortInfo y)
             {
-                return Math.Sign(x.Depth - y.Depth);
+                return MathF.Sign(x.Depth - y.Depth);
             }
         };
 
@@ -212,7 +212,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 var maximum = new Vector3(GizmoPlaneLength);
 
                 for (int axis = 0; axis < 3; axis++)
-                    maximum[axis] *= Math.Sign(gizmoViewInverse[3, axis]); // translation planes move to always face the camera.
+                    maximum[axis] *= MathF.Sign(gizmoViewInverse[3, axis]); // translation planes move to always face the camera.
 
                 maximum[pair.Value] = AxisBodyRadius;
 
@@ -279,7 +279,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             if (UseSnap)
                 translation = MathUtil.Snap(translation, SnapValue);
 
-            var scaleValue = translation > 0 ? (float)Math.Exp(translation) : 1 / ((float)Math.Exp(-translation));
+            var scaleValue = translation > 0 ? MathF.Exp(translation) : 1 / (MathF.Exp(-translation));
 
             return Math.Max(MathUtil.ZeroTolerance, Math.Min(MaxScaleValue, scaleValue));
         }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -210,8 +210,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         {
             if (cameraService.Component.Projection == CameraProjectionMode.Perspective)
             {
-                var distanceToSelectedEntity = Math.Abs(Vector3.TransformCoordinate(AnchorEntity.Transform.WorldMatrix.TranslationVector, cameraService.ViewMatrix).Z);
-                return SizeFactor * DefaultScale * 2f * (float)Math.Tan(MathUtil.DegreesToRadians(cameraService.VerticalFieldOfView / 2)) * distanceToSelectedEntity;
+                var distanceToSelectedEntity = MathF.Abs(Vector3.TransformCoordinate(AnchorEntity.Transform.WorldMatrix.TranslationVector, cameraService.ViewMatrix).Z);
+                return SizeFactor * DefaultScale * 2f * MathF.Tan(MathUtil.DegreesToRadians(cameraService.VerticalFieldOfView / 2)) * distanceToSelectedEntity;
             }
 
             return SizeFactor * DefaultScale * cameraService.Component.OrthographicSize;
@@ -306,7 +306,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 planeNormal = Vector3.Cross(planeVector, axisVector);
 
                 //This is a temporary fix for weird rotation behavior, it's not working for translation tho
-                if (MathUtil.NearEqual(Math.Abs(Vector3.Dot(axisVector, Vector3.Normalize(cameraVector))), 1.0f))
+                if (MathUtil.NearEqual(MathF.Abs(Vector3.Dot(axisVector, Vector3.Normalize(cameraVector))), 1.0f))
                 {
                     planeNormal = axisVector;
                 }
@@ -380,7 +380,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 if (mouseDragPixel.Length() < TransformationStartPixelThreshold)
                     return;
 
-                TransformationDirection = Math.Abs(mouseDragPixel.X) > Math.Abs(mouseDragPixel.Y) ? Vector2.UnitX : Vector2.UnitY;
+                TransformationDirection = MathF.Abs(mouseDragPixel.X) > MathF.Abs(mouseDragPixel.Y) ? Vector2.UnitX : Vector2.UnitY;
 
                 // ensure that the current transformation is not the identity (due to snap it might require more mouse movement to actually start the transformation)
                 var currentTransformation = CalculateTransformation();

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ViewportGridGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ViewportGridGizmo.cs
@@ -189,7 +189,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                     var coordinateAxis = new Vector3 { [i] = 1.0f };
                     var dotProduct = Vector3.Dot(viewInvert.Forward, coordinateAxis);
 
-                    if (Math.Abs(dotProduct) > 0.99f)
+                    if (MathF.Abs(dotProduct) > 0.99f)
                     {
                         upVector = coordinateAxis;
                         viewAxisIndex = i;
@@ -210,10 +210,10 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             var originPosition = Vector3.Zero;
 
             // Add a small offset along the Up axis to avoid depth-fight with objects positioned at height=0
-            snappedPosition[viewAxisIndex] = Math.Sign(viewInvert[3, viewAxisIndex]) * GridVerticalOffset * sceneUnit;
+            snappedPosition[viewAxisIndex] = MathF.Sign(viewInvert[3, viewAxisIndex]) * GridVerticalOffset * sceneUnit;
 
             // Move the grid origin in slightly in front the grid to have it in the foreground
-            originPosition[viewAxisIndex] = snappedPosition[viewAxisIndex] + Math.Sign(viewInvert[3, viewAxisIndex]) * 0.001f * sceneUnit;
+            originPosition[viewAxisIndex] = snappedPosition[viewAxisIndex] + MathF.Sign(viewInvert[3, viewAxisIndex]) * 0.001f * sceneUnit;
             
             // Determine the intersection point of the center of the vieport with the grid plane
             var ray = EditorGameHelper.CalculateRayFromMousePosition(cameraService.Component, new Vector2(0.5f), viewInvert);
@@ -236,7 +236,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             for (var i = 0; i < 3; i++)
             {
                 if (viewAxisIndex != i)
-                    snappedPosition[i] += (float)Math.Round(intersection[i] / gridStringLineUnit) * gridStringLineUnit;
+                    snappedPosition[i] += MathF.Round(intersection[i] / gridStringLineUnit) * gridStringLineUnit;
             }
 
             // Apply positions
@@ -271,7 +271,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         {
             var axisModelUp = new Vector3 { [modelUpAxis] = 1f };
             var axisRotationVector = Vector3.Cross(axisModelUp, upVector);
-            var axisRotationAngle = (float)Math.Acos(Vector3.Dot(axisModelUp, upVector));
+            var axisRotationAngle = MathF.Acos(Vector3.Dot(axisModelUp, upVector));
             entity.Transform.Rotation = Quaternion.RotationAxis(axisRotationVector, axisRotationAngle);
         }
 

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/SpriteEditor/ViewModels/SpriteBordersViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/SpriteEditor/ViewModels/SpriteBordersViewModel.cs
@@ -46,10 +46,10 @@ namespace Stride.Assets.Presentation.AssetEditors.SpriteEditor.ViewModels
                 ClampBorders(ref value);
                 var vector4 = new Vector4
                 {
-                    X = (float)Math.Round(value.X, MidpointRounding.AwayFromZero),
-                    Y = (float)Math.Round(value.Y, MidpointRounding.AwayFromZero),
-                    Z = (float)Math.Round(value.Z, MidpointRounding.AwayFromZero),
-                    W = (float)Math.Round(value.W, MidpointRounding.AwayFromZero),
+                    X = MathF.Round(value.X, MidpointRounding.AwayFromZero),
+                    Y = MathF.Round(value.Y, MidpointRounding.AwayFromZero),
+                    Z = MathF.Round(value.Z, MidpointRounding.AwayFromZero),
+                    W = MathF.Round(value.W, MidpointRounding.AwayFromZero),
                 };
                 borderBinding.Value = vector4;
             }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/UIEditor/Game/UIEditorGameAdornerService.Events.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/UIEditor/Game/UIEditorGameAdornerService.Events.cs
@@ -143,8 +143,8 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.Game
                         // snap the current position, to prevent accumulating some delta when starting dragging
                         if (snapValue > float.Epsilon)
                         {
-                            currentPosition.X = (float)Math.Round(currentPosition.X / snapValue) * snapValue;
-                            currentPosition.Y = (float)Math.Round(currentPosition.Y / snapValue) * snapValue;
+                            currentPosition.X = MathF.Round(currentPosition.X / snapValue) * snapValue;
+                            currentPosition.Y = MathF.Round(currentPosition.Y / snapValue) * snapValue;
                         }
                     }
                 }
@@ -154,8 +154,8 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.Game
                     // snap the world position
                     if (snapValue > float.Epsilon)
                     {
-                        position.X = (float)Math.Round(position.X / snapValue) * snapValue;
-                        position.Y = (float)Math.Round(position.Y / snapValue) * snapValue;
+                        position.X = MathF.Round(position.X / snapValue) * snapValue;
+                        position.Y = MathF.Round(position.Y / snapValue) * snapValue;
                     }
                     // calculate delta
                     var delta = position - currentPosition;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/UIEditor/Game/UIEditorGameCameraService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/UIEditor/Game/UIEditorGameCameraService.cs
@@ -32,10 +32,10 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.Game
         public override void ResetCamera(Vector3 viewDirection)
         {
             var isViewVertical = MathUtil.NearEqual(viewDirection.X, 0) && MathUtil.NearEqual(viewDirection.Z, 0);
-            desiredYaw = isViewVertical ? 0 : (float)Math.Atan2(-viewDirection.X, -viewDirection.Z);
+            desiredYaw = isViewVertical ? 0 : MathF.Atan2(-viewDirection.X, -viewDirection.Z);
 
             var horizontalViewDirection = new Vector2(viewDirection.X, viewDirection.Z);
-            desiredPitch = (float)Math.Atan2(viewDirection.Y, horizontalViewDirection.Length());
+            desiredPitch = MathF.Atan2(viewDirection.Y, horizontalViewDirection.Length());
         }
 
         protected override async Task<bool> Initialize(EditorServiceGame editorGame)
@@ -116,8 +116,8 @@ namespace Stride.Assets.Presentation.AssetEditors.UIEditor.Game
 
             // Perform orientation transition
             var rotationAdaptation = (float)Game.UpdateTime.Elapsed.TotalSeconds * RotationAdaptationSpeed;
-            yaw = Math.Abs(deltaYaw) < rotationAdaptation ? desiredYaw : yaw + rotationAdaptation * Math.Sign(deltaYaw);
-            pitch = Math.Abs(deltaPitch) < rotationAdaptation ? desiredPitch : pitch + rotationAdaptation * Math.Sign(deltaPitch);
+            yaw = Math.Abs(deltaYaw) < rotationAdaptation ? desiredYaw : yaw + rotationAdaptation * MathF.Sign(deltaYaw);
+            pitch = Math.Abs(deltaPitch) < rotationAdaptation ? desiredPitch : pitch + rotationAdaptation * MathF.Sign(deltaPitch);
 
             // Compute base vectors for camera movement
             var rotation = Matrix.RotationYawPitchRoll(yaw, pitch, 0);

--- a/sources/editor/Stride.Assets.Presentation/CurveEditor/ViewModels/RotationCurveViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/CurveEditor/ViewModels/RotationCurveViewModel.cs
@@ -212,16 +212,16 @@ namespace Stride.Assets.Presentation.CurveEditor.ViewModels
         private static void DecomposeXYZ(Matrix matrix, out Vector3 rotation)
         {
             var rotY = Math.Abs(matrix.M13) - 1 < 1e-6f ? Math.Acos(Math.Max(Math.Abs(matrix.M11), Math.Abs(matrix.M33))) : Math.Asin(-matrix.M13);
-            rotation.Y = (float)(Math.Sign(-matrix.M13)*rotY);
+            rotation.Y = (float)(MathF.Sign(-matrix.M13)*rotY);
             var test = Math.Cos(rotY);
             if (test > 1e-6f)
             {
-                rotation.Z = (float)Math.Atan2(matrix.M12, matrix.M11);
-                rotation.X = (float)Math.Atan2(matrix.M23, matrix.M33);
+                rotation.Z = MathF.Atan2(matrix.M12, matrix.M11);
+                rotation.X = MathF.Atan2(matrix.M23, matrix.M33);
             }
             else
             {
-                rotation.Z = (float)Math.Atan2(-matrix.M21, matrix.M31);
+                rotation.Z = MathF.Atan2(-matrix.M21, matrix.M31);
                 rotation.X = 0.0f;
             }
         }

--- a/sources/editor/Stride.Assets.Presentation/Preview/PreviewFromEntity.cs
+++ b/sources/editor/Stride.Assets.Presentation/Preview/PreviewFromEntity.cs
@@ -219,7 +219,7 @@ namespace Stride.Assets.Presentation.Preview
 
                     // calculate the distance to the target needed in order to see it fully
                     // Note: we want the front face of the element to be fully visible (not only center)
-                    distance = radius + radius / (float)Math.Tan(MathUtil.DegreesToRadians(cameraComponent.VerticalFieldOfView / 2));
+                    distance = radius + radius / MathF.Tan(MathUtil.DegreesToRadians(cameraComponent.VerticalFieldOfView / 2));
                     // Make sure the distance is greater than zero
                     distance = Math.Max(distance, 2*MathUtil.ZeroTolerance);
 

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/BasicCameraController.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/BasicCameraController.cs
@@ -243,7 +243,7 @@ namespace ##Namespace##
                             var composite = (GestureEventComposite)gestureEvent;
                             translation.X = -composite.DeltaTranslation.X * TouchMovementSpeed.X;
                             translation.Y = -composite.DeltaTranslation.Y * TouchMovementSpeed.Y;
-                            translation.Z = (float)Math.Log(composite.DeltaScale + 1) * TouchMovementSpeed.Z;
+                            translation.Z = MathF.Log(composite.DeltaScale + 1) * TouchMovementSpeed.Z;
                             break;
                     }
                 }
@@ -264,7 +264,7 @@ namespace ##Namespace##
             up.Normalize();
 
             // Adjust pitch. Prevent it from exceeding up and down facing. Stabilize edge cases.
-            var currentPitch = MathUtil.PiOverTwo - (float)Math.Acos(Vector3.Dot(rotation.Forward, upVector));
+            var currentPitch = MathUtil.PiOverTwo - MathF.Acos(Vector3.Dot(rotation.Forward, upVector));
             pitch = MathUtil.Clamp(currentPitch + pitch, -MaximumPitch, MaximumPitch) - currentPitch;
 
             Vector3 finalTranslation = translation;

--- a/sources/editor/Stride.Editor/Engine/EntityExtensions.cs
+++ b/sources/editor/Stride.Editor/Engine/EntityExtensions.cs
@@ -150,7 +150,7 @@ namespace Stride.Editor.Engine
             if (hasSprite && !(hasModel && meshSelector != null))
             {
                 var spriteSize = spriteComponent.CurrentSprite.Size;
-                var spriteDiagonalSize = (float)Math.Sqrt(spriteSize.X * spriteSize.X + spriteSize.Y * spriteSize.Y);
+                var spriteDiagonalSize = MathF.Sqrt(spriteSize.X * spriteSize.X + spriteSize.Y * spriteSize.Y);
 
                 // Note: this is probably wrong, need to unify with SpriteComponentRenderer
                 var center = worldMatrix.TranslationVector;
@@ -180,7 +180,7 @@ namespace Stride.Editor.Engine
                     var nodeMatrix = node.ModelTransform * worldMatrix;
 
                     var spriteSize = node.Sprite.Size;
-                    var spriteDiagonalSize = (float)Math.Sqrt(spriteSize.X * spriteSize.X + spriteSize.Y * spriteSize.Y);
+                    var spriteDiagonalSize = MathF.Sqrt(spriteSize.X * spriteSize.X + spriteSize.Y * spriteSize.Y);
 
                     Vector3 pos, scale;
                     nodeMatrix.Decompose(out scale, out pos);

--- a/sources/editor/Stride.Editor/Thumbnails/ThumbnailFromEntityCommand.cs
+++ b/sources/editor/Stride.Editor/Thumbnails/ThumbnailFromEntityCommand.cs
@@ -129,8 +129,8 @@ namespace Stride.Editor.Thumbnails
 
             // setup the camera
             var cameraEntity = new Entity("Thumbnail Camera") { cameraComponent };
-            var cameraToFront = new Vector2(1f / (float)Math.Tan(MathUtil.DegreesToRadians(cameraComponent.VerticalFieldOfView / 2 * cameraComponent.AspectRatio)),
-                1f / (float)Math.Tan(MathUtil.DegreesToRadians(cameraComponent.VerticalFieldOfView / 2)));
+            var cameraToFront = new Vector2(1f / MathF.Tan(MathUtil.DegreesToRadians(cameraComponent.VerticalFieldOfView / 2 * cameraComponent.AspectRatio)),
+                1f / MathF.Tan(MathUtil.DegreesToRadians(cameraComponent.VerticalFieldOfView / 2)));
             var cameraDistanceFromCenter = 1f + Math.Max(cameraToFront.X, cameraToFront.Y); // we want the front face of the element to be fully visible (not only center)
             cameraEntity.Transform.Position = new Vector3(0, 0, cameraDistanceFromCenter);
 

--- a/sources/engine/Stride.Assets/Physics/HeightmapAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Physics/HeightmapAssetCompiler.cs
@@ -270,8 +270,8 @@ namespace Stride.Assets.Physics
                 var minHeight = heightRage.X;
                 var maxHeight = heightRage.Y;
 
-                min = (float)Math.Round((minHeight / heightScale), MidpointRounding.AwayFromZero);
-                max = (float)Math.Round((maxHeight / heightScale), MidpointRounding.AwayFromZero);
+                min = MathF.Round((minHeight / heightScale), MidpointRounding.AwayFromZero);
+                max = MathF.Round((maxHeight / heightScale), MidpointRounding.AwayFromZero);
 
                 if (heightScale < 0)
                 {

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontImporter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontImporter.cs
@@ -202,8 +202,8 @@ namespace Stride.Assets.SpriteFont.Compiler
             var pixelHeight = (int)Math.Ceiling(height + 4);
 
 
-            var matrixM31 = -(float)Math.Floor(xOffset) + 1;
-            var matrixM32 = -(float)Math.Floor(yOffset) + 1;
+            var matrixM31 = -MathF.Floor(xOffset) + 1;
+            var matrixM32 = -MathF.Floor(yOffset) + 1;
 
             Bitmap bitmap;
             if (char.IsWhiteSpace(character))

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/TrueTypeImporter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/TrueTypeImporter.cs
@@ -112,8 +112,8 @@ namespace Stride.Assets.SpriteFont.Compiler
             {
                 M11 = 1,
                 M22 = 1,
-                M31 = -(float)Math.Floor(xOffset) + 1,
-                M32 = -(float)Math.Floor(yOffset) + 1
+                M31 = -MathF.Floor(xOffset) + 1,
+                M32 = -MathF.Floor(yOffset) + 1
             };
 
             Bitmap bitmap;
@@ -126,7 +126,7 @@ namespace Stride.Assets.SpriteFont.Compiler
                 var glyphRun = new GlyphRun
                 {
                     FontFace = fontFace,
-                    Advances = new[] { (float)Math.Ceiling(advanceWidth) },
+                    Advances = new[] { MathF.Ceiling(advanceWidth) },
                     FontSize = fontSize,
                     BidiLevel = 0,
                     Indices = indices,

--- a/sources/engine/Stride.Audio.Tests/Engine/TestAudioListenerProcessor.cs
+++ b/sources/engine/Stride.Audio.Tests/Engine/TestAudioListenerProcessor.cs
@@ -74,7 +74,7 @@ namespace Stride.Audio.Tests.Engine
             audio.AddListener(listComp1);
             audio.AddListener(listComp2);
 
-            listComp2Entity.Transform.RotationEulerXYZ = new Vector3((float)Math.PI/2,0,0);
+            listComp2Entity.Transform.RotationEulerXYZ = new Vector3(MathF.PI/2,0,0);
         }
 
         private void EntityPositionUpdate(Game game, int loopCount, int loopCountSum)
@@ -153,7 +153,7 @@ namespace Stride.Audio.Tests.Engine
             BuildEntityHierarchy();
             CreateAndComponentToEntities();
             
-            listComp2Entity.Transform.RotationEulerXYZ = new Vector3((float)Math.PI / 2, 0, 0);
+            listComp2Entity.Transform.RotationEulerXYZ = new Vector3(MathF.PI / 2, 0, 0);
 
             Internal.Refactor.ThrowNotImplementedException("TODO: UPDATE TO USE Scene and Graphics Composer"); 
             // game.Entities.Add(rootEntity);
@@ -260,7 +260,7 @@ namespace Stride.Audio.Tests.Engine
             audio.AddListener(listComp1);
             audio.AddListener(listComp2);
 
-            listComp2Entity.Transform.RotationEulerXYZ = new Vector3((float)Math.PI / 2, 0, 0);
+            listComp2Entity.Transform.RotationEulerXYZ = new Vector3(MathF.PI / 2, 0, 0);
 
             Internal.Refactor.ThrowNotImplementedException("TODO: UPDATE TO USE Scene and Graphics Composer"); 
             //game.Entities.Add(rootEntity);
@@ -401,8 +401,8 @@ namespace Stride.Audio.Tests.Engine
 
             if (loopCount >= 10)
             {
-                listComp1Entity.Transform.RotationEulerXYZ = new Vector3((float)Math.PI / 2, 0, 0);
-                listComp2Entity.Transform.RotationEulerXYZ = new Vector3(0, (float)Math.PI / 2, 0);
+                listComp1Entity.Transform.RotationEulerXYZ = new Vector3(MathF.PI / 2, 0, 0);
+                listComp2Entity.Transform.RotationEulerXYZ = new Vector3(0, MathF.PI / 2, 0);
             }
         }
 

--- a/sources/engine/Stride.Engine.Tests/SpriteTestGame.cs
+++ b/sources/engine/Stride.Engine.Tests/SpriteTestGame.cs
@@ -129,7 +129,7 @@ namespace Stride.Engine.Tests
 
         private void UpdateBall(float totalSeconds)
         {
-            const float rotationSpeed = (float)Math.PI / 2;
+            const float rotationSpeed = MathF.PI / 2;
 
             var deltaRotation = rotationSpeed * totalSeconds;
 

--- a/sources/engine/Stride.Engine.Tests/TestTransformComponent.cs
+++ b/sources/engine/Stride.Engine.Tests/TestTransformComponent.cs
@@ -39,7 +39,7 @@ namespace Stride.Engine.Tests
             Assert.Equal(new Vector3(-1, -2, -3), trans.WorldToLocal(new Vector3(0, 0, 0)));
             Assert.Equal(new Vector3(0, 0, 0), trans.WorldToLocal(new Vector3(1, 2, 3)));
             trans.Position = new Vector3(1, 0, 0);
-            trans.Rotation = Quaternion.RotationX((float)Math.PI * 0.5f);
+            trans.Rotation = Quaternion.RotationX(MathF.PI * 0.5f);
             trans.Scale = new Vector3(2, 2, 2);
             trans.UpdateWorldMatrix();
             Assert.Equal(new Vector3(1, 0, 2), trans.LocalToWorld(new Vector3(0, 1, 0)));
@@ -48,7 +48,7 @@ namespace Stride.Engine.Tests
             Vector3 tS1 = new Vector3(1, 1, 1);
             trans.WorldToLocal(ref tP1, ref tR1, ref tS1);
             Assert.Equal(new Vector3(-0.5f, 0, 0), tP1);
-            Assert.Equal(Quaternion.RotationX((float)Math.PI * -0.5f), tR1);
+            Assert.Equal(Quaternion.RotationX(MathF.PI * -0.5f), tR1);
             Assert.Equal(new Vector3(0.5f, 0.5f, 0.5f), tS1);
         }
     }

--- a/sources/engine/Stride.Engine/Animations/AnimationChannel.cs
+++ b/sources/engine/Stride.Engine/Animations/AnimationChannel.cs
@@ -87,7 +87,7 @@ namespace Stride.Animations
             public int Compare(LinkedListNode<ErrorNode> x, LinkedListNode<ErrorNode> y)
             {
                 if (x.Value.Error != y.Value.Error)
-                    return Math.Sign(x.Value.Error - y.Value.Error);
+                    return MathF.Sign(x.Value.Error - y.Value.Error);
 
                 return x.Value.GetHashCode() - y.Value.GetHashCode();
             }

--- a/sources/engine/Stride.Engine/Engine/TransformComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/TransformComponent.cs
@@ -146,8 +146,7 @@ namespace Stride.Engine
                 float xw = rotation.X * rotation.W;
 
                 rotationEuler.Y = MathF.Asin(2.0f * (yw - zx));
-                double test = Math.Cos(rotationEuler.Y);
-                if (test > 1e-6f)
+                if (MathF.Cos(rotationEuler.Y) > MathUtil.ZeroTolerance)
                 {
                     rotationEuler.Z = MathF.Atan2(2.0f * (xy + zw), 1.0f - (2.0f * (yy + zz)));
                     rotationEuler.X = MathF.Atan2(2.0f * (yz + xw), 1.0f - (2.0f * (yy + xx)));

--- a/sources/engine/Stride.Engine/Engine/TransformComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/TransformComponent.cs
@@ -145,16 +145,16 @@ namespace Stride.Engine
                 float yz = rotation.Y * rotation.Z;
                 float xw = rotation.X * rotation.W;
 
-                rotationEuler.Y = (float)Math.Asin(2.0f * (yw - zx));
+                rotationEuler.Y = MathF.Asin(2.0f * (yw - zx));
                 double test = Math.Cos(rotationEuler.Y);
                 if (test > 1e-6f)
                 {
-                    rotationEuler.Z = (float)Math.Atan2(2.0f * (xy + zw), 1.0f - (2.0f * (yy + zz)));
-                    rotationEuler.X = (float)Math.Atan2(2.0f * (yz + xw), 1.0f - (2.0f * (yy + xx)));
+                    rotationEuler.Z = MathF.Atan2(2.0f * (xy + zw), 1.0f - (2.0f * (yy + zz)));
+                    rotationEuler.X = MathF.Atan2(2.0f * (yz + xw), 1.0f - (2.0f * (yy + xx)));
                 }
                 else
                 {
-                    rotationEuler.Z = (float)Math.Atan2(2.0f * (zw - xy), 2.0f * (zx + yw));
+                    rotationEuler.Z = MathF.Atan2(2.0f * (zw - xy), 2.0f * (zx + yw));
                     rotationEuler.X = 0.0f;
                 }
                 return rotationEuler;
@@ -172,12 +172,12 @@ namespace Stride.Engine
 
                 var halfAngles = value * 0.5f;
 
-                var fSinX = (float)Math.Sin(halfAngles.X);
-                var fCosX = (float)Math.Cos(halfAngles.X);
-                var fSinY = (float)Math.Sin(halfAngles.Y);
-                var fCosY = (float)Math.Cos(halfAngles.Y);
-                var fSinZ = (float)Math.Sin(halfAngles.Z);
-                var fCosZ = (float)Math.Cos(halfAngles.Z);
+                var fSinX = MathF.Sin(halfAngles.X);
+                var fCosX = MathF.Cos(halfAngles.X);
+                var fSinY = MathF.Sin(halfAngles.Y);
+                var fCosY = MathF.Cos(halfAngles.Y);
+                var fSinZ = MathF.Sin(halfAngles.Z);
+                var fCosZ = MathF.Cos(halfAngles.Z);
 
                 var fCosXY = fCosX * fCosY;
                 var fSinXY = fSinX * fSinY;

--- a/sources/engine/Stride.Graphics.Regression/TestCamera.cs
+++ b/sources/engine/Stride.Graphics.Regression/TestCamera.cs
@@ -367,8 +367,8 @@ namespace Stride.Graphics.Regression
 
             // calculate the min distance from the object to see it entirely
             var minimunDistance = Math.Max(
-                boundingSphere.Radius / (2f * (float)Math.Tan(cameraComponent.VerticalFieldOfView * cameraComponent.AspectRatio / 2f)),
-                boundingSphere.Radius / (2f * (float)Math.Tan(cameraComponent.VerticalFieldOfView / 2f)));
+                boundingSphere.Radius / (2f * MathF.Tan(cameraComponent.VerticalFieldOfView * cameraComponent.AspectRatio / 2f)),
+                boundingSphere.Radius / (2f * MathF.Tan(cameraComponent.VerticalFieldOfView / 2f)));
 
             var distance = 1.2f * (minimunDistance + boundingSphere.Radius); // set the view distance such that the object can be seen entirely 
             var parameters = new ViewParameters(upAxis)

--- a/sources/engine/Stride.Graphics.Tests/TestGeometricPrimitives.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestGeometricPrimitives.cs
@@ -92,7 +92,7 @@ namespace Stride.Graphics.Tests
             if (Input.IsKeyPressed(Keys.Right))
                 ChangePrimitiveStartOffset(1);
 
-            projection = Matrix.PerspectiveFovRH((float)Math.PI / 4.0f, (float)GraphicsDevice.Presenter.BackBuffer.ViewWidth / GraphicsDevice.Presenter.BackBuffer.ViewHeight, 0.1f, 100.0f);
+            projection = Matrix.PerspectiveFovRH(MathF.PI / 4.0f, (float)GraphicsDevice.Presenter.BackBuffer.ViewWidth / GraphicsDevice.Presenter.BackBuffer.ViewHeight, 0.1f, 100.0f);
 
             if (GraphicsDevice.Presenter.BackBuffer.ViewWidth < GraphicsDevice.Presenter.BackBuffer.ViewHeight) // the screen is standing up on Android{
                 view = Matrix.LookAtRH(new Vector3(0, 0, 10), new Vector3(0, 0, 0), Vector3.UnitX);
@@ -144,7 +144,7 @@ namespace Stride.Graphics.Tests
                 var time = timeSeconds + i;
 
                 // Setup the World matrice for this primitive
-                var world = Matrix.Scaling((float)Math.Sin(time * 1.5f) * 0.2f + 1.0f) * Matrix.RotationX(time) * Matrix.RotationY(time * 2.0f) * Matrix.RotationZ(time * .7f) * Matrix.Translation(x, y, 0);
+                var world = Matrix.Scaling(MathF.Sin(time * 1.5f) * 0.2f + 1.0f) * Matrix.RotationX(time) * Matrix.RotationY(time * 2.0f) * Matrix.RotationZ(time * .7f) * Matrix.Translation(x, y, 0);
 
                 // Disable Cull only for the plane primitive, otherwise use standard culling
                 var defaultRasterizerState = i == 0 ? RasterizerStates.CullNone : RasterizerStates.CullBack;

--- a/sources/engine/Stride.Graphics.Tests/TestRenderToTexture.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestRenderToTexture.cs
@@ -41,7 +41,7 @@ namespace Stride.Graphics.Tests
             await base.LoadContent();
 
             var view = Matrix.LookAtRH(new Vector3(2,2,2), new Vector3(0, 0, 0), Vector3.UnitY);
-            var projection = Matrix.PerspectiveFovRH((float)Math.PI / 4.0f, (float)GraphicsDevice.Presenter.BackBuffer.ViewWidth / GraphicsDevice.Presenter.BackBuffer.ViewHeight, 0.1f, 100.0f);
+            var projection = Matrix.PerspectiveFovRH(MathF.PI / 4.0f, (float)GraphicsDevice.Presenter.BackBuffer.ViewWidth / GraphicsDevice.Presenter.BackBuffer.ViewHeight, 0.1f, 100.0f);
             worldViewProjection = Matrix.Multiply(view, projection);
 
             geometry = GeometricPrimitive.Cube.New(GraphicsDevice);

--- a/sources/engine/Stride.Graphics.Tests/TestSprite.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestSprite.cs
@@ -82,7 +82,7 @@ namespace Stride.Graphics.Tests
             spriteUv.Sprites[0].Draw(spriteBatch, positionUv, spriteEffects: SpriteEffects.FlipVertically);
 
             positionSphere = positionUv + new Vector2(spriteSphereSize.X + spaceSpan, 0);
-            spriteSphere.Sprites[0].Draw(spriteBatch, positionSphere, (float)Math.PI / 2);
+            spriteSphere.Sprites[0].Draw(spriteBatch, positionSphere, MathF.PI / 2);
 
             positionSphere.X += spriteSphereSize.X + spaceSpan;
             spriteSphere.Sprites[0].Draw(spriteBatch, positionSphere, Color.GreenYellow, Vector2.One);

--- a/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Capsule.cs
+++ b/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Capsule.cs
@@ -144,8 +144,8 @@ namespace Stride.Graphics.GeometricPrimitives
                         latitude = (float)(((i - 1) * Math.PI / (verticalSegments - 2)) - Math.PI / 2.0);
                     }
 
-                    var dy = (float)Math.Sin(latitude);
-                    var dxz = (float)Math.Cos(latitude);
+                    var dy = MathF.Sin(latitude);
+                    var dxz = MathF.Cos(latitude);
 
                     // Create a single ring of vertices at this latitude.
                     for (int j = 0; j <= horizontalSegments; j++)
@@ -153,8 +153,8 @@ namespace Stride.Graphics.GeometricPrimitives
                         float u = (float)j / horizontalSegments;
 
                         var longitude = (float)(j * 2.0 * Math.PI / horizontalSegments);
-                        var dx = (float)Math.Sin(longitude);
-                        var dz = (float)Math.Cos(longitude);
+                        var dx = MathF.Sin(longitude);
+                        var dz = MathF.Cos(longitude);
 
                         dx *= dxz;
                         dz *= dxz;

--- a/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Cylinder.cs
+++ b/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Cylinder.cs
@@ -92,8 +92,8 @@ namespace Stride.Graphics.GeometricPrimitives
             private static Vector3 GetCircleVector(int i, int tessellation)
             {
                 var angle = (float)(i * 2.0 * Math.PI / tessellation);
-                var dx = (float)Math.Sin(angle);
-                var dz = (float)Math.Cos(angle);
+                var dx = MathF.Sin(angle);
+                var dz = MathF.Cos(angle);
 
                 return new Vector3(dx, 0, dz);
             }

--- a/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.GeoSphere.cs
+++ b/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.GeoSphere.cs
@@ -264,8 +264,8 @@ namespace Stride.Graphics.GeometricPrimitives
                         var pos = normal * radius;
 
                         // calculate texture coordinates for this vertex
-                        float longitude = (float)Math.Atan2(normal.X, -normal.Z);
-                        float latitude = (float)Math.Acos(normal.Y);
+                        float longitude = MathF.Atan2(normal.X, -normal.Z);
+                        float latitude = MathF.Acos(normal.Y);
 
                         float u = (float)(longitude / (Math.PI * 2.0) + 0.5);
                         float v = (float)(latitude / Math.PI);

--- a/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Sphere.cs
+++ b/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Sphere.cs
@@ -138,8 +138,8 @@ namespace Stride.Graphics.GeometricPrimitives
                     float v = vScale * (1.0f - (float)i / verticalSegments);
 
                     var latitude = (float)((i * Math.PI / verticalSegments) - Math.PI / 2.0);
-                    var dy = (float)Math.Sin(latitude);
-                    var dxz = (float)Math.Cos(latitude);
+                    var dy = MathF.Sin(latitude);
+                    var dxz = MathF.Cos(latitude);
 
                     // the first point
                     var firstNormal = new Vector3(0, dy, dxz);
@@ -152,8 +152,8 @@ namespace Stride.Graphics.GeometricPrimitives
                         float u = (uScale * j) / horizontalSegments;
 
                         var longitude = (float)(j * 2.0 * Math.PI / horizontalSegments);
-                        var dx = (float)Math.Sin(longitude);
-                        var dz = (float)Math.Cos(longitude);
+                        var dx = MathF.Sin(longitude);
+                        var dz = MathF.Cos(longitude);
 
                         dx *= dxz;
                         dz *= dxz;

--- a/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Torus.cs
+++ b/sources/engine/Stride.Graphics/GeometricPrimitives/GeometricPrimitive.Torus.cs
@@ -144,7 +144,7 @@ namespace Stride.Graphics.GeometricPrimitives
                         float v = 1 - (float)j / tessellation;
 
                         float innerAngle = j * MathUtil.TwoPi / tessellation + MathUtil.Pi;
-                        float dx = (float)Math.Cos(innerAngle), dy = (float)Math.Sin(innerAngle);
+                        float dx = MathF.Cos(innerAngle), dy = MathF.Sin(innerAngle);
 
                         // Create a vertex.
                         var normal = new Vector3(dx, dy, 0);

--- a/sources/engine/Stride.Graphics/SpriteBatch.cs
+++ b/sources/engine/Stride.Graphics/SpriteBatch.cs
@@ -504,8 +504,8 @@ namespace Stride.Graphics
 
             // snap the position the closest 'real' pixel
             Vector2.Modulate(ref drawCommand.Position, ref resolutionRatio, out drawCommand.Position);
-            drawCommand.Position.X = (float)Math.Round(drawCommand.Position.X);
-            drawCommand.Position.Y = (float)Math.Round(drawCommand.Position.Y);
+            drawCommand.Position.X = MathF.Round(drawCommand.Position.X);
+            drawCommand.Position.Y = MathF.Round(drawCommand.Position.Y);
             drawCommand.Position.X /= resolutionRatio.X;
             drawCommand.Position.Y /= resolutionRatio.Y;
 

--- a/sources/engine/Stride.Graphics/SpriteFont.cs
+++ b/sources/engine/Stride.Graphics/SpriteFont.cs
@@ -235,8 +235,8 @@ namespace Stride.Graphics
             var offset = new Vector2(x, y + GetBaseOffsetY(fontSize.Y) + glyph.Offset.Y);
             Vector2.Modulate(ref offset, ref AxisDirectionTable[(int)spriteEffects & 3], out offset);
             Vector2.Add(ref offset, ref parameters.Origin, out offset);
-            offset.X = (float)Math.Round(offset.X);
-            offset.Y = (float)Math.Round(offset.Y);
+            offset.X = MathF.Round(offset.X);
+            offset.Y = MathF.Round(offset.Y);
 
             if (spriteEffects != SpriteEffects.None)
             {
@@ -276,8 +276,8 @@ namespace Stride.Graphics
             var yShift = y + (GetBaseOffsetY(requestedFontSize.Y) + glyph.Offset.Y * auxiliaryScaling.Y);
             if (parameters.SnapText)
             {
-                xShift = (float)Math.Round(xShift);
-                yShift = (float)Math.Round(yShift);
+                xShift = MathF.Round(xShift);
+                yShift = MathF.Round(yShift);
             }
             var xScaledShift = xShift / realVirtualResolutionRatio.X;
             var yScaledShift = yShift / realVirtualResolutionRatio.Y;
@@ -533,7 +533,7 @@ namespace Stride.Graphics
                     // Otherwise the starting offset can fall just in between two pixels and due to float imprecision 
                     // some characters can be aligned to the pixel before and others to the pixel after, resulting in gaps and character overlapping
                     var xStart = (scanOrder == TextAlignment.Center) ? (wholeSize.X - lineSize.X) / 2 : wholeSize.X - lineSize.X;
-                    xStart = (float)Math.Round(xStart); 
+                    xStart = MathF.Round(xStart); 
 
                     // scan the line
                     ForGlyph(commandList, ref text, ref requestedFontSize, action, ref parameters, startIndex, endIndex, updateGpuResources, xStart, yStart);

--- a/sources/engine/Stride.Input/Gestures/GestureRecognizerComposite.cs
+++ b/sources/engine/Stride.Input/Gestures/GestureRecognizerComposite.cs
@@ -72,7 +72,7 @@ namespace Stride.Input
 
             // Update the gesture current rotation value
             var rotSign = beginVectorNormalized[0] * currentVectorNormalized[1] - beginVectorNormalized[1] * currentVectorNormalized[0];
-            currentRotation = Math.Sign(rotSign) * (float)Math.Acos(Vector2.Dot(currentVectorNormalized, beginVectorNormalized));
+            currentRotation = MathF.Sign(rotSign) * MathF.Acos(Vector2.Dot(currentVectorNormalized, beginVectorNormalized));
 
             // Update the gesture current center of transformation
             currentCenter = (FingerIdsToLastPos[secondFingerId] + FingerIdsToLastPos[firstFingerId]) / 2;

--- a/sources/engine/Stride.Navigation/NavigationMeshBuildUtils.cs
+++ b/sources/engine/Stride.Navigation/NavigationMeshBuildUtils.cs
@@ -50,8 +50,8 @@ namespace Stride.Navigation
         public static void SnapBoundingBoxToCellHeight(NavigationMeshBuildSettings settings, ref BoundingBox boundingBox)
         {
             // Snap Y to tile height to avoid height differences between tiles
-            boundingBox.Minimum.Y = (float)Math.Floor(boundingBox.Minimum.Y / settings.CellHeight) * settings.CellHeight;
-            boundingBox.Maximum.Y = (float)Math.Ceiling(boundingBox.Maximum.Y / settings.CellHeight) * settings.CellHeight;
+            boundingBox.Minimum.Y = MathF.Floor(boundingBox.Minimum.Y / settings.CellHeight) * settings.CellHeight;
+            boundingBox.Maximum.Y = MathF.Ceiling(boundingBox.Maximum.Y / settings.CellHeight) * settings.CellHeight;
         }
 
         /// <summary>

--- a/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderBillboard.cs
+++ b/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderBillboard.cs
@@ -89,8 +89,8 @@ namespace Stride.Particles.ShapeBuilders
                 {
                     var rotationAngle = GetParticleRotation(particle, angleField, lifeField);
 
-                    var cosA = (float)Math.Cos(rotationAngle);
-                    var sinA = (float)Math.Sin(rotationAngle);
+                    var cosA = MathF.Cos(rotationAngle);
+                    var sinA = MathF.Sin(rotationAngle);
                     var tempX = unitX * cosA - unitY * sinA;
                     unitY = unitY * cosA + unitX * sinA;
                     unitX = tempX;

--- a/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderHexagon.cs
+++ b/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderHexagon.cs
@@ -87,8 +87,8 @@ namespace Stride.Particles.ShapeBuilders
                 if (hasAngle)
                 {
                     var rotationAngle = GetParticleRotation(particle, angleField, lifeField);
-                    var cosA = (float)Math.Cos(rotationAngle);
-                    var sinA = (float)Math.Sin(rotationAngle);
+                    var cosA = MathF.Cos(rotationAngle);
+                    var sinA = MathF.Sin(rotationAngle);
                     var tempX = unitX * cosA - unitY * sinA;
                     unitY = unitY * cosA + unitX * sinA;
                     unitX = tempX;

--- a/sources/engine/Stride.Particles/Updaters/FieldShapes/Cylinder.cs
+++ b/sources/engine/Stride.Particles/Updaters/FieldShapes/Cylinder.cs
@@ -118,7 +118,7 @@ namespace Stride.Particles.Updaters.FieldShapes
             inverseRotation.Rotate(ref particlePosition);
 //            particlePosition /= fieldSize;
 
-            var maxDist = (float)Math.Sqrt(particlePosition.X * particlePosition.X + particlePosition.Z * particlePosition.Z);
+            var maxDist = MathF.Sqrt(particlePosition.X * particlePosition.X + particlePosition.Z * particlePosition.Z);
 
             var fieldX = radius * fieldSize.X;
             var fieldY = halfHeight * fieldSize.Y;

--- a/sources/engine/Stride.Particles/Updaters/FieldShapes/Torus.cs
+++ b/sources/engine/Stride.Particles/Updaters/FieldShapes/Torus.cs
@@ -80,12 +80,12 @@ namespace Stride.Particles.Updaters.FieldShapes
             inverseRotation.Rotate(ref particlePosition);
             particlePosition /= fieldSize;
 
-            // Start by positioning hte particle on the torus' plane
+            // Start by positioning the particle on the torus' plane
             var projectedPosition = new Vector3(particlePosition.X, 0, particlePosition.Z);
             var distanceFromOrigin = projectedPosition.Length();
             var distSquared = 1 + distanceFromOrigin * distanceFromOrigin - 2 * distanceFromOrigin + particlePosition.Y * particlePosition.Y;
 
-            var totalStrength = (distSquared >= smallRadiusSquared) ? 1 : ((float) Math.Sqrt(distSquared) / smallRadius);
+            var totalStrength = (distSquared >= smallRadiusSquared) ? 1 : MathF.Sqrt(distSquared) / smallRadius;
 
             // Fix the field's axis back to world space
             var forceAxis = Vector3.Cross(alongAxis, projectedPosition);
@@ -93,7 +93,7 @@ namespace Stride.Particles.Updaters.FieldShapes
             forceAxis.Normalize();
             alongAxis = forceAxis;
 
-            projectedPosition = (distanceFromOrigin > 0) ? (projectedPosition/(float)distanceFromOrigin) : projectedPosition;
+            projectedPosition = (distanceFromOrigin > 0) ? (projectedPosition/distanceFromOrigin) : projectedPosition;
             projectedPosition -= particlePosition;
             projectedPosition *= fieldSize;
             fieldRotation.Rotate(ref projectedPosition);

--- a/sources/engine/Stride.Physics/ByteHeightStickArraySource.cs
+++ b/sources/engine/Stride.Physics/ByteHeightStickArraySource.cs
@@ -66,7 +66,7 @@ namespace Stride.Physics
 
             return other.HeightStickSize == HeightStickSize &&
                 other.HeightRange == HeightRange &&
-                Math.Abs(other.HeightScale - HeightScale) < float.Epsilon &&
+                MathF.Abs(other.HeightScale - HeightScale) < float.Epsilon &&
                 other.InitialByte == InitialByte;
         }
     }

--- a/sources/engine/Stride.Physics/ConvexHullDecompositionParameters.cs
+++ b/sources/engine/Stride.Physics/ConvexHullDecompositionParameters.cs
@@ -74,8 +74,8 @@ namespace Stride.Physics
                 other.AngleSampling == AngleSampling &&
                 other.PosRefine == PosRefine &&
                 other.AngleRefine == AngleRefine &&
-                Math.Abs(other.Alpha - Alpha) < float.Epsilon &&
-                Math.Abs(other.Threshold - Threshold) < float.Epsilon;
+                MathF.Abs(other.Alpha - Alpha) < float.Epsilon &&
+                MathF.Abs(other.Threshold - Threshold) < float.Epsilon;
         }
     }
 }

--- a/sources/engine/Stride.Physics/Data/CapsuleColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/CapsuleColliderShapeDesc.cs
@@ -58,8 +58,8 @@ namespace Stride.Physics
         {
             var other = obj as CapsuleColliderShapeDesc;
             return other?.Is2D == Is2D &&
-                   Math.Abs(other.Length - Length) < float.Epsilon &&
-                   Math.Abs(other.Radius - Radius) < float.Epsilon &&
+                   MathF.Abs(other.Length - Length) < float.Epsilon &&
+                   MathF.Abs(other.Radius - Radius) < float.Epsilon &&
                    other.Orientation == Orientation &&
                    other.LocalOffset == LocalOffset &&
                    other.LocalRotation == LocalRotation;

--- a/sources/engine/Stride.Physics/Data/ConeColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/ConeColliderShapeDesc.cs
@@ -52,8 +52,8 @@ namespace Stride.Physics
             var other = obj as ConeColliderShapeDesc;
             if (other == null) return false;
 
-            return Math.Abs(other.Height - Height) < float.Epsilon &&
-                   Math.Abs(other.Radius - Radius) < float.Epsilon &&
+            return MathF.Abs(other.Height - Height) < float.Epsilon &&
+                   MathF.Abs(other.Radius - Radius) < float.Epsilon &&
                    other.Orientation == Orientation &&
                    other.LocalOffset == LocalOffset &&
                    other.LocalRotation == LocalRotation;

--- a/sources/engine/Stride.Physics/Data/CylinderColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/CylinderColliderShapeDesc.cs
@@ -53,8 +53,8 @@ namespace Stride.Physics
             if (other == null)
                 return false;
 
-            return Math.Abs(other.Height - Height) < float.Epsilon &&
-                   Math.Abs(other.Radius - Radius) < float.Epsilon &&
+            return MathF.Abs(other.Height - Height) < float.Epsilon &&
+                   MathF.Abs(other.Radius - Radius) < float.Epsilon &&
                    other.Orientation == Orientation &&
                    other.LocalOffset == LocalOffset &&
                    other.LocalRotation == LocalRotation;

--- a/sources/engine/Stride.Physics/Shapes/CapsuleColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/CapsuleColliderShape.cs
@@ -45,7 +45,7 @@ namespace Stride.Physics
                     {
                         LocalScaling = cachedScaling,
                     };
-                    rotation = Matrix.RotationX((float)Math.PI / 2.0f);
+                    rotation = Matrix.RotationX(MathF.PI / 2.0f);
                     break;
 
                 case ShapeOrientation.UpY:
@@ -61,7 +61,7 @@ namespace Stride.Physics
                     {
                         LocalScaling = cachedScaling,
                     };
-                    rotation = Matrix.RotationZ((float)Math.PI / 2.0f);
+                    rotation = Matrix.RotationZ(MathF.PI / 2.0f);
                     break;
 
                 default:

--- a/sources/engine/Stride.Physics/Shapes/ConeColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/ConeColliderShape.cs
@@ -41,7 +41,7 @@ namespace Stride.Physics
                     {
                         LocalScaling = cachedScaling,
                     };
-                    rotation = Matrix.RotationZ((float)Math.PI / 2.0f);
+                    rotation = Matrix.RotationZ(MathF.PI / 2.0f);
                     break;
                 case ShapeOrientation.UpY:
                     InternalShape = new BulletSharp.ConeShape(Radius, Height)
@@ -55,7 +55,7 @@ namespace Stride.Physics
                     {
                         LocalScaling = cachedScaling,
                     };
-                    rotation = Matrix.RotationX((float)Math.PI / 2.0f);
+                    rotation = Matrix.RotationX(MathF.PI / 2.0f);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Orientation));

--- a/sources/engine/Stride.Physics/Shapes/CylinderColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/CylinderColliderShape.cs
@@ -41,7 +41,7 @@ namespace Stride.Physics
                     {
                         LocalScaling = cachedScaling,
                     };
-                    rotation = Matrix.RotationZ((float)Math.PI / 2.0f);
+                    rotation = Matrix.RotationZ(MathF.PI / 2.0f);
                     break;
                 case ShapeOrientation.UpY:
                     InternalShape = new BulletSharp.CylinderShape(new Vector3(Radius, Height / 2, Radius))
@@ -55,7 +55,7 @@ namespace Stride.Physics
                     {
                         LocalScaling = cachedScaling,
                     };
-                    rotation = Matrix.RotationX((float)Math.PI / 2.0f);
+                    rotation = Matrix.RotationX(MathF.PI / 2.0f);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Orientation));

--- a/sources/engine/Stride.Rendering/Extensions/BoundingExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/BoundingExtensions.cs
@@ -65,7 +65,7 @@ namespace Stride.Extensions
                 }
 
                 //Find the real distance from the DistanceSquared.
-                boundingSphere.Radius = (float)Math.Sqrt(boundingSphere.Radius);
+                boundingSphere.Radius = MathF.Sqrt(boundingSphere.Radius);
             }
 
             return boundingBox;

--- a/sources/engine/Stride.Rendering/Rendering/Compositing/ForceAspectRatioSceneRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Compositing/ForceAspectRatioSceneRenderer.cs
@@ -65,15 +65,15 @@ namespace Stride.Rendering.Compositing
             // Pillarbox 
             if (currentAr > requiredAr)
             {
-                var newWidth = (float)Math.Max(1.0f, Math.Round(currentViewport.Height * requiredAr));
-                var adjX = (float)Math.Round(0.5f * (currentViewport.Width - newWidth));
+                var newWidth = MathF.Max(1.0f, MathF.Round(currentViewport.Height * requiredAr));
+                var adjX = MathF.Round(0.5f * (currentViewport.Width - newWidth));
                 currentViewport = new Viewport(currentViewport.X + (int)adjX, currentViewport.Y, (int)newWidth, currentViewport.Height);
             }
             // Letterbox
             else
             {
-                var newHeight = (float)Math.Max(1.0f, Math.Round(currentViewport.Width / requiredAr));
-                var adjY = (float)Math.Round(0.5f * (currentViewport.Height - newHeight));
+                var newHeight = MathF.Max(1.0f, MathF.Round(currentViewport.Width / requiredAr));
+                var adjY = MathF.Round(0.5f * (currentViewport.Height - newHeight));
                 currentViewport = new Viewport(currentViewport.X, currentViewport.Y + (int)adjY, currentViewport.Width, (int)newHeight);
             }
         }

--- a/sources/engine/Stride.Rendering/Rendering/Images/AntiAliasing/TemporalAntiAliasEffect.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/AntiAliasing/TemporalAntiAliasEffect.cs
@@ -114,7 +114,7 @@ namespace Stride.Rendering.Images
                 float pixelOffsetY = SampleOffsets[i][1] - jitterPixels[1];
                 pixelOffsetX *= Sharpness;
                 pixelOffsetY *= Sharpness;
-                weights[i] = (float)Math.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
+                weights[i] = MathF.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
                 totalWeight += weights[i];
 
                 // Lowpass.
@@ -124,7 +124,7 @@ namespace Stride.Rendering.Images
                 pixelOffsetY *= 0.25f;
                 pixelOffsetX *= Sharpness;
                 pixelOffsetY *= Sharpness;
-                weightLows[i] = (float)Math.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
+                weightLows[i] = MathF.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
                 totalWeightLow += weightLows[i];
             }
 
@@ -133,7 +133,7 @@ namespace Stride.Rendering.Images
                 float pixelOffsetY = SampleOffsets[8][1] - jitterPixels[1];
                 pixelOffsetX *= Sharpness;
                 pixelOffsetY *= Sharpness;
-                weightCenter = (float)Math.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
+                weightCenter = MathF.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
                 totalWeight += weightCenter;
                 weightCenter /= totalWeight;
 
@@ -144,7 +144,7 @@ namespace Stride.Rendering.Images
                 pixelOffsetY *= 0.25f;
                 pixelOffsetX *= Sharpness;
                 pixelOffsetY *= Sharpness;
-                weightLowCenter = (float)Math.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
+                weightLowCenter = MathF.Exp(-2.29f * (pixelOffsetX * pixelOffsetX + pixelOffsetY * pixelOffsetY));
                 totalWeightLow += weightLowCenter;
                 weightLowCenter /= totalWeightLow;
             }

--- a/sources/engine/Stride.Rendering/Rendering/Images/ColorTransforms/ToneMap/ToneMap.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/ColorTransforms/ToneMap/ToneMap.cs
@@ -210,12 +210,12 @@ namespace Stride.Rendering.Images
             if (AutoKeyValue)
             {
                 // From "Perceptual effects in real-time tone mapping" by Grzegorz Krawczyk, Karol Myszkowski, Hans-Peter Seidel, p. 4, Equation 11
-                keyValue = 1.03f - (2.0f / (2.0f + (float)Math.Log10(adaptedLum + 1)));
+                keyValue = 1.03f - (2.0f / (2.0f + MathF.Log10(adaptedLum + 1)));
             }
 
             // Setup parameters
             Parameters.Set(ToneMapShaderKeys.LuminanceTexture, luminanceResult.LocalTexture);
-            Parameters.Set(ToneMapShaderKeys.LuminanceAverageGlobal, (float)Math.Log(adaptedLum, 2));
+            Parameters.Set(ToneMapShaderKeys.LuminanceAverageGlobal, MathF.Log(adaptedLum, 2));
             Parameters.Set(ToneMapShaderKeys.Exposure, (float)Math.Pow(2.0, Exposure));
             Parameters.Set(ToneMapShaderKeys.KeyValue, keyValue);
 

--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/BokehTechnique/Circular/GaussianBokeh.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/BokehTechnique/Circular/GaussianBokeh.cs
@@ -77,7 +77,7 @@ namespace Stride.Rendering.Images
 
             // Blur in one direction
             var blurAngle = 0f;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var firstBlurTexture = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, originalTexture);
@@ -86,7 +86,7 @@ namespace Stride.Rendering.Images
 
             // Second blur pass to ouput the final result
             blurAngle = MathUtil.PiOverTwo;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             directionalBlurEffect.SetInput(0, firstBlurTexture);
             directionalBlurEffect.SetOutput(outputTexture);

--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/BokehTechnique/Hexagonal/McIntoshBokeh.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/BokehTechnique/Hexagonal/McIntoshBokeh.cs
@@ -102,7 +102,7 @@ namespace Stride.Rendering.Images
 
             // Blur in one direction
             var blurAngle = Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var firstBlurTexture = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, originalTexture);
@@ -111,7 +111,7 @@ namespace Stride.Rendering.Images
 
             // Diagonal blur A
             blurAngle = MathUtil.Pi / 3f + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var diagonalBlurA = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, firstBlurTexture);
@@ -120,7 +120,7 @@ namespace Stride.Rendering.Images
 
             // Diagonal blur B
             blurAngle = -MathUtil.Pi / 3f + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var diagonalBlurB = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, firstBlurTexture);
@@ -150,7 +150,7 @@ namespace Stride.Rendering.Images
 
             // Blur in one direction
             var blurAngle = Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var firstBlurTexture = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, originalTexture);
@@ -166,10 +166,10 @@ namespace Stride.Rendering.Images
             optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurKeys.TotalTap, tapNumber);
             optimizedEffect.EffectInstance.UpdateEffect(context.GraphicsDevice);
             optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Radius.ComposeWith("directionalBlurA"), Radius);
-            optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction.ComposeWith("directionalBlurA"), new Vector2((float)Math.Cos(diagonalBlurAngleA), (float)Math.Sin(diagonalBlurAngleA)));
+            optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction.ComposeWith("directionalBlurA"), new Vector2(MathF.Cos(diagonalBlurAngleA), MathF.Sin(diagonalBlurAngleA)));
             optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.TapWeights.ComposeWith("directionalBlurA"), tapWeights);
             optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Radius.ComposeWith("directionalBlurB"), Radius);
-            optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction.ComposeWith("directionalBlurB"), new Vector2((float)Math.Cos(diagonalBlurAngleB), (float)Math.Sin(diagonalBlurAngleB)));
+            optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction.ComposeWith("directionalBlurB"), new Vector2(MathF.Cos(diagonalBlurAngleB), MathF.Sin(diagonalBlurAngleB)));
             optimizedEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.TapWeights.ComposeWith("directionalBlurB"), tapWeights);
             optimizedEffect.Draw((RenderDrawContext)context, "McIntoshBokehPass2_BlurABCombine_tap{0}_radius{1}", tapNumber, (int)Radius);
         }

--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/BokehTechnique/Hexagonal/TripleRhombiBokeh.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/BokehTechnique/Hexagonal/TripleRhombiBokeh.cs
@@ -70,7 +70,7 @@ namespace Stride.Rendering.Images
             // Half-radius of the hexagon
             float halfRadius = Radius * 0.5f; 
             // Half-width of an hexagon pointing up (altitude of an equilateral triangle)
-            float hexagonalHalfWidth = Radius * (float)Math.Sqrt(3f) / 2f;
+            float hexagonalHalfWidth = Radius * MathF.Sqrt(3f) / 2f;
 
             // TODO Check potential different behavior with OGL where vertical addressing (V)
             // is swapped compared to D3D textures. 
@@ -151,7 +151,7 @@ namespace Stride.Rendering.Images
 
             // Vertical blur
             var blurAngle = MathUtil.PiOverTwo + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var verticalBlurTexture = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, originalTexture);
@@ -160,7 +160,7 @@ namespace Stride.Rendering.Images
 
             // Rhombi A (top left)
             blurAngle = 7f * MathUtil.Pi / 6f + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var rhombiA = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, verticalBlurTexture);
@@ -169,7 +169,7 @@ namespace Stride.Rendering.Images
 
             // Rhombi B (top right)
             blurAngle = -MathUtil.Pi / 6f + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var rhombiB = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, verticalBlurTexture);
@@ -178,7 +178,7 @@ namespace Stride.Rendering.Images
 
             //Rhombi C (bottom)
             blurAngle = 7f * MathUtil.Pi / 6f + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var rhombiCTmp = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, originalTexture);
@@ -186,7 +186,7 @@ namespace Stride.Rendering.Images
             directionalBlurEffect.Draw(context, "TripleRhombiBokeh_RhombiCTmp_tap{0}_radius{1}", tapNumber, (int)Radius);
 
             blurAngle = -MathUtil.Pi / 6f + Phase;
-            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            directionalBlurEffect.Parameters.Set(DepthAwareDirectionalBlurUtilKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var rhombiC = NewScopedRenderTarget2D(originalTexture.Description);
             directionalBlurEffect.SetInput(0, rhombiCTmp);

--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/CoCMapBlur.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/CoCMapBlur.cs
@@ -85,7 +85,7 @@ namespace Stride.Rendering.Images
 
             // Blur in one direction
             var blurAngle = 0f;
-            cocBlurEffect.Parameters.Set(CoCMapBlurShaderKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            cocBlurEffect.Parameters.Set(CoCMapBlurShaderKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             var firstBlurTexture = NewScopedRenderTarget2D(originalTexture.Description);
             cocBlurEffect.SetInput(0, originalTexture);
@@ -94,7 +94,7 @@ namespace Stride.Rendering.Images
 
             // Second blur pass to ouput the final result
             blurAngle = MathUtil.PiOverTwo;
-            cocBlurEffect.Parameters.Set(CoCMapBlurShaderKeys.Direction, new Vector2((float)Math.Cos(blurAngle), (float)Math.Sin(blurAngle)));
+            cocBlurEffect.Parameters.Set(CoCMapBlurShaderKeys.Direction, new Vector2(MathF.Cos(blurAngle), MathF.Sin(blurAngle)));
 
             cocBlurEffect.SetInput(0, firstBlurTexture);
             cocBlurEffect.SetOutput(outputTexture);

--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/DepthOfField.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/DepthOfField.cs
@@ -409,7 +409,7 @@ namespace Stride.Rendering.Images
                 var downSizedTexture = originalColorBuffer;
                 if (i > 0)
                 {
-                    downSizedTexture = GetScopedRenderTarget(originalColorBuffer.Description, 1f / (float)Math.Pow(2f, i), originalColorBuffer.Description.Format);
+                    downSizedTexture = GetScopedRenderTarget(originalColorBuffer.Description, 1f / MathF.Pow(2f, i), originalColorBuffer.Description.Format);
                     textureScaler.SetInput(0, downscaledSources[i - 1]);
                     textureScaler.SetOutput(downSizedTexture);
                     textureScaler.Draw(context, "DownScale_Factor{0}", i);

--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/DepthOfField.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/DepthOfField.cs
@@ -446,7 +446,7 @@ namespace Stride.Rendering.Images
 
                 var levelConfig = cocLevels[i];
                 var textureToBlur = downscaledSources[levelConfig.DownscaleFactor];
-                float downscaleFactor = 1f / (float)(Math.Pow(2f, levelConfig.DownscaleFactor));
+                float downscaleFactor = 1f / MathF.Pow(2f, levelConfig.DownscaleFactor);
                 var blurOutput = GetScopedRenderTarget(originalColorBuffer.Description, downscaleFactor, originalColorBuffer.Description.Format);
                 var blurOutputFront = NewScopedRenderTarget2D(blurOutput.Description);
                 float blurRadius = (MaxBokehSize * BokehSizeFactor) * levelConfig.CoCValue * downscaleFactor * originalColorBuffer.Width;

--- a/sources/engine/Stride.Rendering/Rendering/Images/LightStreak/LightStreak.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/LightStreak/LightStreak.cs
@@ -284,8 +284,8 @@ namespace Stride.Rendering.Images
 
                 // Direction vector
                 float angle = MathUtil.DegreesToRadians(Phase) + streak * MathUtil.TwoPi / StreakCount;
-                direction.X = (float)Math.Cos(angle);
-                direction.Y = (float)Math.Sin(angle);
+                direction.X = MathF.Cos(angle);
+                direction.Y = MathF.Sin(angle);
 
                 // Extends the length recursively
                 for (int level = 0; level < IterationCount; level++)
@@ -296,7 +296,7 @@ namespace Stride.Rendering.Images
                     for (int i = 0; i < TapsPerIteration; i++)
                     {
                         tapOffsetsWeights[i].X = i * passLength;
-                        tapOffsetsWeights[i].Y = (float)Math.Pow(MathUtil.Lerp(0.7f, 1.0f, Attenuation), i * passLength);
+                        tapOffsetsWeights[i].Y = MathF.Pow(MathUtil.Lerp(0.7f, 1.0f, Attenuation), i * passLength);
                         totalWeight += tapOffsetsWeights[i].Y;
                     }
                     // Normalizes the weights

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightClusteredPointSpotGroupRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightClusteredPointSpotGroupRenderer.cs
@@ -324,7 +324,7 @@ namespace Stride.Rendering.Lights
 
                     movedClusters.Clear();
 
-                    var radius = (float)Math.Sqrt(1.0f / spotLightData.AngleOffsetAndInvSquareRadius.Z);
+                    var radius = MathF.Sqrt(1.0f / spotLightData.AngleOffsetAndInvSquareRadius.Z);
 
                     Vector3 positionVS;
                     Vector3.TransformCoordinate(ref spotLightData.PositionWS, ref renderView.View, out positionVS);
@@ -378,7 +378,7 @@ namespace Stride.Rendering.Lights
 
                     movedClusters.Clear();
 
-                    var radius = (float)Math.Sqrt(1.0f / pointLightData.InvSquareRadius);
+                    var radius = MathF.Sqrt(1.0f / pointLightData.InvSquareRadius);
 
                     Vector3 positionVS;
                     Vector3.TransformCoordinate(ref pointLightData.PositionWS, ref renderView.View, out positionVS);
@@ -688,7 +688,7 @@ namespace Stride.Rendering.Lights
                 if (d > 0)
                 {
                     float a = lightRadius * lc;
-                    float b = (float)Math.Sqrt(d);
+                    float b = MathF.Sqrt(d);
                     float nx0 = (a + b) / lcSqPluslzSq;
                     float nx1 = (a - b) / lcSqPluslzSq;
 

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSpot.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSpot.cs
@@ -143,17 +143,17 @@ namespace Stride.Rendering.Lights
 
         public override bool Update(RenderLight light)
         {
-            var range = Math.Max(0.001f, Range);
+            var range = MathF.Max(0.001f, Range);
             InvSquareRange = 1.0f / (range * range);
-            var innerAngle = Math.Min(AngleInner, AngleOuter);
-            var outerAngle = Math.Max(AngleInner, AngleOuter);
+            var innerAngle = MathF.Min(AngleInner, AngleOuter);
+            var outerAngle = MathF.Max(AngleInner, AngleOuter);
             AngleOuterInRadians = MathUtil.DegreesToRadians(outerAngle);
-            var cosInner = (float)Math.Cos(MathUtil.DegreesToRadians(innerAngle / 2));
-            var cosOuter = (float)Math.Cos(AngleOuterInRadians * 0.5f);
-            LightAngleScale = 1.0f / Math.Max(0.001f, cosInner - cosOuter);
+            var cosInner = MathF.Cos(MathUtil.DegreesToRadians(innerAngle / 2));
+            var cosOuter = MathF.Cos(AngleOuterInRadians * 0.5f);
+            LightAngleScale = 1.0f / MathF.Max(0.001f, cosInner - cosOuter);
             LightAngleOffset = -cosOuter * LightAngleScale;
 
-            LightRadiusAtTarget = (float)Math.Abs(Range * Math.Sin(AngleOuterInRadians * 0.5f));
+            LightRadiusAtTarget = MathF.Abs(Range * MathF.Sin(AngleOuterInRadians * 0.5f));
 
             return true;
         }
@@ -191,7 +191,7 @@ namespace Stride.Rendering.Lights
             Vector4 projectedTarget;
             Vector4.Transform(ref targetPosition, ref renderView.ViewProjection, out projectedTarget);
 
-            var d = Math.Abs(projectedTarget.W) + 0.00001f;
+            var d = MathF.Abs(projectedTarget.W) + 0.00001f;
             var r = Range * Math.Sin(MathUtil.DegreesToRadians(AngleOuter / 2.0f));
 
             // Handle correctly the case where the eye is inside the sphere

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSpotTextureProjectionRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSpotTextureProjectionRenderer.cs
@@ -136,7 +136,7 @@ namespace Stride.Rendering.Lights
             // Calculate the width and height of the near plane in world space:
             var nearClipDistance = Math.Min(spotLight.ProjectionPlaneDistance, spotLight.Range);
             float angleOuterInRadians = MathUtil.DegreesToRadians(Math.Max(spotLight.AngleInner, spotLight.AngleOuter));
-            float height = (float)Math.Tan(angleOuterInRadians / 2.0f) * nearClipDistance;  // TODO: Is this correct?
+            float height = MathF.Tan(angleOuterInRadians / 2.0f) * nearClipDistance;  // TODO: Is this correct?
             float width = height * spotLight.AspectRatio;  // TODO: Is this correct?
 
             Matrix viewMatrix = light.WorldMatrix;

--- a/sources/engine/Stride.Rendering/Rendering/Materials/Shaders/MaterialKeys.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/Shaders/MaterialKeys.cs
@@ -135,7 +135,7 @@ namespace Stride.Rendering.Materials
 
         private static void ScaleSpecularPower(ref float specularPower, ref float scaledSpecularPower)
         {
-            scaledSpecularPower = (float)Math.Pow(2.0f, 1.0f + specularPower * 13.0f);
+            scaledSpecularPower = MathF.Pow(2.0f, 1.0f + specularPower * 13.0f);
         }
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/Materials/SubsurfaceScattering/SubsurfaceScatteringKernelGenerator.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/SubsurfaceScattering/SubsurfaceScatteringKernelGenerator.cs
@@ -14,7 +14,7 @@ namespace Stride.Rendering.Materials
         private static float GaussianComponent(float variance, float r, float falloff)
         {
             float rr = r / (0.001f + falloff);
-            return (float)Math.Exp((-(rr * rr)) / (2.0f * variance)) / (2.0f * 3.14f * variance);
+            return MathF.Exp((-(rr * rr)) / (2.0f * variance)) / (2.0f * 3.14f * variance);
         }
 
         private static Vector3 Gaussian(float variance, float r, Color3 falloff) // Based on "SeparableSSS::gaussian()".
@@ -115,8 +115,8 @@ namespace Stride.Rendering.Materials
             // Calculate the weights:
             for (int i = 0; i < sampleCount; i++)
             {
-                float w0 = i > 0 ? Math.Abs(kernel[i].W - kernel[i - 1].W) : 0.0f;
-                float w1 = i < sampleCount - 1 ? Math.Abs(kernel[i].W - kernel[i + 1].W) : 0.0f;
+                float w0 = i > 0 ? MathF.Abs(kernel[i].W - kernel[i - 1].W) : 0.0f;
+                float w1 = i < sampleCount - 1 ? MathF.Abs(kernel[i].W - kernel[i + 1].W) : 0.0f;
                 float area = (w0 + w1) / 2.0f;
                 Vector3 t1 = area * Profile(kernel[i].W, falloff);
                 kernel[i].X = t1.X;

--- a/sources/engine/Stride.Rendering/Rendering/Shadows/LightDirectionalShadowMapRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/LightDirectionalShadowMapRenderer.cs
@@ -139,7 +139,7 @@ namespace Stride.Rendering.Shadows
             // TODO: User preference?
             foreach (var vectorUp in VectorUps)
             {
-                if (Math.Abs(Vector3.Dot(direction, vectorUp)) < (1.0 - 0.0001))
+                if (MathF.Abs(Vector3.Dot(direction, vectorUp)) < (1.0 - 0.0001))
                 {
                     side = Vector3.Normalize(Vector3.Cross(vectorUp, direction));
                     upDirection = Vector3.Normalize(Vector3.Cross(direction, side));
@@ -222,8 +222,8 @@ namespace Stride.Rendering.Shadows
                         // Snap camera to texel units (so that shadow doesn't jitter when light doesn't change direction but camera is moving)
                         // Technique from ShaderX7 - Practical Cascaded Shadows Maps -  p310-311
                         var shadowMapHalfSize = lightShadowMap.Size * 0.5f;
-                        float x = (float)Math.Ceiling(Vector3.Dot(target, upDirection) * shadowMapHalfSize / radius) * radius / shadowMapHalfSize;
-                        float y = (float)Math.Ceiling(Vector3.Dot(target, side) * shadowMapHalfSize / radius) * radius / shadowMapHalfSize;
+                        float x = MathF.Ceiling(Vector3.Dot(target, upDirection) * shadowMapHalfSize / radius) * radius / shadowMapHalfSize;
+                        float y = MathF.Ceiling(Vector3.Dot(target, side) * shadowMapHalfSize / radius) * radius / shadowMapHalfSize;
                         float z = Vector3.Dot(target, direction);
 
                         //target = up * x + side * y + direction * R32G32B32_Float.Dot(target, direction);
@@ -264,7 +264,7 @@ namespace Stride.Rendering.Shadows
                 {
                     var shadowPixelPosition = viewProjectionMatrix.TranslationVector * lightShadowMap.Size * 0.5f; // shouln't it be scale and not translation ?
                     shadowPixelPosition.Z = 0;
-                    var shadowPixelPositionRounded = new Vector3((float)Math.Round(shadowPixelPosition.X), (float)Math.Round(shadowPixelPosition.Y), 0.0f);
+                    var shadowPixelPositionRounded = new Vector3(MathF.Round(shadowPixelPosition.X), MathF.Round(shadowPixelPosition.Y), 0.0f);
 
                     var shadowPixelOffset = new Vector4(shadowPixelPositionRounded - shadowPixelPosition, 0.0f);
                     shadowPixelOffset *= 2.0f / lightShadowMap.Size;

--- a/sources/engine/Stride.Rendering/Rendering/Shadows/LightPointShadowMapRendererCubeMap.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/LightPointShadowMapRendererCubeMap.cs
@@ -106,7 +106,7 @@ namespace Stride.Rendering.Shadows
 
             // Calculate angle of the projection with border pixels taken into account to allow filtering
             float halfMapSize = (float)textureMapSize.Width / 2;
-            float halfFov = (float)Math.Atan((halfMapSize + BorderPixels) / halfMapSize);
+            float halfFov = MathF.Atan((halfMapSize + BorderPixels) / halfMapSize);
             shaderData.Projection = Matrix.PerspectiveFovRH(halfFov * 2, 1.0f, clippingPlanes.X, clippingPlanes.Y);
 
             Vector2 atlasSize = new Vector2(lightShadowMap.Atlas.Width, lightShadowMap.Atlas.Height);

--- a/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapRenderer.cs
@@ -282,7 +282,7 @@ namespace Stride.Rendering.Shadows
         private static float ComputeSizeFactor(LightShadowMapSize shadowMapSize)
         {
             // Then reduce the size based on the shadow map size
-            var factor = (float)Math.Pow(2.0f, (int)shadowMapSize - 3.0f);
+            var factor = MathF.Pow(2.0f, (int)shadowMapSize - 3.0f);
             return factor;
         }
     }

--- a/sources/engine/Stride.UI/Controls/Slider.cs
+++ b/sources/engine/Stride.UI/Controls/Slider.cs
@@ -312,7 +312,7 @@ namespace Stride.UI.Controls
         {
             var absoluteValue = rawValue - Minimum;
             var step = (Maximum - Minimum) / TickFrequency;
-            var times = (float)Math.Round(absoluteValue / step);
+            var times = MathF.Round(absoluteValue / step);
             return times * step;
         }
 

--- a/sources/engine/Stride.UI/Engine/UIElementTransformLink.cs
+++ b/sources/engine/Stride.UI/Engine/UIElementTransformLink.cs
@@ -54,7 +54,7 @@ namespace Stride.Engine
             var farPlane = nearPlane + virtualResolution.Z;
             var zOffset = nearPlane + virtualResolution.Z / 2;
             var aspectRatio = virtualResolution.X / virtualResolution.Y;
-            var verticalFov = (float)Math.Atan2(virtualResolution.Y / 2, zOffset) * 2;
+            var verticalFov = MathF.Atan2(virtualResolution.Y / 2, zOffset) * 2;
 
             var cameraComponent = new CameraComponent(nearPlane, farPlane)
             {

--- a/sources/engine/Stride.UI/Panels/StackPanel.cs
+++ b/sources/engine/Stride.UI/Panels/StackPanel.cs
@@ -519,7 +519,7 @@ namespace Stride.UI.Panels
 
             if (IsArrangeValid)
             {
-                AdjustOffsetsAndVisualChildren((float)(side > 0 ? Math.Floor(scrollPosition + 1) : Math.Ceiling(scrollPosition - 1)));
+                AdjustOffsetsAndVisualChildren(side > 0 ? MathF.Floor(scrollPosition + 1) : MathF.Ceiling(scrollPosition - 1));
             }
             else
             {

--- a/sources/engine/Stride.UI/Panels/UniformGrid.cs
+++ b/sources/engine/Stride.UI/Panels/UniformGrid.cs
@@ -142,7 +142,7 @@ namespace Stride.UI.Panels
             }
 
             var validPosition = Math.Max(0, Math.Min(position, elementCount * modulo));
-            var inferiorQuotient = Math.Min(elementCount - 1, (float)Math.Floor(validPosition / modulo));
+            var inferiorQuotient = Math.Min(elementCount - 1, MathF.Floor(validPosition / modulo));
 
             distances.X = (inferiorQuotient+0) * modulo - validPosition;
             distances.Y = (inferiorQuotient+1) * modulo - validPosition;

--- a/sources/engine/Stride.UI/Renderers/DefaultScrollBarRenderer.cs
+++ b/sources/engine/Stride.UI/Renderers/DefaultScrollBarRenderer.cs
@@ -27,7 +27,7 @@ namespace Stride.UI.Renderers
             var barSize = bar.RenderSizeInternal;
             var realVirtualRatio = bar.LayoutingContext.RealVirtualResolutionRatio;
             for (var i = 0; i < 2; i++)
-                barSize[i] = (float)(Math.Ceiling(barSize[i] * realVirtualRatio[i]) / realVirtualRatio[i]);
+                barSize[i] = MathF.Ceiling(barSize[i] * realVirtualRatio[i]) / realVirtualRatio[i];
             
             Batch.DrawRectangle(ref element.WorldMatrixInternal, ref barSize, ref bar.BarColorInternal, context.DepthBias);
         }

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
@@ -363,7 +363,7 @@ namespace Stride.Rendering.UI
 
             public void Update(RenderUIElement renderObject, CameraComponent camera)
             {
-                var frustumHeight = 2 * (float)Math.Tan(MathUtil.DegreesToRadians(camera.VerticalFieldOfView) / 2);
+                var frustumHeight = 2 * MathF.Tan(MathUtil.DegreesToRadians(camera.VerticalFieldOfView) / 2);
 
                 var worldMatrix = renderObject.WorldMatrix;
 
@@ -431,7 +431,7 @@ namespace Stride.Rendering.UI
                 var farPlane = nearPlane + virtualResolution.Z;
                 var zOffset = nearPlane + virtualResolution.Z / 2;
                 var aspectRatio = virtualResolution.X / virtualResolution.Y;
-                var verticalFov = (float)Math.Atan2(virtualResolution.Y / 2, zOffset) * 2;
+                var verticalFov = MathF.Atan2(virtualResolution.Y / 2, zOffset) * 2;
 
                 var cameraComponent = new CameraComponent(nearPlane, farPlane)
                 {

--- a/sources/engine/Stride.VirtualReality/DummyDevice.cs
+++ b/sources/engine/Stride.VirtualReality/DummyDevice.cs
@@ -181,7 +181,7 @@ namespace Stride.VirtualReality
             
             var unitZTransform = Vector3.Transform(Vector3.UnitZ, GetSpaceChangeRotation() * orientationSensor.Quaternion);
             var unitZProjected = new Vector3(unitZTransform.X, 0, unitZTransform.Z);
-            var directionAdjustmentAngle = unitZProjected.Length() > MathUtil.ZeroTolerance ? -Math.Sign(unitZProjected.X) * (float)Math.Acos(unitZProjected.Z / unitZProjected.Length()) : 0;
+            var directionAdjustmentAngle = unitZProjected.Length() > MathUtil.ZeroTolerance ? -MathF.Sign(unitZProjected.X) * MathF.Acos(unitZProjected.Z / unitZProjected.Length()) : 0;
             orientationOffset = Quaternion.RotationY(directionAdjustmentAngle);
 
             // update the head rotation immediately so that it is updated from the current of the frame.

--- a/sources/engine/Stride.Voxels/Voxels/GraphicsCompositor/VoxelRenderer.cs
+++ b/sources/engine/Stride.Voxels/Voxels/GraphicsCompositor/VoxelRenderer.cs
@@ -83,9 +83,9 @@ namespace Stride.Rendering.Voxels
                 if (dataVolume.VoxelGridSnapping)
                 {
                     matTrans /= storageContext.RealVoxelSize();
-                    matTrans.X = (float)Math.Floor(matTrans.X);
-                    matTrans.Y = (float)Math.Floor(matTrans.Y);
-                    matTrans.Z = (float)Math.Floor(matTrans.Z);
+                    matTrans.X = MathF.Floor(matTrans.X);
+                    matTrans.Y = MathF.Floor(matTrans.Y);
+                    matTrans.Z = MathF.Floor(matTrans.Z);
                     matTrans *= storageContext.RealVoxelSize();
 
                     corMatrix = Matrix.Scaling(matScale) * Matrix.Translation(matTrans);

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/Layout/VoxelLayoutAnisotropic.cs
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/Layout/VoxelLayoutAnisotropic.cs
@@ -54,9 +54,9 @@ namespace Stride.Rendering.Voxels
         override public void ApplySamplingParameters(VoxelViewContext viewContext, ParameterCollection parameters)
         {
             if (StorageFormat != StorageFormats.RGBA16F)
-                parameters.Set(BrightnessKey, maxBrightness * (float)Math.PI);
+                parameters.Set(BrightnessKey, maxBrightness * MathF.PI);
             else
-                parameters.Set(BrightnessKey, (float)Math.PI);
+                parameters.Set(BrightnessKey, MathF.PI);
 
             storageTex.ApplySamplingParameters(viewContext, parameters);
         }

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
@@ -74,9 +74,9 @@ namespace Stride.Rendering.Voxels
             for (int i = 0; i < (ClipMapCount + MipMapCount); i++)
             {
                 Vector3 SnappedVolumeTranslation = context.VoxelSpaceTranslation;
-                SnappedVolumeTranslation.X = (float)Math.Floor(SnappedVolumeTranslation.X / voxelScale) * voxelScale;
-                SnappedVolumeTranslation.Y = (float)Math.Floor(SnappedVolumeTranslation.Y / voxelScale) * voxelScale;
-                SnappedVolumeTranslation.Z = (float)Math.Floor(SnappedVolumeTranslation.Z / voxelScale) * voxelScale;
+                SnappedVolumeTranslation.X = MathF.Floor(SnappedVolumeTranslation.X / voxelScale) * voxelScale;
+                SnappedVolumeTranslation.Y = MathF.Floor(SnappedVolumeTranslation.Y / voxelScale) * voxelScale;
+                SnappedVolumeTranslation.Z = MathF.Floor(SnappedVolumeTranslation.Z / voxelScale) * voxelScale;
 
                 if (ShouldUpdateClipIndex(i))
                 {

--- a/sources/presentation/Stride.Core.Presentation/Controls/VectorEditorBase.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/VectorEditorBase.cs
@@ -198,7 +198,7 @@ namespace Stride.Core.Presentation.Controls
 
             var editor = (VectorEditorBase<T>)sender;
             var decimalPlaces = editor.DecimalPlaces;
-            return decimalPlaces < 0 ? basevalue : (float)Math.Round((float)basevalue, decimalPlaces);
+            return decimalPlaces < 0 ? basevalue : MathF.Round((float)basevalue, decimalPlaces);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details
The majority of cases of ``(float)Math.SomeFunctionThatTakesAndReturnsDouble(aFloatInput)`` uses ``MathF`` now, skipping unnecessary double precision operation, the cast to double and back to float.

A couple of minor cases using doubles as input were converted as well; ``LightSpot.cs`` at line 156: ``LightRadiusAtTarget = (float)Math.Abs(Range * Math.Sin(AngleOuterInRadians * 0.5f));``, converting both of those to ``MathF`` would skip the improved precision of ``Abs(Range*Sin)``. For those cases, I didn't think the improved precision was significant enough to leave them in.

Other cases might benefit from these changes but were left untouched as it would require proper testing, see ``SphericalHarmonics.cs``.

``Abs()``, ``Min()``, ``Max()``, and a couple of other minor functions have float32 version within ``Math`` but were converted for consistency with other usages within the file.

## Related Issue
None

## Motivation and Context
Cleaner and more efficient code base.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Sorry, there's a ton of changes, but I triple-checked all of them. If you still want to go through and review all of this, godspeed to you.