### PR TITLE
Removing build-time warnings

### DIFF
--- a/samples/Tests/Stride.Samples.Tests.csproj
+++ b/samples/Tests/Stride.Samples.Tests.csproj
@@ -1,9 +1,10 @@
-﻿<Project>
+<Project>
   <!-- NuGet resolved needed for StrideDefaultAssetsPlugin.LoadDefaultTemplates() -->
   <Import Project="..\..\sources\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="..\..\sources\targets\Stride.UnitTests.props" />
   <PropertyGroup>
     <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>
     <StrideSkipAutoPack>false</StrideSkipAutoPack>
@@ -14,7 +15,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\sources\shared\AttachedChildProcessJob.cs" Link="AttachedChildProcessJob.cs" />
     <Compile Include="..\..\sources\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>

--- a/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
@@ -87,13 +87,16 @@ namespace Stride.Core.Assets.Quantum
 
         public virtual void Dispose()
         {
-            nodeListener.ValueChanging -= AssetContentChanging;
-            nodeListener.ValueChanged -= AssetContentChanged;
-            nodeListener.ItemChanging -= AssetItemChanging;
-            nodeListener.ItemChanged -= AssetItemChanged;
-            nodeListener.Dispose();
-            ClearAllBaseLinks();
-            isDisposed = true;
+            if (!isDisposed)
+            {
+                nodeListener.ValueChanging -= AssetContentChanging;
+                nodeListener.ValueChanged -= AssetContentChanged;
+                nodeListener.ItemChanging -= AssetItemChanging;
+                nodeListener.ItemChanged -= AssetItemChanged;
+                nodeListener.Dispose();
+                ClearAllBaseLinks();
+                isDisposed = true;
+            }
         }
 
         /// <summary>

--- a/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
+++ b/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -15,9 +15,6 @@
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\Stride.Core.IO\NativeLockFile.cs">
-      <Link>Windows\NativeLockFile.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stride.Core.Mathematics\Stride.Core.Mathematics.csproj" />
@@ -28,7 +25,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <!-- <PackageReference Include="Newtonsoft.Json" Version="12.0.3" /> -->
     <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />

--- a/sources/core/Stride.Core.IO/Properties/AssemblyInfo.cs
+++ b/sources/core/Stride.Core.IO/Properties/AssemblyInfo.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable 436 // Stride.PublicKeys is defined in multiple assemblies
 
