### PR TITLE
Fix typo in XAudio2.cpp

### DIFF
--- a/sources/engine/Stride.Audio/Native/XAudio2.cpp
+++ b/sources/engine/Stride.Audio/Native/XAudio2.cpp
@@ -1778,7 +1778,7 @@ extern "C" {
 
 		DLL_EXPORT_API void xnAudioSourceSetBuffer(xnAudioSource* source, xnAudioBuffer* buffer)
 		{
-			//this function is called only when the audio source is acutally fully cached in memory, so we deal only with the first buffer
+			//this function is called only when the audio source is actually fully cached in memory, so we deal only with the first buffer
 			source->streamed_ = false;
 			source->freeBuffers_[0] = buffer;
 			memcpy(&source->single_buffer_, &buffer->buffer_, sizeof(XAUDIO2_BUFFER));


### PR DESCRIPTION


# PR Details

FIxed typo.
```
acutally -> actually
```

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.