### PR TITLE
Address CPP compiler warnings by explicitly casting values after examining …

### DIFF
--- a/sources/tools/Stride.Importer.FBX/AnimationConverter.h
+++ b/sources/tools/Stride.Importer.FBX/AnimationConverter.h
@@ -517,7 +517,8 @@ namespace Stride {
 						if (camera->FieldOfViewY.GetCurve(animLayer))
 						{
 							curves[0] = camera->FieldOfViewY.GetCurve(animLayer);
-							auto FovAnimChannel = ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"VerticalFieldOfView", 1, curves, camera->FieldOfViewY.Get(), false);
+							float defaultValue = static_cast<float>(camera->FieldOfViewY.Get());
+							auto FovAnimChannel = ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"VerticalFieldOfView", 1, curves, defaultValue, false);
 
 							// TODO: Check again Max
 							//if (!exportedFromMaya)
@@ -528,20 +529,23 @@ namespace Stride {
 						if (camera->FocalLength.GetCurve(animLayer))
 						{
 							curves[0] = camera->FocalLength.GetCurve(animLayer);
-							auto flAnimChannel = ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"VerticalFieldOfView", 1, curves, camera->FocalLength.Get(), false);
+							float defaultValue = static_cast<float>(camera->FocalLength.Get());
+							auto flAnimChannel = ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"VerticalFieldOfView", 1, curves, defaultValue, false);
 							ComputeFovFromFL(flAnimChannel, camera);
 						}
 
 						if (camera->NearPlane.GetCurve(animLayer))
 						{
 							curves[0] = camera->NearPlane.GetCurve(animLayer);
-							ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"NearClipPlane", 1, curves, camera->NearPlane.Get(), false);
+							float defaultValue = static_cast<float>(camera->NearPlane.Get());
+							ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"NearClipPlane", 1, curves, defaultValue, false);
 						}
 
 						if (camera->FarPlane.GetCurve(animLayer))
 						{
 							curves[0] = camera->FarPlane.GetCurve(animLayer);
-							ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"FarClipPlane", 1, curves, camera->FarPlane.Get(), false);
+							float defaultValue = static_cast<float>(camera->FarPlane.Get());
+							ProcessAnimationCurveVector<float>(animationClip, cameraComponentKey+"FarClipPlane", 1, curves, defaultValue, false);
 						}
 					}
 					if (importCustomAttributeAnimations)
@@ -561,7 +565,7 @@ namespace Stride {
 
 							// extract the animation from the property
 							auto channelCount = lCurveNode->GetChannelsCount();
-							for (int c = 0; c<channelCount && c<3; ++c)
+							for (unsigned int c = 0; c<channelCount && c<3; ++c)
 								curves[c] = lCurveNode->GetCurve(c);
 
 							FbxDataType lDataType = lProperty.GetPropertyDataType();
@@ -625,9 +629,9 @@ namespace Stride {
 						{
 							parentNodeName = sceneMapping->FindNode(parentNode).Name;
 						}
-
-						float start = animStart.GetSecondDouble();
-						float end = animEnd.GetSecondDouble();
+						
+						FbxLongLong start = static_cast<FbxLongLong>(animStart.GetSecondDouble());
+						FbxLongLong end = static_cast<FbxLongLong>(animEnd.GetSecondDouble());
 
 						FbxTime sampling_period = FbxTimeSeconds(1.f / 60.0f);
 						bool loop_again = true;
@@ -656,9 +660,6 @@ namespace Stride {
 							scalingFrames->Add(KeyFrameData<Vector3>(time, scaling));
 							translationFrames->Add(KeyFrameData<Vector3>(time, translation));
 							rotationFrames->Add(KeyFrameData<Quaternion>(time, rotation));
-							//System::Diagnostics::Debug::WriteLine("[{0}] Parent:{1} Transform.Position[{2}] = {3}", t, parentNodeName, nodeName, translation);
-							//System::Diagnostics::Debug::WriteLine("[{0}] Parent:{1} Transform.Rotation[{2}] = {3}", t, parentNodeName, nodeName, rotation);
-							//System::Diagnostics::Debug::WriteLine("[{0}] Parent:{1} Transform.Scale[{2}] = {3}", t, parentNodeName, nodeName, scaling);
 						}
 
 						CreateCurve(animationClip, String::Format("Transform.Position[{0}]", nodeName), translationFrames);


### PR DESCRIPTION
… safety or by changing the type used.    Also removed some commented out debugging code.

# PR Details

The CPP compiler was issuing 20 warnings about type conversion.   In all cases, there is a safe cast or type change that addresses the warnings.

## Description

The changes are simple explicit type casts or, in one case, a change of a type.  I examined the underlying types and the original code and deemed the changes to be equivalent.

In the case of animStart.GetSecondDouble() and then use in the constructor of FbxTIme, the constructor takes a FbxLongLong (signed long long) so used that type in the cast to make the conversion a bit more obvious.

Some commented out debugging code was also removed.

## Related Issue

#1383 

## Motivation and Context

See #1383 The change is part of addressing all compiler warnings to improve the developer experience and ensure the safety of the code.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.