### PR TITLE
Support VS 2022 + 2019 Extensions in the launcher

### DIFF
--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -10,25 +10,25 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using NuGet.PackageManagement;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using NuGet.Versioning;
 using Stride.Core.Extensions;
 using Stride.Core.Windows;
 using ISettings = NuGet.Configuration.ISettings;
 using PackageSource = NuGet.Configuration.PackageSource;
 using PackageSourceProvider = NuGet.Configuration.PackageSourceProvider;
-using NuGet.Resolver;
-using NuGet.Frameworks;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
-using NuGet.ProjectModel;
-using NuGet.LibraryModel;
-using NuGet.Commands;
 
 namespace Stride.Core.Packages
 {
@@ -155,7 +155,29 @@ namespace Stride.Core.Packages
         /// <summary>
         /// Package Id of the Visual Studio Integration plugin.
         /// </summary>
-        public string VsixPluginId { get; } = "Stride.VisualStudio.Package";
+        public string VsixPackageId { get; } = "Stride.VisualStudio.Package";
+
+        /// <summary>
+        /// The different supported versions of Visual Studio
+        /// </summary>
+        public enum VsixSupportedVsVersion
+        {
+            VS2019,
+            VS2022
+        }
+
+        /// <summary>
+        /// A mapping of the supported versions of VS to a Stride release version range.  
+        /// For each supported VS release, the first Version represents the included earliest Stride version eligible for the VSIX and the second Version is the excluded upper bound.
+        /// </summary>
+        public IReadOnlyDictionary<VsixSupportedVsVersion, (PackageVersion MinVersion, PackageVersion MaxVersion)> VsixVersionToStrideRelease { get; } = new Dictionary<VsixSupportedVsVersion, (PackageVersion, PackageVersion)>
+        {
+            // The VSIX for VS2019 is avaliable in Stride packages of version 4.0.x
+            {VsixSupportedVsVersion.VS2019, (new PackageVersion("4.0"), new PackageVersion("4.1")) },
+
+            // The VSIX for VS2022 is available in Stride packages of version 4.1.x and later.
+            {VsixSupportedVsVersion.VS2022, (new PackageVersion("4.1"), new PackageVersion(int.MaxValue,0,0,0)) },
+        };
 
         /// <summary>
         /// Logger for all operations of the package manager.

--- a/sources/core/Stride.Core.Design/VisualStudio/VisualStudioVersions.cs
+++ b/sources/core/Stride.Core.Design/VisualStudio/VisualStudioVersions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,53 +11,75 @@ namespace Stride.Core.VisualStudio
 {
     public class IDEInfo
     {
-        public IDEInfo(Version version, string displayName, string installationPath, bool complete = true)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IDEInfo"/> class.
+        /// </summary>
+        /// <param name="installationVersion">The version of the VS instance.</param>
+        /// <param name="displayName">The display name of the VS instance</param>
+        /// <param name="installationPath">The path to the installation root of the VS instance.</param>
+        /// <param name="instanceId">The unique identifier for this installation instance.</param>
+        /// <param name="isComplete">Indicates whehter the VS instance is complete.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public IDEInfo(Version installationVersion, string displayName, string installationPath, string instanceId, bool isComplete = true)
         {
-            if (version == null) throw new ArgumentNullException(nameof(version));
-
-            Complete = complete;
             DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
-            Version = version;
+            InstallationVersion = installationVersion ?? throw new ArgumentNullException(nameof(installationVersion));
             InstallationPath = installationPath ?? throw new ArgumentNullException(nameof(installationPath));
+            InstanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+            IsComplete = isComplete;
+
+            var idePath = Path.Combine(InstallationPath, "Common7", "IDE");
+            DevenvPath = Path.Combine(idePath, "devenv.exe");
+            if (!File.Exists(DevenvPath))
+            {
+                DevenvPath = null;
+            }
+
+            VsixInstallerPath = Path.Combine(idePath, "VSIXInstaller.exe");
+            if (!File.Exists(VsixInstallerPath))
+            {
+                VsixInstallerPath = null;
+            }
         }
 
-        public bool Complete { get; }
+        /// <summary>Gets a value indicating whether the instance is complete.</summary>
+        /// <value>Whether the instance is complete.</value>
+        /// <remarks>An instance is complete if it had no errors during install, resume, or repair.</remarks>
+        public bool IsComplete { get; }
 
+        /// <summary> 
+        /// Gets the display name (title) of the product installed in this instance. 
+        /// </summary>
         public string DisplayName { get; }
 
-        public Version Version { get; }
-
-        /// <summary>
-        /// The path to the build tools of this IDE, or <c>null</c>.
-        /// </summary>
-        public string BuildToolsPath { get; internal set; }
+        /// <summary>Gets the version of the product installed in this instance.</summary>
+        /// <value>The version of the product installed in this instance.</value>
+        public Version InstallationVersion { get; }
 
         /// <summary>
         /// The path to the development environment executable of this IDE, or <c>null</c>.
         /// </summary>
-        public string DevenvPath { get; internal set; }
+        public string DevenvPath { get; }
+
+        /// <summary>The root installation path of this IDE.</summary>
+        /// <remarks>Can be empty but not <c>null</c>./remarks>
+        public string InstallationPath { get; }
 
         /// <summary>
-        /// The root installation path of this IDE.
+        /// The hex code for this installation instance. It is used, for example, to create a unique folder in %LocalAppData%
         /// </summary>
-        /// <remarks>
-        /// Can be empty but not <c>null</c>.
-        /// </remarks>
-        public string InstallationPath { get; }
+        public string InstanceId { get; }
 
         /// <summary>
         /// The path to the VSIX installer of this IDE, or <c>null</c>.
         /// </summary>
-        public string VsixInstallerPath { get; internal set; }
-
-        public VSIXInstallerVersion VsixInstallerVersion { get; internal set; }
-
-        public Dictionary<string, string> PackageVersions { get; } = new Dictionary<string, string>();
+        public string VsixInstallerPath { get; }
 
         /// <summary>
-        /// <c>true</c> if this IDE has integrated build tools; otherwise, <c>false</c>.
+        /// The package names and versions of packages installed to this instance.
         /// </summary>
-        public bool HasBuildTools => !string.IsNullOrEmpty(BuildToolsPath);
+        /// <value></value>
+        public Dictionary<string, string> PackageVersions { get; } = new Dictionary<string, string>();
 
         /// <summary>
         /// <c>true</c> if this IDE has a development environment; otherwise, <c>false</c>.
@@ -68,102 +89,68 @@ namespace Stride.Core.VisualStudio
         /// <summary>
         /// <c>true</c> if this IDE has a VSIX installer; otherwise, <c>false</c>.
         /// </summary>
-        public bool HasVsixInstaller => !string.IsNullOrEmpty(VsixInstallerPath) && VsixInstallerVersion != VSIXInstallerVersion.None;
+        public bool HasVsixInstaller => !string.IsNullOrEmpty(VsixInstallerPath);
 
         /// <inheritdoc />
         public override string ToString() => DisplayName;
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum VSIXInstallerVersion
-    {
-        None,
-        VS2019AndFutureVersions,
-    }
-
     public static class VisualStudioVersions
     {
-        // ReSharper disable once InconsistentNaming
         private const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
-        private static Lazy<List<IDEInfo>> IDEInfos = new Lazy<List<IDEInfo>>(BuildIDEInfos);
+        private static readonly Lazy<List<IDEInfo>> IDEInfos = new Lazy<List<IDEInfo>>(BuildIDEInfos);
 
-        public static IDEInfo DefaultIDE = new IDEInfo(new Version("0.0"), "Default IDE", string.Empty);
+        public static IDEInfo DefaultIDE = new IDEInfo(new Version("0.0"), "Default IDE", string.Empty, string.Empty);
 
         /// <summary>
         /// Only lists VS2019+ (previous versions are not supported due to lack of buildTransitive targets).
         /// </summary>
-        public static IEnumerable<IDEInfo> AvailableVisualStudioInstances => IDEInfos.Value.Where(x => x.Version.Major >= 16 && x.HasDevenv);
-
-        /// <summary>
-        /// List all versions of VS2017+ (might be needed by installer process).
-        /// </summary>
-        public static IEnumerable<IDEInfo> AllAvailableVisualStudioInstances => IDEInfos.Value.Where(x => x.Version.Major >= 16 && x.HasDevenv);
-
-        public static IEnumerable<IDEInfo> AvailableBuildTools => IDEInfos.Value.Where(x => x.HasBuildTools);
-
-        public static void Refresh()
-        {
-            IDEInfos = new Lazy<List<IDEInfo>>(BuildIDEInfos);
-        }
+        public static IEnumerable<IDEInfo> AvailableVisualStudioInstances => IDEInfos.Value.Where(x => x.InstallationVersion.Major >= 16 && x.HasDevenv);
 
         private static List<IDEInfo> BuildIDEInfos()
         {
             var ideInfos = new List<IDEInfo>();
 
-            // Visual Studio 15.0 (2017) and later
+            // Visual Studio 16.0 (2019) and later
             try
             {
-                var configuration = new SetupConfiguration();
-
-                var instances = configuration.EnumAllInstances();
-                instances.Reset();
+                var setupInstancesEnum = new SetupConfiguration().EnumAllInstances();
+                setupInstancesEnum.Reset();
                 var inst = new ISetupInstance[1];
 
                 while (true)
                 {
-                    instances.Next(1, inst, out int pceltFetched);
-                    if (pceltFetched <= 0)
+                    setupInstancesEnum.Next(1, inst, out int numFetched);
+                    if (numFetched <= 0)
                         break;
 
                     try
                     {
-                        var inst2 = inst[0] as ISetupInstance2;
-                        if (inst2 == null)
+                        var setupInstance2 = inst[0] as ISetupInstance2;
+                        if (setupInstance2 == null)
                             continue;
 
-                        // Only deal with VS2019+
-                        if (!Version.TryParse(inst2.GetInstallationVersion(), out var version)
-                            || version.Major < 15)
+                        // Only examine VS2019+
+                        if (!Version.TryParse(setupInstance2.GetInstallationVersion(), out var installationVersion)
+                            || installationVersion.Major < 16)
                             continue;
 
-                        var installationPath = inst2.GetInstallationPath();
-                        var buildToolsPath = Path.Combine(installationPath, "MSBuild", "Current", "Bin");
-                        if (!Directory.Exists(buildToolsPath))
-                            buildToolsPath = null;
-                        var idePath = Path.Combine(installationPath, "Common7", "IDE");
-                        var devenvPath = Path.Combine(idePath, "devenv.exe");
-                        if (!File.Exists(devenvPath))
-                            devenvPath = null;
-                        var vsixInstallerPath = Path.Combine(idePath, "VSIXInstaller.exe");
-                        if (!File.Exists(vsixInstallerPath))
-                            vsixInstallerPath = null;
-
-                        var displayName = inst2.GetDisplayName();
+                        var displayName = setupInstance2.GetDisplayName();
                         // Try to append nickname (if any)
                         try
                         {
-                            var nickname = inst2.GetProperties().GetValue("nickname") as string;
+                            var nickname = setupInstance2.GetProperties().GetValue("nickname") as string;
                             if (!string.IsNullOrEmpty(nickname))
                                 displayName = $"{displayName} ({nickname})";
                             else
                             {
-                                var installationName = inst2.GetInstallationName();
+                                var installationName = setupInstance2.GetInstallationName();
                                 // In case of Preview, we have:
                                 // "installationName": "VisualStudioPreview/16.4.0-pre.6.0+29519.161"
                                 // "channelId": "VisualStudio.16.Preview"
                                 if (installationName.Contains("Preview"))
                                 {
-                                    displayName = displayName + " (Preview)";
+                                    displayName += " (Preview)";
                                 }
                             }
                         }
@@ -174,7 +161,7 @@ namespace Stride.Core.VisualStudio
                         try
                         {
                             var minimumRequiredState = InstanceState.Local | InstanceState.Registered;
-                            if ((inst2.GetState() & minimumRequiredState) != minimumRequiredState)
+                            if ((setupInstance2.GetState() & minimumRequiredState) != minimumRequiredState)
                                 continue;
                         }
                         catch (COMException)
@@ -182,16 +169,11 @@ namespace Stride.Core.VisualStudio
                             continue;
                         }
 
-                        var ideInfo = new IDEInfo(version, displayName, installationPath, inst2.IsComplete())
-                        {
-                            BuildToolsPath = buildToolsPath,
-                            DevenvPath = devenvPath,
-                            VsixInstallerVersion = VSIXInstallerVersion.VS2019AndFutureVersions,
-                            VsixInstallerPath = vsixInstallerPath,
-                        };
+                        var ideInfo = new IDEInfo(installationVersion, displayName,
+                            setupInstance2.GetInstallationPath(), setupInstance2.GetInstanceId(), setupInstance2.IsComplete());
 
                         // Fill packages
-                        foreach (var package in inst2.GetPackages())
+                        foreach (var package in setupInstance2.GetPackages())
                         {
                             ideInfo.PackageVersions[package.GetId()] = package.GetVersion();
                         }

--- a/sources/engine/Stride.Assets/StrideConfig.cs
+++ b/sources/engine/Stride.Assets/StrideConfig.cs
@@ -253,36 +253,6 @@ namespace Stride.Assets
             return false;
         }
 
-        /// <summary>
-        /// Check if a particular component set for this IDE version
-        /// </summary>
-        /// <param name="ideInfo">The IDE info to search for the components</param>
-        /// <param name="vsVersionToComponent">A dictionary of Visual Studio versions to their respective paths for a given component</param>
-        /// <returns>true if the IDE has any of the component versions available, false otherwise</returns>
-        internal static bool IsVSComponentAvailableForIDE(IDEInfo ideInfo, IDictionary<Version, string> vsVersionToComponent)
-        {
-            if (ideInfo == null) { throw new ArgumentNullException("ideInfo"); }
-            if (vsVersionToComponent == null) { throw new ArgumentNullException("vsVersionToComponent"); }
-
-            string path = null;
-            if (vsVersionToComponent.TryGetValue(ideInfo.Version, out path))
-            {
-                if (ideInfo.Version == VS2015Version)
-                {
-                    return IsFileInProgramFilesx86Exist(path);
-                }
-                else
-                {
-                    return ideInfo.PackageVersions.ContainsKey(path);
-                }
-            }
-            else if (vsVersionToComponent.TryGetValue(VSAnyVersion, out path))
-            {
-                return ideInfo.PackageVersions.ContainsKey(path);
-            }
-            return false;
-        }
-
         // For VS 2015
         internal static bool IsFileInProgramFilesx86Exist(string path)
         {

--- a/sources/launcher/Stride.Launcher/LauncherInstance.cs
+++ b/sources/launcher/Stride.Launcher/LauncherInstance.cs
@@ -1,20 +1,14 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
-using Stride.Core.Assets;
-using Stride.Core.Assets.Editor;
 using Stride.Core.Extensions;
-using Stride.LauncherApp.Views;
 using Stride.Core.Packages;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.View;
 using Stride.Core.Presentation.Windows;
+using Stride.LauncherApp.Views;
 
 namespace Stride.LauncherApp
 {

--- a/sources/launcher/Stride.Launcher/Resources/Strings.Designer.cs
+++ b/sources/launcher/Stride.Launcher/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Stride.LauncherApp.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -83,7 +83,7 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Would you like to install the latest version of the Visual Studio integration? This is highly recommended for programmers!.
+        ///   Looks up a localized string similar to Would you like to install the latest version of the Visual Studio {0} integration? This is highly recommended for programmers!.
         /// </summary>
         public static string AskInstallVSIX {
             get {
@@ -690,11 +690,11 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} Visual Studio plugin.
+        ///   Looks up a localized string similar to {0} Visual Studio extension.
         /// </summary>
-        public static string ToolTipVisualStudioPlugin {
+        public static string ToolTipVisualStudioExtension {
             get {
-                return ResourceManager.GetString("ToolTipVisualStudioPlugin", resourceCulture);
+                return ResourceManager.GetString("ToolTipVisualStudioExtension", resourceCulture);
             }
         }
         
@@ -717,6 +717,15 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (local update available).
+        /// </summary>
+        public static string VersionButtonLocalUpdateAvailable {
+            get {
+                return ResourceManager.GetString("VersionButtonLocalUpdateAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to (not installed).
         /// </summary>
         public static string VersionButtonUninstalled {
@@ -735,20 +744,11 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (local update available).
+        ///   Looks up a localized string similar to Visual Studio extension.
         /// </summary>
-        public static string VersionButtonLocalUpdateAvailable {
+        public static string VisualStudioExtension {
             get {
-                return ResourceManager.GetString("VersionButtonLocalUpdateAvailable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Visual Studio plugin.
-        /// </summary>
-        public static string VisualStudioPlugin {
-            get {
-                return ResourceManager.GetString("VisualStudioPlugin", resourceCulture);
+                return ResourceManager.GetString("VisualStudioExtension", resourceCulture);
             }
         }
         

--- a/sources/launcher/Stride.Launcher/Resources/Strings.resx
+++ b/sources/launcher/Stride.Launcher/Resources/Strings.resx
@@ -122,7 +122,7 @@
     <comment>Displayed when there is no installed version of Stride</comment>
   </data>
   <data name="AskInstallVSIX" xml:space="preserve">
-    <value>Would you like to install the latest version of the Visual Studio integration? This is highly recommended for programmers!</value>
+    <value>Would you like to install the latest version of the Visual Studio {0} integration? This is highly recommended for programmers!</value>
     <comment>Displayed after the AskInstallVersion message if VSIX is not installed</comment>
   </data>
   <data name="ButtonAnswers" xml:space="preserve">
@@ -293,8 +293,8 @@
     <value>Start Stride Game Studio {0}</value>
     <comment>{0}: long version name</comment>
   </data>
-  <data name="ToolTipVisualStudioPlugin" xml:space="preserve">
-    <value>{0} Visual Studio plugin</value>
+  <data name="ToolTipVisualStudioExtension" xml:space="preserve">
+    <value>{0} Visual Studio extension</value>
     <comment>The tooltip of the Visual Studio Plugin button. {0}: A verb describing the action to do (Install, Reinstall, Update...)</comment>
   </data>
   <data name="UnknownVersion" xml:space="preserve">
@@ -317,8 +317,8 @@
     <value>(local update available)</value>
     <comment>Additional message stating that a local update is available for the version. It is displayed right after the VersionButton text (with a space)</comment>
   </data>
-  <data name="VisualStudioPlugin" xml:space="preserve">
-    <value>Visual Studio plugin</value>
+  <data name="VisualStudioExtension" xml:space="preserve">
+    <value>Visual Studio extension</value>
     <comment>Title of this category</comment>
   </data>
   <data name="VSIXInstallSucessful" xml:space="preserve">

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <!-- Include proper language targets for temporary WPF projects. See https://github.com/dotnet/project-system/issues/1467 -->
-    <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.tmp_proj'">$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
-  </PropertyGroup>
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows7.0</TargetFramework>
@@ -100,23 +94,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\assets\Stride.Core.Packages\Stride.Core.Packages.csproj" />
     <ProjectReference Include="..\..\core\Stride.Core.Design\Stride.Core.Design.csproj" />
     <ProjectReference Include="..\..\core\Stride.Core.IO\Stride.Core.IO.csproj" />
@@ -132,22 +109,19 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Announcements\" />
-  </ItemGroup>
-  <ItemGroup>
     <TrimmerRootAssembly Include="System.Runtime" />
     <TrimmerRootAssembly Include="System.Diagnostics.Debug" />
     <TrimmerRootAssembly Include="System.Runtime.Extensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources\Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="..\..\editor\Stride.PrivacyPolicy\Stride.PrivacyPolicy.projitems" Label="Shared" Condition="Exists('..\..\editor\Stride.PrivacyPolicy\Stride.PrivacyPolicy.projitems')" />
   <Import Project="..\..\editor\Stride.Core.MostRecentlyUsedFiles\Stride.Core.MostRecentlyUsedFiles.projitems" Label="Shared" />
   <Import Project="..\..\assets\Stride.Core.Assets.Yaml\Stride.Core.Assets.Yaml.projitems" Label="Shared" />
   <Import Project="..\..\editor\Stride.Editor.CrashReport\Stride.Editor.CrashReport.projitems" Label="Shared" />
-  <!--   <Target Name="AfterResolveReferences">
-    <ItemGroup>
-      <EmbeddedResource Update="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'">
-        <LogicalName>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target> -->
 </Project>

--- a/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
@@ -1,29 +1,25 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-//#define SIMULATE_OFFLINE
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32;
-
 using Stride.Core.Extensions;
-using Stride.LauncherApp.Resources;
-using Stride.LauncherApp.Services;
 using Stride.Core.Packages;
 using Stride.Core.Presentation.Collections;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.ViewModel;
-using Stride.Metrics;
 using Stride.Core.VisualStudio;
-using System.Diagnostics.CodeAnalysis;
-using NuGet.Configuration;
+using Stride.LauncherApp.Resources;
+using Stride.LauncherApp.Services;
+using Stride.Metrics;
 
 namespace Stride.LauncherApp.ViewModels
 {
@@ -59,8 +55,8 @@ namespace Stride.LauncherApp.ViewModels
 
             DisplayReleaseAnnouncement();
 
-            VsixPackage = new VsixVersionViewModel(this, store, store.VsixPluginId);
-            VsixPackageXenko = new VsixVersionViewModel(this, store, store.VsixPluginId.Replace("Stride", "Xenko"));
+            VsixPackage2019 = new VsixVersionViewModel(this, store, store.VsixPackageId, NugetStore.VsixSupportedVsVersion.VS2019);
+            VsixPackage2022 = new VsixVersionViewModel(this, store, store.VsixPackageId, NugetStore.VsixSupportedVsVersion.VS2022);
             // Commands
             InstallLatestVersionCommand = new AnonymousTaskCommand(ServiceProvider, InstallLatestVersion) { IsEnabled = false };
             OpenUrlCommand = new AnonymousTaskCommand<string>(ServiceProvider, OpenUrl);
@@ -109,9 +105,9 @@ namespace Stride.LauncherApp.ViewModels
 
         public bool ShowBetaVersions { get { return showBetaVersions; } set { SetValue(ref showBetaVersions, value); } }
 
-        public VsixVersionViewModel VsixPackage { get; }
+        public VsixVersionViewModel VsixPackage2019 { get; }
 
-        public VsixVersionViewModel VsixPackageXenko { get; }
+        public VsixVersionViewModel VsixPackage2022 { get; }
 
         public StrideVersionViewModel ActiveVersion { get { return activeVersion; } set { SetValue(ref activeVersion, value); Dispatcher.InvokeAsync(() => StartStudioCommand.IsEnabled = (value != null) && value.CanStart); } }
 
@@ -195,8 +191,8 @@ namespace Stride.LauncherApp.ViewModels
                 var newsTask = FetchNewsPages();
 
                 await RetrieveServerStrideVersions();
-                await VsixPackage.UpdateFromStore();
-                await VsixPackageXenko.UpdateFromStore();
+                await VsixPackage2019.UpdateFromStore();
+                await VsixPackage2022.UpdateFromStore();
                 await CheckForFirstInstall();
 
                 await newsTask;
@@ -407,11 +403,8 @@ namespace Stride.LauncherApp.ViewModels
         {
             try
             {
-#if SIMULATE_OFFLINE
-                var serverPackages = new List<IPackage>();
-#else
                 var serverPackages = await RunLockTask(() => store.FindSourcePackages(store.MainPackageIds, CancellationToken.None).Result.FilterStrideMainPackages().Where(p => !store.IsDevRedirectPackage(p)).OrderByDescending(p => p.Version).ToList());
-#endif
+
                 // Check if we could connect to the server
                 var wasOffline = IsOffline;
                 IsOffline = serverPackages.Count == 0;
@@ -488,8 +481,6 @@ namespace Stride.LauncherApp.ViewModels
         public async Task CheckForFirstInstall()
         {
             const string prerequisitesRunTaskName = "PrerequisitesRun";
-            //const string askedForJapaneseSurveyTaskName = "AskedForJapaneseSurvey";
-            //const string askedForSurveyTaskName = "AskedForSurvey";
 
             if (!HasDoneTask(prerequisitesRunTaskName))
             {
@@ -501,8 +492,6 @@ namespace Stride.LauncherApp.ViewModels
             }
 
             bool firstInstall = StrideVersions.All(x => !x.CanDelete) && StrideVersions.Any(x => x.CanBeDownloaded);
-            //var surveyTaskName = CultureInfo.InstalledUICulture.IetfLanguageTag != "ja-JP" ? askedForSurveyTaskName : askedForJapaneseSurveyTaskName;
-            //bool surveyAsked = HasDoneTask(surveyTaskName);
 
             await Dispatcher.InvokeTask(async () =>
             {
@@ -513,33 +502,28 @@ namespace Stride.LauncherApp.ViewModels
                     {
                         var versionToInstall = StrideVersions.First(x => x.CanBeDownloaded);
                         await versionToInstall.Download(true);
-                    }
-                    if (!VsixPackage.IsLatestVersionInstalled && VisualStudioVersions.AvailableVisualStudioInstances.Any())
-                    {
-                        result = await ServiceProvider.Get<IDialogService>().MessageBox(Strings.AskInstallVSIX, MessageBoxButton.YesNo, MessageBoxImage.Question);
-                        if (result == MessageBoxResult.Yes)
+
+                        // if VS2022 is installed (version 17.x)
+                        if (!VsixPackage2022.IsLatestVersionInstalled && VsixPackage2022.CanBeDownloaded && VisualStudioVersions.AvailableVisualStudioInstances.Any(ide => ide.InstallationVersion.Major == 17))
                         {
-                            await VsixPackage.ExecuteAction();
+                            result = await ServiceProvider.Get<IDialogService>().MessageBox(string.Format(Strings.AskInstallVSIX, "2022"), MessageBoxButton.YesNo, MessageBoxImage.Question);
+                            if (result == MessageBoxResult.Yes)
+                            {
+                                await VsixPackage2022.ExecuteAction();
+                            }
+                        }
+
+                        // if VS2019 is installed (version 16.x)
+                        if (!VsixPackage2019.IsLatestVersionInstalled && VsixPackage2019.CanBeDownloaded && VisualStudioVersions.AvailableVisualStudioInstances.Any(ide => ide.InstallationVersion.Major == 16))
+                        {
+                            result = await ServiceProvider.Get<IDialogService>().MessageBox(string.Format(Strings.AskInstallVSIX, "2019"), MessageBoxButton.YesNo, MessageBoxImage.Question);
+                            if (result == MessageBoxResult.Yes)
+                            {
+                                await VsixPackage2019.ExecuteAction();
+                            }
                         }
                     }
                 }
-                // Disable dialog for the survey
-                //else if (!surveyAsked)
-                //{
-                //    var result = ShowMessage(ServiceProvider, Strings.AskSurvey, MessageBoxButton.YesNo, MessageBoxImage.Question);
-                //    if (result == MessageBoxResult.Yes)
-                //    {
-                //        try
-                //        {
-                //            Process.Start(Urls.Survey1);
-                //        }
-                //        catch
-                //        {
-                //            ShowMessage(ServiceProvider, Strings.ErrorOpeningBrowser, MessageBoxButton.OK, MessageBoxImage.Error);
-                //        }
-                //    }
-                //    SaveTaskAsDone(surveyTaskName);
-                //}
             });
         }
 

--- a/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
@@ -1,14 +1,14 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp) 
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Threading.Tasks;
 using Stride.Core.Extensions;
-using Stride.LauncherApp.Resources;
 using Stride.Core.Packages;
-using Stride.LauncherApp.Services;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.ViewModel;
+using Stride.LauncherApp.Resources;
+using Stride.LauncherApp.Services;
 
 namespace Stride.LauncherApp.ViewModels
 {
@@ -317,7 +317,7 @@ namespace Stride.LauncherApp.ViewModels
 
         private void UpdateStatusInternal()
         {
-            CanBeDownloaded = LocalPackage == null || (LocalPackage != null && ServerPackage != null && LocalPackage.Version < ServerPackage.Version);
+            CanBeDownloaded = (LocalPackage == null && ServerPackage != null) || (LocalPackage != null && ServerPackage != null && LocalPackage.Version < ServerPackage.Version);
             CanDelete = LocalPackage != null;
             DownloadCommand.IsEnabled = CanBeDownloaded;
         }

--- a/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
@@ -1,18 +1,14 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Stride.Core.Extensions;
-using Stride.Core.VisualStudio;
-using Stride.LauncherApp.Resources;
-using Stride.LauncherApp.Services;
 using Stride.Core.Packages;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.Services;
+using Stride.LauncherApp.Resources;
 
 namespace Stride.LauncherApp.ViewModels
 {
@@ -21,17 +17,19 @@ namespace Stride.LauncherApp.ViewModels
         private readonly string packageId;
         private bool isLatestVersionInstalled;
         private string status;
+        private readonly NugetStore.VsixSupportedVsVersion vsixSupportedVsVersion;
 
-        internal VsixVersionViewModel(LauncherViewModel launcher, NugetStore store, string packageId)
+        internal VsixVersionViewModel(LauncherViewModel launcher, NugetStore store, string packageId, NugetStore.VsixSupportedVsVersion vsixSupportedVsVersion)
             : base(launcher, store, null)
         {
             this.packageId = packageId;
+            this.vsixSupportedVsVersion = vsixSupportedVsVersion;
             status = FormatStatus(Strings.ReportChecking);
             ExecuteActionCommand = new AnonymousTaskCommand(ServiceProvider, ExecuteAction) { IsEnabled = false };
         }
 
         /// <inheritdoc/>
-        public override string Name => Strings.VisualStudioPlugin;
+        public override string Name => Strings.VisualStudioExtension;
 
         /// <inheritdoc/>
         public override string FullName => Name;
@@ -75,13 +73,25 @@ namespace Stride.LauncherApp.ViewModels
                 newStatus = LocalPackage == null ? Strings.VSIXVerbInstall : Strings.VSIXVerbUpdate;
                 IsLatestVersionInstalled = false;
             }
-            ExecuteActionCommand.IsEnabled = true;
+
+            // Enable the control only if there is an eligible package for the VS extension.
+            ExecuteActionCommand.IsEnabled = (LocalPackage != null || ServerPackage != null);
             Status = FormatStatus(newStatus);
         }
 
         private string FormatStatus(string status)
         {
-            return $"{packageId.Split('.')[0]}: {status}";
+            string vsixTarget = "Visual Studio ";
+            switch (vsixSupportedVsVersion)
+            {
+                case NugetStore.VsixSupportedVsVersion.VS2019:
+                    vsixTarget += "2019";
+                    break;
+                case NugetStore.VsixSupportedVsVersion.VS2022:
+                    vsixTarget += "2022";
+                    break;
+            }
+            return $"{vsixTarget}: {status}";
         }
 
         /// <inheritdoc/>
@@ -104,8 +114,12 @@ namespace Stride.LauncherApp.ViewModels
         /// <inheritdoc/>
         protected override async Task UpdateVersionsFromStore()
         {
-            LocalPackage = await Launcher.RunLockTask(() => Store.GetLocalPackages(packageId).OrderByDescending(p => p.Version).FirstOrDefault());
-            ServerPackage = await Launcher.RunLockTask(() => Store.FindSourcePackagesById(packageId, CancellationToken.None).Result.OrderByDescending(p => p.Version).FirstOrDefault());
+            var versionRange = Store.VsixVersionToStrideRelease[this.vsixSupportedVsVersion];
+            var minVersion = versionRange.MinVersion;
+            var maxVersion = versionRange.MaxVersion;
+
+            LocalPackage = await Launcher.RunLockTask(() => Store.GetLocalPackages(packageId).Where(package => package.Version >= minVersion && package.Version < maxVersion).OrderByDescending(p => p.Version).FirstOrDefault());
+            ServerPackage = await Launcher.RunLockTask(() => Store.FindSourcePackagesById(packageId, CancellationToken.None).Result.Where(package => package.Version >= minVersion && package.Version < maxVersion).OrderByDescending(p => p.Version).FirstOrDefault());
         }
 
         public async Task ExecuteAction()

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -229,7 +229,7 @@
             </UIElement.Clip>
           </DockPanel>
           <Button Content="{Binding Status}" Command="{Binding ExecuteActionCommand}" ToolTipService.IsEnabled="False"
-                  ToolTip="{Binding Status, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipVisualStudioPlugin}}"
+                  ToolTip="{Binding Status, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipVisualStudioExtension}}"
                   Visibility="{Binding IsProcessing, Converter={sskk:VisibleOrCollapsed}, ConverterParameter={sskk:False}}">
             <i:Interaction.Behaviors>
               <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding Launcher.CurrentToolTip}"
@@ -506,14 +506,14 @@
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Bottom">
                 <UniformGrid Columns="2">
-                  <ContentControl Grid.Column="0" Margin="0,0,2,0" Content="{Binding VsixPackage}"/>
-                  <ContentControl Grid.Column="1" Margin="2,0,0,0" Content="{Binding VsixPackageXenko}"/>
+                  <ContentControl Grid.Column="0" Margin="0,0,2,0" Content="{Binding VsixPackage2019}"/>
+                  <ContentControl Grid.Column="1" Margin="2,0,0,0" Content="{Binding VsixPackage2022}"/>
                 </UniformGrid>
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Bottom">
                 <DockPanel Height="32" Margin="10,0">
                   <Image Source="{StaticResource ImageVisualStudio}" Width="26" Height="26" RenderOptions.BitmapScalingMode="HighQuality" VerticalAlignment="Center"/>
-                  <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.VisualStudioPlugin}" FontSize="24" TextAlignment="Left" VerticalAlignment="Center"/>
+                  <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.VisualStudioExtension}" FontSize="24" TextAlignment="Left" VerticalAlignment="Center"/>
                 </DockPanel>
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}"

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -66,19 +66,6 @@
     <Compile Include="..\..\core\Stride.Core\ScalarStyle.cs" Link="Yaml\ScalarStyle.cs" />
     <Compile Include="..\..\core\Stride.Core\DataStyle.cs" Link="Yaml\DataStyle.cs" />
     <Compile Include="..\..\core\Stride.Core.Yaml\*.cs" Link="Yaml\%(Filename)%(Extension).cs" />
-    <!--<Compile Include="..\..\core\Stride.Core.Yaml\ILookAheadBuffer.cs" Link="Yaml\ILookAheadBuffer.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\LookAheadBuffer.cs" Link="Yaml\LookAheadBuffer.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\Mark.cs" Link="Yaml\Mark.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\Emitter.cs" Link="Yaml\Emitter.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\EmitterState.cs" Link="Yaml\EmitterState.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\IEmitter.cs" Link="Yaml\IEmitter.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\CharacterAnalyzer.cs" Link="Yaml\CharacterAnalyzer.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\SimpleKey.cs" Link="Yaml\SimpleKey.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\YamlException.cs" Link="Yaml\YamlException.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\SyntaxErrorException.cs" Link="Yaml\SyntaxErrorException.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\InsertionQueue.cs" Link="Yaml\InsertionQueue.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\TagDirectiveCollection.cs" Link="Yaml\TagDirectiveCollection.cs" />
-    <Compile Include="..\..\core\Stride.Core.Yaml\Version.cs" Link="Yaml\Version.cs" />-->
     <Compile Include="..\..\core\Stride.Core.Yaml\Schemas\*.cs" Link="Yaml\Schemas\%(Filename)%(Extension)" />
     <Compile Include="..\..\core\Stride.Core.Yaml\Tokens\*.cs" Link="Yaml\Tokens\%(Filename)%(Extension)" />
     <Compile Include="..\..\core\Stride.Core.Yaml\Events\*.cs" Link="Yaml\Events\%(Filename)%(Extension)" />

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.nuspec
@@ -9,8 +9,8 @@
     <projectUrl>http://stride3d.net/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/stride3d/media/master/images/mainlogo/nuget/logo.png</iconUrl>
     <repository type="git" url="https://github.com/stride3d/stride" />
-    <copyright>&#169; Stride contributors and Silicon Studio Corp.</copyright>
-    <description>Visual Studio Integration Plugin for Stride</description>
+    <copyright>&#169; Stride contributors, Silicon Studio Corp. and  the .NET Foundation</copyright>
+    <description>Visual Studio Extension for Stride</description>
     <tags>internal</tags>
   </metadata>
   <files>

--- a/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest
+++ b/sources/tools/Stride.VisualStudio.Package/source.extension.vsixmanifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="248ff1ce-dacd-4404-947a-85e999d3c3ea" Version="4.0.6" Language="en-US" Publisher="Stride" />
-    <DisplayName>Stride</DisplayName>
-    <Description>Stride VisualStudio Package</Description>
+    <Identity Id="Stride.VisualStudio.Package.2022" Version="4.1.0" Language="en-US" Publisher="Stride" />
+    <DisplayName>Stride Tools</DisplayName>
+    <Description>Stride Tools for VS2022</Description>
     <Icon>Resources\VSPackage.ico</Icon>
   </Metadata>
-  <Installation InstalledByMsi="false">
+  <Installation>
    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
    </InstallationTarget>


### PR DESCRIPTION
# Note
**This PR replaces #1405 since that edition had a NuGet package accidentally added then removed in a later comit.  Per suggestion by @xen2, I've squashed the commits and started this new PR so as to preserve the comments attached to the old commits from that PR.**

# PR Details

Since the architecture changed for extensions in 2022, the Stride extension needs to have a new identity and can only be installed on VS 2022.  VS 2019 extension support will come from the 4.0 branch and NuGet package.

- This pulls in and updates @manio143's PR: https://github.com/stride3d/stride/pull/1382

- Update the Launcher to only offer the VS Extension for VS2019 and VS2022.
- Limit the package editions eligible to install VS Extension.  For 2019, this is 4.0.x and for 2022 it's 4.1.x and later.
- Update VisualStudioVersions to support the two editions and clean up code a bit.
- Remove dead code related to VS versions
- Only offer the VSIX installation when a Stride installation is accepted on first run.
- Run uninstall with the /quiet flag to invisibly handle case where VSIX is not actually installed.
- Other minor code clean up and dead code removal.

## Related Issue2
#1388 
#1409 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.