### PR TITLE
Get rid of P/Invoke SizeOf.

### DIFF
--- a/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
@@ -28,6 +28,7 @@
 */
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Stride.Core.Mathematics
@@ -194,7 +195,7 @@ namespace Stride.Core.Mathematics
             if (points == null) throw new ArgumentNullException("points");
             fixed (void* pointsPtr = points)
             {
-                FromPoints((IntPtr)pointsPtr, 0, points.Length, Utilities.SizeOf<Vector3>(), out result);
+                FromPoints((IntPtr)pointsPtr, 0, points.Length, Unsafe.SizeOf<Vector3>(), out result);
             }
         }
 

--- a/sources/core/Stride.Core.Mathematics/Double2.cs
+++ b/sources/core/Stride.Core.Mathematics/Double2.cs
@@ -20,7 +20,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Double2"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Double2>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Double2>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Double2"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Double3.cs
+++ b/sources/core/Stride.Core.Mathematics/Double3.cs
@@ -20,7 +20,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Double3"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Double3>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Double3>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Double3"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Double4.cs
+++ b/sources/core/Stride.Core.Mathematics/Double4.cs
@@ -20,7 +20,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Double4"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Double4>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Double4>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Double4"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Half2.cs
+++ b/sources/core/Stride.Core.Mathematics/Half2.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core.Serialization;
 
@@ -38,7 +39,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Half2"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Half2>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Half2>();
 
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Half3.cs
+++ b/sources/core/Stride.Core.Mathematics/Half3.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core.Serialization;
 
@@ -38,7 +39,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Half3"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Half3>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Half3>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Half3"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Half4.cs
+++ b/sources/core/Stride.Core.Mathematics/Half4.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core.Serialization;
 
@@ -38,7 +39,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Half4"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Half4>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Half4>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Half4"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Int2.cs
+++ b/sources/core/Stride.Core.Mathematics/Int2.cs
@@ -28,6 +28,7 @@
 */
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Stride.Core.Mathematics
@@ -43,7 +44,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Int2"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Int2>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Int2>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Int2"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Int3.cs
+++ b/sources/core/Stride.Core.Mathematics/Int3.cs
@@ -28,6 +28,7 @@
 */
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Stride.Core.Mathematics
@@ -43,7 +44,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Int3"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Int3>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Int3>();
 
         /// <summary>
         /// A <see cref="Int3"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Int4.cs
+++ b/sources/core/Stride.Core.Mathematics/Int4.cs
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Stride.Core.Mathematics
@@ -37,7 +38,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         ///   The size of the <see cref = "Int4" /> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Int4>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Int4>();
 
         /// <summary>
         ///   A <see cref = "Int4" /> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Matrix.cs
+++ b/sources/core/Stride.Core.Mathematics/Matrix.cs
@@ -54,7 +54,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Matrix"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Matrix>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Matrix>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Matrix"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Quaternion.cs
+++ b/sources/core/Stride.Core.Mathematics/Quaternion.cs
@@ -28,6 +28,7 @@
 */
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static System.MathF;
 
@@ -44,7 +45,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Quaternion"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Quaternion>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Quaternion>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Quaternion"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/UInt4.cs
+++ b/sources/core/Stride.Core.Mathematics/UInt4.cs
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core.Serialization;
 
@@ -37,7 +38,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         ///   The size of the <see cref = "UInt4" /> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<UInt4>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<UInt4>();
 
         /// <summary>
         ///   A <see cref = "UInt4" /> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -44,7 +44,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Vector2"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Vector2>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Vector2>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Vector2"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -44,7 +44,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Vector3"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Vector3>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Vector3>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Vector3"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -44,7 +44,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Vector4"/> type, in bytes.
         /// </summary>
-        public static readonly int SizeInBytes = Utilities.SizeOf<Vector4>();
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Vector4>();
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Vector4"/> with all of its components set to zero.

--- a/sources/core/Stride.Core.Tests/TestUtilities.cs
+++ b/sources/core/Stride.Core.Tests/TestUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -28,7 +29,7 @@ namespace Stride.Core.Tests
             var s = new S { A = 32, B = 33 };
 
             // Check SizeOf
-            Assert.Equal(8, Utilities.SizeOf<S>());
+            Assert.Equal(8, Unsafe.SizeOf<S>());
 
             // Write
             Utilities.Write(data + 4, ref s);
@@ -37,11 +38,11 @@ namespace Stride.Core.Tests
             Assert.Equal(s, s2);
 
             // CopyMemory+Fixed (with offset)
-            Utilities.CopyMemory(data + 12, (IntPtr)Interop.Fixed(ref s) + 4, Utilities.SizeOf<int>());
+            Utilities.CopyMemory(data + 12, (IntPtr)Interop.Fixed(ref s) + 4, sizeof(int));
             int b = 0;
             Utilities.Read(data + 12, ref b);
             Assert.Equal(s.B, b);
-            
+
             // FreeMemory
             Utilities.FreeMemory(data);
         }

--- a/sources/core/Stride.Core/Serialization/Serializers/CollectionSerializers.cs
+++ b/sources/core/Stride.Core/Serialization/Serializers/CollectionSerializers.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Stride.Core.Annotations;
 
 namespace Stride.Core.Serialization.Serializers
@@ -319,7 +320,7 @@ namespace Stride.Core.Serialization.Serializers
         /// <inheritdoc/>
         public override void Initialize(SerializerSelector serializerSelector)
         {
-            elementSize = Interop.SizeOf<T>();
+            elementSize = Unsafe.SizeOf<T>();
         }
 
         /// <inheritdoc/>

--- a/sources/core/Stride.Core/Storage/ObjectIdBuilder.cs
+++ b/sources/core/Stride.Core/Storage/ObjectIdBuilder.cs
@@ -245,10 +245,10 @@ namespace Stride.Core.Storage
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write<T>(T[] buffer, int offset, int count) where T : struct
         {
-            var ptr = (IntPtr)Interop.Fixed(buffer) + offset * Interop.SizeOf<T>();
-            Write((byte*)ptr, count * Interop.SizeOf<T>());
+            var ptr = (IntPtr)Interop.Fixed(buffer) + offset * Unsafe.SizeOf<T>();
+            Write((byte*)ptr, count * Unsafe.SizeOf<T>());
         }
-        
+
         /// <summary>
         /// Writes the specified buffer to this instance.
         /// </summary>
@@ -258,7 +258,7 @@ namespace Stride.Core.Storage
         public void Write<T>(ref T data) where T : struct
         {
             var ptr = (byte*)Interop.Fixed(ref data);
-            Write(ptr, Interop.SizeOf<T>());
+            Write(ptr, Unsafe.SizeOf<T>());
         }
 #endif
 

