### PR TITLE
Fix for Issue #1361 - Replace deprecated WebRequest & WebClient

### DIFF
--- a/sources/launcher/Stride.Launcher/Services/SelfUpdater.cs
+++ b/sources/launcher/Stride.Launcher/Services/SelfUpdater.cs
@@ -5,28 +5,28 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-
 using Stride.Core;
 using Stride.Core.Extensions;
-using Stride.LauncherApp.Views;
 using Stride.Core.Packages;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.ViewModel;
+using Stride.LauncherApp.Resources;
+using Stride.LauncherApp.Views;
 using MessageBoxButton = Stride.Core.Presentation.Services.MessageBoxButton;
 using MessageBoxImage = Stride.Core.Presentation.Services.MessageBoxImage;
-using System.Net;
-using Stride.LauncherApp.Resources;
-using System.Text.RegularExpressions;
 
 namespace Stride.LauncherApp.Services
 {
     public static class SelfUpdater
     {
         public static readonly string Version;
+        private static readonly HttpClient httpClient = new();
 
         private static SelfUpdateWindow selfUpdateWindow;
 
@@ -46,7 +46,7 @@ namespace Stride.LauncherApp.Services
                 {
                     await UpdateLauncherFiles(dispatcher, services.Get<IDialogService>(), store, CancellationToken.None);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     dispatcher.Invoke(() => selfUpdateWindow?.ForceClose());
                     throw;
@@ -214,10 +214,13 @@ namespace Stride.LauncherApp.Services
 
 
                 var strideInstaller = Path.Combine(Path.GetTempPath(), $"StrideSetup-{Guid.NewGuid()}.exe");
-                using (WebClient webClient = new WebClient())
-                {
-                    webClient.DownloadFile(strideInstallerUrl, strideInstaller);
-                }
+                var response = await httpClient.GetAsync(strideInstallerUrl);
+                response.EnsureSuccessStatusCode();
+
+                await using var responseStream = await response.Content.ReadAsStreamAsync();
+                await using var fileStream = File.Create(strideInstaller);
+                responseStream.Seek(0, SeekOrigin.Begin);
+                responseStream.CopyTo(fileStream);
 
                 var startInfo = new ProcessStartInfo(strideInstaller)
                 {

--- a/sources/launcher/Stride.Launcher/Services/SelfUpdater.cs
+++ b/sources/launcher/Stride.Launcher/Services/SelfUpdater.cs
@@ -214,13 +214,14 @@ namespace Stride.LauncherApp.Services
 
 
                 var strideInstaller = Path.Combine(Path.GetTempPath(), $"StrideSetup-{Guid.NewGuid()}.exe");
-                var response = await httpClient.GetAsync(strideInstallerUrl);
-                response.EnsureSuccessStatusCode();
+                using (var response = await httpClient.GetAsync(strideInstallerUrl))
+                {
+                    response.EnsureSuccessStatusCode();
 
-                await using var responseStream = await response.Content.ReadAsStreamAsync();
-                await using var fileStream = File.Create(strideInstaller);
-                responseStream.Seek(0, SeekOrigin.Begin);
-                responseStream.CopyTo(fileStream);
+                    await using var responseStream = await response.Content.ReadAsStreamAsync();
+                    await using var fileStream = File.Create(strideInstaller);
+                    responseStream.CopyTo(fileStream);
+                }
 
                 var startInfo = new ProcessStartInfo(strideInstaller)
                 {

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Include proper language targets for temporary WPF projects. See https://github.com/dotnet/project-system/issues/1467 -->
@@ -47,20 +47,6 @@
   <ItemGroup>
     <PackageReference Include="Stride.Metrics" Version="1.0.3" />
     <PackageReference Include="Stride.CrashReport" Version="1.0.2" />
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Management" />
-    <Reference Include="System.Net.Http.Formatting">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\deps\Metrics\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\assets\Stride.Core.Assets\PackageSessionHelper.Solution.cs">

--- a/sources/launcher/Stride.Launcher/ViewModels/DocumentationPageViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/DocumentationPageViewModel.cs
@@ -3,8 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Stride.LauncherApp.Resources;
@@ -17,6 +16,7 @@ namespace Stride.LauncherApp.ViewModels
     internal class DocumentationPageViewModel : DispatcherViewModel
     {
         private static readonly Regex ParsingRegex = new Regex(@"\{([^\{\}]+)\}\{([^\{\}]+)\}\{([^\{\}]+)\}");
+        private static readonly HttpClient httpClient = new();
         private const string DocPageScheme = "page:";
         private const string PageUrlFormatString = "{0}{1}";
 
@@ -71,24 +71,13 @@ namespace Stride.LauncherApp.ViewModels
 
         public static async Task<List<DocumentationPageViewModel>> FetchGettingStartedPages(IViewModelServiceProvider serviceProvider, string version)
         {
-            string urlData = null;
             var result = new List<DocumentationPageViewModel>();
+            string urlData;
             try
             {
-                WebRequest request = WebRequest.Create(string.Format(Urls.GettingStarted, version));
-                using (var reponse = await request.GetResponseAsync())
-                {
-                    using (var str = reponse.GetResponseStream())
-                    {
-                        if (str != null)
-                        {
-                            using (var reader = new StreamReader(str))
-                            {
-                                urlData = reader.ReadToEnd();
-                            }
-                        }
-                    }
-                }
+                var response = await httpClient.GetAsync(string.Format(Urls.GettingStarted, version));
+                response.EnsureSuccessStatusCode();
+                urlData = await response.Content.ReadAsStringAsync();
             }
             catch (Exception)
             {

--- a/sources/launcher/Stride.Launcher/ViewModels/NewsPageViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/NewsPageViewModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml;
 using Stride.LauncherApp.Resources;
@@ -17,6 +17,8 @@ namespace Stride.LauncherApp.ViewModels
 {
     internal class NewsPageViewModel : DispatcherViewModel
     {
+        private static readonly HttpClient httpClient = new();
+
         public NewsPageViewModel(IViewModelServiceProvider serviceProvider)
             : base(serviceProvider)
         {
@@ -63,17 +65,12 @@ namespace Stride.LauncherApp.ViewModels
         public static async Task<List<NewsPageViewModel>> FetchNewsPages(IViewModelServiceProvider serviceProvider, int maxCount)
         {
             var result = new List<NewsPageViewModel>();
-            var rss = new MemoryStream();
+            MemoryStream rss;
             try
             {
-                WebRequest request = WebRequest.Create(Urls.RssFeed);
-                using (var reponse = await request.GetResponseAsync())
-                {
-                    using (var str = reponse.GetResponseStream())
-                    {
-                        str?.CopyTo(rss);
-                    }
-                }
+                HttpResponseMessage response = await httpClient.GetAsync(Urls.RssFeed);
+                response.EnsureSuccessStatusCode();
+                rss = (MemoryStream)await response.Content.ReadAsStreamAsync();
             }
             catch (Exception)
             {

--- a/sources/launcher/Stride.Launcher/ViewModels/ReleaseNotesViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/ReleaseNotesViewModel.cs
@@ -52,7 +52,7 @@ namespace Stride.LauncherApp.ViewModels
             ToggleCommand = new AnonymousCommand(ServiceProvider, Toggle);
         }
 
-        public string BaseUrl { get { return baseUrl; } private set { SetValue(ref baseUrl, value); } }
+        public string BaseUrl { get { return baseUrl; } }
 
         public string Version { get; }
 
@@ -78,10 +78,6 @@ namespace Stride.LauncherApp.ViewModels
                 {
                     response.EnsureSuccessStatusCode();
                     releaseNotesMarkdown = await response.Content.ReadAsStringAsync();
-
-                    // If redirected, the RequestMessage will contain the final full URI for the given response
-                    var responseUri = response.RequestMessage.RequestUri.ToString();
-                    BaseUrl = responseUri.Remove(responseUri.Length - ReleaseNotesFileName.Length);
                 }
             }
             catch (Exception)


### PR DESCRIPTION
# PR Details
1) Replaced all instances of WebRequest with HttpClient plus the appropriate Get + Read operations.

2) Replaced the use of WebClient with HttpClient plus Get + stream read.

3) Removed semi-problematic references and the SDK specifier as they caused the compiler to generate a number of warnings.   All these are not needed in .NET 6.

## Description

See details above and context below.

## Related Issue
#1361 

## Motivation and Context
The top-level motivation is to improve the developer experience when working with the code and ensure that the code is using the most current classes and practices.

This change replaces several instances of deprecated classes with current classes that handle the same functionality.  

Additionally, there were quite a number of warnings output by the compiler due to the .csproj file not being updated for .NET 6.   Updating the .csproj eliminated compiler confusion and the accompanying warning messages when selecting assemblies.  As a nit, the compiler also output a warning that <Project Sdk="Microsoft.NET.Sdk.Desktop"> could be simplified so I made that change to eliminate one more warning.

Also made some minor changes to eliminate other VS-generated suggestions in the affected files.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
There are no tests for the launcher so I have manually verified that the code results in the same experience.

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.  
- [ ] All new and existing tests passed.