### PR TITLE
Fix glslangValidator.bin path for unix platforms

### DIFF
--- a/sources/engine/Stride.Shaders.Compiler/OpenGL/ShaderCompiler.cs
+++ b/sources/engine/Stride.Shaders.Compiler/OpenGL/ShaderCompiler.cs
@@ -123,10 +123,10 @@ namespace Stride.Shaders.Compiler.OpenGL
                         filename = @"win-x64\glslangValidator.exe";
                         break;
                     case PlatformType.Linux:
-                        filename = @"linux-x64\glslangValidator.bin";
+                        filename = @"linux-x64/glslangValidator.bin";
                         break;
                     case PlatformType.macOS:
-                        filename = @"osx-x64\glslangValidator.bin";
+                        filename = @"osx-x64/glslangValidator.bin";
                         break;
                     default:
                         throw new PlatformNotSupportedException();


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Something may have changed in path processing in `Process.Start()` - so I had to replace the Windows-style `\` with Unix-style `/`.

## Related Issue
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.