### PR TITLE
[Graphics] Fix and improve Resource.Reload

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ViewportGridGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ViewportGridGizmo.cs
@@ -135,7 +135,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             var gridTexture = Texture.New(GraphicsDevice, gridImage);
             gridImage.Dispose();
 
-            gridTexture.Reload += @base =>
+            gridTexture.Reload += (@base, services) =>
             {
                 var newImage = imageBuilder();
                 gridTexture.Recreate(newImage.ToDataBox());

--- a/sources/engine/Stride.Graphics/BatchBase.cs
+++ b/sources/engine/Stride.Graphics/BatchBase.cs
@@ -799,7 +799,7 @@ namespace Stride.Graphics
                 if (!IsIndexBufferDynamic)
                 {
                     IndexBuffer = Buffer.Index.New(device, resourceBufferInfo.StaticIndices).DisposeBy(this);
-                    IndexBuffer.Reload = graphicsResource => ((Buffer)graphicsResource).Recreate(resourceBufferInfo.StaticIndices);
+                    IndexBuffer.Reload = (graphicsResource, services) => ((Buffer)graphicsResource).Recreate(resourceBufferInfo.StaticIndices);
                 }
 
                 InputElements = declaration.CreateInputElements();

--- a/sources/engine/Stride.Graphics/Buffer.cs
+++ b/sources/engine/Stride.Graphics/Buffer.cs
@@ -596,7 +596,7 @@ namespace Stride.Graphics
         /// <returns>This instance.</returns>
         public Buffer RecreateWith<T>(T[] dataPointer) where T : struct
         {
-            Reload = (graphicsResource) => ((Buffer)graphicsResource).Recreate(dataPointer);
+            Reload = (graphicsResource, services) => ((Buffer)graphicsResource).Recreate(dataPointer);
 
             return this;
         }
@@ -609,7 +609,7 @@ namespace Stride.Graphics
         /// <returns>This instance.</returns>
         public Buffer RecreateWith(IntPtr dataPointer)
         {
-            Reload = (graphicsResource) => ((Buffer)graphicsResource).Recreate(dataPointer);
+            Reload = (graphicsResource, services) => ((Buffer)graphicsResource).Recreate(dataPointer);
 
             return this;
         }

--- a/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
@@ -42,11 +42,10 @@ namespace Stride.Graphics.Data
                         var contentSerializerContext = stream.Context.Get(ContentSerializerContext.ContentSerializerContextProperty);
                         if (contentSerializerContext != null)
                         {
-                            var assetManager = contentSerializerContext.ContentManager;
-                            var url = contentSerializerContext.Url;
-
-                            texture.Reload = (graphicsResource) =>
+                            texture.Reload = static (graphicsResource, services) =>
                             {
+                                var assetManager = services.GetService<ContentManager>();
+                                assetManager.TryGetAssetUrl(graphicsResource, out var url);
                                 var textureDataReloaded = assetManager.Load<Image>(url);
                                 ((Texture)graphicsResource).Recreate(textureDataReloaded.ToDataBox());
                                 assetManager.Unload(textureDataReloaded);

--- a/sources/engine/Stride.Graphics/Data/TextureImageSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureImageSerializer.cs
@@ -34,11 +34,10 @@ namespace Stride.Graphics.Data
                     var contentSerializerContext = stream.Context.Get(ContentSerializerContext.ContentSerializerContextProperty);
                     if (contentSerializerContext != null)
                     {
-                        var assetManager = contentSerializerContext.ContentManager;
-                        var url = contentSerializerContext.Url;
-
-                        texture.Reload = (graphicsResource) =>
+                        texture.Reload = static (graphicsResource, services) =>
                         {
+                            var assetManager = services.GetService<ContentManager>();
+                            assetManager.TryGetAssetUrl(graphicsResource, out var url);
                             var textureDataReloaded = assetManager.Load<Image>(url);
                             ((Texture)graphicsResource).Recreate(textureDataReloaded.ToDataBox());
                             assetManager.Unload(textureDataReloaded);

--- a/sources/engine/Stride.Graphics/Font/FontCacheManager.cs
+++ b/sources/engine/Stride.Graphics/Font/FontCacheManager.cs
@@ -36,7 +36,7 @@ namespace Stride.Graphics.Font
             ClearCache();
         }
 
-        private void ReloadCache(GraphicsResourceBase graphicsResourceBase)
+        private void ReloadCache(GraphicsResourceBase graphicsResourceBase, IServiceRegistry services)
         {
             foreach (var cacheTexture in cacheTextures)
                 cacheTexture.Recreate();

--- a/sources/engine/Stride.Graphics/GraphicsResourceBase.cs
+++ b/sources/engine/Stride.Graphics/GraphicsResourceBase.cs
@@ -8,7 +8,7 @@ namespace Stride.Graphics
     public partial class GraphicsResourceBase : ComponentBase
     {
         internal GraphicsResourceLifetimeState LifetimeState;
-        public Action<GraphicsResourceBase> Reload;
+        public Action<GraphicsResourceBase, IServiceRegistry> Reload;
 
         /// <summary>
         /// Gets the graphics device attached to this instance.

--- a/sources/engine/Stride.Graphics/OpenGL/GraphicsDevice.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/GraphicsDevice.OpenGL.cs
@@ -831,7 +831,7 @@ namespace Stride.Graphics
             WindowProvidedRenderTexture = Texture.New2D(this, width, height, 1,
                 // TODO: As a workaround, because OpenTK(+OpenGLES) doesn't support to create SRgb backbuffer, we fake it by creating a non-SRgb here and CopyScaler2D is responsible to transform it to non SRgb
                 isFramebufferSRGB ? presentationParameters.BackBufferFormat : presentationParameters.BackBufferFormat.ToNonSRgb(), TextureFlags.RenderTarget | Texture.TextureFlagsCustomResourceId);
-            WindowProvidedRenderTexture.Reload = graphicsResource => { };
+            WindowProvidedRenderTexture.Reload = (graphicsResource, services) => { };
 
             // Extract FBO render target
             if (WindowProvidedFrameBuffer != 0)

--- a/sources/engine/Stride.Graphics/PrimitiveQuad.cs
+++ b/sources/engine/Stride.Graphics/PrimitiveQuad.cs
@@ -150,7 +150,7 @@ namespace Stride.Graphics
                 var vertexBuffer = Buffer.Vertex.New(device, QuadsVertices).DisposeBy(this);
                 
                 // Register reload
-                vertexBuffer.Reload = (graphicsResource) => ((Buffer)graphicsResource).Recreate(QuadsVertices);
+                vertexBuffer.Reload = (graphicsResource, services) => ((Buffer)graphicsResource).Recreate(QuadsVertices);
 
                 VertexBuffer = new VertexBufferBinding(vertexBuffer, VertexDeclaration, QuadsVertices.Length, VertexPositionNormalTexture.Size);
             }

--- a/sources/engine/Stride.Graphics/ResumeManager.cs
+++ b/sources/engine/Stride.Graphics/ResumeManager.cs
@@ -11,9 +11,11 @@ namespace Stride.Graphics
         private GraphicsDevice graphicsDevice;
         private bool deviceHasBeenDestroyed = false;
         private bool deviceHasBeenPaused = false;
+        private IServiceRegistry services;
 
         public ResumeManager(IServiceRegistry services)
         {
+            this.services = services;
             graphicsDevice = services.GetSafeServiceAs<IGraphicsDeviceService>().GraphicsDevice;
         }
 
@@ -124,7 +126,7 @@ namespace Stride.Graphics
                 {
                     if (resource.Reload != null)
                     {
-                        resource.Reload(resource);
+                        resource.Reload(resource, services);
                         resource.LifetimeState = GraphicsResourceLifetimeState.Active;
                     }
                 }

--- a/sources/engine/Stride.Graphics/Texture.Extensions.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions.cs
@@ -78,7 +78,7 @@ namespace Stride.Graphics
                 }
             }
 
-            result.Reload = graphicsResource =>
+            result.Reload = (graphicsResource, services) =>
             {
                 using (var imageStream = new MemoryStream(data))
                 {


### PR DESCRIPTION
# PR Details
Reloading buffers wasn't ever called in editor or in engine I don't think but fixed it just in case someone ends up using it.
Also reduced the amount of unnecessary bloat allocated through some of the more common reload delegate capture, it's not that large but given that those resource are common objects it can quickly add up for a feature that's almost never used.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.