### PR TITLE
Improve native library search on Linux

### DIFF
--- a/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
+++ b/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
@@ -11,6 +11,7 @@ namespace Stride.Core
 {
     public static class NativeLibraryHelper
     {
+        private const string UNIX_LIB_PREFIX = "lib";
         private static readonly Dictionary<string, IntPtr> LoadedLibraries = new Dictionary<string, IntPtr>();
 
         /// <summary>
@@ -18,7 +19,7 @@ namespace Stride.Core
         /// This is useful when we want to have AnyCPU .NET and CPU-specific native code.
         /// Only available on Windows for now.
         /// </summary>
-        /// <param name="libraryName">Name of the library.</param>
+        /// <param name="libraryName">Name of the library, without the extension.</param>
         /// <param name="owner">Type whose assembly location is related to the native library (we can't use GetCallingAssembly as it might be wrong due to optimizations).</param>
         /// <exception cref="System.InvalidOperationException">Library could not be loaded.</exception>
         public static void PreloadLibrary(string libraryName, Type owner)
@@ -34,6 +35,7 @@ namespace Stride.Core
 
                 string cpu;
                 string platform;
+                string extension;
 
                 switch (RuntimeInformation.ProcessArchitecture)
                 {
@@ -65,19 +67,54 @@ namespace Stride.Core
                         throw new PlatformNotSupportedException();
                 }
 
+                switch (Platform.Type)
+                {
+                    case PlatformType.Windows:
+                        extension = ".dll";
+                        break;
+                    case PlatformType.Linux:
+                        extension = ".so";
+                        break;
+                    case PlatformType.macOS:
+                        extension = ".dylib";
+                        break;
+                    default:
+                        throw new PlatformNotSupportedException();
+                }
+
+                var libraryNameWithExtension = libraryName + extension;
+
+                if (Platform.Type != PlatformType.Windows)
+                {
+                    // on linux/macos opening a library without a path will look it up in the global library locations
+                    // e.g. /lib/x86_64-linux-gnu, /lib, /usr/lib, etc. 
+                    if (NativeLibrary.TryLoad(libraryNameWithExtension, out var result))
+                    {
+                        LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                        return;
+                    }
+                    else if (!libraryName.StartsWith(UNIX_LIB_PREFIX)
+                        && NativeLibrary.TryLoad(UNIX_LIB_PREFIX + libraryNameWithExtension, out result))
+                    {
+                        LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                        return;
+                    }
+                }
+
                 // We are trying to load the dll from a shadow path if it is already registered, otherwise we use it directly from the folder
                 {
+                    var platformNativeLibsFolder = $"{platform}-{cpu}";
                     foreach (var libraryPath in new[]
                     {
-                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location) ?? string.Empty, $"{platform}-{cpu}"),
-                        Path.Combine(Environment.CurrentDirectory ?? string.Empty, $"{platform}-{cpu}"),
-                        Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) ?? string.Empty, $"{platform}-{cpu}"),
+                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location) ?? string.Empty, platformNativeLibsFolder),
+                        Path.Combine(Environment.CurrentDirectory ?? string.Empty, platformNativeLibsFolder),
+                        Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) ?? string.Empty, platformNativeLibsFolder),
                         // Also try without platform for Windows-only packages (backward compat for editor packages)
