### PR TITLE
Converted empty array initialization to Array.Empty<T>. Addresses #608

### DIFF
--- a/sources/core/Stride.Core/Collections/ArrayHelper.cs
+++ b/sources/core/Stride.Core/Collections/ArrayHelper.cs
@@ -1,16 +1,19 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+
 namespace Stride.Core.Collections
 {
     /// <summary>
     /// Array helper for a particular type, useful to get an empty array.
     /// </summary>
     /// <typeparam name="T">Type of the array element</typeparam>
+    [Obsolete("This method is deprecated and may be removed in future versions. Please use Array.Empty<T>() instead. See https://docs.microsoft.com/en-us/dotnet/api/system.array.empty?view=net-5.0 for details.")]
     public struct ArrayHelper<T>
     {
         /// <summary>
         /// An empty array of the specified <see cref="T"/> element type.
         /// </summary>
-        public static readonly T[] Empty = new T[0];
+        public static readonly T[] Empty = Array.Empty<T>();
     }
 }

--- a/sources/core/Stride.Core/Collections/FastCollection.cs
+++ b/sources/core/Stride.Core/Collections/FastCollection.cs
@@ -28,7 +28,7 @@ namespace Stride.Core.Collections
 
         public FastCollection()
         {
-            items = ArrayHelper<T>.Empty;
+            items = Array.Empty<T>();
         }
 
         public FastCollection([NotNull] IEnumerable<T> collection)
@@ -78,7 +78,7 @@ namespace Stride.Core.Collections
                     }
                     else
                     {
-                        items = ArrayHelper<T>.Empty;
+                        items = Array.Empty<T>();
                     }
                 }
             }

--- a/sources/core/Stride.Core/Collections/FastList.cs
+++ b/sources/core/Stride.Core/Collections/FastList.cs
@@ -33,7 +33,7 @@ namespace Stride.Core.Collections
 
         public FastList()
         {
-            Items = ArrayHelper<T>.Empty;
+            Items = Array.Empty<T>();
         }
 
         public FastList([NotNull] IEnumerable<T> collection)
@@ -83,7 +83,7 @@ namespace Stride.Core.Collections
                     }
                     else
                     {
-                        Items = ArrayHelper<T>.Empty;
+                        Items = Array.Empty<T>();
                     }
                 }
             }

--- a/sources/core/Stride.Core/Collections/FastListStruct.cs
+++ b/sources/core/Stride.Core/Collections/FastListStruct.cs
@@ -10,7 +10,7 @@ namespace Stride.Core.Collections
 {
     public struct FastListStruct<T> : IEnumerable<T>
     {
-        private static readonly T[] EmptyArray = new T[0];
+        private static readonly T[] EmptyArray = Array.Empty<T>();
 
         public int Count;
 

--- a/sources/core/Stride.Core/Collections/OrderedCollection.cs
+++ b/sources/core/Stride.Core/Collections/OrderedCollection.cs
@@ -34,7 +34,7 @@ namespace Stride.Core.Collections
         {
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
             this.comparer = comparer;
-            items = ArrayHelper<T>.Empty;
+            items = Array.Empty<T>();
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Stride.Core.Collections
                     }
                     else
                     {
-                        items = ArrayHelper<T>.Empty;
+                        items = Array.Empty<T>();
                     }
                 }
             }

--- a/sources/core/Stride.Core/Utilities.cs
+++ b/sources/core/Stride.Core/Utilities.cs
@@ -490,7 +490,7 @@ namespace Stride.Core
 
             System.Diagnostics.Debug.Assert(num >= 0);
             if (num == 0)
-                return new byte[0];
+                return Array.Empty<byte>();
 
             var buffer = new byte[num];
             var bytesRead = 0;

