### PR TITLE
[Yaml] Revert EscapeDataString changes

### DIFF
--- a/sources/core/Stride.Core.Yaml/Serialization/YamlAssemblyRegistry.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/YamlAssemblyRegistry.cs
@@ -158,7 +158,7 @@ namespace Stride.Core.Yaml.Serialization
             if (type == null) throw new ArgumentNullException(nameof(type));
 
             // Prefix all tags by !
-            tag = Uri.EscapeDataString(tag);
+            tag = Uri.EscapeUriString(tag);
             if (tag.StartsWith("tag:"))
             {
                 // shorten tag
@@ -262,7 +262,7 @@ namespace Stride.Core.Yaml.Serialization
                 }
             }
 
-            return Uri.EscapeDataString(tagName);
+            return Uri.EscapeUriString(tagName);
         }
 
         public virtual Type ResolveType(string typeName)


### PR DESCRIPTION
# PR Details
``EscapeDataString`` changes from #1277 swaps ``!`` for ``%21``, we'll look at this whenever ``EscapeUriString`` becomes a problem.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.