### PR TITLE
[FEEDBACK NEEDED] Parallelize render feature preparation

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
@@ -226,20 +226,16 @@ namespace Stride.Rendering
             // Sync point: after extract, before prepare (game simulation could resume now)
 
             // Generate and execute prepare effect jobs
-            foreach (var renderFeature in RenderFeatures)
-            // We might be able to parallelize too as long as we resepect render feature dependency graph (probably very few dependencies in practice)
+            Dispatcher.For(0, RenderFeatures.Count, i =>
             {
-                // Divide into task chunks for parallelism
-                renderFeature.PrepareEffectPermutations(context);
-            }
+                RenderFeatures[i].PrepareEffectPermutations(context);
+            });
 
             // Generate and execute prepare jobs
-            foreach (var renderFeature in RenderFeatures)
-            // We might be able to parallelize too as long as we resepect render feature dependency graph (probably very few dependencies in practice)
+            Dispatcher.For(0, RenderFeatures.Count, i =>
             {
-                // Divide into task chunks for parallelism
-                renderFeature.Prepare(context);
-            }
+                RenderFeatures[i].Prepare(context);
+            });
 
             // Sort
             Dispatcher.ForEach(Views, view =>


### PR DESCRIPTION
# PR Details

Parallelizes render feature preparation. Initial tests yielded a nearly 10% boost to simple objects on screen in Focus engine. It's unclear the specific advantage here. This PR is derived from @phr00t's commit to FocusEngine https://github.com/phr00t/FocusEngine/commit/b159b23f06a6cf880b03303add4c74f050001bc8

## Motivation and Context

We are avoiding parallelization due to speculation regarding the render feature dependency graph. It's unclear if that's a real concern or how we might address it here. I would like to better understand what that change would need.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.