### PR TITLE
Solve editor problem with dictionary

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddPrimitiveKeyCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddPrimitiveKeyCommand.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Linq;
+using System.ComponentModel;
 using Stride.Core.Annotations;
 using Stride.Core.Reflection;
 using Stride.Core.Presentation.Quantum;
@@ -56,7 +57,7 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             NodeIndex? newKey;
 			if (dictionaryDescriptor.KeyType == typeof(string))
                 newKey = GenerateStringKey(value, dictionaryDescriptor, parameter as string);
-            else if (dictionaryDescriptor.KeyType.GetMethod("Parse", new Type[] { typeof(string) }) != null)
+            else if (TypeDescriptor.GetConverter(dictionaryDescriptor.KeyType).CanConvertFrom(typeof(string)))
                 newKey = GenerateGenericKey(value, dictionaryDescriptor, parameter as string);
             else if (dictionaryDescriptor.KeyType.IsEnum)
                 newKey = new NodeIndex(parameter);
@@ -107,7 +108,9 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             object key = keyType.Default();
 
             if (!string.IsNullOrWhiteSpace(baseValue))
-                key = keyType.GetMethod("Parse", new Type[] { typeof(string) }).Invoke(null, new string[] { baseValue });
+            {
+                key = TypeDescriptor.GetConverter(keyType).ConvertFromString(baseValue);
+            }
 
             if (key != null && !dictionaryDescriptor.ContainsKey(dictionary, key))
             {

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddPrimitiveKeyCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddPrimitiveKeyCommand.cs
@@ -55,7 +55,7 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             var value = nodePresenter.Value;
 
             NodeIndex? newKey;
-			if (parameter != null && TypeDescriptor.GetConverter(dictionaryDescriptor.KeyType).CanConvertFrom(parameter.GetType()))
+            if (parameter != null && TypeDescriptor.GetConverter(dictionaryDescriptor.KeyType).CanConvertFrom(parameter.GetType()))
                 newKey = GenerateGenericKey(value, dictionaryDescriptor, parameter);
             else if (dictionaryDescriptor.KeyType.IsEnum)
                 newKey = new NodeIndex(parameter);

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddPrimitiveKeyCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddPrimitiveKeyCommand.cs
@@ -53,20 +53,25 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             var dictionaryDescriptor = (DictionaryDescriptor)nodePresenter.Descriptor;
             var value = nodePresenter.Value;
 
-            NodeIndex newKey;
-            if(dictionaryDescriptor.KeyType == typeof(string))
+            NodeIndex? newKey;
+			if (dictionaryDescriptor.KeyType == typeof(string))
                 newKey = GenerateStringKey(value, dictionaryDescriptor, parameter as string);
+            else if (dictionaryDescriptor.KeyType.GetMethod("Parse", new Type[] { typeof(string) }) != null)
+                newKey = GenerateGenericKey(value, dictionaryDescriptor, parameter as string);
             else if (dictionaryDescriptor.KeyType.IsEnum)
                 newKey = new NodeIndex(parameter);
             else
                 newKey = new NodeIndex(Activator.CreateInstance(dictionaryDescriptor.KeyType));
 
-            var newItem = dictionaryDescriptor.ValueType.Default();
-            var instance = CreateInstance(dictionaryDescriptor.ValueType);
-            if (!AddNewItemCommand.IsReferenceType(dictionaryDescriptor.ValueType) && (assetNodePresenter == null || !assetNodePresenter.IsObjectReference(instance)))
-                newItem = instance;
+            if (newKey != null)
+            {
+                var newItem = dictionaryDescriptor.ValueType.Default();
+                var instance = CreateInstance(dictionaryDescriptor.ValueType);
+                if (!AddNewItemCommand.IsReferenceType(dictionaryDescriptor.ValueType) && (assetNodePresenter == null || !assetNodePresenter.IsObjectReference(instance)))
+                    newItem = instance;
 
-            nodePresenter.AddItem(newItem, newKey);
+                nodePresenter.AddItem(newItem, newKey.Value);
+            }
         }
 
         /// <summary>
@@ -94,7 +99,25 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             return ObjectFactoryRegistry.NewInstance(type);
         }
 
