### PR TITLE
Missing Resource.Designer.cs fix

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Android/ProjectExecutable.Android.ttproj
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Android/ProjectExecutable.Android.ttproj
@@ -5,3 +5,4 @@ Files:
   - {Source: Properties\AssemblyInfo.cs.t4, Target: Properties\AssemblyInfo.cs, IsTemplate: true}
   - {Source: Properties\AndroidManifest.xml.t4, Target: Properties\AndroidManifest.xml, IsTemplate: true}
   - {Source: Resources\drawable\GameIcon120.png, Target: Resources\drawable\Icon.png }
+  - {Source: Resources\Resource.Designer.cs.t4, Target: Resources\Resource.Designer.cs, IsTemplate: true }

--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Android/Resources/Resource.Designer.cs.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Android/Resources/Resource.Designer.cs.t4
@@ -1,0 +1,7 @@
+<#@ template inherits="ProjectTemplateTransformation" language="C#" #>
+#pragma warning disable 1591
+//------------------------------------------------------------------------------
+// Build your Android project to generate this file
+//------------------------------------------------------------------------------
+
+#pragma warning restore 1591


### PR DESCRIPTION
# PR Details
The Resource.Designer.cs file is required to compile Android apps with Xamarin. By default the file is not included in either Stride/Xenko 3.x or 4.x and is instead generated when the Android project is first compiled. A change in 4.x makes this file a requirement for Stride's Project Generator to create a new Android project, when the file isn't found an error is thrown and the project fails to create.

## Description
An empty Resource.Designer.cs.t4 file has been added to the Android template. This file is regenerated in a project specific context when the user first compiles their Android app via Stride or Visual Studio.

## Related Issue
#827 

## Motivation and Context
While workarounds are possible (documented in the above issue), this bug prevents the Android platform from working "out of the box" on impacted versions of Stride.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.