--- a/sources/core/Stride.Core/Storage/ObjectIdSimpleBuilder.cs
+++ b/sources/core/Stride.Core/Storage/ObjectIdSimpleBuilder.cs
@@ -119,7 +119,7 @@ namespace Stride.Core.Storage
         public void Write<T>(T data) where T : struct
         {
             var pData = (int*)Interop.Fixed(ref data);
-            var count = Utilities.SizeOf<T>() >> 2;
+            var count = Unsafe.SizeOf<T>() >> 2;
             for (var i = 0; i < count; i++)
             {
                 Write(*pData++);

--- a/sources/core/Stride.Core/UnmanagedArray.cs
+++ b/sources/core/Stride.Core/UnmanagedArray.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Runtime.CompilerServices;
 using Stride.Core.Annotations;
 
 namespace Stride.Core
@@ -13,7 +14,7 @@ namespace Stride.Core
         public UnmanagedArray(int length)
         {
             Length = length;
-            sizeOfT = Utilities.SizeOf<T>();
+            sizeOfT = Unsafe.SizeOf<T>();
             var finalSize = length * sizeOfT;
             Pointer = Utilities.AllocateMemory(finalSize);
             isShared = false;
@@ -22,7 +23,7 @@ namespace Stride.Core
         public UnmanagedArray(int length, IntPtr unmanagedDataPtr)
         {
             Length = length;
-            sizeOfT = Utilities.SizeOf<T>();
+            sizeOfT = Unsafe.SizeOf<T>();
             Pointer = unmanagedDataPtr;
             isShared = true;
         }

--- a/sources/core/Stride.Core/Utilities.Interop.cs
+++ b/sources/core/Stride.Core/Utilities.Interop.cs
@@ -2,17 +2,17 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 //
 // Copyright (c) 2010-2012 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -141,6 +141,7 @@ namespace Stride.Core
             throw new NotImplementedException();
         }
 
+        [Obsolete("Use System.Runtime.CompilerServices.Unsafe.SizeOf<T>()", error: true)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int SizeOf<T>()
         {

--- a/sources/core/Stride.Core/Utilities.cs
+++ b/sources/core/Stride.Core/Utilities.cs
@@ -112,10 +112,17 @@ namespace Stride.Core
         /// <typeparam name="T">a struct to evaluate</typeparam>
         /// <returns>sizeof this struct</returns>
         [Obsolete("Use System.Runtime.CompilerServices.Unsafe.SizeOf<T>()")]
-        public static int SizeOf<T>() where T : struct
-        {
-            return Unsafe.SizeOf<T>();
-        }
+        public static int SizeOf<T>() where T : struct => Unsafe.SizeOf<T>();
+
+        /// <summary>
+        /// Return the sizeof an array of struct. Equivalent to sizeof operator but works on generics too.
+        /// </summary>
+        /// <typeparam name="T">a struct</typeparam>
+        /// <param name="array">The array of struct to evaluate.</param>
+        /// <returns>sizeof in bytes of this array of struct</returns>
+        [Obsolete("Use System.Runtime.CompilerServices.Unsafe.SizeOf<T>() * array.Length")]
+        public static int SizeOf<T>(T[] array) where T : struct
+            => array is null ? 0 : array.Length * Unsafe.SizeOf<T>();
 
         /// <summary>
         /// Pins the specified source and call an action with the pinned pointer.

--- a/sources/core/Stride.Core/Utilities.cs
+++ b/sources/core/Stride.Core/Utilities.cs
@@ -111,20 +111,10 @@ namespace Stride.Core
         /// </summary>
         /// <typeparam name="T">a struct to evaluate</typeparam>
         /// <returns>sizeof this struct</returns>
+        [Obsolete("Use System.Runtime.CompilerServices.Unsafe.SizeOf<T>()")]
         public static int SizeOf<T>() where T : struct
         {
-            return Interop.SizeOf<T>();
-        }
-
-        /// <summary>
-        /// Return the sizeof an array of struct. Equivalent to sizeof operator but works on generics too.
-        /// </summary>
-        /// <typeparam name="T">a struct</typeparam>
-        /// <param name="array">The array of struct to evaluate.</param>
-        /// <returns>sizeof in bytes of this array of struct</returns>
-        public static int SizeOf<T>(T[] array) where T : struct
-        {
-            return array == null ? 0 : array.Length * Interop.SizeOf<T>();
+            return Unsafe.SizeOf<T>();
         }
 
         /// <summary>
@@ -164,7 +154,7 @@ namespace Stride.Core
         {
             if (source == null) return null;
 
-            var buffer = new byte[SizeOf<T>() * source.Length];
+            var buffer = new byte[Unsafe.SizeOf<T>() * source.Length];
 
             if (source.Length == 0)
                 return buffer;
@@ -802,16 +792,6 @@ namespace Stride.Core
             {
                 Interop.CopyInlineOut(out data, (void*)source);
             }
-        }
-
-        /// <summary>
-        /// Return the sizeof a struct from a CLR. Equivalent to sizeof operator but works on generics too.
-        /// </summary>
-        /// <typeparam name="T">a struct to evaluate</typeparam>
-        /// <returns>sizeof this struct</returns>
-        internal static int UnsafeSizeOf<T>()
-        {
-            return Interop.SizeOf<T>();
         }
 
         /// <summary>

--- a/sources/engine/Stride.Engine/Animations/AnimationCurve.cs
+++ b/sources/engine/Stride.Engine/Animations/AnimationCurve.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Collections;
 using Stride.Internals;
@@ -95,10 +96,7 @@ namespace Stride.Animations
 
         /// <inheritdoc/>
         [DataMemberIgnore]
-        public override int ElementSize
-        {
-            get { return Utilities.UnsafeSizeOf<T>(); }
-        }
+        public override int ElementSize => Unsafe.SizeOf<T>();
 
         /// <inheritdoc/>
         [DataMemberIgnore]

--- a/sources/engine/Stride.Engine/Animations/AnimationKeyValuePairArraySerializer.cs
+++ b/sources/engine/Stride.Engine/Animations/AnimationKeyValuePairArraySerializer.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Serialization;
 
@@ -35,7 +36,7 @@ namespace Stride.Animations
             if (mode == ArchiveMode.Deserialize)
             {
                 int count = obj.Length;
-                var rawData = stream.ReadBytes(Utilities.SizeOf<AnimationKeyValuePair<T>>() * count);
+                var rawData = stream.ReadBytes(Unsafe.SizeOf<AnimationKeyValuePair<T>>() * count);
                 fixed (void* rawDataPtr = rawData)
                 {
                     Utilities.Read((IntPtr)rawDataPtr, obj, 0, count);

--- a/sources/engine/Stride.Engine/Updater/UpdatableFieldT.cs
+++ b/sources/engine/Stride.Engine/Updater/UpdatableFieldT.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1649 // File name must match first type name
 
 using System;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 
 namespace Stride.Updater
@@ -15,7 +16,7 @@ namespace Stride.Updater
         public UpdatableField(int offset)
         {
             Offset = offset;
-            Size = Interop.SizeOf<T>();
+            Size = Unsafe.SizeOf<T>();
         }
 
         /// <inheritdoc/>

--- a/sources/engine/Stride.Graphics/Buffer.cs
+++ b/sources/engine/Stride.Graphics/Buffer.cs
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Serialization;
 using Stride.Core.Serialization.Contents;
@@ -168,7 +169,7 @@ namespace Stride.Graphics
         /// for optimal performances.</remarks>
         public TData[] GetData<TData>(CommandList commandList) where TData : struct
         {
-            var toData = new TData[this.Description.SizeInBytes / Utilities.SizeOf<TData>()];
+            var toData = new TData[this.Description.SizeInBytes / Unsafe.SizeOf<TData>()];
             GetData(commandList, toData);
             return toData;
         }
@@ -235,7 +236,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe void GetData<TData>(CommandList commandList, Buffer stagingTexture, ref TData toData) where TData : struct
         {
-            GetData(commandList, stagingTexture, new DataPointer(Interop.Fixed(ref toData), Utilities.SizeOf<TData>()));
+            GetData(commandList, stagingTexture, new DataPointer(Interop.Fixed(ref toData), Unsafe.SizeOf<TData>()));
         }
 
         /// <summary>
@@ -250,7 +251,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe void GetData<TData>(CommandList commandList, Buffer stagingTexture, TData[] toData) where TData : struct
         {
-            GetData(commandList, stagingTexture, new DataPointer(Interop.Fixed(toData), toData.Length * Utilities.SizeOf<TData>()));
+            GetData(commandList, stagingTexture, new DataPointer(Interop.Fixed(toData), toData.Length * Unsafe.SizeOf<TData>()));
         }
         
         /// <summary>
@@ -266,7 +267,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe void SetData<TData>(CommandList commandList, ref TData fromData, int offsetInBytes = 0) where TData : struct
         {
-            SetData(commandList, new DataPointer(Interop.Fixed(ref fromData), Utilities.SizeOf<TData>()), offsetInBytes);
+            SetData(commandList, new DataPointer(Interop.Fixed(ref fromData), Unsafe.SizeOf<TData>()), offsetInBytes);
         }
 
         /// <summary>
@@ -282,7 +283,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe void SetData<TData>(CommandList commandList, TData[] fromData, int offsetInBytes = 0) where TData : struct
         {
-            SetData(commandList, new DataPointer(Interop.Fixed(fromData), (fromData.Length * Utilities.SizeOf<TData>())), offsetInBytes);
+            SetData(commandList, new DataPointer(Interop.Fixed(fromData), (fromData.Length * Unsafe.SizeOf<TData>())), offsetInBytes);
         }
 
         /// <summary>
@@ -388,8 +389,8 @@ namespace Stride.Graphics
         /// <returns>An instance of a new <see cref="Buffer" /></returns>
         public static Buffer<T> New<T>(GraphicsDevice device, int elementCount, BufferFlags bufferFlags, GraphicsResourceUsage usage = GraphicsResourceUsage.Default) where T : struct
         {
-            int bufferSize = Utilities.SizeOf<T>() * elementCount;
-            int elementSize = Utilities.SizeOf<T>();
+            int bufferSize = Unsafe.SizeOf<T>() * elementCount;
+            int elementSize = Unsafe.SizeOf<T>();
 
             var description = NewDescription(bufferSize, elementSize, bufferFlags, usage);
             return new Buffer<T>(device, description, bufferFlags, PixelFormat.None, IntPtr.Zero);
@@ -466,8 +467,8 @@ namespace Stride.Graphics
         /// <returns>An instance of a new <see cref="Buffer" /></returns>
         public static unsafe Buffer<T> New<T>(GraphicsDevice device, ref T value, BufferFlags bufferFlags, PixelFormat viewFormat, GraphicsResourceUsage usage = GraphicsResourceUsage.Default) where T : struct
         {
-            int bufferSize = Utilities.SizeOf<T>();
-            int elementSize = ((bufferFlags & BufferFlags.StructuredBuffer) != 0) ? Utilities.SizeOf<T>() : 0;
+            int bufferSize = Unsafe.SizeOf<T>();
+            int elementSize = ((bufferFlags & BufferFlags.StructuredBuffer) != 0) ? Unsafe.SizeOf<T>() : 0;
 
             viewFormat = CheckPixelFormat(bufferFlags, elementSize, viewFormat);
 
@@ -501,8 +502,8 @@ namespace Stride.Graphics
         /// <returns>An instance of a new <see cref="Buffer" /></returns>
         public static unsafe Buffer<T> New<T>(GraphicsDevice device, T[] initialValue, BufferFlags bufferFlags, PixelFormat viewFormat, GraphicsResourceUsage usage = GraphicsResourceUsage.Default) where T : struct
         {
-            int bufferSize = Utilities.SizeOf<T>() * initialValue.Length;
-            int elementSize = Utilities.SizeOf<T>();
+            int bufferSize = Unsafe.SizeOf<T>() * initialValue.Length;
+            int elementSize = Unsafe.SizeOf<T>();
             viewFormat = CheckPixelFormat(bufferFlags, elementSize, viewFormat);
 
             var description = NewDescription(bufferSize, elementSize, bufferFlags, usage);
@@ -634,7 +635,7 @@ namespace Stride.Graphics
         protected internal Buffer(GraphicsDevice device, BufferDescription description, BufferFlags viewFlags, PixelFormat viewFormat, IntPtr dataPointer) : base(device)
         {
             InitializeFromImpl(description, viewFlags, viewFormat, dataPointer);
-            this.ElementSize = Utilities.SizeOf<T>();
+            this.ElementSize = Unsafe.SizeOf<T>();
             this.ElementCount = Description.SizeInBytes / ElementSize;
         }
 

--- a/sources/engine/Stride.Graphics/Data/BufferData.cs
+++ b/sources/engine/Stride.Graphics/Data/BufferData.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Serialization.Contents;
 
@@ -54,7 +55,7 @@ namespace Stride.Graphics.Data
         /// <returns>A buffer data.</returns>
         public static BufferData New<T>(BufferFlags bufferFlags, T[] content) where T : struct
         {
-            var sizeOf = Utilities.SizeOf(content);
+            var sizeOf = Unsafe.SizeOf<T>() * content.Length;
             var buffer = new byte[sizeOf];
             Utilities.Write(buffer, content, 0, content.Length);
             return new BufferData(bufferFlags, buffer);

--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -25,6 +25,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Annotations;
 using Stride.Core.Mathematics;
@@ -670,7 +671,7 @@ namespace Stride.Graphics
             var widthOnMip = CalculateMipSize((int)Width, mipLevel);
             var rowStride = widthOnMip * Format.SizeInBytes();
 
-            var dataStrideInBytes = Utilities.SizeOf<TData>() * widthOnMip;
+            var dataStrideInBytes = Unsafe.SizeOf<TData>() * widthOnMip;
             var width = ((double)rowStride / dataStrideInBytes) * widthOnMip;
             if (Math.Abs(width - (int)width) > double.Epsilon)
                 throw new ArgumentException("sizeof(TData) / sizeof(Format) * Width is not an integer");
@@ -756,7 +757,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe bool GetData<TData>(CommandList commandList, Texture stagingTexture, TData[] toData, int arraySlice = 0, int mipSlice = 0, bool doNotWait = false) where TData : struct
         {
-            return GetData(commandList, stagingTexture, new DataPointer((IntPtr)Interop.Fixed(toData), toData.Length * Utilities.SizeOf<TData>()), arraySlice, mipSlice, doNotWait);
+            return GetData(commandList, stagingTexture, new DataPointer((IntPtr)Interop.Fixed(toData), toData.Length * Unsafe.SizeOf<TData>()), arraySlice, mipSlice, doNotWait);
         }
 
         /// <summary>
@@ -774,7 +775,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe void SetData<TData>(CommandList commandList, TData[] fromData, int arraySlice = 0, int mipSlice = 0, ResourceRegion? region = null) where TData : struct
         {
-            SetData(commandList, new DataPointer((IntPtr)Interop.Fixed(fromData), fromData.Length * Utilities.SizeOf<TData>()), arraySlice, mipSlice, region);
+            SetData(commandList, new DataPointer((IntPtr)Interop.Fixed(fromData), fromData.Length * Unsafe.SizeOf<TData>()), arraySlice, mipSlice, region);
         }
 
         /// <summary>
@@ -1213,7 +1214,7 @@ namespace Stride.Graphics
             // Check that the textureData size is correct
             if (textureData == null) throw new ArgumentNullException("textureData");
             Image.ComputePitch(format, width, height, out var rowPitch, out var slicePitch, out _, out _);
-            if (Utilities.SizeOf(textureData) != (slicePitch * depth)) throw new ArgumentException("Invalid size for Image");
+            if (Unsafe.SizeOf<T>() * textureData.Length != (slicePitch * depth)) throw new ArgumentException("Invalid size for Image");
 
             return new DataBox(fixedPointer, rowPitch, slicePitch);
         }

--- a/sources/engine/Stride.Graphics/VertexHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexHelper.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Mathematics;
 
@@ -36,7 +36,7 @@ namespace Stride.Graphics
         {
             if (vertexDeclaration == null) throw new ArgumentNullException("vertexDeclaration");
             if (vertexBufferData == null) throw new ArgumentNullException("vertexBufferData");
-            var vertexStride = Utilities.SizeOf<T>();
+            var vertexStride = Unsafe.SizeOf<T>();
             var vertexBufferPtr = Interop.Fixed(vertexBufferData);
             return GenerateMultiTextureCoordinates(vertexDeclaration, (IntPtr)vertexBufferPtr, vertexBufferData.Length, 0, vertexStride, maxTexcoord);
         }
@@ -112,7 +112,7 @@ namespace Stride.Graphics
         /// </exception>
         /// <exception cref="System.InvalidOperationException">The vertex buffer must contain at least the TEXCOORD</exception>
         /// <remarks>
-        /// The original vertex buffer must contain at least a TEXCOORD[0-9] attribute in order for this method to work. 
+        /// The original vertex buffer must contain at least a TEXCOORD[0-9] attribute in order for this method to work.
         /// This method will copy the value of the first existing TEXCOORD found in the vertex buffer to the newly created TEXCOORDS.
         /// </remarks>
         public static unsafe VertexTransformResult GenerateMultiTextureCoordinates(VertexDeclaration vertexDeclaration, IntPtr vertexBufferData, int vertexCount, int vertexOffset, int vertexStride, int maxTexcoord = 9)
@@ -208,7 +208,7 @@ namespace Stride.Graphics
             if (vertexBufferData == null) throw new ArgumentNullException("vertexBufferData");
             if (typeof(T) == typeof(byte)) throw new ArgumentOutOfRangeException("T", "Type vertex can't be a byte");
 
-            var vertexStride = Utilities.SizeOf<T>();
+            var vertexStride = Unsafe.SizeOf<T>();
             var vertexBufferPtr = Interop.Fixed(vertexBufferData);
             fixed (void* indexBufferPtr = indexBuffer)
             {
@@ -362,7 +362,7 @@ namespace Stride.Graphics
                     // Gram-Schmidt orthogonalize
                     var newTangentUnormalized = tangent - normal * Vector3.Dot(normal, tangent);
                     var length = newTangentUnormalized.Length();
-                    
+
                     // Workaround to handle degenerated case
                     // TODO: We need to understand more how we can handle this more accurately
                     if (MathUtil.IsZero(length))

--- a/sources/engine/Stride.Particles/ParticleFieldDescription.cs
+++ b/sources/engine/Stride.Particles/ParticleFieldDescription.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using Stride.Core;
 
 namespace Stride.Particles
@@ -28,7 +29,7 @@ namespace Stride.Particles
         public ParticleFieldDescription(string name)
             : base(name)
         {
-            FieldSize = ParticleUtilities.AlignedSize(Utilities.SizeOf<T>(), 4);
+            FieldSize = ParticleUtilities.AlignedSize(Unsafe.SizeOf<T>(), 4);
         }
 
         public ParticleFieldDescription(string name, T defaultValue)

--- a/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderRibbon.cs
+++ b/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderRibbon.cs
@@ -8,6 +8,7 @@ using Stride.Particles.Initializers;
 using Stride.Particles.Sorters;
 using Stride.Particles.VertexLayouts;
 using Stride.Particles.ShapeBuilders.Tools;
+using System.Runtime.CompilerServices;
 
 namespace Stride.Particles.ShapeBuilders
 {
@@ -194,11 +195,11 @@ namespace Stride.Particles.ShapeBuilders
 
                 particleCapacity = requiredCapacity;
 
-                int positionDataSize = Utilities.SizeOf<Vector3>() * particleCapacity;
+                int positionDataSize = Unsafe.SizeOf<Vector3>() * particleCapacity;
                 positionDataSize = (positionDataSize % 4 == 0) ? positionDataSize : (positionDataSize + 4 - (positionDataSize % 4));
                 positionData = Utilities.AllocateMemory(positionDataSize);
 
-                int sizeDataSize = Utilities.SizeOf<float>() * particleCapacity;
+                int sizeDataSize = sizeof(float) * particleCapacity;
                 sizeDataSize = (sizeDataSize % 4 == 0) ? sizeDataSize : (sizeDataSize + 4 - (sizeDataSize % 4));
                 sizeData = Utilities.AllocateMemory(sizeDataSize);
             }

--- a/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderTrail.cs
+++ b/sources/engine/Stride.Particles/ShapeBuilders/ShapeBuilderTrail.cs
@@ -8,6 +8,7 @@ using Stride.Particles.Initializers;
 using Stride.Particles.Sorters;
 using Stride.Particles.VertexLayouts;
 using Stride.Particles.ShapeBuilders.Tools;
+using System.Runtime.CompilerServices;
 
 namespace Stride.Particles.ShapeBuilders
 {
@@ -208,11 +209,11 @@ namespace Stride.Particles.ShapeBuilders
 
                 particleCapacity = requiredCapacity;
 
-                int positionDataSize = Utilities.SizeOf<Vector3>() * particleCapacity;
+                int positionDataSize = Unsafe.SizeOf<Vector3>() * particleCapacity;
                 positionDataSize = (positionDataSize % 4 == 0) ? positionDataSize : (positionDataSize + 4 - (positionDataSize % 4));
                 positionData = Utilities.AllocateMemory(positionDataSize);
 
-                int directionDataSize = Utilities.SizeOf<Vector3>() * particleCapacity;
+                int directionDataSize = Unsafe.SizeOf<Vector3>() * particleCapacity;
                 directionDataSize = (directionDataSize % 4 == 0) ? directionDataSize : (directionDataSize + 4 - (directionDataSize % 4));
                 directionData = Utilities.AllocateMemory(directionDataSize);
             }

--- a/sources/engine/Stride.Physics/HeightStickArraySourceFromHeightmap.cs
+++ b/sources/engine/Stride.Physics/HeightStickArraySourceFromHeightmap.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Mathematics;
 
@@ -64,7 +65,7 @@ namespace Stride.Physics
             var heightsLength = heights.Length;
             if (heightStickArrayLength < heightsLength) throw new ArgumentException($"{ nameof(heightStickArray) }.{ nameof(heightStickArray.Length) } is not enough to copy.");
 
-            heightStickArray.Write(heights, index * Utilities.SizeOf<T>(), 0, heightsLength);
+            heightStickArray.Write(heights, index * Unsafe.SizeOf<T>(), 0, heightsLength);
         }
 
         public bool Match(object obj)

--- a/sources/engine/Stride.Rendering/Extensions/HalfBufferExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/HalfBufferExtensions.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Graphics;
@@ -43,19 +44,19 @@ namespace Stride.Extensions
                         vertexElementFormat = PixelFormat.R16G16_Float;
 
                         // Adjust next offset if current object has been resized
-                        offsetShift = Utilities.SizeOf<Half2>() - Utilities.SizeOf<Vector2>();
+                        offsetShift = Unsafe.SizeOf<Half2>() - Unsafe.SizeOf<Vector2>();
                         break;
                     case PixelFormat.R32G32B32_Float:
                         vertexElementFormat = PixelFormat.R16G16B16A16_Float;
 
                         // Adjust next offset if current object has been resized
-                        offsetShift = Utilities.SizeOf<Half4>() - Utilities.SizeOf<Vector3>();
+                        offsetShift = Unsafe.SizeOf<Half4>() - Unsafe.SizeOf<Vector3>();
                         break;
                     case PixelFormat.R32G32B32A32_Float:
                         vertexElementFormat = PixelFormat.R16G16B16A16_Float;
 
                         // Adjust next offset if current object has been resized
-                        offsetShift = Utilities.SizeOf<Half4>() - Utilities.SizeOf<Vector4>();
+                        offsetShift = Unsafe.SizeOf<Half4>() - Unsafe.SizeOf<Vector4>();
                         break;
                 }
 

--- a/sources/engine/Stride.Rendering/Extensions/IndexExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/IndexExtensions.cs
@@ -91,7 +91,7 @@ namespace Stride.Extensions
             }
 
             // Generate index buffer
-            var indexBufferData = new byte[indexMapping.Indices.Length * Utilities.SizeOf<int>()];
+            var indexBufferData = new byte[indexMapping.Indices.Length * sizeof(int)];
             fixed (int* indexDataStart = &indexMapping.Indices[0])
             fixed (byte* indexBufferDataStart = &indexBufferData[0])
             {
@@ -126,7 +126,7 @@ namespace Stride.Extensions
 
             // Create new index buffer
             var indexCount = meshData.IndexBuffer.Count;
-            var indexBufferData = new byte[indexCount * Utilities.SizeOf<ushort>()];
+            var indexBufferData = new byte[indexCount * sizeof(ushort)];
             fixed (byte* oldIndexBufferDataStart = &meshData.IndexBuffer.Buffer.GetDataSafe()[0])
             fixed (byte* indexBufferDataStart = &indexBufferData[0])
             {
@@ -281,7 +281,7 @@ namespace Stride.Extensions
             
             // copy them into a byte[]
             var triangleCount = meshData.IndexBuffer.Count / 3;
-            var indexBufferData = new byte[triangleCount * 12 * Utilities.SizeOf<int>()];
+            var indexBufferData = new byte[triangleCount * 12 * sizeof(int)];
             fixed (int* indexDataStart = &newIndices[0])
             fixed (byte* indexBufferDataStart = &indexBufferData[0])
             {

--- a/sources/engine/Stride.Rendering/Extensions/MergeExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/MergeExtensions.cs
@@ -130,7 +130,7 @@ namespace Stride.Extensions
                             else
                                 sourceBufferContent = CreateShortIndexBuffer(offset, meshDrawData.IndexBuffer.Count, sourceBufferContent, is32Bit);
                         }
-                        
+
                         fixed (byte* sourceBufferDataStart = &sourceBufferContent[0])
                         {
                             Utilities.CopyMemory((IntPtr)destBufferDataCurrent, (IntPtr)sourceBufferDataStart,
@@ -151,7 +151,7 @@ namespace Stride.Extensions
 
             return result;
         }
-        
+
         /// <summary>
         /// Group meshes that can be merged because they have the same vertex declaration.
         /// </summary>
@@ -199,7 +199,7 @@ namespace Stride.Extensions
         {
             if (meshDrawDatas.Count == 0)
                 return new List<List<MeshDraw>>();
-                
+
             if (meshDrawDatas.Count == 1)
                 return new List<List<MeshDraw>> { meshDrawDatas.ToList() };
 
@@ -252,6 +252,7 @@ namespace Stride.Extensions
         public static byte[] CreateShortIndexBuffer(int offset, int count, byte[] baseIndices = null, bool is32Bit = true)
         {
             var indices = new ushort[count];
+            var sizeOf = count * sizeof(ushort);
             if (baseIndices == null)
             {
                 for (var i = 0; i < count; ++i)
@@ -270,7 +271,6 @@ namespace Stride.Extensions
                 }
             }
 
-            var sizeOf = Utilities.SizeOf(indices);
             var buffer = new byte[sizeOf];
             Utilities.Write(buffer, indices, 0, indices.Length);
             return buffer;
@@ -287,6 +287,7 @@ namespace Stride.Extensions
         public static byte[] CreateIntIndexBuffer(int offset, int count, byte[] baseIndices = null, bool is32Bits = true)
         {
             var indices = new uint[count];
+            var sizeOf = count * sizeof(uint);
             if (baseIndices == null)
             {
                 for (var i = 0; i < count; ++i)
@@ -305,7 +306,6 @@ namespace Stride.Extensions
                 }
             }
 
-            var sizeOf = Utilities.SizeOf(indices);
             var buffer = new byte[sizeOf];
             Utilities.Write(buffer, indices, 0, indices.Length);
             return buffer;

--- a/sources/engine/Stride.Rendering/Extensions/PolySortExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/PolySortExtensions.cs
@@ -31,7 +31,7 @@ namespace Stride.Extensions
             }
 
             const int PolySize = 3; // currently only triangle list are supported
-            var polyIndicesSize = PolySize * Utilities.SizeOf<int>();
+            var polyIndicesSize = PolySize * sizeof(int);
             var vertexBuffer = meshData.VertexBuffers[0];
             var oldIndexBuffer = meshData.IndexBuffer;
             var vertexStride = vertexBuffer.Declaration.VertexStride;
@@ -48,7 +48,7 @@ namespace Stride.Extensions
                     var accu = Vector3.Zero;
                     for (var u = 0; u < PolySize; ++u)
                     {
-                        var curIndex = *(int*)(indexBufferPointerStart + Utilities.SizeOf<int>() * (i * PolySize + u));
+                        var curIndex = *(int*)(indexBufferPointerStart + sizeof(int) * (i * PolySize + u));
                         var pVertexPos = (Vector3*)(vertexBufferPointerStart + vertexStride * curIndex);
                         accu += *pVertexPos;
                     }
@@ -64,7 +64,7 @@ namespace Stride.Extensions
             var sortedIndices = sortList.OrderBy(x => Vector3.Dot(x.Value, viewDirectionForSorting)).Select(x => x.Key).ToList();   // TODO have a generic delegate for sorting
             
             // re-write the index buffer
-            var newIndexBufferData = new byte[oldIndexBuffer.Count * Utilities.SizeOf<int>()];
+            var newIndexBufferData = new byte[oldIndexBuffer.Count * sizeof(int)];
             fixed (byte* newIndexDataStart = &newIndexBufferData[0])
             fixed (byte* oldIndexDataStart = &oldIndexBuffer.Buffer.GetSerializationData().Content[0])
             {

--- a/sources/engine/Stride.Rendering/Extensions/VertexExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/VertexExtensions.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core;
 using Stride.Graphics.Data;
@@ -28,11 +29,11 @@ namespace Stride.Extensions
 
             int outputSize = expectedSize * count;
 
-            int checkSize = (int)(outputSize / Utilities.SizeOf<T>()) * Utilities.SizeOf<T>();
+            int checkSize = (int)(outputSize / Unsafe.SizeOf<T>()) * Unsafe.SizeOf<T>();
             if (checkSize != outputSize)
                 throw new ArgumentException(string.Format("Size of T is not a multiple of totalSize {0}", outputSize));
 
-            var output = new T[outputSize / Utilities.SizeOf<T>()];
+            var output = new T[outputSize / Unsafe.SizeOf<T>()];
 
             var handleOutput = GCHandle.Alloc(output, GCHandleType.Pinned);
             var ptrOutput = handleOutput.AddrOfPinnedObject();

--- a/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Core.Threading;
@@ -98,7 +99,7 @@ namespace Stride.Rendering
 
         private static unsafe void SetBufferData<TData>(CommandList commandList, Buffer buffer, TData[] fromData, int elementCount) where TData : struct
         {
-            var dataPointer = new DataPointer(Interop.Fixed(fromData), Math.Min(elementCount, fromData.Length) * Utilities.SizeOf<TData>());
+            var dataPointer = new DataPointer(Interop.Fixed(fromData), Math.Min(elementCount, fromData.Length) * Unsafe.SizeOf<TData>());
             buffer.SetData(commandList, dataPointer);
         }
 

--- a/sources/engine/Stride.VirtualReality/OpenVR/OpenVR.cs
+++ b/sources/engine/Stride.VirtualReality/OpenVR/OpenVR.cs
@@ -9,6 +9,7 @@ using Valve.VR;
 using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Graphics;
+using System.Runtime.CompilerServices;
 
 namespace Stride.VirtualReality
 {
@@ -131,7 +132,7 @@ namespace Stride.VirtualReality
             public bool GetTouchUp(ButtonId buttonId) { return GetTouchUp(1ul << (int)buttonId); }
 
             public Vector2 GetAxis(ButtonId buttonId = ButtonId.ButtonSteamVrTouchpad)
-            {               
+            {
                 var axisId = (uint)buttonId - (uint)EVRButtonId.k_EButton_Axis0;
                 switch (axisId)
                 {
@@ -147,7 +148,7 @@ namespace Stride.VirtualReality
             public void Update()
             {
                 PreviousState = State;
-                Valve.VR.OpenVR.System.GetControllerState(ControllerIndex, ref State, (uint)Utilities.SizeOf<VRControllerState_t>());
+                Valve.VR.OpenVR.System.GetControllerState(ControllerIndex, ref State, (uint)Unsafe.SizeOf<VRControllerState_t>());
             }
         }
 
@@ -254,7 +255,7 @@ namespace Stride.VirtualReality
             pose = Matrix.Identity;
             var eye = eyeIndex == 0 ? EVREye.Eye_Left : EVREye.Eye_Right;
             var eyeToHead = Valve.VR.OpenVR.System.GetEyeToHeadTransform(eye);
-            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref eyeToHead), Utilities.SizeOf<HmdMatrix34_t>());
+            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref eyeToHead), Unsafe.SizeOf<HmdMatrix34_t>());
         }
 
         public static void UpdatePoses()
@@ -291,9 +292,9 @@ namespace Stride.VirtualReality
                 {
                     if (currentIndex == controllerIndex)
                     {
-                        Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref DevicePoses[index].mDeviceToAbsoluteTracking), Utilities.SizeOf<HmdMatrix34_t>());
-                        Utilities.CopyMemory((IntPtr)Interop.Fixed(ref velocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vVelocity), Utilities.SizeOf<HmdVector3_t>());
-                        Utilities.CopyMemory((IntPtr)Interop.Fixed(ref angVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vAngularVelocity), Utilities.SizeOf<HmdVector3_t>());
+                        Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref DevicePoses[index].mDeviceToAbsoluteTracking), Unsafe.SizeOf<HmdMatrix34_t>());
+                        Utilities.CopyMemory((IntPtr)Interop.Fixed(ref velocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vVelocity), Unsafe.SizeOf<HmdVector3_t>());
+                        Utilities.CopyMemory((IntPtr)Interop.Fixed(ref angVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vAngularVelocity), Unsafe.SizeOf<HmdVector3_t>());
 
                         var state = DeviceState.Invalid;
                         if (DevicePoses[index].bDeviceIsConnected && DevicePoses[index].bPoseIsValid)
@@ -326,9 +327,9 @@ namespace Stride.VirtualReality
             angVelocity = Vector3.Zero;
             var index = trackerIndex;
 
-            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref DevicePoses[index].mDeviceToAbsoluteTracking), Utilities.SizeOf<HmdMatrix34_t>());
-            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref velocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vVelocity), Utilities.SizeOf<HmdVector3_t>());
-            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref angVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vAngularVelocity), Utilities.SizeOf<HmdVector3_t>());
+            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref DevicePoses[index].mDeviceToAbsoluteTracking), Unsafe.SizeOf<HmdMatrix34_t>());
+            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref velocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vVelocity), Unsafe.SizeOf<HmdVector3_t>());
+            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref angVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vAngularVelocity), Unsafe.SizeOf<HmdVector3_t>());
 
             var state = DeviceState.Invalid;
             if (DevicePoses[index].bDeviceIsConnected && DevicePoses[index].bPoseIsValid)