+[assembly: InternalsVisibleTo("Stride.Core.Design" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Core.IO.Serializers" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Engine" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Engine.Step1" + Stride.PublicKeys.Default)]

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="..\..\targets\Stride.Core.props" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
@@ -27,7 +27,7 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </PackageReference>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />

--- a/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests2.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests2.cs
@@ -1335,7 +1335,7 @@ Enum: OldValue2
 
             public int Value { get; private set; }
 
-            protected bool Equals(MyClassImmutable other)
+            private bool Equals(MyClassImmutable other)
             {
                 return string.Equals(Name, other.Name) && Value == other.Value;
             }

--- a/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
+++ b/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dirkster.AvalonDock" Version="4.60.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />

--- a/sources/engine/Stride.Assets.Tests2/Stride.Assets.Tests2.csproj
+++ b/sources/engine/Stride.Assets.Tests2/Stride.Assets.Tests2.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="xunit" Version="2.4.2-pre.12" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.32" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />

--- a/sources/engine/Stride.Assets/Stride.Assets.csproj
+++ b/sources/engine/Stride.Assets/Stride.Assets.csproj
@@ -16,13 +16,11 @@
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
-    <!--PackageReference Include="Esent.Interop" Version="1.9.4" /-->
-    <PackageReference Include="FFmpeg.AutoGen" Version="3.4.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
     <PackageReference Include="SSH.NET" Version="2016.1.0" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />

--- a/sources/engine/Stride.Particles/Spawners/SpawnerFromParent.cs
+++ b/sources/engine/Stride.Particles/Spawners/SpawnerFromParent.cs
@@ -33,7 +33,7 @@ namespace Stride.Particles.Spawners
         /// Referenced parent emitter
         /// </summary>
         [DataMemberIgnore]
-        protected ParticleEmitter Parent;
+        private ParticleEmitter Parent;
 
         /// <summary>
         /// Referenced parent emitter's name
@@ -122,7 +122,7 @@ namespace Stride.Particles.Spawners
         /// Gets a field accessor to the parent emitter's spawn control field, if it exists
         /// </summary>
         /// <returns></returns>
-        protected ParticleFieldAccessor<ParticleChildrenAttribute> GetSpawnControlField()
+        private ParticleFieldAccessor<ParticleChildrenAttribute> GetSpawnControlField()
         {
             var groupIndex = (int)parentControlFlag;
             if (groupIndex >= ParticleFields.ChildrenFlags.Length)

--- a/sources/engine/Stride.Particles/VertexLayouts/ParticleBufferState.cs
+++ b/sources/engine/Stride.Particles/VertexLayouts/ParticleBufferState.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Stride.Core;
+
+namespace Stride.Particles.VertexLayouts
+{
+    public struct ParticleBufferState
+    {
+        public readonly IntPtr VertexBufferOrigin;
+        private readonly ParticleVertexBuilder vertexBuilder;
+
+        public IntPtr VertexBuffer;
+        public int CurrentParticleIndex;
+        public int CurrentVertex;
+        public int VertexStride;
+
+        public int VerticesPerSegCurrent;
+
+        public int VerticesPerSegFirst;
+        public int VerticesPerSegMiddle;
+        public int VerticesPerSegLast;
+
+
+        public ParticleBufferState(IntPtr vertexBufferPtr, ParticleVertexBuilder builder)
+        {
+            VertexBuffer        = vertexBufferPtr;
+            VertexBufferOrigin  = vertexBufferPtr;
+
+            vertexBuilder       = builder;
+
+            VertexStride        = builder.VertexDeclaration.VertexStride;
+            CurrentParticleIndex = 0;
+            CurrentVertex       = 0;
+
+            VerticesPerSegCurrent = vertexBuilder.VerticesPerParticle;
+            VerticesPerSegFirst = vertexBuilder.VerticesPerParticle;
+            VerticesPerSegMiddle = vertexBuilder.VerticesPerParticle;
+            VerticesPerSegLast = vertexBuilder.VerticesPerParticle;
+        }
+
+        /// <summary>
+        /// Sets how many vertices are associated with the first, middle and last quad segments of the buffer. In case of billboards 1 segment = 1 quad but other shapes might be laid out differently
+        /// </summary>
+        /// <param name="verticesForFirstSegment">Number of vertices for the first segment</param>
+        /// <param name="verticesForMiddleSegment">Number of vertices for the middle segments</param>
+        /// <param name="verticesForLastSegment">Number of vertices for the last segment</param>
+        public void SetVerticesPerSegment(int verticesForFirstSegment, int verticesForMiddleSegment, int verticesForLastSegment)
+        {
+            VerticesPerSegFirst = verticesForFirstSegment;
+            VerticesPerSegMiddle = verticesForMiddleSegment;
+            VerticesPerSegLast = verticesForLastSegment;
+
+            VerticesPerSegCurrent = VerticesPerSegFirst;
+        }
+
+        /// <summary>
+        /// Sets the data for the current vertex using the provided <see cref="AttributeAccessor"/>
+        /// </summary>
+        /// <param name="accessor">Accessor to the vertex data</param>
+        /// <param name="ptrRef">Pointer to the source data</param>
+        public void SetAttribute(AttributeAccessor accessor, IntPtr ptrRef)
+        {
+            Utilities.CopyMemory(VertexBuffer + accessor.Offset, ptrRef, accessor.Size);
+        }
+
+        /// <summary>
+        /// Sets the same data for the all vertices in the current particle using the provided <see cref="AttributeAccessor"/>
+        /// </summary>
+        /// <param name="accessor">Accessor to the vertex data</param>
+        /// <param name="ptrRef">Pointer to the source data</param>
+        public void SetAttributePerParticle(AttributeAccessor accessor, IntPtr ptrRef)
+        {
+            for (var i = 0; i < vertexBuilder.VerticesPerParticle; i++)
+            {
+                Utilities.CopyMemory(VertexBuffer + accessor.Offset + i * VertexStride, ptrRef, accessor.Size);
+            }
+        }
+
+        /// <summary>
+        /// Sets the same data for the all vertices in the current particle using the provided <see cref="AttributeAccessor"/>
+        /// </summary>
+        /// <param name="accessor">Accessor to the vertex data</param>
+        /// <param name="ptrRef">Pointer to the source data</param>
+        public void SetAttributePerSegment(AttributeAccessor accessor, IntPtr ptrRef)
+        {
+            for (var i = 0; i < VerticesPerSegCurrent; i++)
+            {
+                Utilities.CopyMemory(VertexBuffer + accessor.Offset + i * VertexStride, ptrRef, accessor.Size);
+            }
+        }
+
+        /// <summary>
+        /// Transforms attribute data using already written data from another attribute
+        /// </summary>
+        /// <typeparam name="T">Type data</typeparam>
+        /// <param name="accessorTo">Vertex attribute accessor to the destination attribute</param>
+        /// <param name="accessorFrom">Vertex attribute accessor to the source attribute</param>
+        /// <param name="transformMethod">Transform method for the type data</param>
+        public void TransformAttributePerSegment<T, U>(AttributeAccessor accessorFrom, AttributeAccessor accessorTo, IAttributeTransformer<T, U> transformMethod, ref U transformer) 
+            where T : struct
+            where U : struct
+        {
+            for (var i = 0; i < VerticesPerSegCurrent; i++)
+            {
+                var temp = Utilities.Read<T>(VertexBuffer + accessorFrom.Offset + i * VertexStride);
+
+                transformMethod.Transform(ref temp, ref transformer);
+
+                Utilities.Write(VertexBuffer + accessorTo.Offset + i * VertexStride, ref temp);
+            }
+        }
+
+        public void TransformAttributePerParticle<T, U>(AttributeAccessor accessorFrom, AttributeAccessor accessorTo, IAttributeTransformer<T, U> transformMethod, ref U transformer) 
+            where T : struct
+            where U : struct
+        {
+            for (var i = 0; i < vertexBuilder.VerticesPerParticle; i++)
+            {
+                var temp = Utilities.Read<T>(VertexBuffer + accessorFrom.Offset + i * VertexStride);
+
+                transformMethod.Transform(ref temp, ref transformer);
+
+                Utilities.Write(VertexBuffer + accessorTo.Offset + i * VertexStride, ref temp);
+            }
+        }
+
+
+        public AttributeAccessor GetAccessor(AttributeDescription desc) => vertexBuilder.GetAccessor(desc);
+
+        public AttributeDescription DefaultTexCoords => vertexBuilder.DefaultTexCoords;
+
+        /// <summary>
+        /// Advances the pointer to the next vertex in the buffer, so that it can be written
+        /// </summary>
+        public void NextVertex()
+        {
+            if (++CurrentVertex >= (vertexBuilder.MaxParticles * vertexBuilder.VerticesPerParticle))
+                CurrentVertex = (vertexBuilder.MaxParticles * vertexBuilder.VerticesPerParticle) - 1;
+
+            VertexBuffer = VertexBufferOrigin + VertexStride * CurrentVertex;
+        }
+
+        /// <summary>
+        /// Advances the pointer to the next particle in the buffer, so that its first vertex can be written
+        /// </summary>
+        public void NextParticle()
+        {
+            if (++CurrentParticleIndex >= vertexBuilder.MaxParticles)
+                CurrentParticleIndex = vertexBuilder.MaxParticles - 1;
+
+            VertexBuffer = VertexBufferOrigin + (VertexStride * CurrentParticleIndex * vertexBuilder.VerticesPerParticle);
+        }
+
+        /// <summary>
+        /// Advances the pointer to the next segment in the buffer, so that its first vertex can be written
+        /// </summary>
+        public void NextSegment()
+        {
+            // The number of segments is tied to the number of particles
+            if (++CurrentParticleIndex >= vertexBuilder.MaxParticles)
+            {
+                // Already at the last particle
+                CurrentParticleIndex = vertexBuilder.MaxParticles - 1;
+                return;
+            }
+
+            VertexBuffer += VertexStride * VerticesPerSegCurrent;
+            VerticesPerSegCurrent = (CurrentParticleIndex < vertexBuilder.MaxParticles - 1) ? VerticesPerSegMiddle : VerticesPerSegLast;
+        }
+
+        /// <summary>
+        /// Moves the index to the beginning of the buffer so that the data can be filled from the first particle again
+        /// </summary>
+        public void StartOver()
+        {
+            VertexBuffer = VertexBufferOrigin;
+            CurrentParticleIndex = 0;
+            CurrentVertex = 0;
+            VerticesPerSegCurrent = VerticesPerSegFirst;
+        }
+    }
+}

--- a/sources/engine/Stride.Particles/VertexLayouts/ParticleVertexBuilder.cs
+++ b/sources/engine/Stride.Particles/VertexLayouts/ParticleVertexBuilder.cs
@@ -1,190 +1,11 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using Stride.Core;
 using Stride.Graphics;
-using Buffer = Stride.Graphics.Buffer;
 
 namespace Stride.Particles.VertexLayouts
 {
-    public struct ParticleBufferState
-    {
-        public readonly IntPtr VertexBufferOrigin;
-        private readonly ParticleVertexBuilder vertexBuilder;
-
-        public IntPtr VertexBuffer;
-        public int CurrentParticleIndex;
-        public int CurrentVertex;
-        public int VertexStride;
-
-        public int VerticesPerSegCurrent;
-
-        public int VerticesPerSegFirst;
-        public int VerticesPerSegMiddle;
-        public int VerticesPerSegLast;
-
-
-        public ParticleBufferState(IntPtr vertexBufferPtr, ParticleVertexBuilder builder)
-        {
-            VertexBuffer        = vertexBufferPtr;
-            VertexBufferOrigin  = vertexBufferPtr;
-
-            vertexBuilder       = builder;
-
-            VertexStride        = builder.VertexDeclaration.VertexStride;
-            CurrentParticleIndex = 0;
-            CurrentVertex       = 0;
-
-            VerticesPerSegCurrent = vertexBuilder.VerticesPerParticle;
-            VerticesPerSegFirst = vertexBuilder.VerticesPerParticle;
-            VerticesPerSegMiddle = vertexBuilder.VerticesPerParticle;
-            VerticesPerSegLast = vertexBuilder.VerticesPerParticle;
-        }
-
-        /// <summary>
-        /// Sets how many vertices are associated with the first, middle and last quad segments of the buffer. In case of billboards 1 segment = 1 quad but other shapes might be laid out differently
-        /// </summary>
-        /// <param name="verticesForFirstSegment">Number of vertices for the first segment</param>
-        /// <param name="verticesForMiddleSegment">Number of vertices for the middle segments</param>
-        /// <param name="verticesForLastSegment">Number of vertices for the last segment</param>
-        public void SetVerticesPerSegment(int verticesForFirstSegment, int verticesForMiddleSegment, int verticesForLastSegment)
-        {
-            VerticesPerSegFirst = verticesForFirstSegment;
-            VerticesPerSegMiddle = verticesForMiddleSegment;
-            VerticesPerSegLast = verticesForLastSegment;
-
-            VerticesPerSegCurrent = VerticesPerSegFirst;
-        }
-
-        /// <summary>
-        /// Sets the data for the current vertex using the provided <see cref="AttributeAccessor"/>
-        /// </summary>
-        /// <param name="accessor">Accessor to the vertex data</param>
-        /// <param name="ptrRef">Pointer to the source data</param>
-        public void SetAttribute(AttributeAccessor accessor, IntPtr ptrRef)
-        {
-            Utilities.CopyMemory(VertexBuffer + accessor.Offset, ptrRef, accessor.Size);
-        }
-
-        /// <summary>
-        /// Sets the same data for the all vertices in the current particle using the provided <see cref="AttributeAccessor"/>
-        /// </summary>
-        /// <param name="accessor">Accessor to the vertex data</param>
-        /// <param name="ptrRef">Pointer to the source data</param>
-        public void SetAttributePerParticle(AttributeAccessor accessor, IntPtr ptrRef)
-        {
-            for (var i = 0; i < vertexBuilder.VerticesPerParticle; i++)
-            {
-                Utilities.CopyMemory(VertexBuffer + accessor.Offset + i * VertexStride, ptrRef, accessor.Size);
-            }
-        }
-
-        /// <summary>
-        /// Sets the same data for the all vertices in the current particle using the provided <see cref="AttributeAccessor"/>
-        /// </summary>
-        /// <param name="accessor">Accessor to the vertex data</param>
-        /// <param name="ptrRef">Pointer to the source data</param>
-        public void SetAttributePerSegment(AttributeAccessor accessor, IntPtr ptrRef)
-        {
-            for (var i = 0; i < VerticesPerSegCurrent; i++)
-            {
-                Utilities.CopyMemory(VertexBuffer + accessor.Offset + i * VertexStride, ptrRef, accessor.Size);
-            }
-        }
-
-        /// <summary>
-        /// Transforms attribute data using already written data from another attribute
-        /// </summary>
-        /// <typeparam name="T">Type data</typeparam>
-        /// <param name="accessorTo">Vertex attribute accessor to the destination attribute</param>
-        /// <param name="accessorFrom">Vertex attribute accessor to the source attribute</param>
-        /// <param name="transformMethod">Transform method for the type data</param>
-        public void TransformAttributePerSegment<T, U>(AttributeAccessor accessorFrom, AttributeAccessor accessorTo, IAttributeTransformer<T, U> transformMethod, ref U transformer) 
-            where T : struct
-            where U : struct
-        {
-            for (var i = 0; i < VerticesPerSegCurrent; i++)
-            {
-                var temp = Utilities.Read<T>(VertexBuffer + accessorFrom.Offset + i * VertexStride);
-
-                transformMethod.Transform(ref temp, ref transformer);
-
-                Utilities.Write(VertexBuffer + accessorTo.Offset + i * VertexStride, ref temp);
-            }
-        }
-
-        public void TransformAttributePerParticle<T, U>(AttributeAccessor accessorFrom, AttributeAccessor accessorTo, IAttributeTransformer<T, U> transformMethod, ref U transformer) 
-            where T : struct
-            where U : struct
-        {
-            for (var i = 0; i < vertexBuilder.VerticesPerParticle; i++)
-            {
-                var temp = Utilities.Read<T>(VertexBuffer + accessorFrom.Offset + i * VertexStride);
-
-                transformMethod.Transform(ref temp, ref transformer);
-
-                Utilities.Write(VertexBuffer + accessorTo.Offset + i * VertexStride, ref temp);
-            }
-        }
-
-
-        public AttributeAccessor GetAccessor(AttributeDescription desc) => vertexBuilder.GetAccessor(desc);
-
-        public AttributeDescription DefaultTexCoords => vertexBuilder.DefaultTexCoords;
-
-        /// <summary>
-        /// Advances the pointer to the next vertex in the buffer, so that it can be written
-        /// </summary>
-        public void NextVertex()
-        {
-            if (++CurrentVertex >= (vertexBuilder.MaxParticles * vertexBuilder.VerticesPerParticle))
-                CurrentVertex = (vertexBuilder.MaxParticles * vertexBuilder.VerticesPerParticle) - 1;
-
-            VertexBuffer = VertexBufferOrigin + VertexStride * CurrentVertex;
-        }
-
-        /// <summary>
-        /// Advances the pointer to the next particle in the buffer, so that its first vertex can be written
-        /// </summary>
-        public void NextParticle()
-        {
-            if (++CurrentParticleIndex >= vertexBuilder.MaxParticles)
-                CurrentParticleIndex = vertexBuilder.MaxParticles - 1;
-
-            VertexBuffer = VertexBufferOrigin + (VertexStride * CurrentParticleIndex * vertexBuilder.VerticesPerParticle);
-        }
-
-        /// <summary>
-        /// Advances the pointer to the next segment in the buffer, so that its first vertex can be written
-        /// </summary>
-        public void NextSegment()
-        {
-            // The number of segments is tied to the number of particles
-            if (++CurrentParticleIndex >= vertexBuilder.MaxParticles)
-            {
-                // Already at the last particle
-                CurrentParticleIndex = vertexBuilder.MaxParticles - 1;
-                return;
-            }
-
-            VertexBuffer += VertexStride * VerticesPerSegCurrent;
-            VerticesPerSegCurrent = (CurrentParticleIndex < vertexBuilder.MaxParticles - 1) ? VerticesPerSegMiddle : VerticesPerSegLast;
-        }
-
-        /// <summary>
-        /// Moves the index to the beginning of the buffer so that the data can be filled from the first particle again
-        /// </summary>
-        public void StartOver()
-        {
-            VertexBuffer = VertexBufferOrigin;
-            CurrentParticleIndex = 0;
-            CurrentVertex = 0;
-            VerticesPerSegCurrent = VerticesPerSegFirst;
-        }
-    }
-
     /// <summary>
     /// Manager class for the vertex buffer stream which can dynamically change the required vertex layout and rebuild the buffer based on the particle fields
     /// </summary>
@@ -196,8 +17,6 @@ namespace Stride.Particles.VertexLayouts
         public readonly int IndicesPerQuad = 6;
 
         public delegate void TransformAttributeDelegate<T>(ref T value);
-
-        private readonly int indexStructSize;
 
         private readonly Dictionary<AttributeDescription, AttributeAccessor> availableAttributes;
 
@@ -219,8 +38,6 @@ namespace Stride.Particles.VertexLayouts
             vertexElementList = new List<VertexElement>();
 
             ResetVertexElementList();
-
-            indexStructSize = sizeof(short);
 
             availableAttributes = new Dictionary<AttributeDescription, AttributeAccessor>();
 

--- a/sources/targets/Stride.UnitTests.targets
+++ b/sources/targets/Stride.UnitTests.targets
@@ -85,7 +85,7 @@
 
   <ItemGroup>
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.32" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
# PR Details

Continuing to chip away at numerous varieties of build-time warnings and make minor code cleanup changes.

- Add a runtime ID to Stride.Samples.Tests so the compiler won't evaluate a different architecture as its dependencies and emit a warning.
- In Stride.Samples.Tests, remove link to AttachedChildProcessJob.cs as its not needed and results in a duplicate symbol warning.
- In AssetPropertGraph, actually use the isDisposed field.
- In several projects, use the released version of System.Collections.Immutable rather than the prerelease.
- In Stride.Core.Design, allow it to see the internal NativeLockFile compiled into Stride.Core.IO and avoid the duplicate symbol warning.
- Correct a few cases of sealed classes having protected members.
- As hygene, move ParticleBufferState to its own .cs
- In ParticleVertexBuilder, remove the unused indexStructSize
- Across multiple test projects, use the release version of Microsoft.NET.Test.Sdk rather than the prerelease version.

## Related Issue
#1383 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.