### PR TITLE
[Physics] Static mesh, asset and editor support

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.sdpkg
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.sdpkg
@@ -49,6 +49,7 @@ TemplateFolders:
         - !file Templates/Assets/Physics/ColliderShapeBox.sdtpl
         - !file Templates/Assets/Physics/ColliderShapeCapsule.sdtpl
         - !file Templates/Assets/Physics/ColliderShapeConvexHull.sdtpl
+        - !file Templates/Assets/Physics/ColliderShapeStatic.sdtpl
         - !file Templates/Assets/Physics/ColliderShapeCylinder.sdtpl
         - !file Templates/Assets/Physics/ColliderShapePlane.sdtpl
         - !file Templates/Assets/Physics/ColliderShapeSphere.sdtpl

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/.sdtpl/ColliderStaticMesh.png
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/.sdtpl/ColliderStaticMesh.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d245607ff8d227f58d45626dc9619a0e27328a38c949a662fe9ee2533d222570
+size 8704

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Physics/ColliderShapeStatic.sdtpl
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Physics/ColliderShapeStatic.sdtpl
@@ -1,0 +1,10 @@
+!TemplateAssetFactory
+Id: 5A3CD5E3-4328-36AF-A41C-8146D2D21F83
+AssetTypeName: ColliderShapeAsset
+Name: Static mesh
+Scope: Asset
+Description: A collider based on a model asset
+Group: Physics
+Icon: ..\.sdtpl\ColliderStaticMesh.png
+DefaultOutputName: ColliderStaticMesh
+FactoryTypeName: ColliderShapeStaticMeshFactory

--- a/sources/editor/Stride.Assets.Presentation/Templates/ColliderShapeStaticMeshFactoryTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/ColliderShapeStaticMeshFactoryTemplateGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Stride contributors (https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Threading.Tasks;

--- a/sources/editor/Stride.Assets.Presentation/Templates/ColliderShapeStaticMeshFactoryTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/ColliderShapeStaticMeshFactoryTemplateGenerator.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Threading.Tasks;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Editor.Services;
+using Stride.Core.Assets.Templates;
+using Stride.Core;
+using Stride.Core.IO;
+using Stride.Assets.Models;
+using Stride.Assets.Physics;
+using Stride.Physics;
+using Stride.Rendering;
+
+namespace Stride.Assets.Presentation.Templates
+{
+    public class ColliderShapeStaticMeshFactoryTemplateGenerator : AssetFactoryTemplateGenerator
+    {
+        private static readonly PropertyKey<Model> ModelKey = new PropertyKey<Model>("Model", typeof(ColliderShapeStaticMeshFactoryTemplateGenerator));
+        public new static readonly ColliderShapeStaticMeshFactoryTemplateGenerator Default = new ColliderShapeStaticMeshFactoryTemplateGenerator();
+
+        public static readonly Guid TemplateId = new Guid("5A3CD5E3-4328-36AF-A41C-8146D2D21F83");
+
+        public override bool IsSupportingTemplate(TemplateDescription templateDescription)
+        {
+            if (templateDescription == null) throw new ArgumentNullException(nameof(templateDescription));
+            return templateDescription.Id == TemplateId;
+        }
+
+        protected override async Task<bool> PrepareAssetCreation(AssetTemplateGeneratorParameters parameters)
+        {
+            if (!await base.PrepareAssetCreation(parameters))
+                return false;
+
+            var modelViewModel = await BrowseForAsset(parameters.Package, new[] { typeof(IModelAsset) }, new UFile(parameters.Name).GetFullDirectory(), "Select a model to use for this static mesh - _cancel to leave the model empty_");
+            var model = ContentReferenceHelper.CreateReference<Model>(modelViewModel);
+            parameters.SetTag(ModelKey, model);
+            return true;
+        }
+
+        protected override void PostAssetCreation(AssetTemplateGeneratorParameters parameters, AssetItem assetItem)
+        {
+            base.PostAssetCreation(parameters, assetItem);
+            var model = parameters.GetTag(ModelKey);
+            ((StaticMeshColliderShapeDesc)((ColliderShapeAsset)assetItem.Asset).ColliderShapes[0]).Model = model;
+        }
+    }
+}

--- a/sources/editor/Stride.Assets.Presentation/Templates/StrideTemplates.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/StrideTemplates.cs
@@ -18,6 +18,7 @@ namespace Stride.Assets.Presentation.Templates
             // Specific asset templates must be registered after AssetFactoryTemplateGenerator
             TemplateManager.Register(HeightmapFactoryTemplateGenerator.Default);
             TemplateManager.Register(ColliderShapeHullFactoryTemplateGenerator.Default);
+            TemplateManager.Register(ColliderShapeStaticMeshFactoryTemplateGenerator.Default);
             TemplateManager.Register(ProceduralModelFactoryTemplateGenerator.Default);
             TemplateManager.Register(SkyboxFactoryTemplateGenerator.Default);
             TemplateManager.Register(GraphicsCompositorTemplateGenerator.Default);

--- a/sources/engine/Stride.Assets/Physics/ColliderShapeAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Physics/ColliderShapeAssetCompiler.cs
@@ -74,6 +74,19 @@ namespace Stride.Assets.Physics
                         }
                     }
                 }