-        internal static NodeIndex GenerateStringKey(object dictionary, ITypeDescriptor descriptor, string baseValue)
+        internal static NodeIndex? GenerateGenericKey(object dictionary, ITypeDescriptor descriptor, string baseValue)
+        {
+            // TODO: use a dialog service and popup a message when the given key is invalid
+            DictionaryDescriptor dictionaryDescriptor = descriptor as DictionaryDescriptor;
+            Type keyType = dictionaryDescriptor.KeyType;
+            object key = keyType.Default();
+
+            if (!string.IsNullOrWhiteSpace(baseValue))
+                key = keyType.GetMethod("Parse", new Type[] { typeof(string) }).Invoke(null, new string[] { baseValue });
+
+            if (key != null && !dictionaryDescriptor.ContainsKey(dictionary, key))
+            {
+                return new NodeIndex(key);
+            }
+
+            return null;
+        }
+
+        internal static NodeIndex? GenerateStringKey(object dictionary, ITypeDescriptor descriptor, string baseValue)
         {
             // TODO: use a dialog service and popup a message when the given key is invalid
             const string defaultKey = "Key";
@@ -104,13 +127,13 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
 
             var i = 1;
             string baseName = baseValue;
-            var dictionaryDescriptor = (DictionaryDescriptor)descriptor;
-            while (dictionaryDescriptor.ContainsKey(dictionary, baseValue))
+            DictionaryDescriptor dictionaryDescriptor = descriptor as DictionaryDescriptor;
+            if (!dictionaryDescriptor.ContainsKey(dictionary, baseValue))
             {
-                baseValue = baseName + " " + ++i;
+                return new NodeIndex(baseValue);
             }
 
-            return new NodeIndex(baseValue);
+            return null;
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/RenameStringKeyCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/RenameStringKeyCommand.cs
@@ -1,11 +1,12 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
 using System.Linq;
 using Stride.Core.Annotations;
-using Stride.Core.Reflection;
 using Stride.Core.Presentation.Quantum;
 using Stride.Core.Presentation.Quantum.Presenters;
 using Stride.Core.Quantum;
+using Stride.Core.Reflection;
 
 namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
 {
@@ -37,9 +38,12 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             if (memberCollection?.ReadOnly == true)
                 return false;
 
-            // ... and is indexed by strings...
-            if (dictionaryDescriptor.KeyType != typeof(string))
+            // ... and is indexed by strings, or can be parsed from string...
+            if (dictionaryDescriptor.KeyType != typeof(string)
+                && dictionaryDescriptor.KeyType.GetMethod("Parse", new Type[] { typeof(string) }) == null)
+            {
                 return false;
+            }
 
             // ... and supports remove and insert
             // TODO: ... and can remove items - we don't have this information yet in DictionaryDescriptor
@@ -52,8 +56,22 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
             var currentValue = nodePresenter.Value;
             var collectionNode = ((ItemNodePresenter)nodePresenter).OwnerCollection;
             collectionNode.RemoveItem(nodePresenter.Value, nodePresenter.Index);
-            var newName = AddPrimitiveKeyCommand.GenerateStringKey(collectionNode.Value, collectionNode.Descriptor, (string)parameter);
-            collectionNode.AddItem(currentValue, newName);
+            DictionaryDescriptor DictionaryDescriptor = collectionNode.Descriptor as DictionaryDescriptor;
+            Type keyType = DictionaryDescriptor.KeyType;
+            NodeIndex? newName = null;
+            if (keyType == typeof(string))
+            {
+                newName = AddPrimitiveKeyCommand.GenerateStringKey(collectionNode.Value, collectionNode.Descriptor, (string)parameter);
+            }
+            else if (keyType.GetMethod("Parse", new Type[] { typeof(string) }) != null)
+            {
+                newName = AddPrimitiveKeyCommand.GenerateGenericKey(collectionNode.Value, collectionNode.Descriptor, (string)parameter);
+            }
+
+            if (newName != null)
+            {
+                collectionNode.AddItem(currentValue, newName.Value);
+            }
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -484,6 +484,64 @@
     </DataTemplate>
   </pvdr:DictionaryTemplateProvider>
 
+  <!-- Provider for dictionary with a number key: Button to add an entry, TextBlock to describe the collection -->
+  <pvdr:DictionaryNumberKeyTemplateProvider x:Key="DictionaryNumberKeyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
+    <pvdr:DictionaryNumberKeyTemplateProvider.OverriddenProviderNames>
+      <s:String>Dictionary</s:String>
+    </pvdr:DictionaryNumberKeyTemplateProvider.OverriddenProviderNames>
+    <DataTemplate DataType="qvm:NodeViewModel">
+      <DockPanel>
+        <ComboBox DockPanel.Dock="Right" Margin="2,0"
+                  Visibility="{sd:MultiBinding {Binding HasCommand_AddPrimitiveKey}, {Binding HasAssociatedData_ReadOnlyCollection, Converter={sd:InvertBool}},
+                                                 Converter={sd:MultiChained {sd:AndMultiConverter}, {sd:VisibleOrCollapsed}}, FallbackValue={sd:Collapsed}}">
+          <ComboBox.Template>
+            <ControlTemplate TargetType="{x:Type ComboBox}">
+              <Grid x:Name="grid">
+                <ToggleButton x:Name="ToggleButton" Width="16" Height="16" Background="Transparent"
+                              Focusable="false" ClickMode="Press"
+                              ToolTip="{sd:Localize Add a new entry to the dictionary, Context=ToolTip}" SnapsToDevicePixels="True"
+                              IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                  <Image Source="{StaticResource ImageAdd}" Width="16" Height="16" Margin="-1"/>
+                </ToggleButton>
+                <Popup x:Name="Popup" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Left" AllowsTransparency="True"
+                       VerticalOffset="{Binding ActualHeight, RelativeSource={RelativeSource TemplatedParent}}"
+                       HorizontalOffset="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                       PlacementTarget="{Binding ElementName=ToggleButton}" PopupAnimation="Slide">
+                  <DockPanel MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True"
+                             Background="{DynamicResource ControlBackgroundBrush}" Margin="10">
+                    <TextBlock DockPanel.Dock="Left" Margin="8,0,0,0" VerticalAlignment="Center"
+                               Text="{sd:Localize Key name:}"/>
+                    <sd:TextBox sd:FocusManager.IsFocused="{Binding IsOpen, ElementName=Popup}" CancelOnLostFocus="True"
+                                  Text="0" Margin="8" SelectAllOnFocus="True" Width="160"
+                                  ValidateCommand="{Binding AddPrimitiveKey}" x:Name="TextBox"
+                                  ValidateCommandParameter="{Binding Text, RelativeSource={RelativeSource Self}}"/>
+                  </DockPanel>
+                </Popup>
+              </Grid>
+              <ControlTemplate.Triggers>
+                <Trigger Property="IsEnabled" Value="false">
+                  <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}" />
+                  <Setter Property="Opacity" TargetName="grid" Value="0.5" />
+                </Trigger>
+                <!-- This makes sure we can validate the textbox again even if the text is not changed -->
+                <Trigger Property="IsOpen" SourceName="Popup" Value="False">
+                  <Setter Property="Text" TargetName="TextBox" Value="" />
+                </Trigger>
+                <Trigger Property="IsOpen" SourceName="Popup" Value="True">
+                  <Setter Property="Text" TargetName="TextBox" Value="0" />
+                </Trigger>
+              </ControlTemplate.Triggers>
+            </ControlTemplate>
+          </ComboBox.Template>
+        </ComboBox>
+        <TextBlock Margin="2" DockPanel.Dock="Left">
+          <Run Text="{sd:Localize Dictionary}"/> -
+          <Run Text="{sd:Localize {}{0} item, Plural={}{0} items, Count={Binding Children.Count, Mode=OneWay}, IsStringFormat=True}"/>
+        </TextBlock>
+      </DockPanel>
+    </DataTemplate>
+  </pvdr:DictionaryNumberKeyTemplateProvider>
+
   <!-- Provider for dictionary with a string key: Button to add an entry, TextBlock to describe the collection -->
   <pvdr:DictionaryStringKeyTemplateProvider x:Key="DictionaryStringKeyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <pvdr:DictionaryStringKeyTemplateProvider.OverriddenProviderNames>