@@ -357,9 +358,9 @@ namespace Stride.VirtualReality
             {
                 if (Valve.VR.OpenVR.System.GetTrackedDeviceClass(index) == ETrackedDeviceClass.HMD)
                 {
-                    Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref DevicePoses[index].mDeviceToAbsoluteTracking), Utilities.SizeOf<HmdMatrix34_t>());
-                    Utilities.CopyMemory((IntPtr)Interop.Fixed(ref linearVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vVelocity), Utilities.SizeOf<HmdVector3_t>());
-                    Utilities.CopyMemory((IntPtr)Interop.Fixed(ref angularVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vAngularVelocity), Utilities.SizeOf<HmdVector3_t>());
+                    Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref DevicePoses[index].mDeviceToAbsoluteTracking), Unsafe.SizeOf<HmdMatrix34_t>());
+                    Utilities.CopyMemory((IntPtr)Interop.Fixed(ref linearVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vVelocity), Unsafe.SizeOf<HmdVector3_t>());
+                    Utilities.CopyMemory((IntPtr)Interop.Fixed(ref angularVelocity), (IntPtr)Interop.Fixed(ref DevicePoses[index].vAngularVelocity), Unsafe.SizeOf<HmdVector3_t>());
 
                     var state = DeviceState.Invalid;
                     if (DevicePoses[index].bDeviceIsConnected && DevicePoses[index].bPoseIsValid)
