### PR TITLE
[Threading] Threadpool, lifo semaphore

### DIFF
--- a/sources/core/Stride.Core/Threading/ThreadPool.SemaphoreW.cs
+++ b/sources/core/Stride.Core/Threading/ThreadPool.SemaphoreW.cs
@@ -15,7 +15,7 @@ namespace Stride.Core.Threading
         /// <summary>
         /// Mostly lifted from dotnet's LowLevelLifoSemaphore
         /// </summary>
-        private class SemaphoreW : ISemaphore
+        private sealed class SemaphoreW : ISemaphore
         {
             private const int SpinSleep0Threshold = 10;
             

--- a/sources/core/Stride.Core/Threading/ThreadPool.cs
+++ b/sources/core/Stride.Core/Threading/ThreadPool.cs
@@ -217,7 +217,7 @@ namespace Stride.Core.Threading
 
 
 
-        private class DotnetLifoSemaphore : ISemaphore
+        private sealed class DotnetLifoSemaphore : ISemaphore
         {
             private readonly IDisposable semaphore;
             private readonly Func<int, bool, bool> wait;


### PR DESCRIPTION
# PR Details
Now that .Net6 uses their fully managed threadpool by default we can hook into their lifo semaphore which improves performances slightly.
I did benchmark their ``System.Threading.ThreadPool.UnsafeQueueUserWorkItem`` again under net6 and ours still performed better, so still no reason to migrate to dotnet's threadpool.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.