### PR TITLE
[Physics] Raycast and ShapeSweep can filter out triggers, true by default

### DIFF
--- a/sources/engine/Stride.Physics/Simulation.cs
+++ b/sources/engine/Stride.Physics/Simulation.cs
@@ -1133,7 +1133,13 @@ namespace Stride.Physics
 
         private abstract class StrideReusableRayResultCallback : BulletSharp.RayResultCallback
         {
-            public bool HitNoContResp;
+            /// <summary>
+            /// Our <see cref="PhysicsTriggerComponentBase"/> have <see cref="BulletSharp.CollisionFlags.NoContactResponse"/>
+            /// set to let objects pass through them.
+            /// By default we want intersection test to reflect that behavior to avoid throwing off our users.
+            /// This boolean controls whether the test ignores(when false) or includes(when true) <see cref="PhysicsTriggerComponentBase"/>.
+            /// </summary>
+            private bool hitNoContactResponseObjects;
             public Vector3 RayFromWorld { get; protected set; }
             public Vector3 RayToWorld { get; protected set; }
 
@@ -1176,12 +1182,12 @@ namespace Stride.Physics
                 Flags = 0;
                 CollisionFilterGroup = (int)filterGroup;
                 CollisionFilterMask = (int)filterMask;
-                HitNoContResp = hitNoContResp;
+                hitNoContactResponseObjects = hitNoContResp;
             }
 
             public override bool NeedsCollision(BulletSharp.BroadphaseProxy proxy0)
             {
-                if (HitNoContResp == false 
+                if (hitNoContactResponseObjects == false 
                     && proxy0.ClientObject is BulletSharp.CollisionObject co 
                     && (co.CollisionFlags & BulletSharp.CollisionFlags.NoContactResponse) != 0)
                 {
@@ -1194,7 +1200,13 @@ namespace Stride.Physics
 
         private abstract class StrideReusableConvexResultCallback : BulletSharp.ConvexResultCallback
         {
-            public bool HitNoContResp;
+            /// <summary>
+            /// Our <see cref="PhysicsTriggerComponentBase"/> have <see cref="BulletSharp.CollisionFlags.NoContactResponse"/>
+            /// set to let objects pass through them.
+            /// By default we want intersection test to reflect that behavior to avoid throwing off our users.
+            /// This boolean controls whether the test ignores(when false) or includes(when true) <see cref="PhysicsTriggerComponentBase"/>.
+            /// </summary>
+            private bool hitNoContactResponseObjects;
             
             public HitResult ComputeHitResult(ref BulletSharp.LocalConvexResult convexResult, bool normalInWorldSpace)
             {
@@ -1225,12 +1237,12 @@ namespace Stride.Physics
                 ClosestHitFraction = float.PositiveInfinity;
                 CollisionFilterGroup = (int)filterGroup;
                 CollisionFilterMask = (int)filterMask;
-                HitNoContResp = hitNoContResp;
+                hitNoContactResponseObjects = hitNoContResp;
             }
 
             public override bool NeedsCollision(BulletSharp.BroadphaseProxy proxy0)
             {
-                if (HitNoContResp == false 
+                if (hitNoContactResponseObjects == false 
                     && proxy0.ClientObject is BulletSharp.CollisionObject co 
                     && (co.CollisionFlags & BulletSharp.CollisionFlags.NoContactResponse) != 0)
                 {

--- a/sources/engine/Stride.Physics/Simulation.cs
+++ b/sources/engine/Stride.Physics/Simulation.cs
@@ -509,8 +509,8 @@ namespace Stride.Physics
         /// <summary>
         /// Raycasts and returns the closest hit
         /// </summary>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
+        /// <param name="from">The starting point of this raycast</param>
+        /// <param name="to">The end point of this raycast</param>
         /// <param name="filterGroup">The collision group of this raycast</param>
         /// <param name="filterFlags">The collision group that this raycast can collide with</param>
         /// <param name="hitTriggers">Whether this test should collide with <see cref="PhysicsTriggerComponentBase"/></param>
@@ -525,13 +525,13 @@ namespace Stride.Physics
         /// <summary>
         /// Raycasts, returns true when it hit something
         /// </summary>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
-        /// <param name="result">Raycast info</param>
+        /// <param name="from">The starting point of this raycast</param>
+        /// <param name="to">The end point of this raycast</param>
+        /// <param name="result">Information about this test</param>
         /// <param name="filterGroup">The collision group of this raycast</param>
         /// <param name="filterFlags">The collision group that this raycast can collide with</param>
         /// <param name="hitTriggers">Whether this test should collide with <see cref="PhysicsTriggerComponentBase"/></param>
-        /// <returns>True if the test collided with something</returns>
+        /// <returns>True if the test collided with an object in the simulation</returns>
         public bool Raycast(Vector3 from, Vector3 to, out HitResult result, CollisionFilterGroups filterGroup = DefaultGroup, CollisionFilterGroupFlags filterFlags = DefaultFlags, bool hitTriggers = false)
         {
             var callback = StrideClosestRayResultCallback.Shared(ref from, ref to, hitTriggers, filterGroup, filterFlags);
@@ -544,9 +544,9 @@ namespace Stride.Physics
         /// Raycasts penetrating any shape the ray encounters.
         /// Filtering by CollisionGroup
         /// </summary>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
-        /// <param name="resultsOutput">The list to fill with results.</param>
+        /// <param name="from">The starting point of this raycast</param>
+        /// <param name="to">The end point of this raycast</param>
+        /// <param name="resultsOutput">The collection to add intersections to</param>
         /// <param name="filterGroup">The collision group of this raycast</param>
         /// <param name="filterFlags">The collision group that this raycast can collide with</param>
         /// <param name="hitTriggers">Whether this test should collide with <see cref="PhysicsTriggerComponentBase"/></param>
@@ -559,9 +559,9 @@ namespace Stride.Physics
         /// <summary>
         /// Performs a sweep test using a collider shape and returns the closest hit
         /// </summary>
-        /// <param name="shape">The shape.</param>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
+        /// <param name="shape">The shape used when testing collisions with colliders in the simulation</param>
+        /// <param name="from">The starting point of this sweep</param>
+        /// <param name="to">The end point of this sweep</param>
         /// <param name="filterGroup">The collision group of this shape sweep</param>
         /// <param name="filterFlags">The collision group that this shape sweep can collide with</param>
         /// <param name="hitTriggers">Whether this test should collide with <see cref="PhysicsTriggerComponentBase"/></param>
@@ -583,10 +583,10 @@ namespace Stride.Physics
         /// <summary>
         /// Performs a sweep test using a collider shape and never stops until "to"
         /// </summary>
-        /// <param name="shape">The shape.</param>
-        /// <param name="from">From.</param>
-        /// <param name="to">To.</param>
-        /// <param name="resultsOutput">The list to fill with results.</param>
+        /// <param name="shape">The shape against which colliders in the simulation will be tested</param>
+        /// <param name="from">The starting point of this sweep</param>
+        /// <param name="to">The end point of this sweep</param>
+        /// <param name="resultsOutput">The collection to add hit results to</param>
         /// <param name="filterGroup">The collision group of this shape sweep</param>
         /// <param name="filterFlags">The collision group that this shape sweep can collide with</param>
         /// <param name="hitTriggers">Whether this test should collide with <see cref="PhysicsTriggerComponentBase"/></param>


### PR DESCRIPTION
# PR Details
Users most likely wouldn't expect triggers to be returned when looking for collisions through those one shot tests given that triggers don't collide with anything.
If they still would like to test for those as well, they can do so by setting the appropriate boolean when calling those methods.

## Related Issue
None reported.

## Motivation and Context
Bug fix, kind of.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.