### PR TITLE
Fixed shader compiler parsing of ByteAddressBuffer and RWByteAddressByffer

### DIFF
--- a/sources/engine/Stride.Shaders.Parser/Mixins/ShaderKeyGeneratorBase.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/ShaderKeyGeneratorBase.cs
@@ -328,7 +328,7 @@ namespace Stride.Shaders.Parser.Mixins
         protected static bool IsBufferType(TypeBase type)
         {
             // TODO we should improve AST type system
-            return type is GenericBaseType && type.Name.Text.Contains("Buffer");
+            return (type is GenericBaseType && type.Name.Text.Contains("Buffer")) || type.IsByteAddressBufferType();
         }
     }
 }

--- a/sources/engine/Stride.Shaders.Parser/Mixins/ShaderMixinCodeGen.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/ShaderMixinCodeGen.cs
@@ -294,6 +294,19 @@ namespace Stride.Shaders.Parser.Mixins
             ProcessInitialValueStatus = false;
         }
 
+        public override void Visit(TypeName typeName)
+        {
+            if (typeName.IsByteAddressBufferType())
+            {
+                Write("Buffer");
+                ProcessInitialValueStatus = false;
+            }
+            else
+            {
+                base.Visit(typeName);
+            }
+        }
+
         /// <summary>
         /// Visits the specified for each statement.
         /// </summary>

--- a/sources/engine/Stride.Shaders.Parser/ShaderLinker.cs
+++ b/sources/engine/Stride.Shaders.Parser/ShaderLinker.cs
@@ -226,7 +226,7 @@ namespace Stride.Shaders.Parser
 
                 LinkVariable(effectReflection, variable.Name, parameterKey, slotCount);
             }
-            else if (variable.Type is TextureType || variable.Type is GenericBaseType)
+            else if (variable.Type is TextureType || variable.Type is GenericBaseType || variable.Type.IsByteAddressBufferType())
             {
                 LinkVariable(effectReflection, variable.Name, parameterKey, slotCount);
             }

--- a/sources/shaders/Stride.Core.Shaders/Analysis/Hlsl/HlslSemanticAnalysis.cs
+++ b/sources/shaders/Stride.Core.Shaders/Analysis/Hlsl/HlslSemanticAnalysis.cs
@@ -313,6 +313,17 @@ namespace Stride.Core.Shaders.Analysis.Hlsl
             if (value != null)
                 return value;
 
+            value = ByteAddressBufferType.Parse(name);
+            if (value != null)
+            {
+                if (value.TypeInference.TargetType == null && BuiltinObjects.TryGetValue(value.Name, out var predefinedType))
+                {
+                    value.TypeInference.TargetType = predefinedType;
+                }
+
+                return value;
+            }
+
             // Replace shader objects
             if (name == "VertexShader" || name == "GeometryShader" || name == "PixelShader")
                 return new ObjectType(name);

--- a/sources/shaders/Stride.Core.Shaders/Ast/Hlsl/ByteAddressBufferType.cs
+++ b/sources/shaders/Stride.Core.Shaders/Ast/Hlsl/ByteAddressBufferType.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stride.Core.Shaders.Ast.Hlsl
+{
+    public static class ByteAddressBufferType
+    {
+        public static readonly ObjectType ByteAddressBuffer = new ObjectType("ByteAddressBuffer");
+
+        public static readonly ObjectType RWByteAddressBuffer = new ObjectType("RWByteAddressBuffer");
+
+        private static readonly ObjectType[] ObjectTypes = new[] { ByteAddressBuffer, RWByteAddressBuffer };
+
+        public static bool IsByteAddressBufferType(this TypeBase type)
+        {
+            return Parse(type.Name) != null;
+        }
+
+        /// <summary>
+        /// Parses the specified name.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <returns></returns>
+        public static ObjectType Parse(string name)
+        {
+            foreach (var objectType in ObjectTypes)
+            {
+                if (string.Compare(name, objectType.Name.Text, StringComparison.OrdinalIgnoreCase) == 0)
+                    return objectType;
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# PR Details

Fixes both parsing and shader key generation for ByteAddressBuffer and RWByteAddressBuffer

## Related Issue
Fixes #248 

## Motivation and Context

The current system only works properly for generic types and textures. This change modifies that to also handle the ByteAddressBufferRWByteAddressBuffer types.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.