### PR TITLE
Fix for #1363 - remove explicit reference to assemblies in .NET SDK to eliminate compiler warning.

### DIFF
--- a/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <Import Project="..\..\targets\Stride.Core.props" />
 
@@ -14,9 +14,6 @@
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Reference Include="PresentationFramework.Aero" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>


### PR DESCRIPTION
# PR Details
Remove last explicit reference to .NET SDK assembly to eliminate related compiler warning.

## Description
Simple change to remove ref to PresentationFramework.Aero left in Stride.Core.Presentation.csproj

## Related Issue
#1363

## Motivation and Context
Trivially removes one more warning and a potential source of nondeterminism.  Additional change made in #1362.  This should eliminate the last of the existing issues of this type. 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.