### PR TITLE
[Graphics] Fix resource memory leak

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsResource.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsResource.Direct3D.cs
@@ -86,8 +86,8 @@ namespace Stride.Graphics
 
         protected internal override void OnDestroyed()
         {
-            ReleaseComObject(ref shaderResourceView);
-            ReleaseComObject(ref unorderedAccessView);
+            TryReleaseComObject(ref shaderResourceView);
+            TryReleaseComObject(ref unorderedAccessView);
 
             base.OnDestroyed();
         }

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsResourceBase.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsResourceBase.Direct3D.cs
@@ -59,7 +59,7 @@ namespace Stride.Graphics
         {
             Destroyed?.Invoke(this, EventArgs.Empty);
 
-            ReleaseComObject(ref nativeDeviceChild);
+            TryReleaseComObject(ref nativeDeviceChild);
             NativeResource = null;
         }
 
@@ -107,6 +107,21 @@ namespace Stride.Graphics
                 Debug.Assert(refCountResult >= 0);
                 comObject = null;
             }
+        }
+
+        /// <summary> Returns true if the object was previously allocated and has been released </summary>
+        internal static bool TryReleaseComObject<T>(ref T comObject) where T : CppObject, IUnknown
+        {
+            if(comObject != null && comObject.NativePointer != IntPtr.Zero)
+            {
+                var refCountResult = comObject.Release();
+                Debug.Assert(refCountResult >= 0);
+                comObject = null;
+                return true;
+            }
+            
+            comObject = null;
+            return false;
         }
     }
 }

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -272,14 +272,17 @@ namespace Stride.Graphics
         private FastList<Texture> DestroyChildrenTextures(Texture parentTexture)
         {
             var fastList = new FastList<Texture>();
-            foreach (var resource in GraphicsDevice.Resources)
+            foreach (var wRef in GraphicsDevice.Resources)
             {
-                var texture = resource as Texture;
-                if (texture != null && texture.ParentTexture == parentTexture)
+                if (wRef.TryGetTarget(out var resource) && resource is Texture texture && texture.ParentTexture == parentTexture)
                 {
-                    texture.OnDestroyed();
                     fastList.Add(texture);
                 }
+            }
+
+            foreach (var texture in fastList)
+            {
+                texture.OnDestroyed();
             }
 
             return fastList;

--- a/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
@@ -208,8 +208,8 @@ namespace Stride.Graphics
                 GraphicsDevice.RegisterTextureMemoryUsage(-SizeInBytes);
             }
 
-            ReleaseComObject(ref renderTargetView);
-            ReleaseComObject(ref depthStencilView);
+            TryReleaseComObject(ref renderTargetView);
+            TryReleaseComObject(ref depthStencilView);
 
             base.OnDestroyed();
         }

--- a/sources/engine/Stride.Graphics/SamplerState.cs
+++ b/sources/engine/Stride.Graphics/SamplerState.cs
@@ -54,9 +54,12 @@ namespace Stride.Graphics
 
         protected override void Destroy()
         {
-            lock (GraphicsDevice.CachedSamplerStates)
+            if (GraphicsDevice != null)
             {
-                GraphicsDevice.CachedSamplerStates.Remove(Description);
+                lock (GraphicsDevice.CachedSamplerStates)
+                {
+                    GraphicsDevice.CachedSamplerStates.Remove(Description);
+                }
             }
 
             base.Destroy();


### PR DESCRIPTION
# PR Details
It's unlikely that resources were ever manually released given that objects that hold and uses those buffers do not implement IDisposable, they are expected to be GC'ed not explicitly 'destroyed'.
The device's resources are now weakly referenced and native stuff is cleaned up when resource are GC'ed, through their destructor.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.