### PR TITLE
[Input] Fix mouse release for Winforms

### DIFF
--- a/sources/engine/Stride.Input/Windows/MouseWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/MouseWinforms.cs
@@ -33,9 +33,9 @@ namespace Stride.Input
             uiControl.MouseDown += OnMouseDown;
             uiControl.MouseUp += OnMouseUp;
             uiControl.MouseWheel += OnMouseWheelEvent;
-            uiControl.MouseCaptureChanged += OnLostMouseCapture;
             uiControl.SizeChanged += OnSizeChanged;
             uiControl.GotFocus += OnGotFocus;
+            uiControl.LostFocus += OnLostFocus;
 
             OnSizeChanged(this, null);
 
@@ -52,8 +52,9 @@ namespace Stride.Input
             uiControl.MouseDown -= OnMouseDown;
             uiControl.MouseUp -= OnMouseUp;
             uiControl.MouseWheel -= OnMouseWheelEvent;
-            uiControl.MouseCaptureChanged -= OnLostMouseCapture;
             uiControl.SizeChanged -= OnSizeChanged;
+            uiControl.GotFocus -= OnGotFocus;
+            uiControl.LostFocus -= OnLostFocus;
 
             if (rawInputMouse != null)
             {
@@ -141,6 +142,15 @@ namespace Stride.Input
             }
         }
 
+        private void OnLostFocus(object sender, EventArgs args)
+        {
+            var buttonsToRelease = DownButtons.ToArray();
+            foreach (var button in buttonsToRelease)
+            {
+                MouseState.HandleButtonUp(button);
+            }
+        }
+
         private void OnMouseMove(object sender, MouseEventArgs e)
         {
             if (!isPositionLocked)
@@ -180,15 +190,6 @@ namespace Stride.Input
         {
             uiControl.Focus();
             MouseState.HandleButtonDown(ConvertMouseButton(mouseEventArgs.Button));
-        }
-
-        private void OnLostMouseCapture(object sender, EventArgs args)
-        {
-            var buttonsToRelease = DownButtons.ToArray();
-            foreach (var button in buttonsToRelease)
-            {
-                MouseState.HandleButtonUp(button);
-            }
         }
 
         private static MouseButton ConvertMouseButton(MouseButtons mouseButton)


### PR DESCRIPTION
# PR Details
For some reason Winforms fires the `MouseCaptureChanged` when holding both and releasing just one of the two mouse buttons, see #1303
[Here's what the docs says about that event](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.control.mousecapturechanged?view=windowsdesktop-6.0):
> Now, click and hold the left mouse button on the Button control. While still clicking the mouse, press ALT+TAB to switch to another program. Notice that the MouseCaptureChanged event is raised enabling you to potentially handle this scenario.

It makes sense then that the engine removes any mouse button held when that event occurs but afaict it shouldn't occur in this case. I swapped it to `LostFocus` instead anyway since it makes more sense.

## Related Issue
#1303

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.