### PR TITLE
[Input] Improve Input.Keys docs and fix a couple of keymapping in SDL

### DIFF
--- a/sources/engine/Stride.Input/Keys.cs
+++ b/sources/engine/Stride.Input/Keys.cs
@@ -906,6 +906,6 @@ namespace Stride.Input
         /// <summary>
         /// The numeric keypad 'decimal' key.
         /// </summary>
-        NumPadDecimal = 181,
+        [System.Obsolete($"Use {nameof(Decimal)} instead")] NumPadDecimal = 181,
     }
 }

--- a/sources/engine/Stride.Input/Keys.cs
+++ b/sources/engine/Stride.Input/Keys.cs
@@ -9,7 +9,7 @@ namespace Stride.Input
     public enum Keys
     {
         /// <summary>
-        /// The 'none' key.
+        /// Invalid key.
         /// </summary>
         None = 0,
 
@@ -19,9 +19,14 @@ namespace Stride.Input
         Cancel = 1,
 
         /// <summary>
-        /// The 'back' key.
+        /// The 'back'/'backspace' key.
         /// </summary>
         Back = 2,
+
+        /// <summary>
+        /// The 'back'/'backspace' key.
+        /// </summary>
+        BackSpace = Back,
 
         /// <summary>
         /// The 'tab' key.
@@ -39,14 +44,14 @@ namespace Stride.Input
         Clear = 5,
 
         /// <summary>
-        /// The 'enter' key.
+        /// The 'enter'/'return' key.
         /// </summary>
         Enter = 6,
 
         /// <summary>
-        /// The 'return' key.
+        /// The 'enter'/'return' key.
         /// </summary>
-        Return = 6,
+        Return = Enter,
 
         /// <summary>
         /// The 'pause' key.
@@ -54,12 +59,12 @@ namespace Stride.Input
         Pause = 7,
 
         /// <summary>
-        /// The 'capital' key.
+        /// The 'capslock'/'capital' key.
         /// </summary>
-        Capital = 8,
+        Capital = CapsLock,
 
         /// <summary>
-        /// The 'capslock' key.
+        /// The 'capslock'/'capital' key.
         /// </summary>
         CapsLock = 8,
 
@@ -124,22 +129,22 @@ namespace Stride.Input
         Space = 18,
 
         /// <summary>
-        /// The 'pageup' key.
+        /// The 'pageup'/'prior' key.
         /// </summary>
         PageUp = 19,
 
         /// <summary>
-        /// The 'prior' key.
+        /// The 'pageup'/'prior' key.
         /// </summary>
-        Prior = 19,
+        Prior = PageUp,
 
         /// <summary>
-        /// The 'next' key.
+        /// The 'pagedown'/'next' key.
         /// </summary>
-        Next = 20,
+        Next = PageDown,
 
         /// <summary>
-        /// The 'pagedown' key.
+        /// The 'pagedown'/'next' key.
         /// </summary>
         PageDown = 20,
 
@@ -179,7 +184,7 @@ namespace Stride.Input
         Select = 27,
 
         /// <summary>
-        /// The 'print' key.
+        /// The 'print' key, not to be confused with <see cref="PrintScreen"/>.
         /// </summary>
         Print = 28,
 
@@ -189,14 +194,14 @@ namespace Stride.Input
         Execute = 29,
 
         /// <summary>
-        /// The 'printscreen' key.
+        /// The 'snapshot'/'printscreen' key.
         /// </summary>
         PrintScreen = 30,
 
         /// <summary>
-        /// The 'snapshot' key.
+        /// The 'snapshot'/'printscreen' key
         /// </summary>
-        Snapshot = 30,
+        Snapshot = PrintScreen,
 
         /// <summary>
         /// The 'insert' key.
@@ -214,52 +219,52 @@ namespace Stride.Input
         Help = 33,
 
         /// <summary>
-        /// The 'd0' key.
+        /// The number row '0' key.
         /// </summary>
         D0 = 34,
 
         /// <summary>
-        /// The 'd1' key.
+        /// The number row '1' key.
         /// </summary>
         D1 = 35,
 
         /// <summary>
-        /// The 'd2' key.
+        /// The number row '2' key.
         /// </summary>
         D2 = 36,
 
         /// <summary>
-        /// The 'd3' key.
+        /// The number row '3' key.
         /// </summary>
         D3 = 37,
 
         /// <summary>
-        /// The 'd4' key.
+        /// The number row '4' key.
         /// </summary>
         D4 = 38,
 
         /// <summary>
-        /// The 'd5' key.
+        /// The number row '5' key.
         /// </summary>
         D5 = 39,
 
         /// <summary>
-        /// The 'd6' key.
+        /// The number row '6' key.
         /// </summary>
         D6 = 40,
 
         /// <summary>
-        /// The 'd7' key.
+        /// The number row '7' key.
         /// </summary>
         D7 = 41,
 
         /// <summary>
-        /// The 'd8' key.
+        /// The number row '8' key.
         /// </summary>
         D8 = 42,
 
         /// <summary>
-        /// The 'd9' key.
+        /// The number row '9' key.
         /// </summary>
         D9 = 43,
 
@@ -394,17 +399,17 @@ namespace Stride.Input
         Z = 69,
 
         /// <summary>
-        /// The 'leftwin' key.
+        /// The left 'windows'/'command'/'meta' key.
         /// </summary>
         LeftWin = 70,
 
         /// <summary>
-        /// The 'rightwin' key.
+        /// The right 'windows'/'command'/'meta' key.
         /// </summary>
         RightWin = 71,
 
         /// <summary>
-        /// The 'apps' key.
+        /// The 'apps'/'Menu'/'FN2' key, between the windows and right ctrl key on a 104 keys keyboard.
         /// </summary>
         Apps = 72,
 
@@ -414,62 +419,62 @@ namespace Stride.Input
         Sleep = 73,
 
         /// <summary>
-        /// The 'numpad0' key.
+        /// The numeric keypad '0' key.
         /// </summary>
         NumPad0 = 74,
 
         /// <summary>
-        /// The 'numpad1' key.
+        /// The numeric keypad '1' key.
         /// </summary>
         NumPad1 = 75,
 
         /// <summary>
-        /// The 'numpad2' key.
+        /// The numeric keypad '2' key.
         /// </summary>
         NumPad2 = 76,
 
         /// <summary>
-        /// The 'numpad3' key.
+        /// The numeric keypad '3' key.
         /// </summary>
         NumPad3 = 77,
 
         /// <summary>
-        /// The 'numpad4' key.
+        /// The numeric keypad '4' key.
         /// </summary>
         NumPad4 = 78,
 
         /// <summary>
-        /// The 'numpad5' key.
+        /// The numeric keypad '5' key.
         /// </summary>
         NumPad5 = 79,
 
         /// <summary>
-        /// The 'numpad6' key.
+        /// The numeric keypad '6' key.
         /// </summary>
         NumPad6 = 80,
 
         /// <summary>
-        /// The 'numpad7' key.
+        /// The numeric keypad '7' key.
         /// </summary>
         NumPad7 = 81,
 
         /// <summary>
-        /// The 'numpad8' key.
+        /// The numeric keypad '8' key.
         /// </summary>
         NumPad8 = 82,
 
         /// <summary>
-        /// The 'numpad9' key.
+        /// The numeric keypad '9' key.
         /// </summary>
         NumPad9 = 83,
 
         /// <summary>
-        /// The 'multiply' key.
+        /// The numeric keypad 'multiply' key.
         /// </summary>
         Multiply = 84,
 
         /// <summary>
-        /// The 'add' key.
+        /// The numeric keypad 'add' key.
         /// </summary>
         Add = 85,
 
@@ -479,137 +484,137 @@ namespace Stride.Input
         Separator = 86,
 
         /// <summary>
-        /// The 'subtract' key.
+        /// The numeric keypad 'subtract' key.
         /// </summary>
         Subtract = 87,
 
         /// <summary>
-        /// The 'decimal' key.
+        /// The numeric keypad 'decimal' and 'decimal separator' key.
         /// </summary>
         Decimal = 88,
 
         /// <summary>
-        /// The 'divide' key.
+        /// The numeric keypad 'divide' key.
         /// </summary>
         Divide = 89,
 
         /// <summary>
-        /// The 'f1' key.
+        /// The function key 'f1'.
         /// </summary>
         F1 = 90,
 
         /// <summary>
-        /// The 'f2' key.
+        /// The function key 'f2'.
         /// </summary>
         F2 = 91,
 
         /// <summary>
-        /// The 'f3' key.
+        /// The function key 'f3'.
         /// </summary>
         F3 = 92,
 
         /// <summary>
-        /// The 'f4' key.
+        /// The function key 'f4'.
         /// </summary>
         F4 = 93,
 
         /// <summary>
-        /// The 'f5' key.
+        /// The function key 'f5'.
         /// </summary>
         F5 = 94,
 
         /// <summary>
-        /// The 'f6' key.
+        /// The function key 'f6'.
         /// </summary>
         F6 = 95,
 
         /// <summary>
-        /// The 'f7' key.
+        /// The function key 'f7'.
         /// </summary>
         F7 = 96,
 
         /// <summary>
-        /// The 'f8' key.
+        /// The function key 'f8'.
         /// </summary>
         F8 = 97,
 
         /// <summary>
-        /// The 'f9' key.
+        /// The function key 'f9'.
         /// </summary>
         F9 = 98,
 
         /// <summary>
-        /// The 'f10' key.
+        /// The function key 'f10'.
         /// </summary>
         F10 = 99,
 
         /// <summary>
-        /// The 'f11' key.
+        /// The function key 'f11'.
         /// </summary>
         F11 = 100,
 
         /// <summary>
-        /// The 'f12' key.
+        /// The function key 'f12'.
         /// </summary>
         F12 = 101,
 
         /// <summary>
-        /// The 'f13' key.
+        /// The function key 'f13'.
         /// </summary>
         F13 = 102,
 
         /// <summary>
-        /// The 'f14' key.
+        /// The function key 'f14'.
         /// </summary>
         F14 = 103,
 
         /// <summary>
-        /// The 'f15' key.
+        /// The function key 'f15'.
         /// </summary>
         F15 = 104,
 
         /// <summary>
-        /// The 'f16' key.
+        /// The function key 'f16'.
         /// </summary>
         F16 = 105,
 
         /// <summary>
-        /// The 'f17' key.
+        /// The function key 'f17'.
         /// </summary>
         F17 = 106,
 
         /// <summary>
-        /// The 'f18' key.
+        /// The function key 'f18'.
         /// </summary>
         F18 = 107,
 
         /// <summary>
-        /// The 'f19' key.
+        /// The function key 'f19'.
         /// </summary>
         F19 = 108,
 
         /// <summary>
-        /// The 'f20' key.
+        /// The function key 'f20'.
         /// </summary>
         F20 = 109,
 
         /// <summary>
-        /// The 'f21' key.
+        /// The function key 'f21'.
         /// </summary>
         F21 = 110,
 
         /// <summary>
-        /// The 'f22' key.
+        /// The function key 'f22'.
         /// </summary>
         F22 = 111,
 
         /// <summary>
-        /// The 'f23' key.
+        /// The function key 'f23'.
         /// </summary>
         F23 = 112,
 
         /// <summary>
-        /// The 'f24' key.
+        /// The function key 'f24'.
         /// </summary>
         F24 = 113,
 
@@ -619,37 +624,37 @@ namespace Stride.Input
         NumLock = 114,
 
         /// <summary>
-        /// The 'scroll' key.
+        /// The 'scroll'/'scroll lock' key.
         /// </summary>
         Scroll = 115,
 
         /// <summary>
-        /// The 'leftshift' key.
+        /// The left 'shift' key.
         /// </summary>
         LeftShift = 116,
 
         /// <summary>
-        /// The 'rightshift' key.
+        /// The right 'shift' key.
         /// </summary>
         RightShift = 117,
 
         /// <summary>
-        /// The 'leftctrl' key.
+        /// The left 'ctrl' key.
         /// </summary>
         LeftCtrl = 118,
 
         /// <summary>
-        /// The 'rightctrl' key.
+        /// The right 'ctrl' key.
         /// </summary>
         RightCtrl = 119,
 
         /// <summary>
-        /// The 'leftalt' key.
+        /// The left 'alt' key.
         /// </summary>
         LeftAlt = 120,
 
         /// <summary>
-        /// The 'rightalt' key.
+        /// The right 'alt' key.
         /// </summary>
         RightAlt = 121,
 
@@ -744,107 +749,107 @@ namespace Stride.Input
         LaunchApplication2 = 139,
 
         /// <summary>
-        /// The 'oem1' key.
+        /// The 'oem1'/'semicolon' key, to the right of the 'L' key on a standard US layout.
         /// </summary>
-        Oem1 = 140,
+        Oem1 = OemSemicolon,
 
         /// <summary>
-        /// The 'oemsemicolon' key.
+        /// The 'oem1'/'semicolon' key, to the right of the 'L' key on a standard US layout.
         /// </summary>
         OemSemicolon = 140,
 
         /// <summary>
-        /// The 'oemplus' key.
+        /// The 'oemplus'/'Equals' key, to the left of the backspace key on a standard US layout.
         /// </summary>
         OemPlus = 141,
 
         /// <summary>
-        /// The 'oemcomma' key.
+        /// The 'oemcomma' key, to the right of the 'M' key on a standard US layout.
         /// </summary>
         OemComma = 142,
 
         /// <summary>
-        /// The 'oemminus' key.
+        /// The 'oemminus' key, to the right of the number row '0' key on a standard US layout.
         /// </summary>
         OemMinus = 143,
 
         /// <summary>
-        /// The 'oemperiod' key.
+        /// The 'oemperiod' key, right between 'M' and the right shift key on a standard US layout.
         /// </summary>
         OemPeriod = 144,
 
         /// <summary>
-        /// The 'oem2' key.
+        /// The 'oemquestion'/'oem2' key, next to 'right shift' on a standard US layout.
         /// </summary>
-        Oem2 = 145,
+        Oem2 = OemQuestion,
 
         /// <summary>
-        /// The 'oemquestion' key.
+        /// The 'oemquestion'/'oem2' key, next to 'right shift' on a standard US layout.
         /// </summary>
         OemQuestion = 145,
 
         /// <summary>
-        /// The 'oem3' key.
+        /// The 'oemtilde'/'oem3' key, above 'tab' on a standard US layout.
         /// </summary>
-        Oem3 = 146,
+        Oem3 = OemTilde,
 
         /// <summary>
-        /// The 'oemtilde' key.
+        /// The 'oemtilde'/'oem3' key, above 'tab' on a standard US layout.
         /// </summary>
         OemTilde = 146,
 
         /// <summary>
-        /// The 'oem4' key.
+        /// The 'OemOpenBrackets'/'oem4' key, to the right of 'P' on a standard US layout.
         /// </summary>
-        Oem4 = 149,
+        Oem4 = OemOpenBrackets,
 
         /// <summary>
-        /// The 'oemopenbrackets' key.
+        /// The 'OemOpenBrackets'/'oem4' key, to the right of 'P' on a standard US layout.
         /// </summary>
         OemOpenBrackets = 149,
 
         /// <summary>
-        /// The 'oem5' key.
+        /// The 'OemPipe'/'oem5' key, either at the lower left of the 'return' key for ISO or between 'return' and 'backspace' for ANSI on a standard US layout.
         /// </summary>
-        Oem5 = 150,
+        Oem5 = OemPipe,
 
         /// <summary>
-        /// The 'oempipe' key.
+        /// The 'OemPipe'/'oem5' key, either at the lower left of the 'return' key for ISO or between 'return' and 'backspace' for ANSI on a standard US layout.
         /// </summary>
         OemPipe = 150,
 
         /// <summary>
-        /// The 'oem6' key.
+        /// The 'OemCloseBrackets'/'oem6' key, second key to the right of 'P' on a standard US layout.
         /// </summary>
-        Oem6 = 151,
+        Oem6 = OemCloseBrackets,
 
         /// <summary>
-        /// The 'oemclosebrackets' key.
+        /// The 'OemCloseBrackets'/'oem6' key, second key to the right of 'P' on a standard US layout.
         /// </summary>
         OemCloseBrackets = 151,
 
         /// <summary>
-        /// The 'oem7' key.
+        /// The 'OemQuotes'/'oem7' key, second key to the right of 'L' on a standard US layout.
         /// </summary>
-        Oem7 = 152,
+        Oem7 = OemQuotes,
 
         /// <summary>
-        /// The 'oemquotes' key.
+        /// The 'OemQuotes'/'oem7' key, second key to the right of 'L' on a standard US layout.
         /// </summary>
         OemQuotes = 152,
 
         /// <summary>
-        /// The 'oem8' key.
+        /// The 'oem8' key, on a UK layout the left most key on the number row, same position as <see cref="OemTilde"/> on US layout.
         /// </summary>
         Oem8 = 153,
 
         /// <summary>
-        /// The 'oem102' key.
+        /// The 'OemBackSlash'/'oem102' key, on US ISO keyboards this key sits between left shift and 'Z'.
         /// </summary>
-        Oem102 = 154,
+        Oem102 = OemBackslash,
 
         /// <summary>
-        /// The 'oembackslash' key.
+        /// The 'OemBackSlash'/'oem102' key, on US ISO keyboards this key sits between left shift and 'Z'.
         /// </summary>
         OemBackslash = 154,
 
@@ -879,12 +884,12 @@ namespace Stride.Input
         Zoom = 168,
 
         /// <summary>
-        /// The 'noname' key.
+        /// A windows-reserved key.
         /// </summary>
         NoName = 169,
 
         /// <summary>
-        /// The 'pa1' key.
+        /// The 'PA1' or 'Program Action'/'Program Attention' 1 key on a 3270 IBM keyboard.
         /// </summary>
         Pa1 = 170,
 
@@ -894,12 +899,12 @@ namespace Stride.Input
         OemClear = 171,
 
         /// <summary>
-        /// The 'numpad enter' key.
+        /// The numeric keypad 'enter' key in SDL and RawInput, Winforms forwards it to <see cref="Return"/> instead.
         /// </summary>
         NumPadEnter = 180,
 
         /// <summary>
-        /// The 'numpad decimal' key.
+        /// The numeric keypad 'decimal' key.
         /// </summary>
         NumPadDecimal = 181,
     }

