### PR TITLE
[Rendering] Simplifies ortho check in SubsurfaceScatteringBlur

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Images/SubsurfaceScattering/SubsurfaceScatteringBlur.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/SubsurfaceScattering/SubsurfaceScatteringBlur.cs
@@ -120,35 +120,12 @@ namespace Stride.Rendering.SubsurfaceScattering
             blurVShader.Parameters.Set(SubsurfaceScatteringKeys.BlurHorizontally, false);
         }
 
-        private Vector2 CalculateProjectionSizeOnPlane(RenderView renderView, float viewSpaceDistance)
-        {
-            Vector3 centerViewSpace = new Vector3(0.0f, 0.0f, -viewSpaceDistance);  // Negate because we are using right handed projection matrices (-Z points into the screen).
-            Vector3 topRightViewSpace = new Vector3(1.0f, 1.0f, -viewSpaceDistance);
-
-            Vector3 centerClipSpace = Vector3.TransformCoordinate(centerViewSpace, renderView.Projection);
-            Vector3 topRightClipSpace = Vector3.TransformCoordinate(topRightViewSpace, renderView.Projection);
-
-            Vector2 sphereDimensions = new Vector2(topRightClipSpace.X - centerClipSpace.X, topRightClipSpace.Y - centerClipSpace.Y);
-            return sphereDimensions;
-        }
-
-        private bool UsesOrthographicProjection(RenderView renderView)
-        {
-            // TODO: STABILITY: Find a more accurate (and maybe faster?) way of detecting orthographic matrices.
-            Vector2 projectedSphereDimensionsOnNearPlane = CalculateProjectionSizeOnPlane(renderView, renderView.NearClipPlane);
-            Vector2 projectedSphereDimensionsOnFarPlane = CalculateProjectionSizeOnPlane(renderView, renderView.FarClipPlane);
-
-            Vector2 nearFarPlaneRatio = projectedSphereDimensionsOnFarPlane / projectedSphereDimensionsOnNearPlane;
-
-            return nearFarPlaneRatio.Y > 0.01f ? true : false;
-        }
-
         private void UpdatePermutationParameters(RenderDrawContext context)
         {
             SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.KernelSizeJittering, JitterKernelSize);
             SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.FollowSurface, FollowSurface ? 1 : 0);
             SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.MaxMaterialCount, (int)MaxMaterialCount);
-            SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.OrthographicProjection, UsesOrthographicProjection(context.RenderContext.RenderView));
+            SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.OrthographicProjection, context.RenderContext.RenderView.Projection.M44 == 1);
             SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.KernelLength, SubsurfaceScatteringSettings.SamplesPerScatteringKernel2);
             SetPermutationParameterForBothShaders(SubsurfaceScatteringKeys.RenderMode, (int)ActiveRenderMode);
 


### PR DESCRIPTION
Simplifies ortho check in SubsurfaceScatteringBlur, much better performance too

# PR Details

Just a simplification.

## Description

The orthographic projection matrix has a 1 at the element M44, while perspective matrices have a 0 there.

## Related Issue

found during the work on PR #1142.

## Motivation and Context

Performance improvement.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.