### PR TITLE
Fixes index out of bounds when reporting variable name ambiguity

### DIFF
--- a/sources/engine/Stride.Shaders.Parser/Utility/StrideMessageCode.cs
+++ b/sources/engine/Stride.Shaders.Parser/Utility/StrideMessageCode.cs
@@ -40,7 +40,7 @@ namespace Stride.Shaders.Parser.Utility
         public static readonly MessageCode ErrorExternMemberNotFound                = new MessageCode("E0226", "There is no member [{0}] for the type [{1}] in class [{2}]");
         public static readonly MessageCode ErrorStreamNotFound                      = new MessageCode("E0227", "Unable to find stream variable [{0}] in class [{1}]");
         public static readonly MessageCode ErrorStreamUsage                         = new MessageCode("E0228", "the stream [{0}] was read first THEN written in class [{1}]");
-        public static readonly MessageCode ErrorVariableNameAmbiguity               = new MessageCode("E0229", "The name [{0}] is ambiguous within variables in class [{2}]");
+        public static readonly MessageCode ErrorVariableNameAmbiguity               = new MessageCode("E0229", "The name [{0}] is ambiguous within variables in class [{1}]");
         public static readonly MessageCode ErrorMethodNameAmbiguity                 = new MessageCode("E0230", "The name [{0}] is ambiguous within methods in class [{1}]");
         public static readonly MessageCode ErrorMissingMethod                       = new MessageCode("E0231", "The method [{0}] in class [{1}] is not defined");
         public static readonly MessageCode ErrorCyclicMethod                        = new MessageCode("E0232", "Method [{0}] performs a cyclic call, which is not allowed in class [{1}]");


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

The two call sites provide only two arguments, not three:
![grafik](https://user-images.githubusercontent.com/573618/138147128-28971e0f-034e-4ed8-a6df-e2aac31dcbd6.png)

The crash came up while debugging a client project.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.