### PR TITLE
DebugText Color Fix

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -96,7 +96,7 @@ namespace Stride.Profiling
             // TODO GRAPHICS REFACTOR where to get command list from?
             Game.GraphicsContext.CommandList.SetRenderTargetAndViewport(null, Game.GraphicsDevice.Presenter.BackBuffer);
 
-            var currentColor = overlayMessages.Peek().TextColor;
+            var currentColor = TextColor;
             fastTextRenderer.Begin(Game.GraphicsContext);
             foreach (var msg in overlayMessages)
             {


### PR DESCRIPTION
# PR Details
RenderText.Print() will now work as intended when a custom text color (or colour) is set.

## Description
If a custom color is set in RenderText.Print() the text will remain the default Light Green. This is because msg.TextColor != currentColor was essentially comparing against itself and as a result always returning a value of False. With this change, msg.TextColor is now being compared to the current/default TextColor value.

## Related Issue
#1155

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.