+                else if (desc is StaticMeshColliderShapeDesc)
+                {
+                    var staticDesc = desc as StaticMeshColliderShapeDesc;
+                    if (staticDesc.Model != null)
+                    {
+                        var url = AttachedReferenceManager.GetUrl(staticDesc.Model);
+
+                        if (!string.IsNullOrEmpty(url))
+                        {
+                            yield return new ObjectUrl(UrlType.Content, url);
+                        }
+                    }
+                }
                 else if (desc is HeightfieldColliderShapeDesc)
                 {
                     var heightfieldDesc = desc as HeightfieldColliderShapeDesc;
@@ -113,14 +126,10 @@ namespace Stride.Assets.Physics
 
                 // Cloned list of collider shapes
                 var descriptions = Parameters.ColliderShapes.ToList();
-
-                var validShapes = Parameters.ColliderShapes.Where(x => x != null
-                    && (x.GetType() != typeof(ConvexHullColliderShapeDesc) || ((ConvexHullColliderShapeDesc)x).Model != null)).ToList();
-
-                //pre process special types
-                foreach (var convexHullDesc in
-                    (from shape in validShapes let type = shape.GetType() where type == typeof(ConvexHullColliderShapeDesc) select shape)
-                    .Cast<ConvexHullColliderShapeDesc>())
+                foreach (var convexHullDesc in 
+                    from shape in Parameters.ColliderShapes
+                    where shape is ConvexHullColliderShapeDesc hullShape && hullShape.Model != null
+                    select ((ConvexHullColliderShapeDesc)shape))
                 {
                     // Clone the convex hull shape description so the fields that should not be serialized can be cleared (Model in this case)
                     ConvexHullColliderShapeDesc convexHullDescClone = new ConvexHullColliderShapeDesc

--- a/sources/engine/Stride.Assets/Physics/ColliderShapeFactories.cs
+++ b/sources/engine/Stride.Assets/Physics/ColliderShapeFactories.cs
@@ -44,6 +44,19 @@ namespace Stride.Assets.Physics
         }
     }
 
+    public class ColliderShapeStaticMeshFactory : AssetFactory<ColliderShapeAsset>
+    {
+        public static ColliderShapeAsset Create()
+        {
+            return new ColliderShapeAsset { ColliderShapes = { new StaticMeshColliderShapeDesc() } };
+        }
+
+        public override ColliderShapeAsset New()
+        {
+            return Create();
+        }
+    }
+
     public class ColliderShapeCylinderFactory : AssetFactory<ColliderShapeAsset>
     {
         public static ColliderShapeAsset Create()

--- a/sources/engine/Stride.Navigation/NavigationMeshBuilder.cs
+++ b/sources/engine/Stride.Navigation/NavigationMeshBuilder.cs
@@ -562,18 +562,18 @@ namespace Stride.Navigation
                         {
                             var mesh = (StaticMeshColliderShape)shape;
                             Matrix transform = mesh.PositiveCenterMatrix * entityWorldMatrix;
+                            
+                            mesh.GetMeshDataCopy(out var verts, out var indices);
 
                             // Convert hull indices to int
-                            int[] indices = new int[mesh.Indices.Count];
-                            if (mesh.Indices.Count % 3 != 0) throw new InvalidOperationException($"{shapeType} does not consist of triangles");
-                            for (int i = 0; i < mesh.Indices.Count; i += 3)
+                            if (indices.Length % 3 != 0) throw new InvalidOperationException($"{shapeType} does not consist of triangles");
+                            for (int i = 0; i < indices.Length; i += 3)
                             {
-                                indices[i] = (int)mesh.Indices[i];
-                                indices[i + 2] = (int)mesh.Indices[i + 1]; // NOTE: Reversed winding to create left handed input
-                                indices[i + 1] = (int)mesh.Indices[i + 2];
+                                // NOTE: Reversed winding to create left handed input
+                                (indices[i + 1], indices[i + 2]) = (indices[i + 2], indices[i + 1]);
                             }
 
-                            entityNavigationMeshInputBuilder.AppendArrays(mesh.Vertices.ToArray(), indices, transform);
+                            entityNavigationMeshInputBuilder.AppendArrays(verts, indices, transform);
                         }
                         else if (shapeType == typeof(HeightfieldColliderShape))
                         {

--- a/sources/engine/Stride.Physics/Data/BoxColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/BoxColliderShapeDesc.cs
@@ -42,9 +42,9 @@ namespace Stride.Physics
             return other?.Is2D == Is2D && other.Size == Size && other.LocalOffset == LocalOffset && other.LocalRotation == LocalRotation;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
-            return new BoxColliderShape(Is2D, Size) { LocalOffset = LocalOffset, LocalRotation = LocalRotation };
+            return new BoxColliderShape(Is2D, Size) { LocalOffset = LocalOffset, LocalRotation = LocalRotation, Description = this };
         }
     }
 }