--- a/sources/editor/Stride.Core.Assets.Editor/View/TemplateProviders/DictionaryNumberKeyTemplateProvider.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/TemplateProviders/DictionaryNumberKeyTemplateProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;

--- a/sources/editor/Stride.Core.Assets.Editor/View/TemplateProviders/DictionaryNumberKeyTemplateProvider.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/TemplateProviders/DictionaryNumberKeyTemplateProvider.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters;
+using Stride.Core.Presentation.Quantum;
+using Stride.Core.Presentation.Quantum.ViewModels;
+
+namespace Stride.Core.Assets.Editor.View.TemplateProviders
+{
+    public class DictionaryNumberKeyTemplateProvider : DictionaryTemplateProvider
+    {
+        public override string Name => "DictionaryNumberKey";
+
+        /// <summary>
+        /// If set to true, this provider will accept nodes representing entries of a number-keyed dictionary.
+        /// Otherwise, it will accept nodes representing the number-keyed dictionary itself.
+        /// </summary>
+        public bool ApplyForItems { get; set; }
+
+        private static readonly HashSet<Type> NumericTypes = new HashSet<Type>
+        {
+            typeof(sbyte),  typeof(byte),  typeof(short),
+            typeof(ushort),  typeof(int),  typeof(uint),
+            typeof(long), typeof(ulong),   typeof(nint),
+            typeof(nuint), typeof(float),   typeof(double),
+            typeof(decimal),
+        };
+
+        public override bool MatchNode(NodeViewModel node)
+        {
+            if (ApplyForItems)
+            {
+                node = node.Parent;
+                if (node == null)
+                    return false;
+            }
+
+            if (!base.MatchNode(node))
+                return false;
+
+            if (node.AssociatedData.TryGetValue(DictionaryNodeUpdater.DictionaryNodeKeyType.Name, out var value))
+            {
+                var type = (Type)value;
+                return NumericTypes.Contains(type);
+            }
+
+            return false;
+        }
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation.Quantum/Presenters/ItemNodePresenter.cs
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/Presenters/ItemNodePresenter.cs
@@ -26,7 +26,9 @@ namespace Stride.Core.Presentation.Quantum.Presenters
             Name = index.ToString();
             Order = index.IsInt ? (int?)index.Int : null; // So items are sorted by index instead of string
             CombineKey = Name;
-            DisplayName = Index.IsInt ? "Item " + Index : Index.ToString();
+            DisplayName = (container.Descriptor.Category != DescriptorCategory.Dictionary && Index.IsInt)
+                        ? "Item " + Index
+                        : Index.ToString();
 
             container.ItemChanging += OnItemChanging;
             container.ItemChanged += OnItemChanged;

--- a/sources/presentation/Stride.Core.Presentation.Quantum/ViewModels/NodeViewModel.cs
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/ViewModels/NodeViewModel.cs
@@ -396,13 +396,44 @@ namespace Stride.Core.Presentation.Quantum.ViewModels
         protected void CheckDynamicMemberConsistency()
         {
             var memberNames = new HashSet<string>();
+            // We should allow space or empty or null or '.' appear when it's a string key dictionary
+            // And we should allow space or '.' appear when it's a char key dictionary
+            bool freeName = false;
+            bool allowSpCharOnly = false;
+            if (HasDictionary)
+            {
+                Type[] genericTypes = Type.GetGenericArguments();
+                if (genericTypes[0] == typeof(string))
+                {
+                    freeName = true;
+                }
+                else if (genericTypes[0] == typeof(char))
+                {
+                    allowSpCharOnly = true;
+                }
+            }
+
             foreach (var child in Children)
             {
-                if (string.IsNullOrWhiteSpace(child.Name))
-                    throw new InvalidOperationException("This node has a child with a null or blank name");
+                if (!freeName)
+                {
+                    if (allowSpCharOnly)
+                    {
+                        if (child.Name == null)
+                            throw new InvalidOperationException("This node has a child with a null name");
+                    }
+                    else
+                    {
+                        if (string.IsNullOrWhiteSpace(child.Name))
+                            throw new InvalidOperationException("This node has a child with a null or blank name");
+                    }
 
-                if (child.Name.Contains('.'))
-                    throw new InvalidOperationException($"This node has a child which contains a period (.) in its name: {child.Name}");
+                    if (!allowSpCharOnly)
+                    {
+                        if (child.Name.Contains('.'))
+                            throw new InvalidOperationException($"This node has a child which contains a period (.) in its name: {child.Name}");
+                    }
+                }
 
                 if (memberNames.Contains(child.Name))
                     throw new InvalidOperationException($"This node contains several members named {child.Name}");


### PR DESCRIPTION
Fix the problem dictionary with int type key can't change key in editor.
Add support to dictionary editor with key type as char, bool, or other number type, and can modify key now.