### PR TITLE
Fix typo in AssignmentExpression.cs

### DIFF
--- a/sources/shaders/Stride.Core.Shaders/Ast/AssignmentExpression.cs
+++ b/sources/shaders/Stride.Core.Shaders/Ast/AssignmentExpression.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Stride.Core.Shaders.Ast
 {
     /// <summary>
-    /// An assigment expression
+    /// An assignment expression
     /// </summary>
     public partial class AssignmentExpression : Expression
     {


### PR DESCRIPTION


# PR Details

FIxed typo.
```
assigment -> assignment
```

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.