### PR TITLE
public Model Generate(IServiceRegistry services) added

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/ProceduralModels/PrimitiveProceduralModelBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/ProceduralModels/PrimitiveProceduralModelBase.cs
@@ -76,6 +76,15 @@ namespace Stride.Rendering.ProceduralModels
         [DataMemberIgnore]
         public IEnumerable<KeyValuePair<string, MaterialInstance>> MaterialInstances { get { yield return new KeyValuePair<string, MaterialInstance>("Material", MaterialInstance); } }
 
+        public Model Generate(IServiceRegistry services)
+        {
+            var model = new Model();
+
+            Generate(services, model);
+
+            return model;
+        }
+
         public void Generate(IServiceRegistry services, Model model)
         {
             if (model == null) throw new ArgumentNullException(nameof(model));


### PR DESCRIPTION
# PR Details

Another signature added for ```Generate()``` method.

New 
```c# 
public Model Generate(IServiceRegistry services)
```

Existing 
```c# 
public void Generate(IServiceRegistry services, Model model)
```

## Description

This will simplify creating Primitive Models from 

```c#
var model = new Model();

new CubeProceduralModel().Generate(game.Services, model);

model.Materials.Add(new Material())
```
to 

```c#
var model = new CubeProceduralModel().Generate(game.Services);

model.Materials.Add(new Material());
```

## Related Issue

Resolves #1258

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.