### PR TITLE
[Rendering] Fixes PostFX applied to RenderTextures

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Compositing/RenderTextureSceneRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Compositing/RenderTextureSceneRenderer.cs
@@ -35,7 +35,11 @@ namespace Stride.Rendering.Compositing
 
             using (drawContext.PushRenderTargetsAndRestore())
             {
-                var depthBuffer = PushScopedResource(context.Allocator.GetTemporaryTexture2D(RenderTexture.ViewWidth, RenderTexture.ViewHeight, drawContext.CommandList.DepthStencilBuffer.ViewFormat, TextureFlags.DepthStencil));
+                var depthBufferTextureFlags = TextureFlags.DepthStencil;
+                if (context.GraphicsDevice.Features.HasDepthAsSRV)
+                    depthBufferTextureFlags |= TextureFlags.ShaderResource;
+
+                var depthBuffer = PushScopedResource(context.Allocator.GetTemporaryTexture2D(RenderTexture.ViewWidth, RenderTexture.ViewHeight, drawContext.CommandList.DepthStencilBuffer.ViewFormat, depthBufferTextureFlags));
                 drawContext.CommandList.SetRenderTargetAndViewport(depthBuffer, RenderTexture);
 
                 Child?.Draw(drawContext);


### PR DESCRIPTION
# PR Details

Fixes PostFX applied to RenderTextures.

## Description

Sets the ShaderResource flag of the temporary depth buffer if rendered into a RenderTexture, this allows post effects that rely on the depth buffer to work.

- [x] needs port to master branch

## Related Issue

Very similar to the PR #1160 of @johang88.

## Motivation and Context

Render a scene graph with multiple textures/cameras, including PostFX.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.