### PR TITLE
Fix TopDownRPG sample punch animation

### DIFF
--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Core/Utils.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Core/Utils.cs
@@ -164,7 +164,7 @@ namespace TopDownRPG.Core
             var minDistance = float.PositiveInfinity;
 
             var result = new FastList<HitResult>();
-            simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ(), result);
+            simulation.RaycastPenetrating(vectorNear.XYZ(), vectorFar.XYZ(), result, hitTriggers: true);
             foreach (var hitResult in result)
             {
                 ClickType type = ClickType.Empty;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
 Fix TopDownRPG punch animation caused in raycast not detecting trigger collider when attacking.

## Description

<!--- Describe your changes in detail -->
Punch logic uses raycast check with a trigger collider.
#1105 disabled trigger check by default, which is a breaking change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.