@@ -388,7 +389,7 @@ namespace Stride.VirtualReality
             projection = Matrix.Identity;
             var eye = eyeIndex == 0 ? EVREye.Eye_Left : EVREye.Eye_Right;
             var proj = Valve.VR.OpenVR.System.GetProjectionMatrix(eye, near, far);
-            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref projection), (IntPtr)Interop.Fixed(ref proj), Utilities.SizeOf<Matrix>());
+            Utilities.CopyMemory((IntPtr)Interop.Fixed(ref projection), (IntPtr)Interop.Fixed(ref proj), Unsafe.SizeOf<Matrix>());
         }
 
         public static void ShowMirror()
@@ -406,7 +407,7 @@ namespace Stride.VirtualReality
             var nativeDevice = device.NativeDevice.NativePointer;
             var eyeTexSrv = IntPtr.Zero;
             Valve.VR.OpenVR.Compositor.GetMirrorTextureD3D11(eyeIndex == 0 ? EVREye.Eye_Left : EVREye.Eye_Right, nativeDevice, ref eyeTexSrv);
-            
+
             var tex = new Texture(device);
             var srv = new ShaderResourceView(eyeTexSrv);
 
@@ -436,7 +437,7 @@ namespace Stride.VirtualReality
                 eColorSpace = EColorSpace.Auto,
                 handle = texture.NativeResource.NativePointer,
             };
