### PR TITLE
[Template] Fix first and third person delta time usage

### DIFF
--- a/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/PlayerInput.cs
+++ b/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/PlayerInput.cs
@@ -91,6 +91,11 @@ namespace FirstPersonShooter.Player
                     cameraDirection = Vector2.Zero;
                 else
                     cameraDirection.Normalize();
+                
+                // Contrary to a mouse, driving camera rotation from a stick must be scaled by delta time.
+                // The amount of camera rotation with a stick is constant over time based on the tilt of the stick,
+                // Whereas mouse driven rotation is already constrained by time, it is driven by the difference in position from last *time* to this *time*.
+                cameraDirection *= (float)this.Game.UpdateTime.Elapsed.TotalSeconds;
 
                 // Mouse-based camera rotation.
                 //  Only enabled after you click the screen to lock your cursor, pressing escape will cancel it.

--- a/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/WeaponScript.cs
+++ b/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/WeaponScript.cs
@@ -77,7 +77,7 @@ namespace FirstPersonShooter.Player
             bool didReload;
             reloadEvent.TryReceive(out didReload);
 
-            cooldownRemaining = (cooldownRemaining > 0) ? (cooldownRemaining - this.GetSimulation().FixedTimeStep) : 0f;
+            cooldownRemaining = (cooldownRemaining > 0) ? (cooldownRemaining - (float)this.Game.UpdateTime.Elapsed.TotalSeconds) : 0f;
             if (cooldownRemaining > 0)
                 return; // Can't shoot yet
 

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/Assets/MainScene.sdscene
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/Assets/MainScene.sdscene
@@ -2861,7 +2861,7 @@ Hierarchy:
                         JumpReactionThreshold: 0.15
                     809bf66aef692646891c293be4ca17b2: !ThirdPersonPlatformer.Player.PlayerInput,ThirdPersonPlatformer.Game
                         Id: 6af69b80-69ef-4626-891c-293be4ca17b2
-                        MouseSensitivity: 100.0
+                        MouseSensitivity: 1.0
                         DeadZone: 0.25
                         Camera: ref!! 65d1b71f-4862-4efc-b7c1-3c9d933979c7
                         KeysLeft:

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Camera/ThirdPersonCamera.cs
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Camera/ThirdPersonCamera.cs
@@ -121,22 +121,20 @@ namespace ThirdPersonPlatformer.Camera
         /// </summary>
         private void UpdateCameraOrientation()
         {
-            var dt = this.GetSimulation().FixedTimeStep;
-
             // Camera movement from player input
             Vector2 cameraMovement;
             cameraDirectionEvent.TryReceive(out cameraMovement);
 
             if (InvertY) cameraMovement.Y *= -1;
-            targetRotationXYZ.X += cameraMovement.Y * dt * VerticalSpeed;
+            targetRotationXYZ.X += cameraMovement.Y * VerticalSpeed;
             targetRotationXYZ.X = Math.Max(targetRotationXYZ.X, -MaxVerticalAngle);
             targetRotationXYZ.X = Math.Min(targetRotationXYZ.X, -MinVerticalAngle);
 
             if (InvertX) cameraMovement.X *= -1;
-            targetRotationXYZ.Y -= cameraMovement.X * dt * RotationSpeed;
+            targetRotationXYZ.Y -= cameraMovement.X * RotationSpeed;
 
             // Very simple lerp to allow smoother transition of the camera towards its desired destination. You can change this behavior with a different one, better suited for your game.
-            cameraRotationXYZ = Vector3.Lerp(cameraRotationXYZ, targetRotationXYZ, 0.15f);
+            cameraRotationXYZ = Vector3.Lerp(cameraRotationXYZ, targetRotationXYZ, 0.25f);
             Entity.GetParent().Transform.RotationEulerXYZ = new Vector3(MathUtil.DegreesToRadians(cameraRotationXYZ.X), MathUtil.DegreesToRadians(cameraRotationXYZ.Y), 0);
         }
 

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Player/PlayerInput.cs
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Player/PlayerInput.cs
@@ -30,7 +30,7 @@ namespace ThirdPersonPlatformer.Player
         /// <summary>
         /// Multiplies move movement by this amount to apply aim rotations
         /// </summary>
-        public float MouseSensitivity = 100.0f;
+        public float MouseSensitivity = 1f;
 
         public List<Keys> KeysLeft { get; } = new List<Keys>();
 
@@ -97,6 +97,11 @@ namespace ThirdPersonPlatformer.Player
                     cameraDirection = Vector2.Zero;
                 else
                     cameraDirection.Normalize();
+                
+                // Contrary to a mouse, driving camera rotation from a stick must be scaled by delta time.
+                // The amount of camera rotation with a stick is constant over time based on the tilt of the stick,
+                // Whereas mouse driven rotation is already constrained by time, it is driven by the difference in position from last *time* to this *time*.
+                cameraDirection *= (float)this.Game.UpdateTime.Elapsed.TotalSeconds;
 
                 // Mouse-based camera rotation. Only enabled after you click the screen to lock your cursor, pressing escape cancels this
                 if (Input.IsMouseButtonDown(MouseButton.Left))


### PR DESCRIPTION
# PR Details
Some points in the template use `this.GetSimulation().FixedTimeStep` as the delta time, that represents the delta between fixed update of the physics simulation, not the delta between each update of the game loop.
It also tends to apply that delta to mouse input, which leads to sluggish controls.

Also very small change to camera interpolation for TPP, the camera now comes slightly faster to rest, easier to gauge distances to jump when the camera is not rotating.

## Related Issue
None.

## Motivation and Context
Fix bug.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.