--- a/sources/engine/Stride.Input/SDL/KeyboardSDL.cs
+++ b/sources/engine/Stride.Input/SDL/KeyboardSDL.cs
@@ -63,12 +63,9 @@ namespace Stride.Input
         private void OnKeyEvent(KeyboardEvent e)
         {
             // Try to map to a stride key
-            Keys key;
-            if (SDLKeys.MapKeys.TryGetValue((KeyCode)e.Keysym.Sym, out key) && key != Keys.None)
+            Keys key = SDLKeys.MapKey((KeyCode)e.Keysym.Sym, e.Keysym.Scancode);
+            if (key != Keys.None)
             {
-                // SDL maps OEM102 and OEM5 (OemBackslash and OemPipe) to the same keycode, swap to OEM5 based on the scancode
-                if (key == Keys.OemBackslash && e.Keysym.Scancode != Scancode.ScancodeNonusbackslash)
-                    key = Keys.OemPipe;
                 if ((EventType)e.Type == EventType.Keydown)
                     HandleKeyDown(key);
                 else
@@ -117,204 +114,196 @@ namespace Stride.Input
         /// </summary>
         private static class SDLKeys
         {
-            /// <summary>
-            /// Map between SDL keys and Stride keys.
-            /// </summary>
-            internal static readonly Dictionary<KeyCode, Keys> MapKeys = NewMapKeys();
-
-            /// <summary>
-            /// Create a mapping between <see cref="KeyCode"/> and <see cref="Stride.Input.Keys"/>
-            /// </summary>
-            /// <remarks>Not all <see cref="Stride.Input.Keys"/> have a corresponding SDL entries. For the moment they are commented out in the code below.</remarks>
-            /// <returns>A new map.</returns>
-            private static Dictionary<KeyCode, Keys> NewMapKeys()
+            internal static Keys MapKey(KeyCode input, Scancode scancode)
             {
                 // Resources: http://kbdlayout.info/kbdusx/overview+virtualkeys
                 //            https://wiki.libsdl.org/SDL_Keycode
                 //            http://kbdedit.com/manual/low_level_vk_list.html
-                var map = new Dictionary<KeyCode, Keys>(200);
-                map[KeyCode.KUnknown] = Keys.None;
-                map[KeyCode.KCancel] = Keys.Cancel;
-                map[KeyCode.KBackspace] = Keys.Back;
-                map[KeyCode.KKPTab] = map[KeyCode.KTab] = Keys.Tab;
-                //            map [KeyCode.KUnknown] = Keys.LineFeed;
-                map[KeyCode.KClear] = map[KeyCode.KClearagain] = map[KeyCode.KKPClear] = map[KeyCode.KKPClearentry] = Keys.Clear;
-                map[KeyCode.KReturn] = map[KeyCode.KReturn2] = Keys.Return;
-                map[KeyCode.KPause] = Keys.Pause;
-                //            map [KeyCode.KCapslock] = Keys.Capital; // Capital is the same as CapsLock
-                map[KeyCode.KCapslock] = Keys.CapsLock;
-                //            map [KeyCode.KUnknown] = Keys.HangulMode;
-                //            map [KeyCode.KUnknown] = Keys.KanaMode;
-                //            map [KeyCode.KUnknown] = Keys.JunjaMode;
-                //            map [KeyCode.KUnknown] = Keys.FinalMode;
-                //            map [KeyCode.KUnknown] = Keys.HanjaMode;
-                //            map [KeyCode.KUnknown] = Keys.KanjiMode;
-                map[KeyCode.KEscape] = Keys.Escape;
-                //            map [KeyCode.KUnknown] = Keys.ImeConvert;
-                //            map [KeyCode.KUnknown] = Keys.ImeNonConvert;
-                //            map [KeyCode.KUnknown] = Keys.ImeAccept;
-                //            map [KeyCode.KUnknown] = Keys.ImeModeChange;
-                map[KeyCode.KSpace] = map[KeyCode.KKPSpace] = Keys.Space;
-                map[KeyCode.KPageup] = Keys.PageUp;
-                map[KeyCode.KPrior] = Keys.Prior;
-                //            map [KeyCode.KPagedown] = Keys.Next; // Next is the same as PageDown
-                map[KeyCode.KPagedown] = Keys.PageDown;
-                map[KeyCode.KEnd] = Keys.End;
-                map[KeyCode.KHome] = Keys.Home;
-                map[KeyCode.KLeft] = Keys.Left;
-                map[KeyCode.KUp] = Keys.Up;
-                map[KeyCode.KRight] = Keys.Right;
-                map[KeyCode.KDown] = Keys.Down;
-                map[KeyCode.KSelect] = Keys.Select;
-                //            map [KeyCode.KUnknown] = Keys.Print;
-                map[KeyCode.KExecute] = Keys.Execute;
-                map[KeyCode.KPrintscreen] = Keys.PrintScreen;
-                //            map [KeyCode.KPrintscreen] = Keys.Snapshot; // Snapshot is the same as PrintScreen
-                map[KeyCode.KInsert] = Keys.Insert;
-                map[KeyCode.KDelete] = Keys.Delete;
-                map[KeyCode.KHelp] = Keys.Help;
-                map[KeyCode.K0] = Keys.D0;
-                map[KeyCode.K1] = Keys.D1;
-                map[KeyCode.K2] = Keys.D2;
-                map[KeyCode.K3] = Keys.D3;
-                map[KeyCode.K4] = Keys.D4;
-                map[KeyCode.K5] = Keys.D5;
-                map[KeyCode.K6] = Keys.D6;
-                map[KeyCode.K7] = Keys.D7;
-                map[KeyCode.K8] = Keys.D8;
-                map[KeyCode.K9] = Keys.D9;
-                map[KeyCode.KA] = Keys.A;
-                map[KeyCode.KB] = Keys.B;
-                map[KeyCode.KC] = Keys.C;
-                map[KeyCode.KD] = Keys.D;
-                map[KeyCode.KE] = Keys.E;
-                map[KeyCode.KF] = Keys.F;
-                map[KeyCode.KG] = Keys.G;
-                map[KeyCode.KH] = Keys.H;
-                map[KeyCode.KI] = Keys.I;
-                map[KeyCode.KJ] = Keys.J;
-                map[KeyCode.KK] = Keys.K;
-                map[KeyCode.KL] = Keys.L;
-                map[KeyCode.KM] = Keys.M;
-                map[KeyCode.KN] = Keys.N;
-                map[KeyCode.KO] = Keys.O;
-                map[KeyCode.KP] = Keys.P;
-                map[KeyCode.KQ] = Keys.Q;
-                map[KeyCode.KR] = Keys.R;
-                map[KeyCode.KS] = Keys.S;
-                map[KeyCode.KT] = Keys.T;
-                map[KeyCode.KU] = Keys.U;
-                map[KeyCode.KV] = Keys.V;
-                map[KeyCode.KW] = Keys.W;
-                map[KeyCode.KX] = Keys.X;
-                map[KeyCode.KY] = Keys.Y;
-                map[KeyCode.KZ] = Keys.Z;
-                map[KeyCode.KLgui] = Keys.LeftWin;
-                map[KeyCode.KRgui] = Keys.RightWin;
-                map[KeyCode.KApplication] = Keys.Apps; // TODO: Verify value
-                map[KeyCode.KSleep] = Keys.Sleep;
-                map[KeyCode.KKP0] = Keys.NumPad0;
-                map[KeyCode.KKP1] = Keys.NumPad1;
-                map[KeyCode.KKP2] = Keys.NumPad2;
-                map[KeyCode.KKP3] = Keys.NumPad3;
-                map[KeyCode.KKP4] = Keys.NumPad4;
-                map[KeyCode.KKP5] = Keys.NumPad5;
-                map[KeyCode.KKP6] = Keys.NumPad6;
-                map[KeyCode.KKP7] = Keys.NumPad7;
-                map[KeyCode.KKP8] = Keys.NumPad8;
-                map[KeyCode.KKP9] = Keys.NumPad9;
-                map[KeyCode.KKPMultiply] = Keys.Multiply;
-                map[KeyCode.KPlus]/*KPlus is not a physical key*/ = map[KeyCode.KKPPlus] = Keys.Add;
-                map[KeyCode.KSeparator] = Keys.Separator;
-                map[KeyCode.KKPMinus] = Keys.Subtract;
-                map[KeyCode.KKPPeriod] = map[KeyCode.KKPDecimal] = Keys.Decimal;
-                map[KeyCode.KThousandsseparator] = map[KeyCode.KDecimalseparator] = Keys.Decimal; // See ISO/IEC 9995-4
-                map[KeyCode.KKPDivide] = Keys.Divide;
-                map[KeyCode.KF1] = Keys.F1;
-                map[KeyCode.KF2] = Keys.F2;
-                map[KeyCode.KF3] = Keys.F3;
-                map[KeyCode.KF4] = Keys.F4;
-                map[KeyCode.KF5] = Keys.F5;
-                map[KeyCode.KF6] = Keys.F6;
-                map[KeyCode.KF7] = Keys.F7;
-                map[KeyCode.KF8] = Keys.F8;
-                map[KeyCode.KF9] = Keys.F9;
-                map[KeyCode.KF10] = Keys.F10;
-                map[KeyCode.KF11] = Keys.F11;
-                map[KeyCode.KF12] = Keys.F12;
-                map[KeyCode.KF13] = Keys.F13;
-                map[KeyCode.KF14] = Keys.F14;
-                map[KeyCode.KF15] = Keys.F15;
-                map[KeyCode.KF16] = Keys.F16;
-                map[KeyCode.KF17] = Keys.F17;
-                map[KeyCode.KF18] = Keys.F18;
-                map[KeyCode.KF19] = Keys.F19;
-                map[KeyCode.KF20] = Keys.F20;
-                map[KeyCode.KF21] = Keys.F21;
-                map[KeyCode.KF22] = Keys.F22;
-                map[KeyCode.KF23] = Keys.F23;
-                map[KeyCode.KF24] = Keys.F24;
-                map[KeyCode.KNumlockclear] = Keys.NumLock;
-                map[KeyCode.KScrolllock] = Keys.Scroll;
-                map[KeyCode.KLshift] = Keys.LeftShift;
-                map[KeyCode.KRshift] = Keys.RightShift;
-                map[KeyCode.KLctrl] = Keys.LeftCtrl;
-                map[KeyCode.KRctrl] = Keys.RightCtrl;
-                map[KeyCode.KLalt] = Keys.LeftAlt;
-                map[KeyCode.KRalt] = Keys.RightAlt;
-                map[KeyCode.KACBack] = Keys.BrowserBack;
-                map[KeyCode.KACForward] = Keys.BrowserForward;
-                map[KeyCode.KACRefresh] = Keys.BrowserRefresh;
-                map[KeyCode.KACStop] = Keys.BrowserStop;
-                map[KeyCode.KACSearch] = Keys.BrowserSearch;
-                map[KeyCode.KACBookmarks] = Keys.BrowserFavorites;
-                map[KeyCode.KACHome] = Keys.BrowserHome;
-                map[KeyCode.KAudiomute] = Keys.VolumeMute;
-                map[KeyCode.KVolumedown] = Keys.VolumeDown;
-                map[KeyCode.KVolumeup] = Keys.VolumeUp;
-                map[KeyCode.KAudionext] = Keys.MediaNextTrack;
-                map[KeyCode.KAudioprev] = Keys.MediaPreviousTrack;
-                map[KeyCode.KAudiostop] = Keys.MediaStop;
-                map[KeyCode.KAudioplay] = Keys.MediaPlayPause;
-                map[KeyCode.KMail] = Keys.LaunchMail;
-                map[KeyCode.KMediaselect] = Keys.SelectMedia;
-                map[KeyCode.KApp1] = Keys.LaunchApplication1;
-                map[KeyCode.KApp2] = Keys.LaunchApplication2;
-                //            map [KeyCode.KSemicolon] = Keys.Oem1; // Same as OemSemicolon
-                map[KeyCode.KSemicolon] = Keys.OemSemicolon;
-                map[KeyCode.KEquals] = Keys.OemPlus;
-                map[KeyCode.KComma] = Keys.OemComma;
-                map[KeyCode.KMinus] = Keys.OemMinus;
-                map[KeyCode.KPeriod] = Keys.OemPeriod;
-                //            map [KeyCode.KUnknown] = Keys.Oem2; // Same as OemQuestion
-                map[KeyCode.KSlash] = Keys.OemQuestion;
-                //            map [KeyCode.KUnknown] = Keys.Oem3; // Same as OemTilde
-                map[KeyCode.KBackquote] = Keys.OemTilde;
-                //            map [KeyCode.KUnknown] = Keys.Oem4; // Same as OemOpenBrackets
-                map[KeyCode.KLeftbracket] = Keys.OemOpenBrackets;
-                //            map [KeyCode.KUnknown] = Keys.Oem5; // Same as OemPipe
-                map[KeyCode.KBackslash] = Keys.OemPipe; // Will be overwritten lower, SDL maps both to same KeyCode, we have to select based on scancode
-                //            map [KeyCode.KUnknown] = Keys.Oem6; // Same as OemCloseBrackets
-                map[KeyCode.KRightbracket] = Keys.OemCloseBrackets;
-                //            map [KeyCode.KUnknown] = Keys.Oem7; // same as OemQuotes
-                map[KeyCode.KQuote] = Keys.OemQuotes;
-                // SDL maps OEM8 to Backquote which is already OEMTilde, this key is often used to open in game consoles and such, I think we should keep it as is
-                // to avoid UK players being unable to access that feature
-                // http://kbdlayout.info/kbdsmsfi
-                // map[KeyCode.KBackquote] = Keys.Oem8;
-                //            map [KeyCode.KUnknown] = Keys.Oem102; // same as OemBackslash
-                map[KeyCode.KBackslash] = Keys.OemBackslash;
-                //            map [KeyCode.KUnknown] = Keys.Attn;
-                map[KeyCode.KCrsel] = Keys.CrSel;
-                map[KeyCode.KExsel] = Keys.ExSel;
-                //            map [KeyCode.KUnknown] = Keys.EraseEof;
-                //            map [KeyCode.KUnknown] = Keys.Play;
-                //            map [KeyCode.KUnknown] = Keys.Zoom;
-                //            map [KeyCode.KUnknown] = Keys.NoName;
-                //            map [KeyCode.KUnknown] = Keys.Pa1;
-                map[KeyCode.KClear] = Keys.OemClear;
-                map[KeyCode.KKPEnter] = Keys.NumPadEnter;
-                return map;
+                switch(input)
+                {
+                    case KeyCode.KUnknown: return Keys.None;
+                    case KeyCode.KCancel: return Keys.Cancel;
+                    case KeyCode.KKPBackspace: case KeyCode.KBackspace: return Keys.Back;
+                    case KeyCode.KTab: case KeyCode.KKPTab: return Keys.Tab;
+                    //            KeyCode.KUnknown: return Keys.LineFeed;
+                    case KeyCode.KClear: case KeyCode.KClearagain: case KeyCode.KKPClear: case KeyCode.KKPClearentry: return Keys.Clear;
+                    case KeyCode.KReturn: case KeyCode.KReturn2: return Keys.Return;
+                    case KeyCode.KPause: return Keys.Pause;
+                    //            KeyCode.KCapslock: return Keys.Capital; // Capital is the same as CapsLock
+                    case KeyCode.KCapslock: return Keys.CapsLock;
+                    //            KeyCode.KUnknown: return Keys.HangulMode;
+                    //            KeyCode.KUnknown: return Keys.KanaMode;
+                    //            KeyCode.KUnknown: return Keys.JunjaMode;
+                    //            KeyCode.KUnknown: return Keys.FinalMode;
+                    //            KeyCode.KUnknown: return Keys.HanjaMode;
+                    //            KeyCode.KUnknown: return Keys.KanjiMode;
+                    case KeyCode.KEscape: return Keys.Escape;
+                    //            KeyCode.KUnknown: return Keys.ImeConvert;
+                    //            KeyCode.KUnknown: return Keys.ImeNonConvert;
+                    //            KeyCode.KUnknown: return Keys.ImeAccept;
+                    //            KeyCode.KUnknown: return Keys.ImeModeChange;
+                    case KeyCode.KSpace: case KeyCode.KKPSpace: return Keys.Space;
+                    case KeyCode.KPageup: return Keys.PageUp;
+                    case KeyCode.KPrior: return Keys.Prior;
+                    //            KeyCode.KPagedown: return Keys.Next; // Next is the same as PageDown
+                    case KeyCode.KPagedown: return Keys.PageDown;
+                    case KeyCode.KEnd: return Keys.End;
+                    case KeyCode.KHome: return Keys.Home;
+                    case KeyCode.KLeft: return Keys.Left;
+                    case KeyCode.KUp: return Keys.Up;
+                    case KeyCode.KRight: return Keys.Right;
+                    case KeyCode.KDown: return Keys.Down;
+                    case KeyCode.KSelect: return Keys.Select;
+                    //            KeyCode.KUnknown: return Keys.Print;
+                    case KeyCode.KExecute: return Keys.Execute;
+                    case KeyCode.KPrintscreen: return Keys.PrintScreen;
+                    //            KeyCode.KPrintscreen: return Keys.Snapshot; // Snapshot is the same as PrintScreen
+                    case KeyCode.KInsert: return Keys.Insert;
+                    case KeyCode.KDelete: return Keys.Delete;
+                    case KeyCode.KHelp: return Keys.Help;
+                    case KeyCode.K0: return Keys.D0;
+                    case KeyCode.K1: return Keys.D1;
+                    case KeyCode.K2: return Keys.D2;
+                    case KeyCode.K3: return Keys.D3;
+                    case KeyCode.K4: return Keys.D4;
+                    case KeyCode.K5: return Keys.D5;
+                    case KeyCode.K6: return Keys.D6;
+                    case KeyCode.K7: return Keys.D7;
+                    case KeyCode.K8: return Keys.D8;
+                    case KeyCode.K9: return Keys.D9;
+                    case KeyCode.KA: return Keys.A;
+                    case KeyCode.KB: return Keys.B;
+                    case KeyCode.KC: return Keys.C;
+                    case KeyCode.KD: return Keys.D;
+                    case KeyCode.KE: return Keys.E;
+                    case KeyCode.KF: return Keys.F;
+                    case KeyCode.KG: return Keys.G;
+                    case KeyCode.KH: return Keys.H;
+                    case KeyCode.KI: return Keys.I;
+                    case KeyCode.KJ: return Keys.J;
+                    case KeyCode.KK: return Keys.K;
+                    case KeyCode.KL: return Keys.L;
+                    case KeyCode.KM: return Keys.M;
+                    case KeyCode.KN: return Keys.N;
+                    case KeyCode.KO: return Keys.O;
+                    case KeyCode.KP: return Keys.P;
+                    case KeyCode.KQ: return Keys.Q;
+                    case KeyCode.KR: return Keys.R;
+                    case KeyCode.KS: return Keys.S;
+                    case KeyCode.KT: return Keys.T;
+                    case KeyCode.KU: return Keys.U;
+                    case KeyCode.KV: return Keys.V;
+                    case KeyCode.KW: return Keys.W;
+                    case KeyCode.KX: return Keys.X;
+                    case KeyCode.KY: return Keys.Y;
+                    case KeyCode.KZ: return Keys.Z;
+                    case KeyCode.KLgui: return Keys.LeftWin;
+                    case KeyCode.KRgui: return Keys.RightWin;
+                    case KeyCode.KApplication: return Keys.Apps;
+                    case KeyCode.KSleep: return Keys.Sleep;
+                    case KeyCode.KKP0: return Keys.NumPad0;
+                    case KeyCode.KKP1: return Keys.NumPad1;
+                    case KeyCode.KKP2: return Keys.NumPad2;
+                    case KeyCode.KKP3: return Keys.NumPad3;
+                    case KeyCode.KKP4: return Keys.NumPad4;
+                    case KeyCode.KKP5: return Keys.NumPad5;
+                    case KeyCode.KKP6: return Keys.NumPad6;
+                    case KeyCode.KKP7: return Keys.NumPad7;
+                    case KeyCode.KKP8: return Keys.NumPad8;
+                    case KeyCode.KKP9: return Keys.NumPad9;
+                    case KeyCode.KKPMultiply: return Keys.Multiply;
+                    case KeyCode.KPlus/*KPlus is not a physical key*/: case KeyCode.KKPPlus: return Keys.Add;
+                    case KeyCode.KSeparator: return Keys.Separator;
+                    case KeyCode.KKPMinus: return Keys.Subtract;
+                    case KeyCode.KKPComma: case KeyCode.KKPPeriod: case KeyCode.KKPDecimal: return Keys.Decimal;
+                    case KeyCode.KThousandsseparator: case KeyCode.KDecimalseparator: return Keys.Decimal; // See ISO/IEC 9995-4
+                    case KeyCode.KKPDivide: return Keys.Divide;
+                    case KeyCode.KF1: return Keys.F1;
+                    case KeyCode.KF2: return Keys.F2;
+                    case KeyCode.KF3: return Keys.F3;
+                    case KeyCode.KF4: return Keys.F4;
+                    case KeyCode.KF5: return Keys.F5;
+                    case KeyCode.KF6: return Keys.F6;
+                    case KeyCode.KF7: return Keys.F7;
+                    case KeyCode.KF8: return Keys.F8;
+                    case KeyCode.KF9: return Keys.F9;
+                    case KeyCode.KF10: return Keys.F10;
+                    case KeyCode.KF11: return Keys.F11;
+                    case KeyCode.KF12: return Keys.F12;
+                    case KeyCode.KF13: return Keys.F13;
+                    case KeyCode.KF14: return Keys.F14;
+                    case KeyCode.KF15: return Keys.F15;
+                    case KeyCode.KF16: return Keys.F16;
+                    case KeyCode.KF17: return Keys.F17;
+                    case KeyCode.KF18: return Keys.F18;
+                    case KeyCode.KF19: return Keys.F19;
+                    case KeyCode.KF20: return Keys.F20;
+                    case KeyCode.KF21: return Keys.F21;
+                    case KeyCode.KF22: return Keys.F22;
+                    case KeyCode.KF23: return Keys.F23;
+                    case KeyCode.KF24: return Keys.F24;
+                    case KeyCode.KNumlockclear: return Keys.NumLock;
+                    case KeyCode.KScrolllock: return Keys.Scroll;
+                    case KeyCode.KLshift: return Keys.LeftShift;
+                    case KeyCode.KRshift: return Keys.RightShift;
+                    case KeyCode.KLctrl: return Keys.LeftCtrl;
+                    case KeyCode.KRctrl: return Keys.RightCtrl;
+                    case KeyCode.KLalt: return Keys.LeftAlt;
+                    case KeyCode.KRalt: return Keys.RightAlt;
+                    case KeyCode.KACBack: return Keys.BrowserBack;
+                    case KeyCode.KACForward: return Keys.BrowserForward;
+                    case KeyCode.KACRefresh: return Keys.BrowserRefresh;
+                    case KeyCode.KACStop: return Keys.BrowserStop;
+                    case KeyCode.KACSearch: return Keys.BrowserSearch;
+                    case KeyCode.KACBookmarks: return Keys.BrowserFavorites;
+                    case KeyCode.KACHome: return Keys.BrowserHome;
+                    case KeyCode.KAudiomute: return Keys.VolumeMute;
+                    case KeyCode.KVolumedown: return Keys.VolumeDown;
+                    case KeyCode.KVolumeup: return Keys.VolumeUp;
+                    case KeyCode.KAudionext: return Keys.MediaNextTrack;
+                    case KeyCode.KAudioprev: return Keys.MediaPreviousTrack;
+                    case KeyCode.KAudiostop: return Keys.MediaStop;
+                    case KeyCode.KAudioplay: return Keys.MediaPlayPause;
+                    case KeyCode.KMail: return Keys.LaunchMail;
+                    case KeyCode.KMediaselect: return Keys.SelectMedia;
+                    case KeyCode.KApp1: return Keys.LaunchApplication1;
+                    case KeyCode.KApp2: return Keys.LaunchApplication2;
+                    //            KeyCode.KSemicolon: return Keys.Oem1; // Same as OemSemicolon
+                    case KeyCode.KSemicolon: return Keys.OemSemicolon;
+                    case KeyCode.KEquals: return Keys.OemPlus;
+                    case KeyCode.KComma: return Keys.OemComma;
+                    case KeyCode.KMinus: return Keys.OemMinus;
+                    case KeyCode.KPeriod: return Keys.OemPeriod;
+                    //            KeyCode.KUnknown: return Keys.Oem2; // Same as OemQuestion
+                    case KeyCode.KSlash: return Keys.OemQuestion;
+                    //            KeyCode.KUnknown: return Keys.Oem3; // Same as OemTilde
+                    case KeyCode.KBackquote: return Keys.OemTilde;
+                    //            KeyCode.KUnknown: return Keys.Oem4; // Same as OemOpenBrackets
+                    case KeyCode.KLeftbracket: return Keys.OemOpenBrackets;
+                    //            KeyCode.KUnknown: return Keys.Oem5; // Same as OemPipe
+                    case KeyCode.KBackslash when scancode != Scancode.ScancodeNonusbackslash: return Keys.OemPipe; // SDL maps both Oem5 and Oem102 to the same KeyCode; we have to select based on scancode
+                    //            KeyCode.KUnknown: return Keys.Oem6; // Same as OemCloseBrackets
+                    case KeyCode.KRightbracket: return Keys.OemCloseBrackets;
+                    //            KeyCode.KUnknown: return Keys.Oem7; // same as OemQuotes
+                    case KeyCode.KQuote: return Keys.OemQuotes;
+                    // SDL maps OEM8 to Backquote which is already OEMTilde; this key is often used to open in game consoles and such; I think we should keep it as is
+                    // to avoid UK players being unable to access that feature
+                    // http://kbdlayout.info/kbdsmsfi
+                    // KeyCode.KBackquote: return Keys.Oem8;
+                    //            KeyCode.KUnknown: return Keys.Oem102; // same as OemBackslash
+                    case KeyCode.KBackslash when scancode == Scancode.ScancodeNonusbackslash: return Keys.OemBackslash;
+                    //            KeyCode.KUnknown: return Keys.Attn;
+                    case KeyCode.KCrsel: return Keys.CrSel;
+                    case KeyCode.KExsel: return Keys.ExSel;
+                    //            KeyCode.KUnknown: return Keys.EraseEof;
+                    //            KeyCode.KUnknown: return Keys.Play;
+                    //            KeyCode.KUnknown: return Keys.Zoom;
+                    //            KeyCode.KUnknown: return Keys.NoName;
+                    //            KeyCode.KUnknown: return Keys.Pa1;
+                    //            KeyCode.KUnknown: return Keys.OemClear;
+                    case KeyCode.KKPEnter: return Keys.NumPadEnter;
+                    default: return Keys.None;
+                }
             }
         }
     }

--- a/sources/engine/Stride.Input/SDL/KeyboardSDL.cs
+++ b/sources/engine/Stride.Input/SDL/KeyboardSDL.cs
@@ -66,6 +66,9 @@ namespace Stride.Input
             Keys key;
             if (SDLKeys.MapKeys.TryGetValue((KeyCode)e.Keysym.Sym, out key) && key != Keys.None)
             {
+                // SDL maps OEM102 and OEM5 (OemBackslash and OemPipe) to the same keycode, swap to OEM5 based on the scancode
+                if (key == Keys.OemBackslash && e.Keysym.Scancode != Scancode.ScancodeNonusbackslash)
+                    key = Keys.OemPipe;
                 if ((EventType)e.Type == EventType.Keydown)
                     HandleKeyDown(key);
                 else
@@ -126,23 +129,20 @@ namespace Stride.Input
             /// <returns>A new map.</returns>
             private static Dictionary<KeyCode, Keys> NewMapKeys()
             {
+                // Resources: http://kbdlayout.info/kbdusx/overview+virtualkeys
+                //            https://wiki.libsdl.org/SDL_Keycode
+                //            http://kbdedit.com/manual/low_level_vk_list.html
                 var map = new Dictionary<KeyCode, Keys>(200);
                 map[KeyCode.KUnknown] = Keys.None;
                 map[KeyCode.KCancel] = Keys.Cancel;
                 map[KeyCode.KBackspace] = Keys.Back;
-                map[KeyCode.KTab] = Keys.Tab;
-                map[KeyCode.KKPTab] = Keys.Tab;
+                map[KeyCode.KKPTab] = map[KeyCode.KTab] = Keys.Tab;
                 //            map [KeyCode.KUnknown] = Keys.LineFeed;
-                map[KeyCode.KClear] = Keys.Clear;
-                map[KeyCode.KClearagain] = Keys.Clear;
-                map[KeyCode.KKPClear] = Keys.Clear;
-                map[KeyCode.KKPClearentry] = Keys.Clear;
-                map[KeyCode.KKPEnter] = Keys.Enter;
-                map[KeyCode.KReturn] = Keys.Return;
-                map[KeyCode.KReturn2] = Keys.Return;
+                map[KeyCode.KClear] = map[KeyCode.KClearagain] = map[KeyCode.KKPClear] = map[KeyCode.KKPClearentry] = Keys.Clear;
+                map[KeyCode.KReturn] = map[KeyCode.KReturn2] = Keys.Return;
                 map[KeyCode.KPause] = Keys.Pause;
-                map[KeyCode.KCapslock] = Keys.Capital;
-                //            map [KeyCode.KCapslock] = Keys.CapsLock;
+                //            map [KeyCode.KCapslock] = Keys.Capital; // Capital is the same as CapsLock
+                map[KeyCode.KCapslock] = Keys.CapsLock;
                 //            map [KeyCode.KUnknown] = Keys.HangulMode;
                 //            map [KeyCode.KUnknown] = Keys.KanaMode;
                 //            map [KeyCode.KUnknown] = Keys.JunjaMode;
@@ -154,15 +154,13 @@ namespace Stride.Input
                 //            map [KeyCode.KUnknown] = Keys.ImeNonConvert;
                 //            map [KeyCode.KUnknown] = Keys.ImeAccept;
                 //            map [KeyCode.KUnknown] = Keys.ImeModeChange;
-                map[KeyCode.KSpace] = Keys.Space;
-                map[KeyCode.KKPSpace] = Keys.Space;
+                map[KeyCode.KSpace] = map[KeyCode.KKPSpace] = Keys.Space;
                 map[KeyCode.KPageup] = Keys.PageUp;
                 map[KeyCode.KPrior] = Keys.Prior;
-                //            map [KeyCode.KPagedown] = Keys.Next); // Next is the same as PageDo;
+                //            map [KeyCode.KPagedown] = Keys.Next; // Next is the same as PageDown
                 map[KeyCode.KPagedown] = Keys.PageDown;
                 map[KeyCode.KEnd] = Keys.End;
                 map[KeyCode.KHome] = Keys.Home;
-                map[KeyCode.KACHome] = Keys.Home;
                 map[KeyCode.KLeft] = Keys.Left;
                 map[KeyCode.KUp] = Keys.Up;
                 map[KeyCode.KRight] = Keys.Right;
@@ -171,7 +169,7 @@ namespace Stride.Input
                 //            map [KeyCode.KUnknown] = Keys.Print;
                 map[KeyCode.KExecute] = Keys.Execute;
                 map[KeyCode.KPrintscreen] = Keys.PrintScreen;
-                //            map [KeyCode.KPrintscreen] = Keys.Snapshot); // Snapshot is the same as PageDo;
+                //            map [KeyCode.KPrintscreen] = Keys.Snapshot; // Snapshot is the same as PrintScreen
                 map[KeyCode.KInsert] = Keys.Insert;
                 map[KeyCode.KDelete] = Keys.Delete;
                 map[KeyCode.KHelp] = Keys.Help;
@@ -226,13 +224,11 @@ namespace Stride.Input
                 map[KeyCode.KKP8] = Keys.NumPad8;
                 map[KeyCode.KKP9] = Keys.NumPad9;
                 map[KeyCode.KKPMultiply] = Keys.Multiply;
-                map[KeyCode.KPlus] = Keys.OemPlus;
-                map[KeyCode.KKPPlus] = Keys.Add;
+                map[KeyCode.KPlus]/*KPlus is not a physical key*/ = map[KeyCode.KKPPlus] = Keys.Add;
                 map[KeyCode.KSeparator] = Keys.Separator;
-                map[KeyCode.KMinus] = Keys.OemMinus;
                 map[KeyCode.KKPMinus] = Keys.Subtract;
-                map[KeyCode.KDecimalseparator] = Keys.Decimal;
-                map[KeyCode.KKPDecimal] = Keys.NumPadDecimal;
+                map[KeyCode.KKPPeriod] = map[KeyCode.KKPDecimal] = Keys.Decimal;
+                map[KeyCode.KThousandsseparator] = map[KeyCode.KDecimalseparator] = Keys.Decimal; // See ISO/IEC 9995-4
                 map[KeyCode.KKPDivide] = Keys.Divide;
                 map[KeyCode.KF1] = Keys.F1;
                 map[KeyCode.KF2] = Keys.F2;
@@ -282,28 +278,31 @@ namespace Stride.Input
                 map[KeyCode.KAudioplay] = Keys.MediaPlayPause;
                 map[KeyCode.KMail] = Keys.LaunchMail;
                 map[KeyCode.KMediaselect] = Keys.SelectMedia;
-                //            map [KeyCode.KUnknown] = Keys.LaunchApplication1;
-                //            map [KeyCode.KUnknown] = Keys.LaunchApplication2;
-                //            map [KeyCode.KUnknown] = Keys.Oem1;
+                map[KeyCode.KApp1] = Keys.LaunchApplication1;
+                map[KeyCode.KApp2] = Keys.LaunchApplication2;
+                //            map [KeyCode.KSemicolon] = Keys.Oem1; // Same as OemSemicolon
                 map[KeyCode.KSemicolon] = Keys.OemSemicolon;
+                map[KeyCode.KEquals] = Keys.OemPlus;
                 map[KeyCode.KComma] = Keys.OemComma;
+                map[KeyCode.KMinus] = Keys.OemMinus;
                 map[KeyCode.KPeriod] = Keys.OemPeriod;
-                // Verified with http://kbdlayout.info/
-                map[KeyCode.KKPPeriod] = Keys.NumPadDecimal;
-                //            map [KeyCode.KUnknown] = Keys.Oem2;
+                //            map [KeyCode.KUnknown] = Keys.Oem2; // Same as OemQuestion
                 map[KeyCode.KSlash] = Keys.OemQuestion;
-                //            map [KeyCode.KUnknown] = Keys.Oem3;
+                //            map [KeyCode.KUnknown] = Keys.Oem3; // Same as OemTilde
                 map[KeyCode.KBackquote] = Keys.OemTilde;
-                //            map [KeyCode.KUnknown] = Keys.Oem4;
+                //            map [KeyCode.KUnknown] = Keys.Oem4; // Same as OemOpenBrackets
                 map[KeyCode.KLeftbracket] = Keys.OemOpenBrackets;
-                //            map [KeyCode.KUnknown] = Keys.Oem5;
-                //            map [KeyCode.KUnknown] = Keys.OemPipe;
-                //            map [KeyCode.KUnknown] = Keys.Oem6;
+                //            map [KeyCode.KUnknown] = Keys.Oem5; // Same as OemPipe
+                map[KeyCode.KBackslash] = Keys.OemPipe; // Will be overwritten lower, SDL maps both to same KeyCode, we have to select based on scancode
+                //            map [KeyCode.KUnknown] = Keys.Oem6; // Same as OemCloseBrackets
                 map[KeyCode.KRightbracket] = Keys.OemCloseBrackets;
-                //            map [KeyCode.KUnknown] = Keys.Oem7;
+                //            map [KeyCode.KUnknown] = Keys.Oem7; // same as OemQuotes
                 map[KeyCode.KQuote] = Keys.OemQuotes;
-                //            map [KeyCode.KUnknown] = Keys.Oem8;
-                //            map [KeyCode.KUnknown] = Keys.Oem102;
+                // SDL maps OEM8 to Backquote which is already OEMTilde, this key is often used to open in game consoles and such, I think we should keep it as is
+                // to avoid UK players being unable to access that feature
+                // http://kbdlayout.info/kbdsmsfi
+                // map[KeyCode.KBackquote] = Keys.Oem8;
+                //            map [KeyCode.KUnknown] = Keys.Oem102; // same as OemBackslash
                 map[KeyCode.KBackslash] = Keys.OemBackslash;
                 //            map [KeyCode.KUnknown] = Keys.Attn;
                 map[KeyCode.KCrsel] = Keys.CrSel;
@@ -314,6 +313,7 @@ namespace Stride.Input
                 //            map [KeyCode.KUnknown] = Keys.NoName;
                 //            map [KeyCode.KUnknown] = Keys.Pa1;
                 map[KeyCode.KClear] = Keys.OemClear;
+                map[KeyCode.KKPEnter] = Keys.NumPadEnter;
                 return map;
             }
         }


### PR DESCRIPTION
# PR Details
Related to PR #1263 
- Made ``NumPadDecimal`` obsolete, the US key mapped to character ``.`` and ``>`` is ``OemPeriod``, not ``Decimal``. ``Decimal`` already maps to the numpad in winforms and in rawinput most likely as well given that there isn't any specific logic for it. Made changes to the SDL keyboard to reflect that.

- Fixed a conflict between ``OemBackslash`` and ``OemPipe``.
- ``NumPadEnter`` and ``OemPlus`` mapped to the right key.
- Support for ``LaunchApplication1`` and ``LaunchApplication2`` keys.

- Swapped SDL keyboard key mapping from a dictionary to a switch, I'm not too sure why we would use a dictionary for this when a switch is as easy to use and maintain ... ? Separated that change into its own push in case that's something we don't want.

- Improved the summary for most of the ``Input.Keys``, it should be clearer now what those oems are and when two label map to the same value.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.