### PR TITLE
Add new button to launcher for VS2022 VSIX

### DIFF
--- a/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
@@ -81,6 +81,7 @@ namespace Stride.LauncherApp.ViewModels
 
         private string FormatStatus(string status)
         {
+            // TODO: add VS2019 vs VS2022 mark once packageId is established
             return $"{packageId.Split('.')[0]}: {status}";
         }
 

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -505,9 +505,10 @@
                 </DockPanel>
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Bottom">
-                <UniformGrid Columns="2">
-                  <ContentControl Grid.Column="0" Margin="0,0,2,0" Content="{Binding VsixPackage}"/>
-                  <ContentControl Grid.Column="1" Margin="2,0,0,0" Content="{Binding VsixPackageXenko}"/>
+                <UniformGrid Columns="3">
+                  <ContentControl Grid.Column="0" Margin="0,0,2,0" Content="{Binding VsixPackage2019}"/>
+                  <ContentControl Grid.Column="1" Margin="2,0,2,0" Content="{Binding VsixPackage2022}"/>
+                  <ContentControl Grid.Column="2" Margin="2,0,0,0" Content="{Binding VsixPackageXenko}"/>
                 </UniformGrid>
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Bottom">


### PR DESCRIPTION
# PR Details

## Description

This PR adds a 3rd button to the launcher for VSIX installation - there's still TODOs that need to be figured out:

- [ ] PackageId - new id for the new package, while the previous one stays the same for VS2019
- [ ] Label formatting - Currently we take prefix of package id (to the first dot) as label for the button (Stride/Xenko)

## Related Issue

#1306

## Motivation and Context

VS2022 plugins are not backwards compatible with VS2019, therefore we need to deploy a new plugin. Support for VS2019 needs to be maintained for Stride 4.0

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.