### PR TITLE
Migrate `[RemoveInitLocals]` to `[SkipLocalsInit]` and obsolete `RemoveInitLocalsAttribute`

### DIFF
--- a/sources/core/Stride.Core/IL/RemoveInitLocalsAttribute.cs
+++ b/sources/core/Stride.Core/IL/RemoveInitLocalsAttribute.cs
@@ -8,7 +8,7 @@ namespace Stride.Core.IL
     /// <summary>
     /// Using this optimization attribute will prevent local variables in this method to be zero-ed in the prologue (if the runtime supports it).
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method), Obsolete("Use System.Runtime.CompilerServices.SkipLocalsInitAttribute")]
     public class RemoveInitLocalsAttribute : Attribute
     {
     }

--- a/sources/engine/Stride.Rendering/Rendering/EffectValidator.cs
+++ b/sources/engine/Stride.Rendering/Rendering/EffectValidator.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Stride.Core.Collections;
-using Stride.Core.Extensions;
-using Stride.Core.IL;
-using Stride.Rendering;
 
 namespace Stride.Rendering
 {
@@ -30,10 +28,11 @@ namespace Stride.Rendering
 
         public void Initialize()
         {
-            EffectValues = new FastListStruct<EffectParameterEntry>(4);
-            
-            // Add a dummy value so that an effect without parameter fails validation first time
-            EffectValues.Add(new EffectParameterEntry());
+            EffectValues = new FastListStruct<EffectParameterEntry>(4)
+            {
+                // Add a dummy value so that an effect without parameter fails validation first time
+                new EffectParameterEntry()
+            };
         }
 
         public void BeginEffectValidation()
@@ -43,7 +42,7 @@ namespace Stride.Rendering
             ShouldSkip = false;
         }
 
-        [RemoveInitLocals]
+        [SkipLocalsInit]
         public void ValidateParameter<T>(PermutationParameterKey<T> key, T value)
         {
             // Check if value was existing and/or same
@@ -68,7 +67,7 @@ namespace Stride.Rendering
                 effectChanged = true;
             }
         }
-        
+
         public bool EndEffectValidation()
         {
             if (effectValuesValidated < EffectValues.Count)


### PR DESCRIPTION
Migrate `[RemoveInitLocals]` to `[SkipLocalsInit]` and obsolete `RemoveInitLocalsAttribute`

## Related Issue

Similar in spirit to #1461.

## Motivation and Context

Eliminates one usage scenario of IL weaving.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Use of `[RemoveInitLocals]` will produce a compiler warning and direct the developer to using `[SkipLocalsInit]` instead.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.