### PR TITLE
[Samples] Fix build error of VRSanbox

### DIFF
--- a/samples/Templates/VRSandbox/VRSandbox/VRSandbox.Game/Player/HandController.cs
+++ b/samples/Templates/VRSandbox/VRSandbox/VRSandbox.Game/Player/HandController.cs
@@ -114,8 +114,8 @@ namespace VRSandbox.Player
             while (enumerator.MoveNext())
             {
                 var collision = enumerator.Current;
-                var entityA = collision?.ColliderA?.Entity;
-                var entityB = collision?.ColliderB?.Entity;
+                var entityA = collision.ColliderA?.Entity;
+                var entityB = collision.ColliderB?.Entity;
 
                 var otherEntity = (entityA == Entity) ? entityB : entityA;
 


### PR DESCRIPTION
Just removing a null check, as the type has changed from class to a struct and cannot be null.

## Description

Just removes a null check.

## Related Issue

Fixes #1457

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

