### PR TITLE
Warning fixes for C# code, part 1

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/Tasks/PackAssets.cs
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/Tasks/PackAssets.cs
@@ -172,7 +172,7 @@ namespace Stride.Core.Assets.CompilerApp.Tasks
                             RegisterItem(outputFile);
                         }
                     }
-                    catch (YamlException e)
+                    catch (YamlException)
                     {
                         // Not a Yaml asset? Process it as binary (copy)
                         File.Copy(asset.FilePath, outputFile, true);

--- a/sources/assets/Stride.Core.Assets/DirectoryHelper.cs
+++ b/sources/assets/Stride.Core.Assets/DirectoryHelper.cs
@@ -11,8 +11,6 @@ namespace Stride.Core.Assets
     public static class DirectoryHelper
     {
         private const string StrideSolution = @"build\Stride.sln";
-        private const string StrideNuspec = @"stride.nuspec";
-        private static string packageDirectoryOverride;
 
         /// <summary>
         /// Gets the path to the file corresponding to the given package name in the given directory.

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -63,8 +63,6 @@ namespace Stride.Core.Assets
 
         internal readonly List<UFile> FilesToDelete = new List<UFile>();
 
-        private PackageSession session;
-
         private UFile packagePath;
         internal UFile PreviousPackagePath;
         private bool isDirty;

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -220,8 +220,6 @@ namespace Stride.Core.Assets
 
     public class StandalonePackage : PackageContainer
     {
-        private readonly Package package;
-
         public StandalonePackage([NotNull] Package package)
             : base(package)
         {
@@ -232,7 +230,7 @@ namespace Stride.Core.Assets
         /// </summary>
         public List<string> Assemblies { get; } = new List<string>();
 
-        public override string ToString() => $"Package: {package.Meta.Name}";
+        public override string ToString() => $"Package: {Package.Meta.Name}";
     }
 
     public enum DependencyType

--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -18,15 +17,12 @@ using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using Stride.Core;
 using Stride.Core.Extensions;
 using Stride.Core.Windows;
 using ISettings = NuGet.Configuration.ISettings;
 using PackageSource = NuGet.Configuration.PackageSource;
 using PackageSourceProvider = NuGet.Configuration.PackageSourceProvider;
-using Settings = NuGet.Configuration.Settings;
 using NuGet.Resolver;
-using System.Reflection;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -42,7 +38,7 @@ namespace Stride.Core.Packages
     public class NugetStore : INugetDownloadProgress
     {
         private IPackagesLogger logger;
-        private readonly ISettings settings, localSettings;
+        private readonly ISettings settings;
         private ProgressReport currentProgressReport;
 
         private readonly string oldRootDirectory;

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/OldCollectionDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/OldCollectionDescriptor.cs
@@ -243,16 +243,6 @@ namespace Stride.Core.Reflection
             return collection == null || GetCollectionCountFunction == null ? -1 : GetCollectionCountFunction(collection);
         }
 
-        /// <summary>
-        /// Determines whether the specified type is collection.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns><c>true</c> if the specified type is collection; otherwise, <c>false</c>.</returns>
-        public static bool IsCollection(Type type)
-        {
-            return TypeHelper.IsCollection(type);
-        }
-
         protected override bool PrepareMember(MemberDescriptorBase member, MemberInfo metadataClassMemberInfo)
         {
             // Filter members

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/DirectoryBaseViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/DirectoryBaseViewModel.cs
@@ -165,8 +165,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// <param name="newParent">The nwe parent of this directory.</param>
         protected void SetParent(DirectoryBaseViewModel oldParent, DirectoryBaseViewModel newParent)
         {
-            var directory = this as DirectoryViewModel;
-            if (directory == null) throw new InvalidOperationException("Can't change the parent of this folder");
+            if (this is not DirectoryViewModel directory) throw new InvalidOperationException("Can't change the parent of this folder");
 
             Dispatcher.Invoke(() =>
             {
@@ -206,15 +205,12 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
             foreach (var child in children)
             {
-                var mountPoint = child as MountPointViewModel;
-                var directory = child as DirectoryViewModel;
-                var asset = child as AssetViewModel;
-                if (mountPoint != null)
+                if (child is MountPointViewModel mountPoint)
                 {
                     message = DragDropBehavior.InvalidDropAreaMessage;
                     return false;
                 }
-                if (directory != null)
+                if (child is DirectoryViewModel directory)
                 {
                     if (directory == this)
                     {
@@ -224,11 +220,6 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     if (directory.Root.GetType() != Root.GetType())
                     {
                         message = "Incompatible folder";
-                        return false;
-                    }
-                    if (directory.Root is ProjectViewModel && Root != directory.Root)
-                    {
-                        message = "Can't move source files between projects";
                         return false;
                     }
                     if (SubDirectories.Any(x => x.Name == directory.Name))
@@ -252,7 +243,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                         currentParent = currentParent.Parent;
                     }
                 }
-                else if (asset != null)
+                else if (child is AssetViewModel asset)
                 {
                     if (asset.IsLocked)
                     {
@@ -272,11 +263,6 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     if (asset.Directory.Root.GetType() != Root.GetType())
                     {
                         message = "Incompatible folder";
-                        return false;
-                    }
-                    if (asset.Directory.Root is ProjectViewModel && Root != asset.Directory.Root)
-                    {
-                        message = "Can't move source files between projects";
                         return false;
                     }
                 }

--- a/sources/engine/Stride.Graphics/BufferPool.cs
+++ b/sources/engine/Stride.Graphics/BufferPool.cs
@@ -15,7 +15,7 @@ namespace Stride.Graphics
         private const bool UseBufferOffsets = false;
 #endif
 
-        private int constantBufferAlignment;
+        private readonly int constantBufferAlignment;
         public int Size;
         public IntPtr Data;
 
@@ -35,8 +35,11 @@ namespace Stride.Graphics
             this.allocator = allocator;
 
             Size = size;
+
+#pragma warning disable 162 // Unreachable code detected
             if (!UseBufferOffsets)
                 Data = Marshal.AllocHGlobal(size);
+#pragma warning disable 162 // Unreachable code detected
 
             Reset();
         }
@@ -48,8 +51,10 @@ namespace Stride.Graphics
 
         public void Dispose()
         {
+#pragma warning disable 162 // Unreachable code detected
             if (UseBufferOffsets)
                 allocator.ReleaseReference(constantBuffer);
+#pragma warning restore 162
             else
                 Marshal.FreeHGlobal(Data);
             Data = IntPtr.Zero;
@@ -57,6 +62,7 @@ namespace Stride.Graphics
 
         public void Map(CommandList commandList)
         {
+#pragma warning disable 162 // Unreachable code detected
             if (UseBufferOffsets)
             {
                 using (new DefaultCommandListLock(commandList))
@@ -66,10 +72,12 @@ namespace Stride.Graphics
                     Data = mappedConstantBuffer.DataBox.DataPointer;
                 }
             }
+#pragma warning restore 162
         }
 
         public void Unmap()
         {
+#pragma warning disable 162
             if (UseBufferOffsets && mappedConstantBuffer.Resource != null)
             {
                 using (new DefaultCommandListLock(commandList))
@@ -78,10 +86,12 @@ namespace Stride.Graphics
                     mappedConstantBuffer = new MappedResource();
                 }
             }
+#pragma warning restore 162
         }
 
         public void Reset()
         {
+#pragma warning disable 162
             if (UseBufferOffsets)
             {
                 // Release previous buffer
@@ -90,6 +100,7 @@ namespace Stride.Graphics
 
                 constantBuffer = allocator.GetTemporaryBuffer(new BufferDescription(Size, BufferFlags.ConstantBuffer, GraphicsResourceUsage.Dynamic));
             }
+#pragma warning restore 162
 
             bufferAllocationOffset = 0;
         }
@@ -112,12 +123,15 @@ namespace Stride.Graphics
                 throw new InvalidOperationException();
 
             // Map (if needed)
+#pragma warning disable 162
             if (UseBufferOffsets && mappedConstantBuffer.Resource == null)
                 Map(commandList);
+#pragma warning restore 162
 
             bufferPoolAllocationResult.Data = Data + result;
             bufferPoolAllocationResult.Size = size;
 
+#pragma warning disable 162
             if (UseBufferOffsets)
             {
                 bufferPoolAllocationResult.Uploaded = true;
@@ -141,6 +155,7 @@ namespace Stride.Graphics
                     }
                 }
             }
+#pragma warning restore 162
         }
     }
 

--- a/sources/engine/Stride.Graphics/CommandList.cs
+++ b/sources/engine/Stride.Graphics/CommandList.cs
@@ -20,11 +20,10 @@ namespace Stride.Graphics
 
         private int boundScissorCount;
         private readonly Rectangle[] scissors = new Rectangle[MaxViewportAndScissorRectangleCount];
-        private bool scissorsDirty = false;
 
         private Texture depthStencilBuffer;
 
-        private Texture[] renderTargets = new Texture[MaxRenderTargetCount];
+        private readonly Texture[] renderTargets = new Texture[MaxRenderTargetCount];
         private int renderTargetCount;
 
         /// <summary>
@@ -74,7 +73,6 @@ namespace Stride.Graphics
                 viewports[i] = new Viewport();
 
             // Setup empty scissors
-            scissorsDirty = true;
             for (int i = 0; i < scissors.Length; i++)
                 scissors[i] = new Rectangle();
 
@@ -144,7 +142,6 @@ namespace Stride.Graphics
         /// <param name="rectangle">The scissor rectangle.</param>
         public void SetScissorRectangle(Rectangle rectangle)
         {
-            scissorsDirty = true;
             boundScissorCount = 1;
             scissors[0] = rectangle;
             SetScissorRectangleImpl(ref rectangle);
@@ -166,7 +163,6 @@ namespace Stride.Graphics
         /// <param name="scissorRectangles">The set of scissor rectangles to bind.</param>
         public void SetScissorRectangles(int scissorCount, Rectangle[] scissorRectangles)
         {
-            scissorsDirty = true;
             boundScissorCount = scissorCount;
             for (int i = 0; i < scissorCount; ++i)
             {

--- a/sources/engine/Stride.Rendering/Rendering/Lights/DirectionalLightData.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/DirectionalLightData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Stride.Core.Mathematics;
@@ -7,9 +7,11 @@ namespace Stride.Rendering.Lights
 {
     public struct DirectionalLightData
     {
+#pragma warning disable 169 // The field <X> is never used
         public Vector3 DirectionWS;
         private float padding0;
         public Color3 Color;
         private float padding1;
+#pragma warning restore 169
     }
 }

--- a/sources/engine/Stride.VirtualReality/OpenVR/OpenVrTrackedDevice.cs
+++ b/sources/engine/Stride.VirtualReality/OpenVR/OpenVrTrackedDevice.cs
@@ -10,7 +10,6 @@ namespace Stride.VirtualReality
 {
     internal class OpenVRTrackedDevice : TrackedItem
     {
-        private readonly int id;
         private OpenVR.TrackedDevice trackedDevice;
         private DeviceState internalState;
         private Vector3 currentPos;

--- a/sources/tools/Stride.VisualStudio.Package/Classifiers/ClassificationColorManager.cs
+++ b/sources/tools/Stride.VisualStudio.Package/Classifiers/ClassificationColorManager.cs
@@ -20,12 +20,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Windows.Media;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Classification;
-using Microsoft.VisualStudio.Text.Formatting;
 
 namespace Stride.VisualStudio.Classifiers
 {


### PR DESCRIPTION
# PR Details

The first round of addressing C# related warnings.  Part of issue #1383 

## Description

Fixes the following warnings:
- CS0108 'OldCollectionDescriptor.IsCollection(Type)' hides inherited member 'CollectionDescriptor.IsCollection(Type)'. Use the new keyword if hiding was intended.
- CS0162 Unreachable code
- CS0168 The variable 'e' is declared but never used
- CS0169 The field 'foo' is never used
- CS0184 The given expression is never of the provided ('ProjectViewModel') type

Plus some minor using cleanup and making code a tad more consistent.
## Related Issue
#1383 

## Motivation and Context

See linked issue for details.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. **_Test results are identical to master_**