--- a/sources/engine/Stride.Particles/Sorters/ArrayPool.cs
+++ b/sources/engine/Stride.Particles/Sorters/ArrayPool.cs
@@ -2,9 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Stride.Particles.Sorters
 {
@@ -12,7 +9,7 @@ namespace Stride.Particles.Sorters
     {
         private readonly Dictionary<int, Stack<T[]>> _pool = new Dictionary<int, Stack<T[]>>();
 
-        public readonly T[] Empty = new T[0];
+        public static readonly T[] Empty = Array.Empty<T>();
 
         public virtual void Clear()
         {

--- a/sources/engine/Stride.VirtualReality/OculusOVR/OculusOvrHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OculusOVR/OculusOvrHmd.cs
@@ -26,7 +26,7 @@ namespace Stride.VirtualReality
         private OculusTouchController leftHandController;
         private OculusTouchController rightHandController;
         private readonly List<OculusOverlay> overlays = new List<OculusOverlay>();
-        private IntPtr[] overlayPtrs = new IntPtr[0];
+        private IntPtr[] overlayPtrs = Array.Empty<IntPtr>();
 
         internal OculusOvrHmd()
         {
@@ -137,7 +137,7 @@ namespace Stride.VirtualReality
 
         public override TouchController RightHand => rightHandController;
 
-        public override TrackedItem[] TrackedItems => new TrackedItem[0];
+        public override TrackedItem[] TrackedItems => Array.Empty<TrackedItem>();
 
         public override bool CanInitialize
         {

--- a/sources/engine/Stride.VirtualReality/WindowsMixedReality/WindowsMixedRealityHmd.cs
+++ b/sources/engine/Stride.VirtualReality/WindowsMixedReality/WindowsMixedRealityHmd.cs
@@ -63,7 +63,7 @@ namespace Stride.VirtualReality
 
         public override TouchController RightHand => rightHandController;
 
-        public override TrackedItem[] TrackedItems => new TrackedItem[0];
+        public override TrackedItem[] TrackedItems => Array.Empty<TrackedItem>();
 
         public override bool CanInitialize => true;
 

--- a/sources/presentation/Stride.Core.Presentation/Extensions/ObjectExtensions.cs
+++ b/sources/presentation/Stride.Core.Presentation/Extensions/ObjectExtensions.cs
@@ -75,7 +75,7 @@ namespace Stride.Core.Presentation.Extensions
             }
             else
             {
-                var constructorInfo = instanceType.GetConstructor(new Type[0]);
+                var constructorInfo = instanceType.GetConstructor(Array.Empty<Type>());
                 generator.Emit(OpCodes.Newobj, constructorInfo);
                 generator.Emit(OpCodes.Stloc_0);
             }

--- a/sources/presentation/Stride.Core.Presentation/Services/DummyTransaction.cs
+++ b/sources/presentation/Stride.Core.Presentation/Services/DummyTransaction.cs
@@ -16,7 +16,7 @@ namespace Stride.Core.Presentation.Services
 
         public Guid Id { get; } = Guid.NewGuid();
 
-        public IReadOnlyList<Operation> Operations { get; } = new Operation[0];
+        public IReadOnlyList<Operation> Operations { get; } = Array.Empty<Operation>();
 
         public bool IsEmpty => true;
 

--- a/sources/presentation/Stride.Core.Presentation/ViewModel/EditableViewModel.cs
+++ b/sources/presentation/Stride.Core.Presentation/ViewModel/EditableViewModel.cs
@@ -293,7 +293,7 @@ namespace Stride.Core.Presentation.ViewModel
             {
                 var toIListMethod = sender.GetType().GetMethod("ToIList");
                 if (toIListMethod != null)
-                    list = (IList)toIListMethod.Invoke(sender, new object[0]);
+                    list = (IList)toIListMethod.Invoke(sender, Array.Empty<object>());
             }
             if (!UndoRedoService.UndoRedoInProgress && !suspendedCollections.Contains(collectionName))
             {


### PR DESCRIPTION
# PR Details
Converts the underlying `ArrayHelper.Empty<T>` implementation to use `Array.Empty<T>` instead. Also adjusts places where array initialization was occurring needlessly.

## Description
Deprecated `ArrayHelper.Empty<T>` in favor of `Array.Empty<T>` (marked as obsolete for compatibility). Modifies multiple projects and collections, including `FastCollection`, `FastList`, and `ArrayPool` to use the static empty array instead of producing a new empty array each time. This may have minor improvements in overall memory usage, though the difference would likely be imperceptible for most applications.

## Related Issue
#608 

## Motivation and Context

Empty array initialization still requires memory space. Limiting this through use of static readonly values is preferred. .NET has supported `Array.Empty<T>` as far back as .NET Framework 4.6 and implements the strategy similar to the internal Array Helper. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.