### PR TITLE
Switched the default build verbosity to normal

### DIFF
--- a/build/compile.bat
+++ b/build/compile.bat
@@ -5,7 +5,7 @@ setlocal
 set STARTTIME=%TIME%
 set __SkipTestBuild=true
 set __BuildType=Debug
-set __BuildVerbosity=m
+set __BuildVerbosity=n
 set __BuildDoc=0
 set __ContinueOnError=false
 set __SelectedProject=Stride.sln
@@ -36,7 +36,7 @@ echo.
 echo   debug   : Build debug version
 echo   release : Build release version
 echo   tests   : Build tests
-echo verbosity : Verbosity level [q]uiet, [m]inimal, [n]ormal or [d]iagnostic. Default is [m]inimal
+echo verbosity : Verbosity level [q]uiet, [m]inimal, [n]ormal or [d]iagnostic. Default is [n]ormal
 echo   project : Chosen project
 echo.
 


### PR DESCRIPTION
# PR Details

Switched the default build verbosity to normal to better align with restore.


## Description

Either way it's somewhat opaque, but build processes should have more information this way.

This is a follow up from https://github.com/stride3d/stride/pull/1286 and https://github.com/stride3d/stride/pull/1283 .

This change doesn't really effect anything, and it might be making things more verbose, but it does align both steps to use the same command and verbosity. 

It's a bit confusing what the command is doing outside of just calling msbuild with some arguments that could be build file provided, but if it works it works.

## Related Issue

https://github.com/stride3d/stride/pull/1286 and https://github.com/stride3d/stride/pull/1283 both relate.

## Motivation and Context

This started with a change to make the build steps a bit clearer, because I misinterpreted then and figure someone else might have the same issue.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.