### PR TITLE
Fixes "key already exists" exception when preloading library containing uppercase letters 

### DIFF
--- a/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
+++ b/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
@@ -12,7 +12,7 @@ namespace Stride.Core
     public static class NativeLibraryHelper
     {
         private const string UNIX_LIB_PREFIX = "lib";
-        private static readonly Dictionary<string, IntPtr> LoadedLibraries = new Dictionary<string, IntPtr>();
+        private static readonly Dictionary<string, IntPtr> LoadedLibraries = new Dictionary<string, IntPtr>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Try to preload the library.
@@ -90,13 +90,13 @@ namespace Stride.Core
                     // e.g. /lib/x86_64-linux-gnu, /lib, /usr/lib, etc. 
                     if (NativeLibrary.TryLoad(libraryNameWithExtension, out var result))
                     {
-                        LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                        LoadedLibraries.Add(libraryName, result);
                         return;
                     }
                     else if (!libraryName.StartsWith(UNIX_LIB_PREFIX)
                         && NativeLibrary.TryLoad(UNIX_LIB_PREFIX + libraryNameWithExtension, out result))
                     {
-                        LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                        LoadedLibraries.Add(libraryName, result);
                         return;
                     }
                 }
@@ -117,7 +117,7 @@ namespace Stride.Core
                         var libraryFilename = Path.Combine(libraryPath, libraryNameWithExtension);
                         if (NativeLibrary.TryLoad(libraryFilename, out var result))
                         {
-                            LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                            LoadedLibraries.Add(libraryName, result);
                             return;
                         }
                     }
@@ -129,7 +129,7 @@ namespace Stride.Core
                     var libraryFilename = Path.Combine(p, libraryNameWithExtension);
                     if (NativeLibrary.TryLoad(libraryFilename, out var result))
                     {
-                        LoadedLibraries.Add(libraryName.ToLowerInvariant(), result);
+                        LoadedLibraries.Add(libraryName, result);
                         return;
                     }
                 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes crash when calling `PreloadLibrary` multiple times with a library name containing uppercase letters (for example "libGLESv2"). Instead of using lowercase letters when storing the result in the dictionary, simply tell the dictionary to use a comparer ignoring character casing.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.