--- a/sources/engine/Stride.Physics/Data/CapsuleColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/CapsuleColliderShapeDesc.cs
@@ -65,9 +65,9 @@ namespace Stride.Physics
                    other.LocalRotation == LocalRotation;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
-            return new CapsuleColliderShape(Is2D, Radius, Length, Orientation) { LocalOffset = LocalOffset, LocalRotation = LocalRotation };
+            return new CapsuleColliderShape(Is2D, Radius, Length, Orientation) { LocalOffset = LocalOffset, LocalRotation = LocalRotation, Description = this };
         }
     }
 }

--- a/sources/engine/Stride.Physics/Data/ColliderShapeAssetDesc.cs
+++ b/sources/engine/Stride.Physics/Data/ColliderShapeAssetDesc.cs
@@ -40,7 +40,7 @@ namespace Stride.Physics
             return other.Shape == Shape;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
             if (Shape == null)
             {
@@ -49,7 +49,9 @@ namespace Stride.Physics
 
             if (Shape.Shape == null)
             {
-                Shape.Shape = PhysicsColliderShape.Compose(Shape.Descriptions);
+                Shape.Shape = PhysicsColliderShape.Compose(Shape.Descriptions, services);
+                if(Shape.Shape != null)
+                    Shape.Shape.Description = this;
             }
 
             return this.Shape.Shape;

--- a/sources/engine/Stride.Physics/Data/ConeColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/ConeColliderShapeDesc.cs
@@ -59,9 +59,9 @@ namespace Stride.Physics
                    other.LocalRotation == LocalRotation;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
-            return new ConeColliderShape(Height, Radius, Orientation) { LocalOffset = LocalOffset, LocalRotation = LocalRotation };
+            return new ConeColliderShape(Height, Radius, Orientation) { LocalOffset = LocalOffset, LocalRotation = LocalRotation, Description = this };
         }
     }
 }

--- a/sources/engine/Stride.Physics/Data/ConvexHullColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/ConvexHullColliderShapeDesc.cs
@@ -70,7 +70,7 @@ namespace Stride.Physics
                    other.Decomposition.Match(Decomposition);
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
             if (ConvexHulls == null) return null;
             ColliderShape shape;

--- a/sources/engine/Stride.Physics/Data/CylinderColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/CylinderColliderShapeDesc.cs
@@ -60,9 +60,9 @@ namespace Stride.Physics
                    other.LocalRotation == LocalRotation;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
-            return new CylinderColliderShape(Height, Radius, Orientation) { LocalOffset = LocalOffset, LocalRotation = LocalRotation };
+            return new CylinderColliderShape(Height, Radius, Orientation) { LocalOffset = LocalOffset, LocalRotation = LocalRotation, Description = this };
         }
     }
 }

--- a/sources/engine/Stride.Physics/Data/HeightfieldColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/HeightfieldColliderShapeDesc.cs
@@ -107,7 +107,7 @@ namespace Stride.Physics
                 0f;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
             object unmanagedArray;
 
@@ -149,6 +149,7 @@ namespace Stride.Physics
                         {
                             LocalOffset = LocalOffset + new Vector3(0, GetCenteringOffset(), 0),
                             LocalRotation = LocalRotation,
+                            Description = this
                         };
 
             return shape;

