### PR TITLE
Linux Platform Build Fix

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Linux/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Linux/$ProjectName$.csproj.t4
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework><#= Properties.TargetFramework #></TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
# PR Details
The Linux template no longer generates with TargetFramework incorrectly set to net5.0-windows and instead uses .net5.0

## Description
TargetFramework has been manually set to net5.0, this is inline with the macOS template and also the Linux template in 4.0, as a result of this change Linux builds will now compile.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.