### PR TITLE
Mesh copy constructor was missing BoundingSphere

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Mesh.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Mesh.cs
@@ -33,6 +33,7 @@ namespace Stride.Rendering
             NodeIndex = mesh.NodeIndex;
             Name = mesh.Name;
             BoundingBox = mesh.BoundingBox;
+            BoundingSphere = mesh.BoundingSphere;
             Skinning = mesh.Skinning;
         }
 


### PR DESCRIPTION
# PR Details

A simple fix to the Mesh copy constructor which was missing copying the BoundingSphere property

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.