-                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location) ?? string.Empty, $"{cpu}"),
-                        Path.Combine(Environment.CurrentDirectory ?? string.Empty, $"{cpu}"),
+                        Path.Combine(Path.GetDirectoryName(owner.GetTypeInfo().Assembly.Location) ?? string.Empty, cpu),
+                        Path.Combine(Environment.CurrentDirectory ?? string.Empty, cpu),
                     })
                     {
-                        var libraryFilename = Path.Combine(libraryPath, libraryName);
+                        var libraryFilename = Path.Combine(libraryPath, libraryNameWithExtension);
                         if (NativeLibrary.TryLoad(libraryFilename, out var result))
                         {
                             LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
@@ -89,7 +126,7 @@ namespace Stride.Core
                 // Attempt to load it from PATH
                 foreach (var p in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator))
                 {
-                    var libraryFilename = Path.Combine(p, libraryName);
+                    var libraryFilename = Path.Combine(p, libraryNameWithExtension);
                     if (NativeLibrary.TryLoad(libraryFilename, out var result))
                     {
                         LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);

--- a/sources/engine/Stride.Assets.Models/AssimpAssetImporter.cs
+++ b/sources/engine/Stride.Assets.Models/AssimpAssetImporter.cs
@@ -16,7 +16,7 @@ namespace Stride.Assets.Models
     {
         static AssimpAssetImporter()
         {
-            NativeLibraryHelper.PreloadLibrary("assimp-vc140-mt.dll", typeof(AssimpAssetImporter));
+            NativeLibraryHelper.PreloadLibrary("assimp-vc140-mt", typeof(AssimpAssetImporter));
         }
 
         // Supported file extensions for this importer

--- a/sources/engine/Stride.Assets.Models/FbxAssetImporter.cs
+++ b/sources/engine/Stride.Assets.Models/FbxAssetImporter.cs
@@ -14,7 +14,7 @@ namespace Stride.Assets.Models
     {
         static FbxAssetImporter()
         {
-            NativeLibraryHelper.PreloadLibrary("libfbxsdk.dll", typeof(FbxAssetImporter));
+            NativeLibraryHelper.PreloadLibrary("libfbxsdk", typeof(FbxAssetImporter));
         }
 
         // Supported file extensions for this importer

--- a/sources/engine/Stride.Assets/Physics/ColliderShapeAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Physics/ColliderShapeAssetCompiler.cs
@@ -27,7 +27,7 @@ namespace Stride.Assets.Physics
     {
         static ColliderShapeAssetCompiler()
         {
-            NativeLibraryHelper.PreloadLibrary("VHACD.dll", typeof(ColliderShapeAssetCompiler));
+            NativeLibraryHelper.PreloadLibrary("VHACD", typeof(ColliderShapeAssetCompiler));
         }
 
         public override IEnumerable<BuildDependencyInfo> GetInputTypes(AssetItem assetItem)

--- a/sources/engine/Stride.Graphics/Font/FontManager.cs
+++ b/sources/engine/Stride.Graphics/Font/FontManager.cs
@@ -79,7 +79,7 @@ namespace Stride.Graphics.Font
             contentManager = new ContentManager(fileProviderService);
 
             // Preload proper freetype native library (depending on CPU type)
-            NativeLibraryHelper.PreloadLibrary("freetype.dll", typeof(FontManager));
+            NativeLibraryHelper.PreloadLibrary("freetype", typeof(FontManager));
 
             // create a freetype library used to generate the bitmaps
             freetypeLibrary = new Library();

--- a/sources/engine/Stride.Physics/Bullet2PhysicsSystem.cs
+++ b/sources/engine/Stride.Physics/Bullet2PhysicsSystem.cs
@@ -23,7 +23,7 @@ namespace Stride.Physics
         static Bullet2PhysicsSystem()
         {
             // Preload proper libbulletc native library (depending on CPU type)
-            NativeLibraryHelper.PreloadLibrary("libbulletc.dll", typeof(Bullet2PhysicsSystem));
+            NativeLibraryHelper.PreloadLibrary("libbulletc", typeof(Bullet2PhysicsSystem));
         }
 
         public Bullet2PhysicsSystem(IServiceRegistry registry)

--- a/sources/engine/Stride.Physics/Module.cs
+++ b/sources/engine/Stride.Physics/Module.cs
@@ -15,7 +15,7 @@ namespace Stride.Engine
             AssemblyRegistry.Register(typeof(Module).GetTypeInfo().Assembly, AssemblyCommonCategories.Assets);
 
             // Preload proper libbulletc native library (depending on CPU type)
-            NativeLibraryHelper.PreloadLibrary("libbulletc.dll", typeof(PhysicsComponent));
+            NativeLibraryHelper.PreloadLibrary("libbulletc", typeof(PhysicsComponent));
         }
     }
 }

--- a/sources/engine/Stride.Shaders.Compiler/EffectCompiler.cs
+++ b/sources/engine/Stride.Shaders.Compiler/EffectCompiler.cs
@@ -46,7 +46,11 @@ namespace Stride.Shaders.Compiler
         public EffectCompiler(IVirtualFileProvider fileProvider)
         {
             FileProvider = fileProvider;
-            NativeLibraryHelper.PreloadLibrary("d3dcompiler_47.dll", typeof(EffectCompiler));
+            if (Platform.IsWindowsDesktop && !d3dCompilerLoaded)
+            {
+                NativeLibraryHelper.PreloadLibrary("d3dcompiler_47", typeof(EffectCompiler));
+                d3dCompilerLoaded = true;
+            }
             SourceDirectories = new List<string>();
             UrlToFilePath = new Dictionary<string, string>();
         }
@@ -89,7 +93,7 @@ namespace Stride.Shaders.Compiler
             // Note: No lock, it's probably fine if it gets called from multiple threads at the same time.
             if (Platform.IsWindowsDesktop && !d3dCompilerLoaded)
             {
-                NativeLibraryHelper.PreloadLibrary("d3dcompiler_47.dll", typeof(EffectCompiler));
+                NativeLibraryHelper.PreloadLibrary("d3dcompiler_47", typeof(EffectCompiler));
                 d3dCompilerLoaded = true;
             }
 

--- a/sources/engine/Stride.VirtualReality/OpenVR/OpenVR.cs
+++ b/sources/engine/Stride.VirtualReality/OpenVR/OpenVR.cs
@@ -196,7 +196,7 @@ namespace Stride.VirtualReality
 
         static OpenVR()
         {
-            NativeLibraryHelper.PreloadLibrary("openvr_api.dll", typeof(OpenVR));
+            NativeLibraryHelper.PreloadLibrary("openvr_api", typeof(OpenVR));
         }
 
         public static bool InitDone = false;

--- a/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
@@ -37,11 +37,11 @@ namespace Stride.TextureConverter
         static TextureTool()
         {
             var type = typeof(TextureTool);
-            NativeLibraryHelper.PreloadLibrary("DxtWrapper.dll", type);
-            NativeLibraryHelper.PreloadLibrary("PVRTexLib.dll", type);
-            NativeLibraryHelper.PreloadLibrary("PvrttWrapper.dll", type);
-            NativeLibraryHelper.PreloadLibrary("FreeImage.dll", type);
-            NativeLibraryHelper.PreloadLibrary("FreeImageNET.dll", type);
+            NativeLibraryHelper.PreloadLibrary("DxtWrapper", type);
+            NativeLibraryHelper.PreloadLibrary("PVRTexLib", type);
+            NativeLibraryHelper.PreloadLibrary("PvrttWrapper", type);
+            NativeLibraryHelper.PreloadLibrary("FreeImage", type);
+            NativeLibraryHelper.PreloadLibrary("FreeImageNET", type);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

For the Stride native libs (`libcore`, `libstride`, `libstrideaudio`) the existing way of locating libraries was mostly fine, but there may be libraries used like `freetype` (and previously SDL) which are assumed to be installed in the system. In order to find those, we need to pass in the correct name of the library file and let the CLR search for it in global library locations.

In order to make the code easier to read, all calls to `PreloadLibrary` should not include the extension (e.g. `.dll`).

## Related Issue

This is a follow up to the work of #1173 as I found myself having to manually create links for some libraries the current approach wasn't finding.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.