### PR TITLE
Camera preview depth buffer created with ShaderResource flag

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameCameraPreviewService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameCameraPreviewService.cs
@@ -313,7 +313,12 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
 
                     // Allocate a RT for the incrust
                     GeneratedIncrust = drawContext.GraphicsContext.Allocator.GetTemporaryTexture2D(TextureDescription.New2D((int)Viewport.Width, (int)Viewport.Height, 1, drawContext.CommandList.RenderTarget.Format, TextureFlags.ShaderResource | TextureFlags.RenderTarget));
-                    var depthBuffer = drawContext.CommandList.DepthStencilBuffer != null ? drawContext.GraphicsContext.Allocator.GetTemporaryTexture2D(TextureDescription.New2D((int)Viewport.Width, (int)Viewport.Height, 1, drawContext.CommandList.DepthStencilBuffer.Format, TextureFlags.DepthStencil)) : null;
+
+                    var depthBufferTextureFlags = TextureFlags.DepthStencil;
+                    if (context.GraphicsDevice.Features.HasDepthAsSRV)
+                        depthBufferTextureFlags |= TextureFlags.ShaderResource;
+
+                    var depthBuffer = drawContext.CommandList.DepthStencilBuffer != null ? drawContext.GraphicsContext.Allocator.GetTemporaryTexture2D(TextureDescription.New2D((int)Viewport.Width, (int)Viewport.Height, 1, drawContext.CommandList.DepthStencilBuffer.Format, depthBufferTextureFlags)) : null;
 
                     // Push and set render target
                     using (drawContext.PushRenderTargetsAndRestore())


### PR DESCRIPTION
# PR Details

`EditorGameCameraPreviewService.GenerateIncrustRenderer` sets `TextureFlags.ShaderResource` when creating the depth buffer if it is supported on the current platform.

## Description

<!--- Describe your changes in detail -->

## Related Issue
Fixes #1159 


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.