### PR TITLE
Update stride package definitions to use a license expression of 'MIT…

### DIFF
--- a/sources/launcher/Stride.Launcher/Stride.Launcher.nuspec
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.nuspec
@@ -5,7 +5,7 @@
     <version>5.0.6</version>
     <authors>Stride</authors>
     <owners>Stride</owners>
-    <licenseUrl>https://stride3d.net/license.txt</licenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <projectUrl>https://stride3d.net/</projectUrl>
     <copyright>&#169; Stride contributors and Silicon Studio Corp.</copyright>
     <description>Stride Launcher

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.nuspec
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.nuspec
@@ -5,7 +5,7 @@
     <version>5.0.6</version>
     <authors>Stride</authors>
     <owners>Stride</owners>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <license type="expression">MIT</license>
     <projectUrl>https://stride3d.net/</projectUrl>
     <copyright>&#169; Stride contributors and Silicon Studio Corp.</copyright>
     <description>Stride Launcher

--- a/sources/targets/Stride.PackageVersion.targets
+++ b/sources/targets/Stride.PackageVersion.targets
@@ -15,7 +15,7 @@
     <StrideNuGetVersion>$(StridePublicVersion)$(StrideNuGetVersionSuffix)$(StrideBuildMetadata)</StrideNuGetVersion>
     
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(StrideNuGetVersion)</PackageVersion>
-    <PackageLicenseUrl>https://github.com/stride3d/stride/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://stride3d.net</PackageProjectUrl>
     <PackageIcon>nuget-icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/stride3d/stride</RepositoryUrl>

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
@@ -5,7 +5,7 @@
     <version>4.1.0</version>
     <authors>Stride</authors>
     <owners>Stride</owners>
-    <licenseUrl>https://github.com/stride3d/stride/blob/master/LICENSE.md</licenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <projectUrl>http://stride3d.net/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/stride3d/media/master/images/mainlogo/nuget/logo.png</iconUrl>
     <repository type="git" url="https://github.com/stride3d/stride" />

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
@@ -5,7 +5,7 @@
     <version>4.1.0</version>
     <authors>Stride</authors>
     <owners>Stride</owners>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <license type="expression">MIT</license>
     <projectUrl>http://stride3d.net/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/stride3d/media/master/images/mainlogo/nuget/logo.png</iconUrl>
     <repository type="git" url="https://github.com/stride3d/stride" />


### PR DESCRIPTION
…' rather than the deprecated licenseUrl.

# PR Details

Updates to move to currently supported 'license' metadata in the Nuget packages and avoid using deprecated 'licenseUrl'

## Description

Simple change to use the license expression of MIT and remove licenseUrl.

## Related Issue
#1381 
#1383

## Motivation and Context

This eliminates nearly 70 compiler warnings and moves the package to the currently supported license metadata.   Since Stride uses a MIT license, the recommendation is to use a license expression as appears in this PR.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
I've inspected the resulting packages and verified that they have the expected license information in the nuspec.

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.