### PR TITLE
Default SceneInstance and Scene added for code-only approach

### DIFF
--- a/sources/engine/Stride.Engine/Engine/SceneSystem.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneSystem.cs
@@ -119,6 +119,10 @@ namespace Stride.Engine
                 else
                     SceneInstance = new SceneInstance(Services, content.Load<Scene>(InitialSceneUrl));
             }
+            else
+            {
+                SceneInstance ??= new SceneInstance(Services) { RootScene = new Scene() };
+            }
 
             if (InitialGraphicsCompositorUrl != null && content.Exists(InitialGraphicsCompositorUrl))
             {


### PR DESCRIPTION
# PR Details

Default SceneInstance and empty Scene is created programmatically if the game is run without the default assets (MainScene.sdscene) created by Game Studio. 

## Description

Discussed here https://github.com/stride3d/stride/discussions/1253#discussioncomment-1979625

else branch added

```c#
else
{
    SceneInstance ??= new SceneInstance(Services) { RootScene = new Scene() };
}
```

## Related Issue

More details in the issue below.

Resolves #1290 

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

We are working on code-only approach and to simplify this approach so a game can be run without a too much boilerplate. Default scene can be always updated/replaced as needed through the code. 

This will help to run a game with a very few lines of the code.

**This change shouldn't affect any existing approach through the Game Studio Editor.**

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.