### PR TITLE
System.Numerics conversions

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Double2.cs
+++ b/sources/core/Stride.Core.Mathematics/Double2.cs
@@ -142,6 +142,12 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator Double2(System.Numerics.Vector2 v) => new(v.X,v.Y);
+
+        /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>

--- a/sources/core/Stride.Core.Mathematics/Double3.cs
+++ b/sources/core/Stride.Core.Mathematics/Double3.cs
@@ -172,6 +172,12 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator Double3(System.Numerics.Vector3 v) => new(v.X, v.Y, v.Z);
+
+        /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>

--- a/sources/core/Stride.Core.Mathematics/Double4.cs
+++ b/sources/core/Stride.Core.Mathematics/Double4.cs
@@ -205,6 +205,12 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator Double4(System.Numerics.Vector4 v) => new(v.X, v.Y, v.Z, v.W);
+
+        /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>

--- a/sources/core/Stride.Core.Mathematics/UInt4.cs
+++ b/sources/core/Stride.Core.Mathematics/UInt4.cs
@@ -184,6 +184,12 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator UInt4(System.Numerics.Vector4 v) => new((uint)v.X, (uint)v.Y,(uint)v.Z,(uint)v.W);
+
+        /// <summary>
         ///   Creates an array containing the elements of the vector.
         /// </summary>
         /// <returns>A four-element array containing the components of the vector.</returns>

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -156,6 +156,15 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator Vector2(System.Numerics.Vector2 v)
+        {
+            return Unsafe.As<System.Numerics.Vector2, Vector2>(ref v);
+        }
+
+        /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -185,6 +185,15 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator Vector3(System.Numerics.Vector3 v)
+        {
+            return Unsafe.As<System.Numerics.Vector3, Vector3>(ref v);
+        }
+
+        /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -217,6 +217,15 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
+        /// Casts from System.Numerics to Stride.Maths vectors
+        /// </summary>
+        /// <param name="v">Value to cast</param>
+        public static implicit operator Vector4(System.Numerics.Vector4 v)
+        {
+            return Unsafe.As<System.Numerics.Vector4, Vector4>(ref v);
+        }
+
+        /// <summary>
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>


### PR DESCRIPTION
# PR Details

Adds implicit conversions between System.Numerics and Stride.Maths vectors
Some casts use `Unsafe.As` for better performance, haven't done any tests though.

## Motivation and Context

A lot nugets use System.Numerics, it would be nice to be able to cast implicitely between Sys Nums and Stride Maths

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.