### PR TITLE
OpenCollective icon added and code adjustments made accordingly

### DIFF
--- a/sources/launcher/Stride.Launcher/Resources/Urls.Designer.cs
+++ b/sources/launcher/Stride.Launcher/Resources/Urls.Designer.cs
@@ -124,6 +124,15 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to https://opencollective.com/stride3d.
+        /// </summary>
+        public static string OpenCollective {
+            get {
+                return ResourceManager.GetString("OpenCollective", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to https://www.reddit.com/r/stride3d.
         /// </summary>
         public static string Reddit {

--- a/sources/launcher/Stride.Launcher/Resources/Urls.resx
+++ b/sources/launcher/Stride.Launcher/Resources/Urls.resx
@@ -140,6 +140,9 @@
   <data name="Issues" xml:space="preserve">
     <value>https://github.com/stride3d/stride/issues/</value>
   </data>
+  <data name="OpenCollective" xml:space="preserve">
+    <value>https://opencollective.com/stride3d</value>
+  </data>
   <data name="Reddit" xml:space="preserve">
     <value>https://www.reddit.com/r/stride3d</value>
   </data>

--- a/sources/launcher/Stride.Launcher/Resources/opencollective-24.png
+++ b/sources/launcher/Stride.Launcher/Resources/opencollective-24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8bbe6eb444102da420dee5c10f11d2956871c5f2d37dfb0ffa5cf04dec6a4a4
+size 962

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
@@ -93,6 +93,7 @@
     <Resource Include="Resources\facebook_24.png" />
     <Resource Include="Resources\reddit_24.png" />
     <Resource Include="Resources\twitter_bird_24.png" />
+    <Resource Include="Resources\opencollective-24.png" />
     <Resource Include="Resources\github.png" />
     <Resource Include="Resources\issues.png" />
     <Resource Include="Resources\Launcher.ico" />

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -32,6 +32,7 @@
       <BitmapImage x:Key="ImageTwitter" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/twitter_bird_24.png"/>
       <BitmapImage x:Key="ImageFacebook" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/facebook_24.png"/>
       <BitmapImage x:Key="ImageReddit" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/reddit_24.png"/>
+      <BitmapImage x:Key="ImageOpenCollective" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/opencollective-24.png"/>
       
       <BitmapImage x:Key="ImageDownload" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/download-26-dark.png"/>
       <BitmapImage x:Key="ImageUpdate" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/update.png"/>
@@ -329,6 +330,17 @@
                                                      DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
                     </i:Interaction.Behaviors>
                   </Button>
+                  <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
+                        Command="{Binding OpenUrlCommand}"
+                        CommandParameter="{x:Static r:Urls.OpenCollective}" SnapsToDevicePixels="True" Margin="2"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
+                        Content="{sskk:Image {StaticResource ImageOpenCollective}, 24, 24, NearestNeighbor}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
+                  </Button>                  
                   <!--<Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
                         Command="{Binding OpenUrlCommand}"
                         CommandParameter="https://www.google.com/" SnapsToDevicePixels="True" Margin="2"

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -302,7 +302,7 @@
                         CommandParameter="{x:Static r:Urls.Twitter}" SnapsToDevicePixels="True" Margin="2"
                         ToolTipService.IsEnabled="False"
                         ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
-                        Content="{sskk:Image {StaticResource ImageTwitter}, 24, 24, NearestNeighbor}">
+                        Content="{sskk:Image {StaticResource ImageTwitter}, 24, 24, HighQuality}">
                     <i:Interaction.Behaviors>
                       <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
                                                      DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
@@ -335,7 +335,7 @@
                         CommandParameter="{x:Static r:Urls.OpenCollective}" SnapsToDevicePixels="True" Margin="2"
                         ToolTipService.IsEnabled="False"
                         ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}"
-                        Content="{sskk:Image {StaticResource ImageOpenCollective}, 24, 24, NearestNeighbor}">
+                        Content="{sskk:Image {StaticResource ImageOpenCollective}, 24, 24, HighQuality}">
                     <i:Interaction.Behaviors>
                       <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
                                                      DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>


### PR DESCRIPTION
# PR Details

Open Collective Image related resources were added to the Stride.Launcher.

## Description

- Reference added to Stride.Launcher.csproj
- LauncherWindow.xaml: OpenCollective BitmapImage reference added
- LauncherWindow.xaml: OpenCollective Button added
- OpenCollective image added to /Resources
- Urls.resx: Link https://opencollective.com/stride3d added

## Related Issue

https://github.com/stride3d/stride/issues/1187

## Motivation and Context

Stride moved to Open Collective so the button was added instead of Patreon.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.