### PR TITLE
Issue 1183 - Fix broken sample game - Space Escape

### DIFF
--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/CustomFogEffect.sdsl
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/CustomFogEffect.sdsl
@@ -1,5 +1,5 @@
 ﻿// Simple fog emulating fixed pipeline as described in http://www.ozone3d.net/tutorials/glsl_fog/p03.php
-shader FogEffect : ShadingBase, TransformationBase, Camera
+shader CustomFogEffect : ShadingBase, TransformationBase, Camera
 {
     cbuffer PerDraw
     {

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/CustomFogEffect.sdsl.cs
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/CustomFogEffect.sdsl.cs
@@ -16,7 +16,7 @@ using Buffer = Stride.Graphics.Buffer;
 
 namespace Stride.Rendering
 {
-    public static partial class FogEffectKeys
+    public static partial class CustomFogEffectKeys
     {
         public static readonly ValueParameterKey<Color4> FogColor = ParameterKeys.NewValue<Color4>(new Color4(1,1,1,1));
         public static readonly ValueParameterKey<float> fogNearPlaneZ = ParameterKeys.NewValue<float>(80.0f);

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/SpaceEscapeEffectMain.sdfx
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/SpaceEscapeEffectMain.sdfx
@@ -23,6 +23,6 @@ namespace SpaceEscape.Effects
             mixin TransformationBendWorld;
 
         if(GameParameters.EnableFog)
-            mixin FogEffect;
+            mixin CustomFogEffect;
     };
 }

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/SpaceEscapeEffectMain.sdfx.cs
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Effects/SpaceEscapeEffectMain.sdfx.cs
@@ -34,7 +34,7 @@ namespace SpaceEscape.Effects
                 if (context.GetParam(GameParameters.EnableBend))
                     context.Mixin(mixin, "TransformationBendWorld");
                 if (context.GetParam(GameParameters.EnableFog))
-                    context.Mixin(mixin, "FogEffect");
+                    context.Mixin(mixin, "CustomFogEffect");
             }
 
             [ModuleInitializer]

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Rendering/BendFogRenderFeature.cs
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Rendering/BendFogRenderFeature.cs
@@ -24,7 +24,7 @@ namespace SpaceEscape.Rendering
         private ConstantBufferOffsetReference bend;
         private ConstantBufferOffsetReference uvChange;
 
-        // Constant buffer layout for FogEffect
+        // Constant buffer layout for CustomFogEffect
         private struct PerDrawFog
         {
             public Color4 FogColor;
@@ -43,7 +43,7 @@ namespace SpaceEscape.Rendering
 
             renderEffectKey = ((RootEffectRenderFeature)RootRenderFeature).RenderEffectKey;
 
-            fog = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(FogEffectKeys.FogColor.Name);
+            fog = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(CustomFogEffectKeys.FogColor.Name);
             bend = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(TransformationBendWorldKeys.DeformFactorX.Name);
             uvChange = ((RootEffectRenderFeature)RootRenderFeature).CreateDrawCBufferOffsetSlot(TransformationTextureUVKeys.TextureRegion.Name);
         }


### PR DESCRIPTION
# PR Details

Fix for the broken sample game - Space Escape

## Description

Name collision of FogEffect in the sample game project with the existing stride IDE object name.  

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
broken sample game - Space Escape issue https://github.com/stride3d/stride/issues/1183

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.