### PR TITLE
Change MaterialAssetCompilers build dependency type to other materials (#1477)

### DIFF
--- a/sources/engine/Stride.Assets/Materials/MaterialAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Materials/MaterialAssetCompiler.cs
@@ -23,7 +23,7 @@ namespace Stride.Assets.Materials
         public override IEnumerable<BuildDependencyInfo> GetInputTypes(AssetItem assetItem)
         {
             yield return new BuildDependencyInfo(typeof(TextureAsset), typeof(AssetCompilationContext), BuildDependencyType.Runtime);
-            yield return new BuildDependencyInfo(typeof(MaterialAsset), typeof(AssetCompilationContext), BuildDependencyType.CompileAsset);
+            yield return new BuildDependencyInfo(typeof(MaterialAsset), typeof(AssetCompilationContext), BuildDependencyType.Runtime);
             yield return new BuildDependencyInfo(typeof(GameSettingsAsset), typeof(AssetCompilationContext), BuildDependencyType.CompileAsset);
         }
 


### PR DESCRIPTION
# PR Details

Set in the MaterialAssetCompiler the BuildDependencyType to materials to Runtime to resolve the issue described in #1477.

## Description

Change the BuildDependencyType to materials to BuildDependencyType.Runtime (as it is in the ModelAssetCompiler). So the AssetDependenciesCompiler also compiles materials referenced by material layers.

## Related Issue

Closes #1477

## Motivation and Context

I'm not able to compile my project with the explained asset setup. With that change it works.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.