### PR TITLE
Fix Matrix.Invert to behave as before #1301

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Matrix.cs
+++ b/sources/core/Stride.Core.Mathematics/Matrix.cs
@@ -50,7 +50,7 @@ namespace Stride.Core.Mathematics
         /// Dotnet's <see cref="System.Numerics.Matrix4x4"/> are row major.
         /// </remarks>
         public const bool LayoutIsRowMajor = false;
-        
+
         /// <summary>
         /// The size of the <see cref="Stride.Core.Mathematics.Matrix"/> type, in bytes.
         /// </summary>
@@ -504,6 +504,7 @@ namespace Stride.Core.Mathematics
 
         /// <summary>
         /// Inverts the matrix.
+        /// If the matrix cannot be inverted (eg. Determinant was zero), then the matrix will be set equivalent to <see cref="Zero"/>.
         /// </summary>
         public void Invert()
         {
@@ -1352,6 +1353,7 @@ namespace Stride.Core.Mathematics
 
         /// <summary>
         /// Calculates the inverse of the specified matrix.
+        /// If the matrix cannot be inverted (eg. Determinant was zero), then <paramref name="result"/> will be <see cref="Zero"/>.
         /// </summary>
         /// <param name="value">The matrix whose inverse is to be calculated.</param>
         /// <param name="result">When the method completes, contains the inverse of the specified matrix.</param>
@@ -1359,11 +1361,15 @@ namespace Stride.Core.Mathematics
         {
             // Invert works the same in row and column major, no need to transpose
             Unsafe.SkipInit(out result);
-            MatrixDotnet.Invert(UnsafeRefAsDotNet(value), out UnsafeRefAsDotNet(result));
+            if (!MatrixDotnet.Invert(UnsafeRefAsDotNet(value), out UnsafeRefAsDotNet(result)))
+            {
+                result = Zero;
+            }
         }
 
         /// <summary>
         /// Calculates the inverse of the specified matrix.
+        /// If the matrix cannot be inverted (eg. Determinant was zero), then the returning matrix will be <see cref="Zero"/>.
         /// </summary>
         /// <param name="value">The matrix whose inverse is to be calculated.</param>
         /// <returns>The inverse of the specified matrix.</returns>
@@ -3080,7 +3086,7 @@ namespace Stride.Core.Mathematics
                 }
             }
         }
-        
+
         static ref MatrixDotnet UnsafeRefAsDotNet(in Matrix m) => ref Unsafe.As<Matrix, MatrixDotnet>(ref Unsafe.AsRef(in m));
         static ref Matrix UnsafeRefFromDotNet(in MatrixDotnet m) => ref Unsafe.As<MatrixDotnet, Matrix>(ref Unsafe.AsRef(in m));
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix Matrix.Invert to return zero matrix if inversion fails, which is how it previously behaved before #1301.
This is because System.Numerics.Matrix4x4.Invert behaves differently and sets the matrix to NaNs on failure (but has a bool return value to check which we don't have).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Revert to previous behavior since NaN can cause issues.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.