### PR TITLE
[Editor] Fix blank material editor and settings panel

### DIFF
--- a/sources/presentation/Stride.Core.Presentation.Quantum/ViewModels/NodeViewModel.cs
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/ViewModels/NodeViewModel.cs
@@ -416,14 +416,23 @@ namespace Stride.Core.Presentation.Quantum.ViewModels
             bool allowSpCharOnly = false;
             if (HasDictionary)
             {
-                Type[] genericTypes = Type.GetGenericArguments();
-                if (genericTypes[0] == typeof(string))
+                foreach (var iType in Type.GetTypeInfo().ImplementedInterfaces)
                 {
-                    freeName = true;
-                }
-                else if (genericTypes[0] == typeof(char))
-                {
-                    allowSpCharOnly = true;
+                    var iTypeInfo = iType.GetTypeInfo();
+                    if (iTypeInfo.IsGenericType == false) 
+                        continue;
+                    if (iTypeInfo.GetGenericTypeDefinition() != typeof(IDictionary<,>))
+                        continue;
+                    Type[] genericTypes = iTypeInfo.GetGenericArguments();
+                    if (genericTypes[0] == typeof(string))
+                    {
+                        freeName = true;
+                    }
+                    else if (genericTypes[0] == typeof(char))
+                    {
+                        allowSpCharOnly = true;
+                    }
+                    break;
                 }
             }
 


### PR DESCRIPTION
# PR Details
An raised exception prevented those panel to display properly, ``HasDictionary`` doesn't imply that the type itself is a dictionary, this change makes it so that it test the implemented interfaces to find the proper first generic type for the implemented dictionary interface.

## Related Issue
Fix: #1272

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.