--- a/sources/engine/Stride.Physics/Data/IColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/IColliderShapeDesc.cs
@@ -2,13 +2,14 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using Stride.Core;
 
 namespace Stride.Physics
 {
     public interface IColliderShapeDesc
     {
         bool Match(object obj);
-        ColliderShape CreateShape();
+        ColliderShape CreateShape(IServiceRegistry services);
     }
 
     public interface IAssetColliderShapeDesc : IColliderShapeDesc

--- a/sources/engine/Stride.Physics/Data/SphereColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/SphereColliderShapeDesc.cs
@@ -39,9 +39,9 @@ namespace Stride.Physics
             return other?.Is2D == Is2D && Math.Abs(other.Radius - Radius) < float.Epsilon && other.LocalOffset == LocalOffset;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
-            return new SphereColliderShape(Is2D, Radius) { LocalOffset = LocalOffset };
+            return new SphereColliderShape(Is2D, Radius) { LocalOffset = LocalOffset, Description = this };
         }
     }
 }

--- a/sources/engine/Stride.Physics/Data/StaticMeshColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/StaticMeshColliderShapeDesc.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) Stride contributors (https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;

--- a/sources/engine/Stride.Physics/Data/StaticMeshColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/StaticMeshColliderShapeDesc.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Stride.Core;
+using Stride.Core.Serialization.Contents;
+using Stride.Rendering;
+using System.Collections.Generic;
+
+namespace Stride.Physics
+{
+    [ContentSerializer(typeof(DataContentSerializer<StaticMeshColliderShapeDesc>))]
+    [DataContract("StaticMeshColliderShapeDesc")]
+    [Display(600, "Static Mesh")]
+    public class StaticMeshColliderShapeDesc : IInlineColliderShapeDesc
+    {
+        /// <userdoc>
+        /// Model asset from which the engine will create the collider.
+        /// </userdoc>
+        [DataMember(30)]
+        public Model Model;
+
+        public bool Match(object obj)
+        {
+            return obj is StaticMeshColliderShapeDesc concDesc && concDesc.Model == Model;
+        }
+        
+        public ColliderShape CreateShape(IServiceRegistry services)
+        {
+            if (Model == null || Model.Meshes.Count == 0)
+                return null;
+            
+            return new StaticMeshColliderShape(Model, services)
+            {
+                NeedsCustomCollisionCallback = true,
+                Description = this,
+            };
+        }
+    }
+}

--- a/sources/engine/Stride.Physics/Data/StaticPlaneColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/StaticPlaneColliderShapeDesc.cs
@@ -32,9 +32,9 @@ namespace Stride.Physics
             return other.Normal == Normal && Math.Abs(other.Offset - Offset) < float.Epsilon;
         }
 
-        public ColliderShape CreateShape()
+        public ColliderShape CreateShape(IServiceRegistry services)
         {
-            return new StaticPlaneColliderShape(Normal, Offset);
+            return new StaticPlaneColliderShape(Normal, Offset){ Description = this };
         }
     }
 }

--- a/sources/engine/Stride.Physics/Engine/PhysicsColliderShape.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsColliderShape.cs
@@ -47,7 +47,7 @@ namespace Stride.Physics
             return new PhysicsColliderShape(descriptions);
         }
 
-        internal static ColliderShape Compose(IReadOnlyList<IAssetColliderShapeDesc> descs)
+        internal static ColliderShape Compose(IReadOnlyList<IAssetColliderShapeDesc> descs, IServiceRegistry assetManager)
         {
             if (descs == null)
             {
@@ -58,7 +58,7 @@ namespace Stride.Physics
 
             if (descs.Count == 1) //single shape case
             {
-                res = CreateShape(descs[0]);
+                res = descs[0].CreateShape(assetManager);
                 if (res == null) return null;
                 res.IsPartOfAsset = true;
             }
@@ -67,7 +67,7 @@ namespace Stride.Physics
                 var compound = new CompoundColliderShape();
                 foreach (var desc in descs)
                 {
-                    var subShape = CreateShape(desc);
+                    var subShape = desc.CreateShape(assetManager);
                     if (subShape == null) continue;
                     compound.AddChildShape(subShape);
                 }
@@ -76,21 +76,6 @@ namespace Stride.Physics
             }
 
             return res;
-        }
-
-        internal static ColliderShape CreateShape(IColliderShapeDesc desc)
-        {
-            if (desc == null)
-                return null;
-
-            ColliderShape shape = desc.CreateShape();
-            
-            if (shape == null) return null;
-
-            //shape.UpdateLocalTransformations();
-            shape.Description = desc;
-
-            return shape;
         }
 
         public void Dispose()

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -632,16 +632,16 @@ namespace Stride.Engine
             }
 
             CanScaleShape = true;
