### PR TITLE
[Rendering] Adds support for DrawAuto and ArgumentBuffer to MeshDraw

### DIFF
--- a/sources/engine/Stride.Graphics/ArgumentBufferBinding.cs
+++ b/sources/engine/Stride.Graphics/ArgumentBufferBinding.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Stride contributors (https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using Stride.Core.Serialization;
+using Stride.Core.Serialization.Serializers;
+
+namespace Stride.Graphics
+{
+    [DataSerializer(typeof(ArgumentBufferBinding.Serializer))]
+    public class ArgumentBufferBinding
+    {
+        public ArgumentBufferBinding(Buffer indexBuffer, int alignedByteOffset = 0)
+        {
+            if (indexBuffer == null) throw new ArgumentNullException("argmentBuffer");
+            Buffer = indexBuffer;
+            AlignedByteOffset = alignedByteOffset;
+        }
+
+        public Buffer Buffer { get; private set; }
+        public int AlignedByteOffset { get; private set; }
+
+        internal class Serializer : DataSerializer<ArgumentBufferBinding>
+        {
+            public override void Serialize(ref ArgumentBufferBinding argumentBufferBinding, ArchiveMode mode, SerializationStream stream)
+            {
+                if (mode == ArchiveMode.Deserialize)
+                {
+                    var buffer = stream.Read<Buffer>();
+                    var offset = stream.ReadInt32();
+
+                    argumentBufferBinding = new ArgumentBufferBinding(buffer, offset);
+                }
+                else
+                {
+                    stream.Write(argumentBufferBinding.Buffer);
+                    stream.Write(argumentBufferBinding.AlignedByteOffset);
+                }
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
@@ -136,11 +136,13 @@ namespace Stride.Rendering.Materials
                         var oldMeshDraw = renderMesh.ActiveMeshDraw;
                         tessellationMeshDraw = new MeshDraw
                         {
-                            VertexBuffers = oldMeshDraw.VertexBuffers,
-                            IndexBuffer = oldMeshDraw.IndexBuffer,
+                            PrimitiveType = tessellationState.Method.GetPrimitiveType(),
                             DrawCount = oldMeshDraw.DrawCount,
                             StartLocation = oldMeshDraw.StartLocation,
-                            PrimitiveType = tessellationState.Method.GetPrimitiveType(),
+                            DrawAuto = oldMeshDraw.DrawAuto,
+                            VertexBuffers = oldMeshDraw.VertexBuffers,
+                            IndexBuffer = oldMeshDraw.IndexBuffer,
+                            ArgumentBuffer = oldMeshDraw.ArgumentBuffer,
                         };
 
                         // adapt the primitive type and index buffer to the tessellation used

--- a/sources/engine/Stride.Rendering/Rendering/MeshDraw.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshDraw.cs
@@ -16,8 +16,12 @@ namespace Stride.Rendering
 
         public int StartLocation;
 
+        public bool DrawAuto;
+
         public VertexBufferBinding[] VertexBuffers;
 
         public IndexBufferBinding IndexBuffer;
+
+        public ArgumentBufferBinding ArgumentBuffer;
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
@@ -215,19 +215,37 @@ namespace Stride.Rendering
                 commandList.SetDescriptorSets(0, descriptorSetsLocal);
                 
                 // Draw
-                if (drawData.IndexBuffer == null)
+                if (drawData.IndexBuffer is null)
                 {
-                    if (renderMesh.InstanceCount > 0)
-                        commandList.DrawInstanced(drawData.DrawCount, renderMesh.InstanceCount, drawData.StartLocation);
+                    if (drawData.DrawAuto)
+                    {
+                        commandList.DrawAuto();
+                    }
+                    else if (drawData.ArgumentBuffer is null)
+                    {
+                        if (renderMesh.InstanceCount > 0)
+                            commandList.DrawInstanced(drawData.DrawCount, renderMesh.InstanceCount, drawData.StartLocation);
+                        else
+                            commandList.Draw(drawData.DrawCount, drawData.StartLocation);
+                    }
                     else
-                        commandList.Draw(drawData.DrawCount, drawData.StartLocation);
+                    {
+                        commandList.DrawInstanced(drawData.ArgumentBuffer.Buffer, drawData.ArgumentBuffer.AlignedByteOffset);
+                    }
                 }
                 else
                 {
-                    if (renderMesh.InstanceCount > 0)
-                        commandList.DrawIndexedInstanced(drawData.DrawCount, renderMesh.InstanceCount, drawData.StartLocation);
+                    if (drawData.ArgumentBuffer is null)
+                    {
+                        if (renderMesh.InstanceCount > 0)
+                            commandList.DrawIndexedInstanced(drawData.DrawCount, renderMesh.InstanceCount, drawData.StartLocation);
+                        else
+                            commandList.DrawIndexed(drawData.DrawCount, drawData.StartLocation);
+                    }
                     else
-                        commandList.DrawIndexed(drawData.DrawCount, drawData.StartLocation);
+                    {
+                        commandList.DrawIndexedInstanced(drawData.ArgumentBuffer.Buffer, drawData.ArgumentBuffer.AlignedByteOffset);
+                    }
                 }
             }
         }


### PR DESCRIPTION


# PR Details

Adds a `DrawAuto` flag and `ArgumentBufferBinding` to `MeshDraw`.

## Description

The new fields will be read by the `MeshRenderFeature` to select the right draw call method.

Questions:
I've just copied the IndexBufferBinding, does this even need a serializer? Also, does it need an asset version increase?
Is the args buffer even placed correctly there? Other ideas on how to solve this are welcome.

## Related Issue

Fixes #1481

## Motivation and Context

Generate geometry on the GPU.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.