### PR TITLE
Update the Visual Studio Extension and the companion installer to only target VS2019.

### DIFF
--- a/sources/core/Stride.Core.Design/VisualStudio/VisualStudioVersions.cs
+++ b/sources/core/Stride.Core.Design/VisualStudio/VisualStudioVersions.cs
@@ -78,7 +78,8 @@ namespace Stride.Core.VisualStudio
     public enum VSIXInstallerVersion
     {
         None,
-        VS2019AndFutureVersions,
+        VS2019,
+        VS2022AndFutureVersions,
     }
 
     public static class VisualStudioVersions
@@ -110,7 +111,7 @@ namespace Stride.Core.VisualStudio
         {
             var ideInfos = new List<IDEInfo>();
 
-            // Visual Studio 15.0 (2017) and later
+            // Visual Studio 16.0 (2019) and later
             try
             {
                 var configuration = new SetupConfiguration();
@@ -133,7 +134,7 @@ namespace Stride.Core.VisualStudio
 
                         // Only deal with VS2019+
                         if (!Version.TryParse(inst2.GetInstallationVersion(), out var version)
-                            || version.Major < 15)
+                            || version.Major < 16)
                             continue;
 
                         var installationPath = inst2.GetInstallationPath();
@@ -186,7 +187,7 @@ namespace Stride.Core.VisualStudio
                         {
                             BuildToolsPath = buildToolsPath,
                             DevenvPath = devenvPath,
-                            VsixInstallerVersion = VSIXInstallerVersion.VS2019AndFutureVersions,
+                            VsixInstallerVersion = version.Major == 16 ? VSIXInstallerVersion.VS2019 : VSIXInstallerVersion.VS2022AndFutureVersions,
                             VsixInstallerPath = vsixInstallerPath,
                         };
 

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -34,7 +34,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.14.0" Version="14.0.23205" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="14.0.25023" />
     <PackageReference Include="VSLangProj" Version="7.0.3301" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26201" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.10.1055">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="NuGet.Commands" Version="5.8.0" />

--- a/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest
+++ b/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="248ff1ce-dacd-4404-947a-85e999d3c3ea" Version="4.0.6" Language="en-US" Publisher="Stride" />
+    <Identity Id="248ff1ce-dacd-4404-947a-85e999d3c3ea" Version="4.0.7" Language="en-US" Publisher="Stride" />
     <DisplayName>Stride</DisplayName>
     <Description>Stride VisualStudio Package</Description>
     <Icon>Resources\VSPackage.ico</Icon>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
@@ -18,6 +18,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>

--- a/sources/tools/Stride.VisualStudio.PackageInstall/Program.cs
+++ b/sources/tools/Stride.VisualStudio.PackageInstall/Program.cs
@@ -24,11 +24,12 @@ namespace Stride.VisualStudio.PackageInstall
 
                 // Locate VSIXInstaller.exe
                 // We now only deal with VS2019+ which has a unified installer. Still getting latest version of VS possible, in case there is some bugfixes or incompatible changes.
-                var visualStudioVersionByVsixVersion = VisualStudioVersions.AvailableVisualStudioInstances.Where(x => x.HasVsixInstaller && x.VsixInstallerVersion == VSIXInstallerVersion.VS2019AndFutureVersions);
+                // Since the Stride 4.0x VS Package is only supported on VS2019, only look for that one version.
+                var visualStudioVersionByVsixVersion = VisualStudioVersions.AvailableVisualStudioInstances.Where(x => x.HasVsixInstaller && x.VsixInstallerVersion == VSIXInstallerVersion.VS2019);
                 var visualStudioVersion = visualStudioVersionByVsixVersion.OrderByDescending(x => x.Version).FirstOrDefault(x => File.Exists(x.VsixInstallerPath));
                 if (visualStudioVersion == null)
                 {
-                    throw new InvalidOperationException($"Could not find a proper installation of Visual Studio 2019 or later");
+                    throw new InvalidOperationException($"Could not find a proper installation of Visual Studio 2019");
                 }
 
                 switch (args[0])


### PR DESCRIPTION
# PR Details

The current VS extension is only valid on VS2019 as the architecture for 2022 has changed and per the code, earlier versions of VS are not supported.   

## Description

Update the VISX manifest to only target editions of VS2019 (16.x) and update the stand-alone installer to detect only 2019 as a valid version of VS.

## Related Issue

#1388

## Motivation and Context

See above

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have manually tested and verified the changes work as expected
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.