### PR TITLE
[Readme] Added a verbosity clamp for msbuild, so it's a bit less screamy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Ask for help or report issues:
 1. Install [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed above
 2. Add MSBuild's directory to your system's *PATH* (ex: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`)
 3. Open a command prompt, point it to a directory and clone Stride to it: `git clone https://github.com/stride3d/stride.git`
-4. Navigate to `/Build` with the command prompt, input `msbuild /t:Restore Stride.sln` then `compile.bat`
+4. Navigate to `/Build` with the command prompt, input `msbuild /t:Restore /verbosity:m Stride.sln` then `compile.bat`
 
 If building failed:
 * If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.


### PR DESCRIPTION
# PR Details

Adds a verbosity argument to msbuild restore based on the trailing comment in https://github.com/stride3d/stride/pull/1283 , personally I don't mind the extra output  but if it's the style of the project then cool.

## Description

Changes a command in a trivial way.

## Related Issue

See the conversation in https://github.com/stride3d/stride/pull/1283

## Motivation and Context

See the conversation in https://github.com/stride3d/stride/pull/1283

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.