-
+            foreach (var desc in ColliderShapes)
+            {
+                if(desc is ColliderShapeAssetDesc)
+                    CanScaleShape = false;
+            }
+            
+            var services = Entity?.EntityManager?.Services;
             if (ColliderShapes.Count == 1) //single shape case
             {
-                if (ColliderShapes[0] == null) return;
-                if (ColliderShapes[0].GetType() == typeof(ColliderShapeAssetDesc))
-                {
-                    CanScaleShape = false;
-                }
-
-                ColliderShape = PhysicsColliderShape.CreateShape(ColliderShapes[0]);
+                ColliderShape = ColliderShapes[0]?.CreateShape(services);
             }
             else if (ColliderShapes.Count > 1) //need a compound shape in this case
             {
@@ -649,12 +649,8 @@ namespace Stride.Engine
                 foreach (var desc in ColliderShapes)
                 {
                     if (desc == null) continue;
-                    if (desc.GetType() == typeof(ColliderShapeAssetDesc))
-                    {
-                        CanScaleShape = false;
-                    }
 
-                    var subShape = PhysicsColliderShape.CreateShape(desc);
+                    var subShape = desc.CreateShape(services);
                     if (subShape != null)
                     {
                         compound.AddChildShape(subShape);

--- a/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
@@ -103,8 +103,10 @@ namespace Stride.Physics
 
         static unsafe SharedMeshData BuildAndShareMeshes(Model model, IServiceRegistry services)
         {
-            var modelUrl = AttachedReferenceManager.GetUrl(model);
-            if (string.IsNullOrWhiteSpace(modelUrl) == false)
+            var sharedContent = services.GetService<ContentManager>();
+
+            string modelUrl = null;
+            if (sharedContent != null && sharedContent.TryGetAssetUrl(model, out modelUrl))
             {
                 lock (MeshSharingCache)
                 {
@@ -117,8 +119,6 @@ namespace Stride.Physics
             }
             
             var dbProvider = services.GetService<IDatabaseFileProviderService>();
-            var sharedContent = services.GetService<ContentManager>();
-
             ContentManager rawContent = null;
             
             Matrix[] nodeTransforms = null;

--- a/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
@@ -5,9 +5,15 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Stride.Core;
+using Stride.Core.Annotations;
+using Stride.Core.IO;
 using Stride.Core.Mathematics;
+using Stride.Core.Serialization;
+using Stride.Core.Serialization.Contents;
 using Stride.Extensions;
 using Stride.Graphics;
+using Stride.Graphics.Data;
 using Stride.Graphics.GeometricPrimitives;
 using Stride.Rendering;
 
@@ -15,55 +21,284 @@ namespace Stride.Physics
 {
     public class StaticMeshColliderShape : ColliderShape
     {
-        private readonly Vector3[] vertices;
-        private readonly int[] indices;
-
-        public IReadOnlyList<Vector3> Vertices => vertices;
-        public IReadOnlyList<int> Indices => indices;
-
-
+        /// <summary> Can be null when this was created without Model </summary>
+        [CanBeNull]
+        public readonly Model Model;
+        
+        private readonly SharedMeshData sharedData;
+        
+        private static readonly Dictionary<string, SharedMeshData> MeshSharingCache = new();
+        
         /// <summary>
-        /// Create a static collider from the vertices provided, ICollection will be duplicated before usage, 
-        /// changes to the collection provided won't be reflected on the collider or <see cref="Vertices"/> and <see cref="Indices"/>.
+        /// Create a static collider from an asset model, any changes the model receives won't be reflected on the collider
         /// </summary>
-        public StaticMeshColliderShape(ICollection<Vector3> vertices, ICollection<int> indices, Vector3 scaling) : this(vertices.ToArray(), indices.ToArray(), scaling)
+        public StaticMeshColliderShape(Model model, IServiceRegistry services) : this(BuildAndShareMeshes(model, services)) => this.Model = model;
+        
+        /// <summary>
+        /// Create a static collider from the data provided, data will only be read, changes to it
+        /// won't be reflected on the collider.
+        /// </summary>
+        public StaticMeshColliderShape(ICollection<Vector3> vertices, ICollection<int> indices) 
+            : this(new SharedMeshData
+            {
+                BulletMesh = new BulletSharp.TriangleIndexVertexArray(indices, new StrideToBulletWrapper(vertices))
+            })
         {
-
         }
-
-        /// <summary>
-        /// Internal constructor, expects readonly array; any changes made to the vertices won't be reflected on the physics shape
-        /// </summary>
-        StaticMeshColliderShape(Vector3[] verticesParam, int[] indicesParam, Vector3 scaling)
+        
+        StaticMeshColliderShape(SharedMeshData sharedDataParam)
         {
+            sharedData = sharedDataParam;
             Type = ColliderShapeTypes.StaticMesh;
             Is2D = false;
 
-            vertices = verticesParam;
-            indices = indicesParam;
-            
-            var meshData = new BulletSharp.TriangleIndexVertexArray(indices, new StrideToBulletWrapper(vertices));
-            var baseCollider = new BulletSharp.BvhTriangleMeshShape(meshData, true);
-            InternalShape = new BulletSharp.ScaledBvhTriangleMeshShape(baseCollider, scaling);
+            InternalShape = new BulletSharp.BvhTriangleMeshShape(sharedDataParam.BulletMesh, true);
             DebugPrimitiveMatrix = Matrix.Scaling(Vector3.One * DebugScaling);
-            Scaling = scaling;
         }
 
-        public override MeshDraw CreateDebugPrimitive(GraphicsDevice device)
+        public override void Dispose()
         {
-            var verts = new VertexPositionNormalTexture[vertices.Length];
-            for(int i = 0; i < vertices.Length; i++)
+            base.Dispose();
+            if (sharedData.Key == null)
             {
-                verts[i].Position = vertices[i];
+                // Not actually shared, dispose and move on
+                sharedData.BulletMesh.Dispose();
+                return;
             }
-            var meshData = new GeometricMeshData<VertexPositionNormalTexture>(verts, indices, false);
 
-            return new GeometricPrimitive(device, meshData).ToMeshDraw();
+            lock (MeshSharingCache)
+            {
+                sharedData.RefCount--;
+                if (sharedData.RefCount == 0)
+                {
+                    MeshSharingCache.Remove(sharedData.Key);
+                    sharedData.BulletMesh.Dispose();
+                }
+            }
         }
         
-        class StrideToBulletWrapper : ICollection<BulletSharp.Math.Vector3>
+        public unsafe void GetMeshDataCopy(out Vector3[] verts, out int[] indices)
         {
-            ICollection<Vector3> internalColl;
+            var iMesh = sharedData.BulletMesh.IndexedMeshArray[0];
+            {
+                int lengthInBytes = iMesh.NumVertices * iMesh.VertexStride;
+                verts = new Span<Vector3>( (void*)iMesh.VertexBase, lengthInBytes / sizeof(Vector3) ).ToArray();
+            }
+            {
+                int lengthInBytes = iMesh.NumTriangles * iMesh.TriangleIndexStride;
+                indices = new Span<int>( (void*)iMesh.TriangleIndexBase, lengthInBytes / sizeof(int) ).ToArray();
+            }
+        }
+        
+        public override MeshDraw CreateDebugPrimitive(GraphicsDevice device)
+        {
+            GetMeshDataCopy(out var verts, out var indices);
+            var vPos = new VertexPositionNormalTexture[verts.Length];
+            for (int i = 0; i < vPos.Length; i++)
+                vPos[i].Position = verts[i];
+            
+            var meshData = new GeometricMeshData<VertexPositionNormalTexture>(vPos, indices, false);
+            return new GeometricPrimitive(device, meshData).ToMeshDraw();
+        }
+
+        static unsafe SharedMeshData BuildAndShareMeshes(Model model, IServiceRegistry services)
+        {
+            var dbProvider = services.GetService<IDatabaseFileProviderService>();
+
+            ContentManager assetManager = null;
+            
+            Matrix[] nodeTransforms = null;
+            if (model.Skeleton != null)
+            {
+                var nodesLength = model.Skeleton.Nodes.Length;
+                nodeTransforms = new Matrix[nodesLength];
+                nodeTransforms[0] = Matrix.Identity;
+                for (var i = 0; i < nodesLength; i++)
+                {
+                    var node = model.Skeleton.Nodes[i];
+                    Matrix localMatrix;
+                    Matrix.Transformation(ref node.Transform.Scale, ref node.Transform.Rotation, ref node.Transform.Position, out localMatrix);
+
+                    Matrix worldMatrix;
+                    if (node.ParentIndex != -1)
+                    {
+                        if (node.ParentIndex >= i)
+                            throw new InvalidOperationException("Skeleton nodes are not sorted");
+                        var nodeTransform = nodeTransforms[node.ParentIndex];
+                        Matrix.Multiply(ref localMatrix, ref nodeTransform, out worldMatrix);
+                    }
+                    else
+                    {
+                        worldMatrix = localMatrix;
+                    }
+
+                    if (i != 0)
+                    {
+                        nodeTransforms[i] = worldMatrix;
+                    }
+                }
+            }
+            
+            int totalVerts = 0, totalIndices = 0;
+            foreach (var meshData in model.Meshes)
+            {
+                totalVerts += meshData.Draw.VertexBuffers[0].Count;
+                totalIndices += meshData.Draw.IndexBuffer.Count;
+            }
+            
+            var combinedVerts = new List<Vector3>(totalVerts);
+            var combinedIndices = new List<int>(totalIndices);
+
+            foreach (var meshData in model.Meshes)
+            {
+                var vBuffer = meshData.Draw.VertexBuffers[0].Buffer;
+                var iBuffer = meshData.Draw.IndexBuffer.Buffer;
+                byte[] verticesBytes = null;
+                byte[] indicesBytes = null;
+                
+                // Both of those can fail when data has already been sent to GPU
+                var vertexBufferRef = AttachedReferenceManager.GetAttachedReference(vBuffer);
+                var indexBufferRef = AttachedReferenceManager.GetAttachedReference(iBuffer);
+                if (vertexBufferRef.Data != null)
+                    verticesBytes = ((BufferData)vertexBufferRef.Data).Content;
+                if (indexBufferRef.Data != null)
+                    indicesBytes = ((BufferData)indexBufferRef.Data).Content;
+                
+                // Editor-specific workaround, we can't load assets when the file provider is null,
+                // will most likely break on non-dx11 APIs
+                if((verticesBytes == null || indicesBytes == null) && dbProvider != null && dbProvider.FileProvider == null)
+                {
+                    var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+                    var commandList = (CommandList)typeof(GraphicsDevice)
+                        .GetField("InternalMainCommandList", flags)
+                        .GetValue(vBuffer.GraphicsDevice);
+                    
+                    verticesBytes = new byte[vBuffer.SizeInBytes];
+                    indicesBytes = new byte[iBuffer.SizeInBytes];
+                    fixed (byte* window = verticesBytes)
+                        FetchBufferFromGPU(vBuffer, commandList, new DataPointer(window, verticesBytes.Length));
+                    fixed (byte* window = indicesBytes)
+                        FetchBufferFromGPU(iBuffer, commandList, new DataPointer(window, indicesBytes.Length));
+                }
+                
+                if (verticesBytes == null && string.IsNullOrEmpty(vertexBufferRef.Url) == false)
+                {
+                    assetManager ??= new ContentManager(dbProvider);
+                    var dataAsset = assetManager.Load<Graphics.Buffer>(vertexBufferRef.Url);
+                    verticesBytes = dataAsset.GetSerializationData().Content;
+                    assetManager.Unload(vertexBufferRef.Url);
+                }
+                if (indicesBytes == null && string.IsNullOrEmpty(indexBufferRef.Url) == false)
+                {
+                    assetManager ??= new ContentManager(dbProvider);
+                    var dataAsset = assetManager.Load<Graphics.Buffer>(indexBufferRef.Url);
+                    indicesBytes = dataAsset.GetSerializationData().Content;
+                    assetManager.Unload(indexBufferRef.Url);
+                }
+                
+                if(verticesBytes == null || indicesBytes == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to find mesh buffers while attempting to build a {nameof(StaticMeshColliderShape)}. " +
+                        $"Make sure that the {nameof(model)} is either an asset on disk or use {nameof(StaticMeshColliderShape)}'s second constructor instead of this one");
+                }
+
+                int vertMappingStart = combinedVerts.Count;
+
+                fixed (byte* bytePtr = verticesBytes)
+                {
+                    var vBindings = meshData.Draw.VertexBuffers[0];
+                    int count = vBindings.Count;
+                    int stride = vBindings.Declaration.VertexStride;
+                    for (int i = 0, vHead = vBindings.Offset; i < count; i++, vHead += stride)
+                    {
+                        var pos = *(Vector3*)(bytePtr + vHead);
+                        
+                        if (nodeTransforms != null)
+                        {
+                            Matrix posMatrix = Matrix.Translation(pos);
+                            Matrix finalMatrix;
+                            Matrix.Multiply(ref posMatrix, ref nodeTransforms[meshData.NodeIndex], out finalMatrix);
+                            pos = finalMatrix.TranslationVector;
+                        }
+
+                        combinedVerts.Add(pos);
+                    }
+                }
+                
+                fixed (byte* bytePtr = indicesBytes)
+                {
+                    if (meshData.Draw.IndexBuffer.Is32Bit)
+                    {
+                        foreach (int i in new Span<int>(bytePtr + meshData.Draw.IndexBuffer.Offset, meshData.Draw.IndexBuffer.Count))
+                        {
+                            combinedIndices.Add(vertMappingStart + i);
+                        }
+                    }
+                    else
+                    {
+                        foreach (ushort i in new Span<ushort>(bytePtr + meshData.Draw.IndexBuffer.Offset, meshData.Draw.IndexBuffer.Count))
+                        {
+                            combinedIndices.Add(vertMappingStart + i);
+                        }
+                    }
+                }
+            }
+
+            var url = AttachedReferenceManager.GetUrl(model);
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return new SharedMeshData
+                {
+                    BulletMesh = new BulletSharp.TriangleIndexVertexArray(combinedIndices, new StrideToBulletWrapper(combinedVerts))
+                };
+            }
+            
+            lock (MeshSharingCache)
+            {
+                if (MeshSharingCache.TryGetValue(url, out var sharedData))
+                {
+                    sharedData.RefCount++;
+                    return sharedData;
+                }
+                
+                sharedData = new SharedMeshData
+                {
+                    BulletMesh = new BulletSharp.TriangleIndexVertexArray(combinedIndices, new StrideToBulletWrapper(combinedVerts)),
+                    Key = url,
+                    RefCount = 1,
+                };
+                MeshSharingCache.Add(url, sharedData);
+                return sharedData;
+            }
+        }
+
+
+        static void FetchBufferFromGPU(Graphics.Buffer buffer, CommandList commandList, DataPointer ptr)
+        {
+            if (buffer.Description.Usage == GraphicsResourceUsage.Staging)
+            {
+                // Directly if this is a staging resource
+                buffer.GetData(commandList, buffer, ptr);
+            }
+            else
+            {
+                // inefficient way to use the Copy method using dynamic staging texture
+                using (var throughStaging = buffer.ToStaging())
+                    buffer.GetData(commandList, throughStaging, ptr);
+            }
+        }
+
+        private record SharedMeshData
+        {
+            public BulletSharp.TriangleIndexVertexArray BulletMesh;
+            public int RefCount;
+            public string Key;
+        }
+        
+        private class StrideToBulletWrapper : ICollection<BulletSharp.Math.Vector3>
+        {
+            private readonly ICollection<Vector3> internalColl;
             public StrideToBulletWrapper(ICollection<Vector3> collectionToConvert)
             {
                 internalColl = collectionToConvert;
@@ -85,11 +320,9 @@ namespace Stride.Physics
                 }
             }
 
-            public void Add(BulletSharp.Math.Vector3 item) { throw new System.InvalidOperationException("Collection is read only"); }
-
-            public bool Remove(BulletSharp.Math.Vector3 item) { throw new System.InvalidOperationException("Collection is read only"); }
-
-            public void Clear() { throw new System.InvalidOperationException("Collection is read only"); }
+            public void Add(BulletSharp.Math.Vector3 item) => throw new System.InvalidOperationException("Collection is read only");
+            public bool Remove(BulletSharp.Math.Vector3 item) => throw new System.InvalidOperationException("Collection is read only");
+            public void Clear() => throw new System.InvalidOperationException("Collection is read only");
 
             public IEnumerator<BulletSharp.Math.Vector3> GetEnumerator()
             {


### PR DESCRIPTION
# PR Details
Finishes implementation of static meshes started in #289 by adding editor and model asset support. 
The shape is created at runtime by deserializing the model's vertex and index buffer from disk since we don't store whole models in cpu memory. (see comments in #289)
Models are shared, using the same model for multiple colliders won't re-allocate vertices and indices, it'll re-use the same buffer in memory.

## Description
![image](https://user-images.githubusercontent.com/5742236/146653106-efdbd6ab-b94f-42a2-9455-9054163912fb.png)
![image](https://user-images.githubusercontent.com/5742236/146653093-28cc23fd-8c11-4541-a5ff-d8197b4318a9.png)
![image](https://user-images.githubusercontent.com/5742236/146652859-da204319-d55b-400e-b0b6-77f965a9769a.png)
(model credit: [luyssport on sketchfab](https://sketchfab.com/3d-models/ftm-0970f30574d047b1976ba0aa6f2ef855))

## Related Issue
Fix #890 
Started of off and replaces PR #1213 and PR #479 

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.