### PR TITLE
[Test] Fixed compiler script test failures and oddities

### DIFF
--- a/sources/engine/Stride.Assets.Tests/TestVisualScriptCompiler.cs
+++ b/sources/engine/Stride.Assets.Tests/TestVisualScriptCompiler.cs
@@ -185,21 +185,26 @@ namespace Stride.Assets.Tests
 
             using (var textWriter = new StringWriter())
             {
-                Console.SetOut(textWriter);
+                try
+                {
+                    Console.SetOut(textWriter);
 
-                // Create class
-                var testInstance = CreateInstance(new[] { compilerResult.SyntaxTree });
-                // Execute method
-                testCode(testInstance);
+                    // Create class
+                    var testInstance = CreateInstance(new[] { compilerResult.SyntaxTree });
+                    // Execute method
+                    testCode(testInstance);
 
-                // Check output
-                textWriter.Flush();
-                Assert.Equal(expectedOutput, textWriter.ToString());
-
-                // Restore Console.Out
-                var standardOutput = new StreamWriter(Console.OpenStandardOutput());
-                standardOutput.AutoFlush = true;
-                Console.SetOut(standardOutput);
+                    // Check output
+                    textWriter.Flush();
+                    Assert.Equal(expectedOutput, textWriter.ToString());
+                }
+                finally
+                {
+                    // Restore Console.Out
+                    var standardOutput = new StreamWriter(Console.OpenStandardOutput());
+                    standardOutput.AutoFlush = true;
+                    Console.SetOut(standardOutput);
+                }
             }
         }
 
@@ -207,7 +212,11 @@ namespace Stride.Assets.Tests
         {
             var compilation = CSharpCompilation.Create("Test.dll",
                 syntaxTrees,
-                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+                new[] {
+                    MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
+                    MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+                },
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             using (var peStream = new MemoryStream())
             using (var pdbStream = new MemoryStream())

--- a/sources/engine/Stride.Assets.Tests/TestVisualScriptCompiler.cs
+++ b/sources/engine/Stride.Assets.Tests/TestVisualScriptCompiler.cs
@@ -210,13 +210,14 @@ namespace Stride.Assets.Tests
 
         private static dynamic CreateInstance(SyntaxTree[] syntaxTrees)
         {
+            var dependentAssemblies = new[] {
+                MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+            };
             var compilation = CSharpCompilation.Create("Test.dll",
                 syntaxTrees,
-                new[] {
-                    MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
-                    MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
-                },
+                dependentAssemblies,
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             using (var peStream = new MemoryStream())
             using (var pdbStream = new MemoryStream())


### PR DESCRIPTION
# PR Details
This fixed the script asset tests that were failing on my local machine. This also addresses a side effect of that failure taking out other tests.

## Description

Fixed the console output not getting reset on a test failure, resulting in other tests failing. Now the output is always reset. _Further improvements may be to avoid using console, as it's a singleton and they cause exactly this problem._

Fixed compilation failing in dotnet 6, due to missing a reference to an assembly containing Console or System.Runtime. The following dependencies are now used:
 * `System.Runtime.dll` - Needed for type Object and Decimal, these are specifically not System.Object, it's something else (I'm not sure what).
 * `System.Console.dll` - Needed for System.Console.
 * `System.Private.CoreLib.dll` - Needed for System.Object, System.Void, and other things.

My guess is previously these were all covered by mscorelib or a similar framework-ish assembly.

Testing to ensure these assemblies are available on the target platforms likely needs to happen, I'm curious what the CI system thinks of this.

## Related Issue

None found, this was an issue found while trying to get the tests running locally.

## Motivation and Context

This was found while trying to get the unit tests to run, they did not run successfully on my machine.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
_The tests pass locally where as they failed previously, CI verification is needed as this seems like a platform dependency thing._