### PR TITLE
Update VisualStudio plugin to VS2022

### DIFF
--- a/build/compile.bat
+++ b/build/compile.bat
@@ -153,7 +153,7 @@ rem Compile our solution. The following variables needs to be set:
 rem "Project" is the solution name
 rem "_platform_target" is the platform being targeted
 :compile
-set _option=/nologo /nr:false /m /verbosity:%__BuildVerbosity% /p:Configuration=%__BuildType% /p:Platform="%_platform_target%" /p:StrideSkipUnitTests=%__SkipTestBuild% %Project%
+set _option=/nologo /nr:false /m /verbosity:%__BuildVerbosity% /p:Configuration=%__BuildType% /p:Platform="%_platform_target%" /p:StrideSkipUnitTests=%__SkipTestBuild% %Project% /p:DeployExtension=false
 
 if "%__BuildDoc%" == "1" set _option=%_option% /p:StrideGenerateDoc=true
 

--- a/sources/tools/Stride.VisualStudio.Package/BuildEngine/IDEBuildLogger.cs
+++ b/sources/tools/Stride.VisualStudio.Package/BuildEngine/IDEBuildLogger.cs
@@ -210,7 +210,7 @@ namespace Stride.VisualStudio.BuildEngine
 
         private void NavigateTo(object sender, EventArgs arguments)
         {
-            Microsoft.VisualStudio.Shell.Task task = sender as Microsoft.VisualStudio.Shell.Task;
+            TaskListItem task = sender as TaskListItem;
             if (task == null)
                 throw new ArgumentException("Sender is not a Microsoft.VisualStudio.Shell.Task", "sender");
 

--- a/sources/tools/Stride.VisualStudio.Package/NShader/NShaderLanguageService.cs
+++ b/sources/tools/Stride.VisualStudio.Package/NShader/NShaderLanguageService.cs
@@ -434,7 +434,7 @@ namespace NShader
 
         private void NavigateToSourceError(object sender, EventArgs e)
         {
-            var task = sender as Microsoft.VisualStudio.Shell.Task;
+            var task = sender as TaskListItem;
             if (task != null)
             {
                 GoToLocation(new RawSourceSpan(task.Document, task.Line + 1, task.Column + 1), null, false);

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -1,6 +1,6 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">16.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -18,23 +18,22 @@
     <StrideSkipAutoPack>true</StrideSkipAutoPack>
     <VSSDKTargetPlatformRegRootSuffix>Stride</VSSDKTargetPlatformRegRootSuffix>
     <DefineConstants>$(DefineConstants);STRIDE_VSPACKAGE</DefineConstants>
-  </PropertyGroup>
+  </PropertyGroup>  
   <ItemGroup>
     <None Remove="NShader\Common\GLSLKeywords.map" />
     <None Remove="NShader\Common\HLSLKeywords.map" />
     <None Remove="NShader\Common\StrideShaderKeywords.map" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE80" Version="8.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4323" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="14.0.23205" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="14.0.23205" />
-    <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.14.0" Version="14.0.23205" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="14.0.25023" />
-    <PackageReference Include="VSLangProj" Version="7.0.3301" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.Build" Version="16.11.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime">
+        <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="NuGet.Commands" Version="6.0.0-preview.3" />
 
     <Reference Include="System.ComponentModel.Composition" />

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Stride.VisualStudio.Package</id>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
     <authors>Stride</authors>
     <owners>Stride</owners>
     <licenseUrl>https://github.com/stride3d/stride/blob/master/LICENSE.md</licenseUrl>

--- a/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest
+++ b/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest
@@ -7,7 +7,9 @@
     <Icon>Resources\VSPackage.ico</Icon>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+   <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+   </InstallationTarget>
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
@@ -18,6 +20,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
# PR Details

Updated VS plugin dependencies to build with msbuild x64 to support VS2022. Migrated code that was changed

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated VisualStudio deps to v17
Targeted VisualStudio 17 in VS plugin

<!--- Describe your changes in detail -->

## Related Issue

Fixes https://github.com/stride3d/stride/issues/1119
Fixes https://github.com/stride3d/stride/issues/1209

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Could not build the VS plugin in VS2022 due to msbuild being x64. The older build targets do not support this.
<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.