### PR TITLE
Added "AllowMultipleComponents" to LightComponent

### DIFF
--- a/sources/engine/Stride.Engine/Engine/LightComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/LightComponent.cs
@@ -19,6 +19,7 @@ namespace Stride.Engine
     // TODO GRAPHICS REFACTOR
     //[DefaultEntityComponentRenderer(typeof(LightComponentRenderer), -10)]
     [DefaultEntityComponentRenderer(typeof(LightProcessor))]
+    [AllowMultipleComponents]
     [ComponentOrder(12000)]
     [ComponentCategory("Lights")]
     public sealed class LightComponent : ActivableEntityComponent


### PR DESCRIPTION
Added AllowMultipleComponentsAttribute to LightComponent class
issue: https://github.com/stride3d/stride/issues/1138

# PR Details

Added AllowMultipleComponentsAttribute to LightComponent class

## Description

Added AllowMultipleComponentsAttribute to LightComponent class

## Related Issue

https://github.com/stride3d/stride/issues/1138

## Motivation and Context

No reason to prevent users to add multiple lights on the same entity.
Use case:
Ambient and directional light to have just one entity handling 'sun light', directional for direct and ambient for indirect.
Spot and point light for a lighthouse's beam.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Don't know how to run tests. Just builded engine and checked if multiple light sources allowed in single entity