### PR TITLE
Changed NuGet restore to use friendly names

### DIFF
--- a/sources/tools/Stride.VisualStudio.Package/Commands/StrideCommandsProxy.cs
+++ b/sources/tools/Stride.VisualStudio.Package/Commands/StrideCommandsProxy.cs
@@ -173,11 +173,11 @@ namespace Stride.VisualStudio.Commands
             {
                 // Try both net5.0 and net472
                 var success = false;
-                foreach (var framework in new[] { ".NET,Version=v5.0", ".NETFramework,Version=v4.7.2" })
+                foreach (var folder in new[] { "net5.0-windows7.0", "net472" })
                 {
                     var logger = new Logger();
                     var solutionRoot = Path.GetDirectoryName(solution);
-                    var (request, result) = await Task.Run(() => RestoreHelper.Restore(logger, NuGetFramework.ParseFrameworkName(framework, DefaultFrameworkNameProvider.Instance), "win", packageName, new VersionRange(packageInfo.ExpectedVersion.ToNuGetVersion()), solutionRoot));
+                    var (request, result) = await Task.Run(() => RestoreHelper.Restore(logger, NuGetFramework.ParseFolder(folder, DefaultFrameworkNameProvider.Instance), "win", packageName, new VersionRange(packageInfo.ExpectedVersion.ToNuGetVersion()), solutionRoot));
                     if (result.Success)
                     {
                         packageInfo.SdkPaths.AddRange(RestoreHelper.ListAssemblies(result.LockFile));


### PR DESCRIPTION
# PR Details

Switches the ambiguous and error prone long names to the friendly names instead.

## Related Issue

#1113 

## Motivation and Context

In some newer versions of .NET 5 SDK, restoration of the visual studio extension was failing. It was unable to resolve `.NET,Version=v5.0` to the version with the windows binding (and specifying other attributes like `Profile` did not work either). 

The recommendation for Target Framework Names is to standardize around the friendly name as it already encodes the platform and version. https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md#mapping-to-long-names

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.