### PR TITLE
[Readme] Updated the readme to call out msbuild instead of dotnet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Ask for help or report issues:
 1. Install [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed above
 2. Add MSBuild's directory to your system's *PATH* (ex: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`)
 3. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
-4. Navigate to `/Build` with the command prompt, input `msbuild /t:Restore Stride.sln` then `msbuild /t:Build Stride.sln` (Add `-m` for improved performance)
+4. Navigate to `/Build` with the command prompt, input `dotnet restore Stride.sln` then `compile.bat`
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Ask for help or report issues:
 1. Install [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed above
 2. Add MSBuild's directory to your system's *PATH* (ex: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`)
 3. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
-4. Navigate to `/Build` with the command prompt, input `dotnet restore Stride.sln` then `compile`
+4. Navigate to `/Build` with the command prompt, input `msbuild /restore Stride.sln` then `msbuild Stride.sln` (Add `-m` for improved performance)
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Ask for help or report issues:
 1. Install [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed above
 2. Add MSBuild's directory to your system's *PATH* (ex: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`)
 3. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
-4. Navigate to `/Build` with the command prompt, input `msbuild /restore Stride.sln` then `msbuild Stride.sln` (Add `-m` for improved performance)
+4. Navigate to `/Build` with the command prompt, input `msbuild /t:Restore Stride.sln` then `msbuild /t:Build Stride.sln` (Add `-m` for improved performance)
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Ask for help or report issues:
 1. Install [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed above
 2. Add MSBuild's directory to your system's *PATH* (ex: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`)
 3. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
-4. Navigate to `/Build` with the command prompt, input `dotnet restore Stride.sln` then `compile.bat`
+4. Navigate to `/Build` with the command prompt, input `msbuild /t:Restore Stride.sln` then `compile.bat`
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.


### PR DESCRIPTION
# PR Details

## Description

The dotnet command can't compile C++, which causes build failures. msbuild from the build tool (or vs) just fine on its own.

The previous step adds msbuild to the path, so this should be fine. To my knowedge dotnet is doing this same thing, just it doesn't have the libraries accessable to the msbuild install at the added-path-location.

Using the `dotnet` you get errors of the flavor:
```
$repoPath\sources\tools\Stride.Assimp.Translation\Stride.Assimp.Translation.vcxproj(34,3): error MSB4019: The imported project "C:\Microsoft.Cpp.Default.props" was not found. Confirm that the expression in the Import declaration "\Microsoft.Cpp.Default.props" is correct, and that the file exists on disk.
```

Using `msbuild` it compiles more successfully.

This may be due to me using a different build pipeline, for instance I need to use https://github.com/stride3d/stride/pull/1276 to build. I'm not sure how this would have worked in previous versions, but it's possible it did maybe? Perhaps something was directly including the cpp props files.

Using the build tools enviorments may avoid this error with dotnet, as that includes a bunch of other things. I didn't test that, and the readme doesn't suggest using that batch file though so I didn't!

## Related Issue

Unknown (didn't check)

## Motivation and Context

Trying to follow the readme didn't work, with these updated steps it works a bit better.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.