### PR TITLE
Add build support to referencing projects that use SemVer 2.0.0 format

### DIFF
--- a/sources/core/Stride.Core.Design.Tests/TestPackageVersion.cs
+++ b/sources/core/Stride.Core.Design.Tests/TestPackageVersion.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Collections.Generic;
+
+using Xunit;
+using Stride.Core;
+
+namespace Stride.Core.Design.Tests
+{
+    public class TestPackageVersion
+    {
+        [Theory]
+        [InlineData("1.0.0")]
+        [InlineData("1.10.100")]
+        [InlineData("1.0.0-alpha", "1.0.0", "alpha")]
+        [InlineData("1.0.0-beta", "1.0.0", "beta")]
+        [InlineData("1.0.0-RC", "1.0.0", "RC")]
+        [InlineData("1.0.0-0", "1.0.0", "0")]
+        [InlineData("1.0.0-0.1.2", "1.0.0", "0.1.2")]
+        [InlineData("1.0.0-alpha.1", "1.0.0", "alpha.1")]
+        [InlineData("1.0.0-alpha.1.0.1", "1.0.0", "alpha.1.0.1")]
+        [InlineData("1.0.0-alpha+001", "1.0.0", "alpha")]
+        [InlineData("1.0.0-rc.1+001", "1.0.0", "rc.1")]
+        [InlineData("1.0.0+build001", "1.0.0", "")]
+        [InlineData("1.0.0.1", "1.0.0.1", "", true)]
+        [InlineData("1.0.0.1-alpha", "1.0.0.1", "alpha", true)]
+        [InlineData("1.0.0.1-alpha+build", "1.0.0.1", "alpha", true)]
+        [InlineData("1.0.0.1+build", "1.0.0.1", "", true)]
+        public void TestParseVersionsByValidVersionStrings(string versionString, string expectedVersionNumber = null, string expectedSpecialVersion = "", bool isFourDigitVersion = false)
+        {
+            expectedVersionNumber ??= versionString;
+
+            Assert.True(PackageVersion.TryParse(versionString, out var pkgVersion), $"Failed to parse '{versionString}'");
+
+            var actualVerStr = pkgVersion.Version.ToString(fieldCount: isFourDigitVersion ? 4 : 3);
+            Assert.Equal(expectedVersionNumber, actualVerStr);
+
+            Assert.Equal(expectedSpecialVersion, pkgVersion.SpecialVersion);
+        }
+    }
+}

--- a/sources/core/Stride.Core.Design/PackageVersion.cs
+++ b/sources/core/Stride.Core.Design/PackageVersion.cs
@@ -24,8 +24,8 @@ namespace Stride.Core
     public sealed partial class PackageVersion : IComparable, IComparable<PackageVersion>, IEquatable<PackageVersion>
     {
         private const RegexOptions Flags = RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
-        private static readonly Regex SemanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", Flags);
-        private static readonly Regex StrictSemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[a-z][0-9a-z-]*)?$", Flags);
+        private static readonly Regex SemanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[0-9a-z]*[\.0-9a-z-]*)?(?<BuildMetadata>\+[0-9a-z]*[\.0-9a-z-]*)?$", Flags);
+        private static readonly Regex StrictSemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[0-9a-z]*[\.0-9a-z-]*)?(?<BuildMetadata>\+[0-9a-z]*[\.0-9a-z-]*)?$", Flags);
         private readonly string originalString;
 
         /// <summary>


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title above -->
http://semver.org now has Semantic Versioning 2.0.0 and if you reference a csproj that contains something like `<PackageVersion>1.0.0-rc.3</PackageVersion>` (a valid SemVer 2.0.0 format), Stride's Asset compiler will error and you can't build your project.

## Description

<!--- Describe your changes in detail -->
Expand regex for supporting `.` within "pre-release version", and ignore "build metadata".
Also note that the regex pattern for the "pre-release version" has expanded to allow alphanumeric instead of just an alphabetic char (as allowed by SemVer).
As per the documentation "Build metadata" has no ordering precedence, so can be safely discarded.

Tests have been added to ensure nothing is broken (hopefully!).


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.