### PR TITLE
Bind opaque output during transparent render stage

### DIFF
--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -842,12 +842,11 @@ namespace Stride.Rendering.Compositing
 
                 foreach (var viewLayout in viewFeature.Layouts)
                 {
-                    var resourceGroup = viewLayout.Entries[renderView.Index].Resources;
-
                     var opaqueLogicalRenderGroup = viewLayout.GetLogicalGroup(opaqueLogicalKey);
                     if (opaqueLogicalRenderGroup.Hash == ObjectId.Empty)
                         continue;
 
+                    var resourceGroup = viewLayout.Entries[renderView.Index].Resources;
                     resourceGroup.DescriptorSet.SetShaderResourceView(opaqueLogicalRenderGroup.DescriptorSlotStart, renderTargetTexture);
                 }
             }

--- a/sources/engine/Stride.Rendering/Rendering/Utils/OpaqueBase.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Utils/OpaqueBase.sdsl
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+/// <summary>
+/// Defines a depth texture.
+/// Various helper functions to extract information from a depth buffer.
+/// </summary>
+shader OpaqueBase : Texturing
+{
+    // -------------------------------------
+    // Resources
+    // -------------------------------------
+    rgroup PerView.Opaque
+    {
+        stage Texture2D OpaqueRenderTarget;
+    }
+
+    float3 GetOpaqueColor(float2 uv)
+    {
+        return OpaqueRenderTarget.SampleLevel(PointSampler, uv, 0.0).xyz;
+    }
+};

--- a/sources/engine/Stride.Rendering/Rendering/Utils/OpaqueBase.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Utils/OpaqueBase.sdsl
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 /// <summary>
-/// Defines a depth texture.
-/// Various helper functions to extract information from a depth buffer.
+/// Defines a texture for the output of the opaque render pass
+/// and a helper function to extract the color of it.
 /// </summary>
 shader OpaqueBase : Texturing
 {


### PR DESCRIPTION
# PR Details

Exposes the output of the opaque render stage in the transparent render stage

## Description

Output of opaque render stage is bound during transparent rendering if `BindOpaqueAsResourceDuringTransparentRendering`is enabled on the `ForwardRenderer`. Added shader `OpaqueBase.sdsl` to give access to it.

## Related Issue

Fixes #1162 

## Motivation and Context

Improves performance for common scenarios like refraction where access to the opaque output is needed by removing the need for an extra rendering of the entire scene.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.