### PR TITLE
Patreon references (button, image, ..) removed

### DIFF
--- a/sources/launcher/Stride.Launcher/Resources/Urls.Designer.cs
+++ b/sources/launcher/Stride.Launcher/Resources/Urls.Designer.cs
@@ -124,15 +124,6 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://www.patreon.com/stride3d.
-        /// </summary>
-        public static string Patreon {
-            get {
-                return ResourceManager.GetString("Patreon", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to https://www.reddit.com/r/stride3d.
         /// </summary>
         public static string Reddit {

--- a/sources/launcher/Stride.Launcher/Resources/Urls.resx
+++ b/sources/launcher/Stride.Launcher/Resources/Urls.resx
@@ -140,9 +140,6 @@
   <data name="Issues" xml:space="preserve">
     <value>https://github.com/stride3d/stride/issues/</value>
   </data>
-  <data name="Patreon" xml:space="preserve">
-    <value>https://www.patreon.com/stride3d</value>
-  </data>
   <data name="Reddit" xml:space="preserve">
     <value>https://www.reddit.com/r/stride3d</value>
   </data>

--- a/sources/launcher/Stride.Launcher/Resources/patreon_mark_coral_24.png
+++ b/sources/launcher/Stride.Launcher/Resources/patreon_mark_coral_24.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f90c53621210cc604a6680facc7414da8684ca52c9dfe48f43cf374f8ed92fdf
-size 418

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
@@ -98,7 +98,6 @@
     <Resource Include="Resources\Launcher.ico" />
     <Resource Include="Resources\delete-26-dark.png" />
     <Resource Include="Resources\download-26-dark.png" />
-    <Resource Include="Resources\patreon_mark_coral_24.png" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.ja-JP.resx" />

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -32,7 +32,6 @@
       <BitmapImage x:Key="ImageTwitter" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/twitter_bird_24.png"/>
       <BitmapImage x:Key="ImageFacebook" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/facebook_24.png"/>
       <BitmapImage x:Key="ImageReddit" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/reddit_24.png"/>
-      <BitmapImage x:Key="ImagePatreon" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/patreon_mark_coral_24.png"/>
       
       <BitmapImage x:Key="ImageDownload" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/download-26-dark.png"/>
       <BitmapImage x:Key="ImageUpdate" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/update.png"/>
@@ -325,17 +324,6 @@
                         ToolTipService.IsEnabled="False"
                         ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
                         Content="{sskk:Image {StaticResource ImageReddit}, 24, 24, NearestNeighbor}">
-                    <i:Interaction.Behaviors>
-                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
-                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
-                    </i:Interaction.Behaviors>
-                  </Button>
-                  <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
-                        Command="{Binding OpenUrlCommand}"
-                        CommandParameter="{x:Static r:Urls.Patreon}" SnapsToDevicePixels="True" Margin="2"
-                        ToolTipService.IsEnabled="False"
-                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
-                        Content="{sskk:Image {StaticResource ImagePatreon}, 24, 24, NearestNeighbor}">
                     <i:Interaction.Behaviors>
                       <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
                                                      DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>


### PR DESCRIPTION
# PR Details

Patreon Image related resources were removed from the Stride.Launcher.
 
## Description

- Reference removed from Stride.Launcher.csproj
- LauncherWindow.xaml: Patreon BitmapImage reference removed
- LauncherWindow.xaml: Patreon Button removed
- Patreon image removed from /Resources
- Urls.resx: Link https://www.patreon.com/stride3d removed

## Related Issue

https://github.com/stride3d/stride/issues/1186

## Motivation and Context

Stride moved from Patreon to Open Collective. The Open Collective button will be added in a separate PR.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.