### PR TITLE
Fixes assembly load exceptions in asset compiler

### DIFF
--- a/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
+++ b/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
@@ -134,9 +134,13 @@ namespace Stride.Core.Reflection
         {
             if (assemblyName == null) throw new ArgumentNullException(nameof(assemblyName));
 
+            // Note: Do not compare by full name as it is too restricive in regards to versioning.
+            // For example consider App -> Foo -> Bar (1.0) with the App referencing a newer version of Bar (2.0)
+            // A full name comparison would now compare Bar (1.0) to Bar (2.0) and fail to load.
+
             // First, check the list of already loaded assemblies
             {
-                var matchingAssembly = loadedAssemblies.FirstOrDefault(x => x.Assembly.FullName == assemblyName.FullName);
+                var matchingAssembly = loadedAssemblies.FirstOrDefault(x => AssemblyName.ReferenceMatchesDefinition(assemblyName, x.Assembly.GetName()));
                 if (matchingAssembly != null)
                     return matchingAssembly.Assembly;
             }
@@ -179,7 +183,7 @@ namespace Stride.Core.Reflection
                         try
                         {
                             var otherAssemblyName = AssemblyName.GetAssemblyName(dependency);
-                            if (otherAssemblyName.FullName == assemblyName.FullName)
+                            if (AssemblyName.ReferenceMatchesDefinition(assemblyName, otherAssemblyName))
                                 return LoadAssemblyFromPathInternal(dependency);
                         }
                         catch (Exception)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes assembly load exception in asset compiler due to full name comparison being too restrictive.
For example consider App -> Foo -> Bar (1.0) with the App referencing a newer version of Bar (2.0)
A full name comparison would now compare Bar (1.0) to Bar (2.0) and fail to load.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Had a third party dependency referencing an older version of a library we already upgraded.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.