### PR TITLE
Fix for issue #1185 - Stride.Launcher - Could not find a part of the path

### DIFF
--- a/sources/launcher/Stride.Launcher/ViewModels/StrideVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/StrideVersionViewModel.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
-using System.DirectoryServices.ActiveDirectory;
 using System.IO;
 using System.Linq;
 using NuGet.Frameworks;
@@ -18,6 +17,8 @@ namespace Stride.LauncherApp.ViewModels
     internal abstract class StrideVersionViewModel : PackageVersionViewModel, IComparable<StrideVersionViewModel>, IComparable<Tuple<int, int>>
     {
         public const string MainExecutables = @"lib\net472\Stride.GameStudio.exe,lib\net472\Xenko.GameStudio.exe,Bin\Windows\Xenko.GameStudio.exe,Bin\Windows-Direct3D11\Xenko.GameStudio.exe";
+        private const string StrideGameStudioExe = "Stride.GameStudio.exe";
+        private const string XenkoGameStudioExe = "Xenko.GameStudio.exe";
 
         private bool isVisible;
         private bool canStart;
@@ -42,14 +43,14 @@ namespace Stride.LauncherApp.ViewModels
                 foreach (var toplevelFolder in new[] { "tools", "lib" })
                 {
                     var libDirectory = Path.Combine(InstallPath, toplevelFolder);
-                    var frameworks = Directory.EnumerateDirectories(libDirectory);
-                    foreach (var frameworkPath in frameworks)
+                    if (Directory.Exists(libDirectory))
                     {
-                        var frameworkFolder = new DirectoryInfo(frameworkPath).Name;
-                        if (File.Exists(Path.Combine(frameworkPath, "Stride.GameStudio.exe"))
-                            || File.Exists(Path.Combine(frameworkPath, "Xenko.GameStudio.exe")))
+                        foreach (var frameworkPath in Directory.EnumerateDirectories(libDirectory))
                         {
-                            Frameworks.Add(frameworkFolder);
+                            if (File.Exists(Path.Combine(frameworkPath, Major >= 4 ? StrideGameStudioExe : XenkoGameStudioExe)))
+                            {
+                                Frameworks.Add(new DirectoryInfo(frameworkPath).Name);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# PR Details

The launcher executable was moved to a new 'tools' directory as part of the fix for #1139.  Older packages did not contain a tools directory so added code to check for the existence of a target directory before delving into it.

Also tightened up the code in the affected area and removed an unused using statement.

## Description

1) Checked for the existence of a target subdirectory before attempting to enumerate it.  This eliminates the exception for all packages.
2) Slightly rearranged the code to make it more efficient in the affected area.
3) Eliminated an unused using statement

## Related Issue

#1139 

## Motivation and Context

Eliminates an exception for packages that do not have the current package layout.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.   ** Sadly, no tests seem to be available for the affected assembly.**
- [ ] All new and existing tests passed.