### PR TITLE
[Rendering] Fixes crash when changing DoF quality at runtime

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/DepthOfField.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/DepthOfField.cs
@@ -428,6 +428,7 @@ namespace Stride.Rendering.Images
             // Creates all the levels with different CoC strengths.
             // (Skips level with CoC 0 which is always the original buffer.)
             combineLevelsEffect.Parameters.Set(CombineLevelsFromCoCKeys.LevelCount, cocLevels.Count);
+            combineLevelsEffect.EffectInstance.UpdateEffect(GraphicsDevice); //update needed if permutation changed and shader has a value array parameter
             combineLevelsEffect.SetInput(0, cocLinearDepthTexture);
             combineLevelsEffect.SetInput(1, blurredCoCTexture);
             combineLevelsEffect.SetInput(2, originalColorBuffer);


### PR DESCRIPTION
# PR Details

Fixes crash when changing DoF quality at runtime.

## Description

Adds an `UpdateEffect()` call after setting the permutation parameter `CombineLevelsFromCoCKeys.LevelCount`. If the quality preset changes, this shader permutation key gets set, which changes the length of an array parameter. If the effect isn't updated, a subsequent `Set` on the array shader parameter throws an exception. The same is already done in the CoCMapBlur effect: https://github.com/stride3d/stride/blob/1c2969e3558228565431e267140557637033a9aa/sources/engine/Stride.Rendering/Rendering/Images/DepthOfField/CoCMapBlur.cs#L81

## Related Issue

https://github.com/vvvv/VL.Stride/issues/333

## Motivation and Context

Avoids a crash when changing the quality preset.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.