### PR TITLE
[Materials] Fixes render stage evaluation if the transparency changes

### DIFF
--- a/sources/engine/Stride.Engine/Rendering/ModelRenderProcessor.cs
+++ b/sources/engine/Stride.Engine/Rendering/ModelRenderProcessor.cs
@@ -120,17 +120,18 @@ namespace Stride.Rendering
 
         private void UpdateMaterial(RenderMesh renderMesh, MaterialPass materialPass, MaterialInstance modelMaterialInstance, ModelComponent modelComponent)
         {
-            renderMesh.MaterialPass = materialPass;
-
             var isShadowCaster = modelComponent.IsShadowCaster;
             if (modelMaterialInstance != null)
                 isShadowCaster &= modelMaterialInstance.IsShadowCaster;
 
-            if (isShadowCaster != renderMesh.IsShadowCaster)
+            if (isShadowCaster != renderMesh.IsShadowCaster
+                || materialPass.HasTransparency != renderMesh.MaterialPass.HasTransparency)
             {
                 renderMesh.IsShadowCaster = isShadowCaster;
                 VisibilityGroup.NeedActiveRenderStageReevaluation = true;
             }
+
+            renderMesh.MaterialPass = materialPass;
         }
 
         private Material FindMaterial(Material materialOverride, MaterialInstance modelMaterialInstance)


### PR DESCRIPTION
 Fixes render stage evaluation if the transparency of a material changes

# PR Details

Render models were not moved to the correct render stage if the transparency of a material is changed at runtime.

## Description

There was already a check for re-evaluating the render stage if the `IsShadowCaster` changes, this now includes a check for changes of the `renderMesh.MaterialPass.HasTransparency`.

- [ ] Needs cherry-pick to `main` branch

## Related Issue

https://github.com/vvvv/VL.Stride/issues/493

## Motivation and Context

Just a bug fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.