### PR TITLE
[Editor] Fix missing editor keyboard input

### DIFF
--- a/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
@@ -48,7 +48,6 @@ namespace Stride.Input
             input = inputManager;
 
             uiControl.LostFocus += UIControlOnLostFocus;
-            MissingInputHack();
 
             // Hook window proc
             defaultWndProc = Win32Native.GetWindowLong(uiControl.Handle, Win32Native.WindowLongType.WndProc);
@@ -63,40 +62,6 @@ namespace Stride.Input
 
             mouse = new MouseWinforms(this, uiControl);
             RegisterDevice(mouse);
-        }
-
-        /// <summary>
-        /// This function houses a hack to fix the window missing some input events,
-        /// see Stride pull #181 for more information (https://github.com/stride3d/stride/pull/181).
-        /// TODO: Find a proper solution to replace this workaround.
-        /// </summary>
-        private void MissingInputHack()
-        {
-#if STRIDE_INPUT_RAWINPUT
-            Device.RegisterDevice(SharpDX.Multimedia.UsagePage.Generic, SharpDX.Multimedia.UsageId.GenericKeyboard, DeviceFlags.None);
-            Device.KeyboardInput += (sender, args) =>
-            {
-                switch (args.State)
-                {
-                    case KeyState.SystemKeyDown:
-                    case KeyState.ImeKeyDown:
-                    case KeyState.KeyDown:
-                    {
-                        keyboard?.HandleKeyUp(args.Key);
-                        heldKeys.Add(args.Key);
-                        break;
-                    }
-                    case KeyState.SystemKeyUp:
-                    case KeyState.ImeKeyUp:
-                    case KeyState.KeyUp:
-                    {
-                        heldKeys.Remove(args.Key);
-                        keyboard?.HandleKeyDown(args.Key);
-                        break;
-                    }
-                }
-            };
-#endif
         }
 
         public override void Dispose()

--- a/sources/presentation/Stride.Core.Presentation/Controls/GameEngineHost.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/GameEngineHost.cs
@@ -126,7 +126,6 @@ namespace Stride.Core.Presentation.Controls
             dpiScale = VisualTreeHelper.GetDpi(this);
 
             var style = NativeHelper.GetWindowLong(Handle, NativeHelper.GWL_STYLE);
-            // Removes Caption bar and the sizing border
             // Must be a child window to be hosted
             style |= NativeHelper.WS_CHILD;
 
@@ -201,6 +200,10 @@ namespace Stride.Core.Presentation.Controls
                     // TODO: do we want SWP_NOCOPYBITS?
                     const int flags = NativeHelper.SWP_ASYNCWINDOWPOS | NativeHelper.SWP_NOACTIVATE | NativeHelper.SWP_NOZORDER;
                     NativeHelper.SetWindowPos(Handle, NativeHelper.HWND_TOP, boundingBox.X, boundingBox.Y, boundingBox.Z, boundingBox.W, flags);
+                
+                    var style = NativeHelper.GetWindowLong(Handle, NativeHelper.GWL_STYLE);
+                    // Workaround for missing keyboard input see issue #94
+                    NativeHelper.SetWindowLong(Handle, NativeHelper.GWL_STYLE, style & ~NativeHelper.WS_CHILD);
                 }
                 
                 if (attached)


### PR DESCRIPTION
# PR Details
See #94
Setting parent to none for the embedded windows (like the scene view) is enough to ensure that all inputs are received, one of the parent control is most likely eating some of the inputs. Debugging the WPF hierarchy would be a real undertaking so I'll leave it at that for now.
This PR sets the ``WS_CHILD`` flag off whenever the layout changes, not exactly sure how it works internally but the window still behaves as a child window while properly receiving inputs and testing the rest of the engine didn't result in any unexpected behavior.

Also removed ``MissingInputHack`` since it relied on rawinput which isn't part of the editor since the net5 changes I think ?

## Related Issue
Fix #94

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.