### PR TITLE
DebugTextSystem configurable time on-screen

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -17,7 +17,7 @@ namespace Stride.Profiling
             public string Message;
             public Int2 Position;
             public Color4 TextColor;
-            public TimeSpan RemeaningTime;
+            public TimeSpan RemainingTime;
         }
         
         private FastTextRenderer fastTextRenderer;
@@ -46,7 +46,7 @@ namespace Stride.Profiling
                 Message = message,
                 Position = position,
                 TextColor = color ?? TextColor,
-                RemeaningTime = timeOnScreen ?? DefaultOnScreenTime,
+                RemainingTime = timeOnScreen ?? DefaultOnScreenTime,
             };
 
             overlayMessages.Add(msg);
@@ -111,9 +111,9 @@ namespace Stride.Profiling
                     fastTextRenderer.Begin(Game.GraphicsContext);
                 }
 
-                msg.RemeaningTime -= gameTime.Elapsed;
+                msg.RemainingTime -= gameTime.Elapsed;
 
-                if (msg.RemeaningTime < TimeSpan.Zero)
+                if (msg.RemainingTime < TimeSpan.Zero)
                 {
                     overlayMessages.RemoveAt(index);
                 }

--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -37,43 +37,18 @@ namespace Stride.Profiling
         /// </summary>
         /// <param name="message"></param>
         /// <param name="position"></param>
-        public void Print(string message, Int2 position)
-        {
-            Print(message, position, TextColor, DefaultOnScreenTime);
-        }
-
-        /// <summary>
-        /// Print a custom overlay message
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="position"></param>
-        /// <param name="color"></param>
-        public void Print(string message, Int2 position, Color4 color)
-        {
-            Print(message, position, color, DefaultOnScreenTime);
-        }
-
-        /// <summary>
-        /// Print a custom overlay message
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="position"></param>
-        /// <param name="timeOnScreen"></param>
-        public void Print(string message, Int2 position, TimeSpan timeOnScreen)
-        {
-            Print(message, position, TextColor, timeOnScreen);
-        }
-
-        /// <summary>
-        /// Print a custom overlay message
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="position"></param>
         /// <param name="color"></param>
         /// <param name="timeOnScreen"></param>
-        public void Print(string message, Int2 position, Color4 color, TimeSpan timeOnScreen)
+        public void Print(string message, Int2 position, Color4? color = null, TimeSpan? timeOnScreen = null)
         {
-            var msg = new DebugOverlayMessage { Message = message, Position = position, TextColor = color, RemeaningTime = timeOnScreen };
+            var msg = new DebugOverlayMessage 
+            { 
+                Message = message,
+                Position = position,
+                TextColor = color ?? TextColor,
+                RemeaningTime = timeOnScreen ?? DefaultOnScreenTime,
+            };
+
             overlayMessages.Add(msg);
 
             //drop one old message if the tail size has been reached
@@ -91,7 +66,7 @@ namespace Stride.Profiling
         /// <summary>
         /// Sets or gets the time that messages will stay on screen by default.
         /// </summary>
-        public TimeSpan DefaultOnScreenTime { get; set; } = TimeSpan.FromSeconds(1);
+        public TimeSpan DefaultOnScreenTime { get; set; } = TimeSpan.Zero;
 
         /// <summary>
         /// Sets or gets the size of the messages queue, older messages will be discarded if the size is greater.
@@ -100,8 +75,6 @@ namespace Stride.Profiling
 
         public override void Update(GameTime gameTime)
         {
-            // if you keep this, the timmers would not work
-            //overlayMessages.Clear();
         }
 
         public override void Draw(GameTime gameTime)

--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -99,6 +99,7 @@ namespace Stride.Profiling
             var currentColor = TextColor;
             fastTextRenderer.Begin(Game.GraphicsContext);
 
+            // the loop is done backwards so when removing elements from the list you don't change the index of elements that weren't processed already
             for (int index = overlayMessages.Count - 1; index > 0; index--)
             {
                 var msg = overlayMessages[index];

--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -39,7 +39,7 @@ namespace Stride.Profiling
         /// <param name="position"></param>
         public void Print(string message, Int2 position)
         {
-            Print(message, position, TextColor);
+            Print(message, position, TextColor, DefaultOnScreenTime);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Stride.Profiling
         /// <param name="color"></param>
         public void Print(string message, Int2 position, Color4 color)
         {
-            Print(message, position, color, TimeSpan.Zero);
+            Print(message, position, color, DefaultOnScreenTime);
         }
 
         /// <summary>
@@ -87,6 +87,11 @@ namespace Stride.Profiling
         /// Sets or gets the color to use when drawing the profiling system fonts.
         /// </summary>
         public Color4 TextColor { get; set; } = Color.LightGreen;
+
+        /// <summary>
+        /// Sets or gets the time that messages will stay on screen by default.
+        /// </summary>
+        public TimeSpan DefaultOnScreenTime { get; set; } = TimeSpan.FromSeconds(1);
 
         /// <summary>
         /// Sets or gets the size of the messages queue, older messages will be discarded if the size is greater.


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes a queue into a list so it can be iterated.

Added variable to hold the default time on screen with an arbitrary value of 1 second.

Added methods to expose the configurable times to the user.

Removed clearing the message queue on every update.

Deleted duplicated if check.

Changed foreach into a for loop that can remove entries after they "expire".

## Related Issue

None that i know

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Debug text dissapear too fast to be useful by itself in a lot of cases

## Types of changes

The changes made on the code allows the user set how much do they want the text to stay on screen in each message and the default value when it's not specified.

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.