### PR TITLE
[Physics] Update WorldMatrix when forcing transformation on PhysicsComponent

### DIFF
--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -405,14 +405,7 @@ namespace Stride.Physics
             Data.PhysicsComponent.Simulation.SimulationProfiler.Mark();
             Data.PhysicsComponent.Simulation.UpdatedRigidbodies++;
 
-            if (BoneIndex == -1)
-            {
-                DerivePhysicsTransformation(out physicsTransform);
-            }
-            else
-            {
-                DeriveBonePhysicsTransformation(out physicsTransform);
-            }
+            DerivePhysicsTransformation(out physicsTransform, false);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details
`UpdatePhysicsTransformation()` is likely to set the transformations of the physics-engine side object based on previous frame transformation instead of latest, [see summary of `WorldMatrix` to explain why](https://github.com/stride3d/stride/blob/master/sources/engine/Stride.Engine/Engine/TransformComponent.cs#L45-L49).
It makes sense that an `Update` function works with up to date data, so this looks more like a bug to me.

More context here https://github.com/stride3d/stride/pull/1401#discussion_r850608711 and in the discussion further below.

Also took the time to clean things up a bit.

## Motivation and Context
Fix bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.