### PR TITLE
added abstractions IIntersectableWithRay and IIntersectableWithPlane

### DIFF
--- a/sources/core/Stride.Core.Mathematics/BoundingBox.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingBox.cs
@@ -37,7 +37,7 @@ namespace Stride.Core.Mathematics
     /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    public struct BoundingBox : IEquatable<BoundingBox>, IFormattable
+    public struct BoundingBox : IEquatable<BoundingBox>, IFormattable, IIntersectableWithRay, IIntersectableWithPlane
     {
         /// <summary>
         /// A <see cref="BoundingBox"/> which represents an empty space.

--- a/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
@@ -37,7 +37,7 @@ namespace Stride.Core.Mathematics
     /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    public struct BoundingSphere : IEquatable<BoundingSphere>, IFormattable
+    public struct BoundingSphere : IEquatable<BoundingSphere>, IFormattable, IIntersectableWithRay, IIntersectableWithPlane
     {
         /// <summary>
         /// An empty bounding sphere (Center = 0 and Radius = 0).

--- a/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
+++ b/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
@@ -27,6 +27,7 @@
 * THE SOFTWARE.
 */
 using System;
+using System.Collections.Generic;
 
 namespace Stride.Core.Mathematics
 {
@@ -1546,6 +1547,41 @@ namespace Stride.Core.Mathematics
                 return true;
             }
  */
+        }
+
+        /// <summary>
+        /// Retrieves the nearest hit object starting from the position of the ray in the direction of the ray.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="objects">The objects that get tested for a collision with the ray.</param>
+        /// <param name="ray">The ray.</param>
+        /// <param name="hitObject">The hit object.</param>
+        /// <param name="distance">The distance from the start of the ray.</param>
+        /// <param name="point">The position of the collision.</param>
+        /// <returns>Whether there was a hit.</returns>
+        public static bool GetNearestHit<T>(IEnumerable<T> objects, ref Ray ray, out T hitObject, out float distance, out Vector3 point)
+            where T : IIntersectableWithRay
+        {
+            bool hit = false;
+            distance = float.PositiveInfinity;
+            hitObject = default;
+
+            foreach (var o in objects)
+            {
+                if (o.Intersects(ref ray, out float d) && (d < distance))
+                {
+                    distance = d;
+                    hitObject = o;
+                    hit = true;
+                }
+            }
+
+            if (hit)
+                hitObject.Intersects(ref ray, out point);
+            else
+                point = default;
+
+            return hit;
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/IIntersectableWithPlane.cs
+++ b/sources/core/Stride.Core.Mathematics/IIntersectableWithPlane.cs
@@ -1,0 +1,15 @@
+namespace Stride.Core.Mathematics
+{
+    /// <summary>
+    /// Allows to determine intersections with a <see cref="Stride.Core.Mathematics.Plane"/>.
+    /// </summary>
+    public interface IIntersectableWithPlane
+    {
+        /// <summary>
+        /// Determines if there is an intersection between the current object and a <see cref="Stride.Core.Mathematics.Plane"/>.
+        /// </summary>
+        /// <param name="plane">The plane to test.</param>
+        /// <returns>Whether the two objects intersected.</returns>
+        public PlaneIntersectionType Intersects(ref Plane plane);
+    }
+}

--- a/sources/core/Stride.Core.Mathematics/IIntersectableWithRay.cs
+++ b/sources/core/Stride.Core.Mathematics/IIntersectableWithRay.cs
@@ -1,0 +1,33 @@
+namespace Stride.Core.Mathematics
+{
+    /// <summary>
+    /// Allows to determine intersections with a <see cref="Stride.Core.Mathematics.Ray"/>.
+    /// </summary>
+    public interface IIntersectableWithRay
+    {
+        /// <summary>
+        /// Determines if there is an intersection between the current object and a <see cref="Stride.Core.Mathematics.Ray"/>.
+        /// </summary>
+        /// <param name="ray">The ray to test.</param>
+        /// <returns>Whether the two objects intersected.</returns>
+        public bool Intersects(ref Ray ray);
+
+        /// <summary>
+        /// Determines if there is an intersection between the current object and a <see cref="Stride.Core.Mathematics.Ray"/>.
+        /// </summary>
+        /// <param name="ray">The ray to test.</param>
+        /// <param name="distance">When the method completes, contains the distance of the intersection,
+        /// or 0 if there was no intersection.</param>
+        /// <returns>Whether the two objects intersected.</returns>
+        public bool Intersects(ref Ray ray, out float distance);
+
+        /// <summary>
+        /// Determines if there is an intersection between the current object and a <see cref="Stride.Core.Mathematics.Ray"/>.
+        /// </summary>
+        /// <param name="ray">The ray to test.</param>
+        /// <param name="point">When the method completes, contains the point of intersection,
+        /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
+        /// <returns>Whether the two objects intersected.</returns>
+        public bool Intersects(ref Ray ray, out Vector3 point);
+    }
+}

--- a/sources/core/Stride.Core.Mathematics/Plane.cs
+++ b/sources/core/Stride.Core.Mathematics/Plane.cs
@@ -37,7 +37,7 @@ namespace Stride.Core.Mathematics
     /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    public struct Plane : IEquatable<Plane>, IFormattable
+    public struct Plane : IEquatable<Plane>, IFormattable, IIntersectableWithRay
     {
         /// <summary>
         /// The normal vector of the plane.


### PR DESCRIPTION
added abstractions IIntersectableWithRay (implemented by BoundingBox, BoundingSphere and Plane) and IIntersectableWithPlane (implemented by BoundingBox and BoundingSphere)

# PR Details

CollisionHelpers now comes with a generic `GetNearestHit` method.
The new interfaces only surface the already done implementations and let you abstract over the concrete types.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.