-           
+
             return Valve.VR.OpenVR.Overlay.SetOverlayTexture(overlayId, ref tex) == EVROverlayError.None;
         }
 
@@ -449,13 +450,13 @@ namespace Stride.VirtualReality
             if (followsHead)
             {
                 HmdMatrix34_t pose = new HmdMatrix34_t();
-                Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref transform), Utilities.SizeOf<HmdMatrix34_t>());
+                Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref transform), Unsafe.SizeOf<HmdMatrix34_t>());
                 Valve.VR.OpenVR.Overlay.SetOverlayTransformTrackedDeviceRelative(overlayId, 0, ref pose);
             }
             else
             {
                 HmdMatrix34_t pose = new HmdMatrix34_t();
-                Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref transform), Utilities.SizeOf<HmdMatrix34_t>());
+                Utilities.CopyMemory((IntPtr)Interop.Fixed(ref pose), (IntPtr)Interop.Fixed(ref transform), Unsafe.SizeOf<HmdMatrix34_t>());
                 Valve.VR.OpenVR.Overlay.SetOverlayTransformAbsolute(overlayId, ETrackingUniverseOrigin.TrackingUniverseSeated, ref pose);
             }
         }

--- a/sources/engine/Stride/Effects/ParameterKey.cs
+++ b/sources/engine/Stride/Effects/ParameterKey.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1402 // File may only contain a single type
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Serialization;
 using Stride.Core.Storage;
