### PR TITLE
[Shaders] Adds TypeName generic to use type parameters in SDSL

### DIFF
--- a/sources/shaders/Stride.Core.Shaders/Ast/Stride/TypeName.cs
+++ b/sources/shaders/Stride.Core.Shaders/Ast/Stride/TypeName.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Stride.Core.Shaders.Ast;
+
+namespace Stride.Core.Shaders.Ast.Stride
+{
+    public partial class TypeName : TypeBase, IDeclaration, IScopeContainer, IGenericStringArgument
+    {
+        #region Constructors and Destructors
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "TypeName" /> class.
+        /// </summary>
+        public TypeName()
+            : base("TypeName")
+        {
+        }
+
+        #endregion
+    }
+}

--- a/sources/shaders/Stride.Core.Shaders/Visitor/VisitorGenerated.cs
+++ b/sources/shaders/Stride.Core.Shaders/Visitor/VisitorGenerated.cs
@@ -39,6 +39,10 @@ namespace Stride.Core.Shaders.Visitor
         {
             return DefaultVisit(memberName);
         }
+        public virtual TResult Visit(Stride.Core.Shaders.Ast.Stride.TypeName typeName)
+        {
+            return DefaultVisit(typeName);
+        }
         public virtual TResult Visit(Stride.Core.Shaders.Ast.Stride.MixinStatement mixinStatement)
         {
             return DefaultVisit(mixinStatement);
@@ -444,6 +448,17 @@ namespace Stride.Core.Shaders.Visitor
             if (!ReferenceEquals(qualifiersTemp, memberName.Qualifiers))
                 memberName.Qualifiers = qualifiersTemp;
             return base.Visit(memberName);
+        }
+        public override Node Visit(Stride.Core.Shaders.Ast.Stride.TypeName typeName)
+        {
+            VisitList(typeName.Attributes);
+            var nameTemp = (Stride.Core.Shaders.Ast.Identifier)VisitDynamic(typeName.Name);
+            if (!ReferenceEquals(nameTemp, typeName.Name))
+                typeName.Name = nameTemp;
+            var qualifiersTemp = (Stride.Core.Shaders.Ast.Qualifier)VisitDynamic(typeName.Qualifiers);
+            if (!ReferenceEquals(qualifiersTemp, typeName.Qualifiers))
+                typeName.Qualifiers = qualifiersTemp;
+            return base.Visit(typeName);
         }
         public override Node Visit(Stride.Core.Shaders.Ast.Stride.MixinStatement mixinStatement)
         {
@@ -1337,6 +1352,20 @@ namespace Stride.Core.Shaders.Visitor
                 Name = memberName.Name,
                 Qualifiers = memberName.Qualifiers,
                 IsBuiltIn = memberName.IsBuiltIn,
+            };
+        }
+        public override Node Visit(Stride.Core.Shaders.Ast.Stride.TypeName typeName)
+        {
+            typeName = (Stride.Core.Shaders.Ast.Stride.TypeName)base.Visit(typeName);
+            return new Stride.Core.Shaders.Ast.Stride.TypeName
+            {
+                Span = typeName.Span,
+                Tags = typeName.Tags,
+                Attributes = typeName.Attributes,
+                TypeInference = typeName.TypeInference,
+                Name = typeName.Name,
+                Qualifiers = typeName.Qualifiers,
+                IsBuiltIn = typeName.IsBuiltIn,
             };
         }
         public override Node Visit(Stride.Core.Shaders.Ast.Stride.MixinStatement mixinStatement)
@@ -2457,6 +2486,10 @@ namespace Stride.Core.Shaders.Visitor
         {
             DefaultVisit(memberName);
         }
+        public virtual void Visit(Stride.Core.Shaders.Ast.Stride.TypeName typeName)
+        {
+            DefaultVisit(typeName);
+        }
         public virtual void Visit(Stride.Core.Shaders.Ast.Stride.MixinStatement mixinStatement)
         {
             DefaultVisit(mixinStatement);
@@ -3479,6 +3512,20 @@ namespace Stride.Core.Shaders.Ast.Stride
 namespace Stride.Core.Shaders.Ast.Stride
 {
     public partial class MemberName
+    {
+        public override void Accept(ShaderVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+        public override TResult Accept<TResult>(ShaderVisitor<TResult> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+}
+namespace Stride.Core.Shaders.Ast.Stride
+{
+    public partial class TypeName
     {
         public override void Accept(ShaderVisitor visitor)
         {


### PR DESCRIPTION
# PR Details

Adds `TypeName` generic parameter to SDSL to instantiate shaders with different type parameters.

## Description

This will allow writing shaders like in a high-level programming language with generic types.

Silly Example:

```hlsl
// definition
shader VectorUtils<TypeName T>
{
    float LengthSquared(T input)
    {
        return dot(input, input);
    }
}

// usage
shader MyShader : VectorUtils<float3>
{
    void Compute()
    {
        ...
        float lenSq = LengthSquared(streams.Position.xyz);

        // or, not sure if this would work too
        float lenSq = VectorUtils<float3>.LengthSquared(streams.Position.xyz);
        ...
    };
}
```

Ping @xen2 and @xoofx before I write more code, the SDSL AST files look a bit machine-generated. Did you use some kind of tool to generate the definitions? If yes, does it still exist? Any other input/thoughts are welcome too.

## Related Issue

https://github.com/vvvv/VL.Stride/issues/352

## Motivation and Context

We generate a lot of little shaders to patch shaders in our visual programming language. For that, we wrote the type permutations by hand at the moment. If we can programmatically instantiate shaders with type parameters at runtime, there need to be significantly fewer shaders to be written.

Also, having generic types in a shader language is badass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.