### PR TITLE
#983 - Normal map feature enables reconstruct z by default

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialNormalMapFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialNormalMapFeature.cs
@@ -38,6 +38,7 @@ namespace Stride.Rendering.Materials
         public MaterialNormalMapFeature(IComputeColor normalMap)
         {
             ScaleAndBias = true;
+            IsXYNormal = true;
             NormalMap = normalMap;
         }
 


### PR DESCRIPTION
# PR Details

Enables reconstruct z by default on the normal map if construct with an `IComputeColor`

## Related Issue

Fixes #983


## Motivation and Context

Reconstruct Z is disabled for materials by default, this is incompatible with the default import setting for normal maps which has compression enabled.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.