@@ -228,7 +229,7 @@ namespace Stride.Rendering
         [DataMemberIgnore]
         public ParameterKeyValueMetadata<T> DefaultValueMetadataT { get; private set; }
 
-        public override int Size => Interop.SizeOf<T>();
+        public override int Size => Unsafe.SizeOf<T>();
 
         public override string ToString()
         {

--- a/sources/engine/Stride/Graphics/DDS.cs
+++ b/sources/engine/Stride/Graphics/DDS.cs
@@ -74,6 +74,7 @@
 // particular purpose and non-infringement.
 #pragma warning disable SA1310 // Field names should not contain underscore
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core;
 
@@ -104,7 +105,7 @@ namespace Stride.Graphics
             /// <param name="aBitMask">A bit mask.</param>
             public DDSPixelFormat(PixelFormatFlags flags, int fourCC, int rgbBitCount, uint rBitMask, uint gBitMask, uint bBitMask, uint aBitMask)
             {
-                Size = Utilities.SizeOf<DDSPixelFormat>();
+                Size = Unsafe.SizeOf<DDSPixelFormat>();
                 Flags = flags;
                 FourCC = fourCC;
                 RGBBitCount = rgbBitCount;

--- a/sources/engine/Stride/Graphics/DDSHelper.cs
+++ b/sources/engine/Stride/Graphics/DDSHelper.cs
@@ -2,17 +2,17 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 //
 // Copyright (c) 2010-2012 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,57 +25,58 @@
 // -----------------------------------------------------------------------------
 // Microsoft Public License (Ms-PL)
 //
-// This license governs use of the accompanying software. If you use the 
+// This license governs use of the accompanying software. If you use the
 // software, you accept this license. If you do not accept the license, do not
 // use the software.
 //
 // 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and 
+// The terms "reproduce," "reproduction," "derivative works," and
 // "distribution" have the same meaning here as under U.S. copyright law.
-// A "contribution" is the original software, or any additions or changes to 
+// A "contribution" is the original software, or any additions or changes to
 // the software.
-// A "contributor" is any person that distributes its contribution under this 
+// A "contributor" is any person that distributes its contribution under this
 // license.
-// "Licensed patents" are a contributor's patent claims that read directly on 
+// "Licensed patents" are a contributor's patent claims that read directly on
 // its contribution.
 //
 // 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the 
-// license conditions and limitations in section 3, each contributor grants 
+// (A) Copyright Grant- Subject to the terms of this license, including the
+// license conditions and limitations in section 3, each contributor grants
 // you a non-exclusive, worldwide, royalty-free copyright license to reproduce
-// its contribution, prepare derivative works of its contribution, and 
+// its contribution, prepare derivative works of its contribution, and
 // distribute its contribution or any derivative works that you create.
 // (B) Patent Grant- Subject to the terms of this license, including the license
-// conditions and limitations in section 3, each contributor grants you a 
+// conditions and limitations in section 3, each contributor grants you a
 // non-exclusive, worldwide, royalty-free license under its licensed patents to
 // make, have made, use, sell, offer for sale, import, and/or otherwise dispose
-// of its contribution in the software or derivative works of the contribution 
+// of its contribution in the software or derivative works of the contribution
 // in the software.
 //
 // 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any 
+// (A) No Trademark License- This license does not grant you rights to use any
 // contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that 
-// you claim are infringed by the software, your patent license from such 
+// (B) If you bring a patent claim against any contributor over patents that
+// you claim are infringed by the software, your patent license from such
 // contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all 
+// (C) If you distribute any portion of the software, you must retain all
 // copyright, patent, trademark, and attribution notices that are present in the
 // software.
-// (D) If you distribute any portion of the software in source code form, you 
-// may do so only under this license by including a complete copy of this 
+// (D) If you distribute any portion of the software in source code form, you
+// may do so only under this license by including a complete copy of this
 // license with your distribution. If you distribute any portion of the software
-// in compiled or object code form, you may only do so under a license that 
+// in compiled or object code form, you may only do so under a license that
 // complies with this license.
 // (E) The software is licensed "as-is." You bear the risk of using it. The
 // contributors give no express warranties, guarantees or conditions. You may
-// have additional consumer rights under your local laws which this license 
-// cannot change. To the extent permitted under your local laws, the 
+// have additional consumer rights under your local laws which this license
+// cannot change. To the extent permitted under your local laws, the
 // contributors exclude the implied warranties of merchantability, fitness for a
 // particular purpose and non-infringement.
 //
 // <auto-generated /> (external file, skip analyzers)
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core;
 
@@ -163,13 +164,13 @@ namespace Stride.Graphics
                                                                  new LegacyMap(PixelFormat.B5G5R5A1_UNorm, ConversionFlags.Format5551, DDS.DDSPixelFormat.A1R5G5B5), // D3DFMT_A1R5G5B5
                                                                  new LegacyMap(PixelFormat.B5G5R5A1_UNorm, ConversionFlags.Format5551
                                                                                                            | ConversionFlags.NoAlpha, new DDS.DDSPixelFormat(DDS.PixelFormatFlags.Rgb, 0, 16, 0x7c00, 0x03e0, 0x001f, 0x0000)), // D3DFMT_X1R5G5B5
-     
+
                                                                  new LegacyMap(PixelFormat.R8G8B8A8_UNorm, ConversionFlags.Expand
                                                                                                            | ConversionFlags.Format8332, new DDS.DDSPixelFormat(DDS.PixelFormatFlags.Rgb, 0, 16, 0x00e0, 0x001c, 0x0003, 0xff00)),
                                                                  // D3DFMT_A8R3G3B2
                                                                  new LegacyMap(PixelFormat.B5G6R5_UNorm, ConversionFlags.Expand
                                                                                                          | ConversionFlags.Format332, new DDS.DDSPixelFormat(DDS.PixelFormatFlags.Rgb, 0, 8, 0xe0, 0x1c, 0x03, 0x00)), // D3DFMT_R3G3B2
-  
+
                                                                  new LegacyMap(PixelFormat.R8_UNorm, ConversionFlags.None, DDS.DDSPixelFormat.L8), // D3DFMT_L8
                                                                  new LegacyMap(PixelFormat.R16_UNorm, ConversionFlags.None, DDS.DDSPixelFormat.L16), // D3DFMT_L16
                                                                  new LegacyMap(PixelFormat.R8G8_UNorm, ConversionFlags.None, DDS.DDSPixelFormat.A8L8), // D3DFMT_A8L8
@@ -297,7 +298,7 @@ namespace Stride.Graphics
             if (headerPtr == IntPtr.Zero)
                 throw new ArgumentException("Pointer to DDS header cannot be null", "headerPtr");
 
-            if (size < (Utilities.SizeOf<DDS.Header>() + sizeof (uint)))
+            if (size < (Unsafe.SizeOf<DDS.Header>() + sizeof (uint)))
                 return false;
 
             // DDS files always start with the same magic number ("DDS ")
@@ -307,7 +308,7 @@ namespace Stride.Graphics
             var header = *(DDS.Header*) ((byte*) headerPtr + sizeof (int));
 
             // Verify header to validate DDS file
-            if (header.Size != Utilities.SizeOf<DDS.Header>() || header.PixelFormat.Size != Utilities.SizeOf<DDS.DDSPixelFormat>())
+            if (header.Size != Unsafe.SizeOf<DDS.Header>() || header.PixelFormat.Size != Unsafe.SizeOf<DDS.DDSPixelFormat>())
                 return false;
 
             // Setup MipLevels
@@ -319,10 +320,10 @@ namespace Stride.Graphics
             if ((header.PixelFormat.Flags & DDS.PixelFormatFlags.FourCC) != 0 && (new FourCC('D', 'X', '1', '0') == header.PixelFormat.FourCC))
             {
                 // Buffer must be big enough for both headers and magic value
-                if (size < (Utilities.SizeOf<DDS.Header>() + sizeof (uint) + Utilities.SizeOf<DDS.HeaderDXT10>()))
+                if (size < (Unsafe.SizeOf<DDS.Header>() + sizeof (uint) + Unsafe.SizeOf<DDS.HeaderDXT10>()))
                     return false;
 
-                var headerDX10 = *(DDS.HeaderDXT10*) ((byte*) headerPtr + sizeof (int) + Utilities.SizeOf<DDS.Header>());
+                var headerDX10 = *(DDS.HeaderDXT10*) ((byte*) headerPtr + sizeof (int) + Unsafe.SizeOf<DDS.Header>());
                 convFlags |= ConversionFlags.DX10;
 
                 description.ArraySize = headerDX10.ArraySize;
@@ -570,52 +571,52 @@ namespace Stride.Graphics
 #endif
                     // Legacy D3DX formats using D3DFMT enum value as FourCC
                     case PixelFormat.R32G32B32A32_Float:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 116; // D3DFMT_A32B32G32R32F
                         break;
                     case PixelFormat.R16G16B16A16_Float:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 113; // D3DFMT_A16B16G16R16F
                         break;
                     case PixelFormat.R16G16B16A16_UNorm:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 36; // D3DFMT_A16B16G16R16
                         break;
                     case PixelFormat.R16G16B16A16_SNorm:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 110; // D3DFMT_Q16W16V16U16
                         break;
                     case PixelFormat.R32G32_Float:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 115; // D3DFMT_G32R32F
                         break;
                     case PixelFormat.R16G16_Float:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 112; // D3DFMT_G16R16F
                         break;
                     case PixelFormat.R32_Float:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 114; // D3DFMT_R32F
                         break;
                     case PixelFormat.R16_Float:
-                        ddpf.Size = Utilities.SizeOf<DDS.DDSPixelFormat>();
+                        ddpf.Size = Unsafe.SizeOf<DDS.DDSPixelFormat>();
                         ddpf.Flags = DDS.PixelFormatFlags.FourCC;
                         ddpf.FourCC = 111; // D3DFMT_R16F
                         break;
                 }
             }
 
-            required = sizeof (int) + Utilities.SizeOf<DDS.Header>();
+            required = sizeof (int) + Unsafe.SizeOf<DDS.Header>();
 
             if (ddpf.Size == 0)
-                required += Utilities.SizeOf<DDS.HeaderDXT10>();
+                required += Unsafe.SizeOf<DDS.HeaderDXT10>();
 
             if (pDestination == IntPtr.Zero)
                 return;
@@ -627,8 +628,8 @@ namespace Stride.Graphics
 
             var header = (DDS.Header*)((byte*)(pDestination) + sizeof (int));
 
-            Utilities.ClearMemory((IntPtr)header, 0, Utilities.SizeOf<DDS.Header>());
-            header->Size = Utilities.SizeOf<DDS.Header>();
+            Utilities.ClearMemory((IntPtr)header, 0, Unsafe.SizeOf<DDS.Header>());
+            header->Size = Unsafe.SizeOf<DDS.Header>();
             header->Flags = DDS.HeaderFlags.Texture;
             header->SurfaceFlags = DDS.SurfaceFlags.Texture;
 
@@ -691,9 +692,9 @@ namespace Stride.Graphics
             {
                 header->PixelFormat = DDS.DDSPixelFormat.DX10;
 
-                var ext = (DDS.HeaderDXT10*)((byte*)(header) + Utilities.SizeOf<DDS.Header>());
+                var ext = (DDS.HeaderDXT10*)((byte*)(header) + Unsafe.SizeOf<DDS.Header>());
 
-                Utilities.ClearMemory((IntPtr) ext, 0, Utilities.SizeOf<DDS.HeaderDXT10>());
+                Utilities.ClearMemory((IntPtr) ext, 0, Unsafe.SizeOf<DDS.HeaderDXT10>());
 
                 ext->DXGIFormat = description.Format;
                 switch (description.Dimension)
@@ -773,7 +774,7 @@ namespace Stride.Graphics
         /// <param name="inFormat"></param>
         /// <param name="pal8"></param>
         /// <param name="flags"></param>
-        static unsafe bool LegacyExpandScanline( IntPtr pDestination, int outSize, PixelFormat outFormat, 
+        static unsafe bool LegacyExpandScanline( IntPtr pDestination, int outSize, PixelFormat outFormat,
                                             IntPtr pSource, int inSize, TEXP_LEGACY_FORMAT inFormat,
                                             uint* pal8, ScanlineFlags flags )
         {
@@ -911,7 +912,7 @@ namespace Stride.Graphics
                     {
 #if DIRECTX11_1
                 case PixelFormat.B4G4R4A4_UNorm :
-                    // D3DFMT_A4L4 -> PixelFormat.B4G4R4A4_UNorm 
+                    // D3DFMT_A4L4 -> PixelFormat.B4G4R4A4_UNorm
                     {
                         byte * sPtr = (byte*)(pSource);
                         short * dPtr = (short*)(pDestination);
@@ -1000,9 +1001,9 @@ namespace Stride.Graphics
             if (!DecodeDDSHeader(pSource, size, flags, out mdata, out convFlags))
                 return null;
 
-            int offset = sizeof (uint) + Utilities.SizeOf<DDS.Header>();
+            int offset = sizeof (uint) + Unsafe.SizeOf<DDS.Header>();
             if ((convFlags & ConversionFlags.DX10) != 0)
-                offset += Utilities.SizeOf<DDS.HeaderDXT10>();
+                offset += Unsafe.SizeOf<DDS.HeaderDXT10>();
 
             var pal8 = (uint*) 0;
             if ((convFlags & ConversionFlags.Pal8) != 0)
@@ -1628,6 +1629,6 @@ namespace Stride.Graphics
 
             Utilities.CopyMemory(pDestination, pSource, Math.Min(outSize, inSize));
         }
- 
+
     }
 }

--- a/sources/engine/Stride/Graphics/PixelBuffer.cs
+++ b/sources/engine/Stride/Graphics/PixelBuffer.cs
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Stride.Core;
 
 namespace Stride.Graphics
@@ -231,7 +232,7 @@ namespace Stride.Graphics
         /// </remarks>
         public T[] GetPixels<T>(int yOffset = 0) where T : struct
         {
-            var sizeOfOutputPixel = Utilities.SizeOf<T>();
+            var sizeOfOutputPixel = Unsafe.SizeOf<T>();
             var totalSize = Width * Height * pixelSize;
             if ((totalSize % sizeOfOutputPixel) != 0)
                 throw new ArgumentException(string.Format("Invalid sizeof(T), not a multiple of current size [{0}]in bytes ", totalSize));
@@ -280,7 +281,7 @@ namespace Stride.Graphics
             }
             else
             {
-                var sizeOfOutputPixel = Utilities.SizeOf<T>() * pixelCount;
+                var sizeOfOutputPixel = Unsafe.SizeOf<T>() * pixelCount;
                 var sizePerWidth = sizeOfOutputPixel / Width;
                 var remainingPixels = sizeOfOutputPixel % Width;
                 for (int i = 0; i < sizePerWidth; i++)
@@ -334,7 +335,7 @@ namespace Stride.Graphics
             }
             else
             {
-                var sizeOfOutputPixel = Utilities.SizeOf<T>() * pixelCount;
+                var sizeOfOutputPixel = Unsafe.SizeOf<T>() * pixelCount;
                 var sizePerWidth = sizeOfOutputPixel / Width;
                 var remainingPixels = sizeOfOutputPixel % Width;
                 for (int i = 0; i < sizePerWidth; i++)

--- a/sources/engine/Stride/Rendering/ParameterCollection.cs
+++ b/sources/engine/Stride/Rendering/ParameterCollection.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core;
 using Stride.Core.Collections;
@@ -293,7 +294,7 @@ namespace Stride.Rendering
             var parameter = GetAccessor(key);
 
             // Align to float4
-            var stride = (Utilities.SizeOf<T>() + 15) / 16 * 16;
+            var stride = (Unsafe.SizeOf<T>() + 15) / 16 * 16;
             var values = new T[parameter.Count];
 
             fixed (byte* dataValues = DataValues)
@@ -327,7 +328,7 @@ namespace Stride.Rendering
             }
 
             // Align to float4
-            var stride = (Utilities.SizeOf<T>() + 15) / 16 * 16;
+            var stride = (Unsafe.SizeOf<T>() + 15) / 16 * 16;
             var sizeInBytes = sourceParameter.Count * stride;
 
             fixed (byte* sourceDataValues = DataValues)
@@ -373,7 +374,7 @@ namespace Stride.Rendering
         public unsafe void Set<T>(ValueParameter<T> parameter, int count, ref T firstValue) where T : struct
         {
             // Align to float4
-            var stride = (Utilities.SizeOf<T>() + 15) / 16 * 16;
+            var stride = (Unsafe.SizeOf<T>() + 15) / 16 * 16;
             var elementCount = parameter.Count;
             if (count > elementCount)
             {


### PR DESCRIPTION
# PR Details

Get rid of P/Invoke SizeOf.

## Description

Eliminates all references to `Stride.Core.Interop.SizeOf<T>()`.

## Related Issue

#1461 

## Motivation and Context

See issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] ~Docs change~ / refactoring / ~dependency upgrade~
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - Use of `Utilities.SizeOf<T>()` and `Utilities.SizeOf<T>(T[])` will now produce warnings with text suggesting alternatives

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

All tests that pass in `master` on my computer pass in this branch too. `TestCopyPasteEntityAsChild` didn't pass running all tests from this branch while it passed in `master`, but passed when stepping through.