### PR TITLE
[Graphics] Fix shader generic support

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/ViewModel/MaterialViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/MaterialViewModel.cs
@@ -96,7 +96,7 @@ namespace Stride.Assets.Presentation.ViewModel
             where T : class, IComputeNode
         {
             var genericsNode = ownerNode[nameof(ComputeShaderClassBase<T>.Generics)].Target;
-            var keysToRemove = new List<object>(node.Generics.Keys);
+            var keysToRemove = new List<string>(node.Generics.Keys);
             if (shader != null)
             {
                 foreach (var generic in shader.ShaderGenerics)
@@ -131,7 +131,11 @@ namespace Stride.Assets.Presentation.ViewModel
             }
 
             // Remove all generics that we don't have anymore
-            keysToRemove.Select(x => new NodeIndex(x)).ForEach(x => genericsNode.Remove(genericsNode.Retrieve(x), x));
+            foreach (var k in keysToRemove)
+            {
+                var x = new NodeIndex(k);
+                genericsNode.Remove(genericsNode.Retrieve(x), x);
+            }
         }
 
         private void UpdateCompositionNodes<T>(ShaderClassType shader, ComputeShaderClassBase<T> node, IObjectNode ownerNode)
@@ -167,4 +171,3 @@ namespace Stride.Assets.Presentation.ViewModel
         }
     }
 }
-

--- a/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/StrideShaderLibrary.cs
@@ -36,11 +36,6 @@ namespace Stride.Shaders.Parser.Mixins
         public ShaderLoader ShaderLoader { get; private set; }
 
         /// <summary>
-        /// Log of all the warnings and errors
-        /// </summary>
-        public LoggerResult ErrorWarningLog = new LoggerResult();
-
-        /// <summary>
         /// The source hashes
         /// </summary>
         public HashSourceCollection SourceHashes = new HashSourceCollection();
@@ -319,18 +314,17 @@ namespace Stride.Shaders.Parser.Mixins
             if (!SourceHashes.ContainsKey(classSource.ClassName))
                 SourceHashes.Add(classSource.ClassName, shaderClass.SourceHash);
 
-            // check if it was a generic class and find out if the instanciation was correct
-            if (shaderType.GenericParameters.Count > 0)
+            // check if it was a generic class and find out if the instantiation was correct
+            var genCount = Math.Max(shaderType.GenericParameters.Count, shaderType.ShaderGenerics.Count);
+            var argCount = classSource.GenericArguments?.Length ?? 0;
+            if (genCount > argCount)
             {
-                if (classSource.GenericArguments == null || classSource.GenericArguments.Length == 0 || shaderType.GenericParameters.Count > classSource.GenericArguments.Length)
-                {
-                    mixinInfo.Instanciated = false;
-                    mixinInfo.Log.Error(StrideMessageCode.ErrorClassSourceNotInstantiated, shaderType.Span, classSource.ClassName);
-                }
-                else
-                {
-                    ModuleMixinInfo.CleanIdentifiers(shaderType.GenericParameters.Select(x => x.Name).ToList());
-                }
+                mixinInfo.Instanciated = false;
+                mixinInfo.Log.Error(StrideMessageCode.ErrorClassSourceNotInstantiated, shaderType.Span, classSource.ClassName, argCount, genCount);
+            }
+            else if (shaderType.GenericParameters.Count > 0)
+            {
+                ModuleMixinInfo.CleanIdentifiers(shaderType.GenericParameters.Select(x => x.Name).ToList());
             }
 
             mixinInfo.MixinAst = shaderType;

--- a/sources/engine/Stride.Shaders.Parser/ShaderMixinParser.cs
+++ b/sources/engine/Stride.Shaders.Parser/ShaderMixinParser.cs
@@ -129,6 +129,7 @@ namespace Stride.Shaders.Parser
             foreach (var moduleMixinInfo in mixinsToAnalyze)
             {
                 allMixinInfos.UnionWith(moduleMixinInfo.MinimalContext);
+                moduleMixinInfo.Log.CopyTo(parsingResult);
             }
             foreach (var moduleMixinInfo in allMixinInfos)
             {

--- a/sources/engine/Stride.Shaders.Parser/Utility/StrideMessageCode.cs
+++ b/sources/engine/Stride.Shaders.Parser/Utility/StrideMessageCode.cs
@@ -70,7 +70,7 @@ namespace Stride.Shaders.Parser.Utility
         public static readonly MessageCode UnknownModuleError                       = new MessageCode("E1200", "Unknown module error");
         public static readonly MessageCode ErrorClassNotFound                       = new MessageCode("E1201", "The class [{0}] was not found from the include path");
         public static readonly MessageCode ErrorDependencyNotInModule               = new MessageCode("E1202", "The mixin [{0}] in [{1}] dependency is not in the module");
-        public static readonly MessageCode ErrorClassSourceNotInstantiated          = new MessageCode("E1203", "The class source [{0}] contains generic parameters and is not instantiated");
+        public static readonly MessageCode ErrorClassSourceNotInstantiated          = new MessageCode("E1203", "The type [{0}] has generic parameters defined but only {1}/{2} arguments were passed when creating its instance");
         public static readonly MessageCode ErrorAmbiguousComposition                = new MessageCode("E1204", "The composition behind the variable [{0}] is ambiguous. Several matching variables were found.");
         
         // mix errors: E2###


### PR DESCRIPTION
# PR Details
Changing shader classes in material composition (see picture below) doesn't add generics necessary for the shader to work.
![image](https://user-images.githubusercontent.com/5742236/128605514-ccf61bf4-c87a-441c-b77c-78440e333358.png)
This PR fixes a bug with the existing code failing to properly add those generics in *and* makes sure that mixin errors are properly logged.

## Related Issue
Fixes #855

## Motivation and Context
Fix bug, yes.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.