### PR TITLE
Color space change bug fix

### DIFF
--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -1039,6 +1039,7 @@ namespace Stride.Games
                             {
                                 try
                                 {
+                                    GraphicsDevice.ColorSpace = graphicsDeviceInformation.PresentationParameters.ColorSpace;
                                     var newWidth = graphicsDeviceInformation.PresentationParameters.BackBufferWidth;
                                     var newHeight = graphicsDeviceInformation.PresentationParameters.BackBufferHeight;
                                     var newFormat = graphicsDeviceInformation.PresentationParameters.BackBufferFormat;
@@ -1070,9 +1071,6 @@ namespace Stride.Games
                         {
                             throw new InvalidOperationException("Unexpected null GraphicsDevice");
                         }
-
-                        // Make sure to copy back coolor space to GraphicsDevice
-                        GraphicsDevice.ColorSpace = graphicsDeviceInformation.PresentationParameters.ColorSpace;
 
                         var presentationParameters = GraphicsDevice.Presenter.Description;
                         isReallyFullScreen = presentationParameters.IsFullScreen;

--- a/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
@@ -95,7 +95,8 @@ namespace Stride.Graphics
             var newTextureDescription = ConvertFromNativeDescription(texture.Description);
 
             // We might have created the swapchain as a non-srgb format (esp on Win10&RT) but we want it to behave like it is (esp. for the view and render target)
-            newTextureDescription.Format = newTextureDescription.Format.ToSRgb();
+            if(isSrgb)
+                newTextureDescription.Format = newTextureDescription.Format.ToSRgb();
 
             return InitializeFrom(newTextureDescription);
         }

--- a/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
@@ -95,8 +95,7 @@ namespace Stride.Graphics
             var newTextureDescription = ConvertFromNativeDescription(texture.Description);
 
             // We might have created the swapchain as a non-srgb format (esp on Win10&RT) but we want it to behave like it is (esp. for the view and render target)
-            if (isSrgb)
-                newTextureDescription.Format = newTextureDescription.Format.ToSRgb();
+            newTextureDescription.Format = newTextureDescription.Format.ToSRgb();
 
             return InitializeFrom(newTextureDescription);
         }


### PR DESCRIPTION
# PR Details

Changes of color space at GameSettings now applied correctly

## Description

GraphicsDeviceManager now applies changes to GraphicsDevice.ColorSpace before calling GraphicsDevice.Presenter.Resize (resize method uses color space info stored at graphics device to resize buffer with PixelFormat)
Texture.Direct3D now always converts textureDescrioptionFormat to srgb (most likely it was a bug, so only srgb format converted to srgb again)

## Related Issue

https://github.com/stride3d/stride/issues/1035

## Motivation and Context

https://github.com/stride3d/stride/issues/1035

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.