### PR TITLE
Fix rotation yaw/pitch/roll decompose calculation bugs on edge cases

### DIFF
--- a/sources/core/Stride.Core.Mathematics.Tests/TestMatrix.cs
+++ b/sources/core/Stride.Core.Mathematics.Tests/TestMatrix.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Xunit;
+
+namespace Stride.Core.Mathematics.Tests
+{
+    public class TestMatrix
+    {
+        /* Note: As seen in the TestCompose* tests, we check both expectedQuat == decompedQuat and expectedQuat == -decompedQuat
+         * This is because different combinations of yaw/pitch/roll can result in the same *orientation*, which is what we're actually testing.
+         * This means that decomposing a rotation matrix or quaternion can actually have multiple answers, but we arbitrarily pick
+         * one result, and this may not have actually been the original yaw/pitch/roll the user chose.
+         */
+
+        [Theory, ClassData(typeof(TestRotationsData.YRPTestData))]
+        public void TestDecomposeYawPitchRollFromQuaternionYPR(float yawDegrees, float pitchDegrees, float rollDegrees)
+        {
+            var yawRadians = MathUtil.DegreesToRadians(yawDegrees);
+            var pitchRadians = MathUtil.DegreesToRadians(pitchDegrees);
+            var rollRadians = MathUtil.DegreesToRadians(rollDegrees);
+
+            var rotQuat = Quaternion.RotationYawPitchRoll(yawRadians, pitchRadians, rollRadians);
+            var rotMatrix = Matrix.RotationQuaternion(rotQuat);
+            rotMatrix.Decompose(out float decomposedYaw, out float decomposedPitch, out float decomposedRoll);
+
+            var expectedQuat = rotQuat;
+            var decompedQuat = Quaternion.RotationYawPitchRoll(decomposedYaw, decomposedPitch, decomposedRoll);
+            Assert.True(expectedQuat == decompedQuat || expectedQuat == -decompedQuat, $"Quat not equals: Expected: {expectedQuat} - Actual: {decompedQuat}");
+        }
+
+        [Theory, ClassData(typeof(TestRotationsData.YRPTestData))]
+        public void TestDecomposeYawPitchRollFromMatrixYPR(float yawDegrees, float pitchDegrees, float rollDegrees)
+        {
+            var yawRadians = MathUtil.DegreesToRadians(yawDegrees);
+            var pitchRadians = MathUtil.DegreesToRadians(pitchDegrees);
+            var rollRadians = MathUtil.DegreesToRadians(rollDegrees);
+
+            var rotMatrix = Matrix.RotationYawPitchRoll(yawRadians, pitchRadians, rollRadians);
+            rotMatrix.Decompose(out float decomposedYaw, out float decomposedPitch, out float decomposedRoll);
+
+            var expectedQuat = Quaternion.RotationYawPitchRoll(yawRadians, pitchRadians, rollRadians);
+            var decompedQuat = Quaternion.RotationYawPitchRoll(decomposedYaw, decomposedPitch, decomposedRoll);
+            Assert.True(expectedQuat == decompedQuat || expectedQuat == -decompedQuat, $"Quat not equals: Expected: {expectedQuat} - Actual: {decompedQuat}");
+        }
+
+        [Theory, ClassData(typeof(TestRotationsData.YRPTestData))]
+        public void TestDecomposeYawPitchRollFromMatricesZXY(float yawDegrees, float pitchDegrees, float rollDegrees)
+        {
+            var yawRadians = MathUtil.DegreesToRadians(yawDegrees);
+            var pitchRadians = MathUtil.DegreesToRadians(pitchDegrees);
+            var rollRadians = MathUtil.DegreesToRadians(rollDegrees);
+
+            // Yaw-Pitch-Roll is the intrinsic rotation order, so extrinsic is the reverse (ie. Z-X-Y)
+            var rotMatrix = Matrix.RotationZ(rollRadians) * Matrix.RotationX(pitchRadians) * Matrix.RotationY(yawRadians);
+            rotMatrix.Decompose(out float decomposedYaw, out float decomposedPitch, out float decomposedRoll);
+
+            var expectedQuat = Quaternion.RotationYawPitchRoll(yawRadians, pitchRadians, rollRadians);
+            var decompedQuat = Quaternion.RotationYawPitchRoll(decomposedYaw, decomposedPitch, decomposedRoll);
+            Assert.True(expectedQuat == decompedQuat || expectedQuat == -decompedQuat, $"Quat not equals: Expected: {expectedQuat} - Actual: {decompedQuat}");
+        }
+
+        [Theory, ClassData(typeof(TestRotationsData.XYZTestData))]
+        public void TestDecomposeXYZFromMatricesXYZ(float yawDegrees, float pitchDegrees, float rollDegrees)
+        {
+            var yawRadians = MathUtil.DegreesToRadians(yawDegrees);
+            var pitchRadians = MathUtil.DegreesToRadians(pitchDegrees);
+            var rollRadians = MathUtil.DegreesToRadians(rollDegrees);
+
+            var rotMatrix = Matrix.RotationX(pitchRadians) * Matrix.RotationY(yawRadians) * Matrix.RotationZ(rollRadians);
+            rotMatrix.DecomposeXYZ(out Vector3 eulerAngles);
+
+            var decompedRotMatrix = Matrix.RotationX(eulerAngles.X) * Matrix.RotationY(eulerAngles.Y) * Matrix.RotationZ(eulerAngles.Z);
+            var decompedQuat = Quaternion.RotationMatrix(decompedRotMatrix);
+
+            var expectedQuat = Quaternion.RotationX(pitchRadians) * Quaternion.RotationY(yawRadians) * Quaternion.RotationZ(rollRadians);
+            Assert.True(expectedQuat == decompedQuat || expectedQuat == -decompedQuat, $"Quat not equals: Expected: {expectedQuat} - Actual: {decompedQuat}");
+        }
+    }
+}

--- a/sources/core/Stride.Core.Mathematics.Tests/TestQuaternion.cs
+++ b/sources/core/Stride.Core.Mathematics.Tests/TestQuaternion.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Xunit;
+
+namespace Stride.Core.Mathematics.Tests
+{
+    public class TestQuaternion
+    {
+        /* Note: As seen in the TestCompose* tests, we check both expectedQuat == decompedQuat and expectedQuat == -decompedQuat
+         * This is because different combinations of yaw/pitch/roll can result in the same *orientation*, which is what we're actually testing.
+         * This means that decomposing a rotation matrix or quaternion can actually have multiple answers, but we arbitrarily pick
+         * one result, and this may not have actually been the original yaw/pitch/roll the user chose.
+         */
+
+        [Theory, ClassData(typeof(TestRotationsData.YRPTestData))]
+        public void TestDecomposeYawPitchRollFromQuaternionYPR(float yawDegrees, float pitchDegrees, float rollDegrees)
+        {
+            var yawRadians = MathUtil.DegreesToRadians(yawDegrees);
+            var pitchRadians = MathUtil.DegreesToRadians(pitchDegrees);
+            var rollRadians = MathUtil.DegreesToRadians(rollDegrees);
+
+            var rotQuat = Quaternion.RotationYawPitchRoll(yawRadians, pitchRadians, rollRadians);
+            Quaternion.RotationYawPitchRoll(ref rotQuat, out float decomposedYaw, out float decomposedPitch, out float decomposedRoll);
+
+            var expectedQuat = rotQuat;
+            var decompedQuat = Quaternion.RotationYawPitchRoll(decomposedYaw, decomposedPitch, decomposedRoll);
+            Assert.True(expectedQuat == decompedQuat || expectedQuat == -decompedQuat, $"Quat not equals: Expected: {expectedQuat} - Actual: {decompedQuat}");
+        }
+
+        [Theory, ClassData(typeof(TestRotationsData.YRPTestData))]
+        public void TestDecomposeYawPitchRollFromQuaternionYXZ(float yawDegrees, float pitchDegrees, float rollDegrees)
+        {
+            var yawRadians = MathUtil.DegreesToRadians(yawDegrees);
+            var pitchRadians = MathUtil.DegreesToRadians(pitchDegrees);
+            var rollRadians = MathUtil.DegreesToRadians(rollDegrees);
+
+            var rotX = Quaternion.RotationX(pitchRadians);
+            var rotY = Quaternion.RotationY(yawRadians);
+            var rotZ = Quaternion.RotationZ(rollRadians);
+            // Yaw-Pitch-Roll is the intrinsic rotation order, so extrinsic is the reverse (ie. Z-X-Y)
+            var rotQuat = rotZ * rotX * rotY;
+            Quaternion.RotationYawPitchRoll(ref rotQuat, out float decomposedYaw, out float decomposedPitch, out float decomposedRoll);
+
+            var expectedQuat = rotQuat;
+            var decompRotX = Quaternion.RotationX(decomposedPitch);
+            var decompRotY = Quaternion.RotationY(decomposedYaw);
+            var decompRotZ = Quaternion.RotationZ(decomposedRoll);
+            var decompedQuat = decompRotZ * decompRotX * decompRotY;
+            Assert.True(expectedQuat == decompedQuat || expectedQuat == -decompedQuat, $"Quat not equals: Expected: {expectedQuat} - Actual: {decompedQuat}");
+        }
+    }
+}

--- a/sources/core/Stride.Core.Mathematics.Tests/TestRotationsData.cs
+++ b/sources/core/Stride.Core.Mathematics.Tests/TestRotationsData.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Stride.Core.Mathematics.Tests
+{
+    public static class TestRotationsData
+    {
+        private static readonly float[] PrimaryAnglesToTest = new[]
+        {
+            // +/-90 are the singularities, but test other angles for coverage
+            -180, -90, -30, 0f, 30, 90, 180
+        };
+
+        public class YRPTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                var result = new List<object[]>();
+                foreach (var pitchDegrees in PrimaryAnglesToTest)
+                {
+                    // For yaw/pitch/roll tests, the second rotation axis contains the singularity issue (ie. pitch/X-axis)
+                    // Yaw & Roll are arbitrary non-zero values to ensure the rotation are working correctly
+                    float yawDegrees = 45;
+                    float rollDegrees = -90;
+                    result.Add(new object[] { yawDegrees, pitchDegrees, rollDegrees });
+                }
+                // For completeness, also test the pitch rotation at singularities by itself
+                result.Add(new object[] { 0, -90, 0 });
+                result.Add(new object[] { 0, 90, 0 });
+
+                return result.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public class XYZTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                var result = new List<object[]>();
+                foreach (var yawDegrees in PrimaryAnglesToTest)
+                {
+                    // For XYZ tests, the second rotation axis contains the singularity issue (ie. yaw/Y-axis)
+                    // Pitch & Roll are arbitrary non-zero values to ensure the rotation are working correctly
+                    float pitchDegrees = 45;
+                    float rollDegrees = -90;
+                    result.Add(new object[] { yawDegrees, pitchDegrees, rollDegrees });
+                }
+                // For completeness, also test the yaw rotation at singularities by itself
+                result.Add(new object[] { -90, 0, 0 });
+                result.Add(new object[] { 90, 0, 0 });
+
+                return result.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/sources/core/Stride.Core.Mathematics/Matrix.cs
+++ b/sources/core/Stride.Core.Mathematics/Matrix.cs
@@ -622,43 +622,91 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Decomposes a rotation matrix with the specified yaw, pitch, roll
+        /// Decomposes a rotation matrix with the specified yaw, pitch, roll value (angles in radians).
         /// </summary>
-        /// <param name="yaw">The yaw.</param>
-        /// <param name="pitch">The pitch.</param>
-        /// <param name="roll">The roll.</param>
+        /// <param name="yaw">The yaw component in radians.</param>
+        /// <param name="pitch">The pitch component in radians.</param>
+        /// <param name="roll">The roll component in radians.</param>
+        /// <remarks>
+        /// This rotation matrix can be represented by <b>intrinsic</b> rotations in the order <paramref name="yaw"/>, <paramref name="pitch"/>, then <paramref name="roll"/>.
+        /// <br/>
+        /// Therefore the <b>extrinsic</b> rotations to achieve this matrix is the reversed order of operations,
+        /// ie. Matrix.RotationZ(roll) * Matrix.RotationX(pitch) * Matrix.RotationY(yaw)
+        /// </remarks>
         public void Decompose(out float yaw, out float pitch, out float roll)
         {
-            pitch = MathF.Asin(-M32);
-            if (MathF.Cos(pitch) > MathUtil.ZeroTolerance)
+            // Adapted from 'Euler Angle Formulas' by David Eberly - https://www.geometrictools.com/Documentation/EulerAngles.pdf
+            // 2.3 Factor as Ry Rx Rz
+            // License under CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+            //
+            // Note the Stride's matrix row/column ordering is swapped, indices starts at one,
+            // and the if-statement ordering is written to minimize the number of operations to get to
+            // the common case, and made to handle the +/- 1 cases better due to low precision in floats
+            if (MathUtil.IsOne(Math.Abs(M32)))
             {
-                roll = MathF.Atan2(M12, M22);
-                yaw = MathF.Atan2(M31, M33);
+                if (M32 >= 0)
+                {
+                    // Edge case where M32 == +1
+                    pitch = -MathUtil.PiOverTwo;
+                    yaw = MathF.Atan2(-M21, M11);
+                    roll = 0;
+                }
+                else
+                {
+                    // Edge case where M32 == -1
+                    pitch = MathUtil.PiOverTwo;
+                    yaw = -MathF.Atan2(-M21, M11);
+                    roll = 0;
+                }
             }
             else
             {
-                roll = MathF.Atan2(-M21, M11);
-                yaw = 0.0f;
+                // Common case
+                pitch = MathF.Asin(-M32);
+                yaw = MathF.Atan2(M31, M33);
+                roll = MathF.Atan2(M12, M22);
             }
         }
 
         /// <summary>
-        /// Decomposes a rotation matrix with the specified X, Y and Z euler angles.
+        /// Decomposes a rotation matrix with the specified X, Y and Z euler angles in radians.
         /// Matrix.RotationX(rotation.X) * Matrix.RotationY(rotation.Y) * Matrix.RotationZ(rotation.Z) should represent the same rotation.
         /// </summary>
         /// <param name="rotation">The vector containing the 3 rotations angles to be applied in order.</param>
         public void DecomposeXYZ(out Vector3 rotation)
         {
-            rotation.Y = MathF.Asin(-M13);
-            if (MathF.Cos(rotation.Y) > MathUtil.ZeroTolerance)
+            // Adapted from 'Euler Angle Formulas' by David Eberly - https://www.geometrictools.com/Documentation/EulerAngles.pdf
+            // 2.6 Factor as Rz Ry Rx
+            // License under CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+            //
+            // Note the Stride's matrix row/column ordering is swapped, indices starts at one,
+            // and the if-statement ordering is written to minimize the number of operations to get to
+            // the common case, and made to handle the +/- 1 cases better due to low precision in floats.
+            // The above documentation implies the *extrinsic* rotation order is X-Y-Z,
+            // so the *intrinsic* rotation is Z-Y-X which is the formula to use here
+            if (MathUtil.IsOne(Math.Abs(M13)))
             {
-                rotation.Z = MathF.Atan2(M12, M11);
-                rotation.X = MathF.Atan2(M23, M33);
+                if (M13 >= 0)
+                {
+                    // Edge case where M13 == +1
+                    rotation.Y = -MathUtil.PiOverTwo;
+                    rotation.Z = MathF.Atan2(-M32, M22);
+                    rotation.X = 0;
+                }
+                else
+                {
+                    // Edge case where M13 == -1
+                    rotation.Y = MathUtil.PiOverTwo;
+                    rotation.Z = -MathF.Atan2(-M32, M22);
+                    rotation.X = 0;
+                }
             }
             else
             {
-                rotation.Z = MathF.Atan2(-M21, M31);
-                rotation.X = 0.0f;
+                // Common case
+                rotation.Y = MathF.Asin(-M13);
+                rotation.Z = MathF.Atan2(M12, M11);
+                rotation.X = MathF.Atan2(M23, M33);
             }
         }
 
@@ -2782,7 +2830,7 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Creates a rotation matrix with a specified yaw, pitch, and roll.
+        /// Creates a rotation matrix with a specified yaw, pitch, and roll value (angles in radians).
         /// </summary>
         /// <param name="yaw">Yaw around the y-axis, in radians.</param>
         /// <param name="pitch">Pitch around the x-axis, in radians.</param>
@@ -2795,7 +2843,7 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Creates a rotation matrix with a specified yaw, pitch, and roll.
+        /// Creates a rotation matrix with a specified yaw, pitch, and roll value (angles in radians).
         /// </summary>
         /// <param name="yaw">Yaw around the y-axis, in radians.</param>
         /// <param name="pitch">Pitch around the x-axis, in radians.</param>

--- a/sources/engine/Stride.Engine/Engine/TransformComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/TransformComponent.cs
@@ -145,28 +145,52 @@ namespace Stride.Engine
                 float yz = rotation.Y * rotation.Z;
                 float xw = rotation.X * rotation.W;
 
-                rotationEuler.Y = MathF.Asin(2.0f * (yw - zx));
-                if (MathF.Cos(rotationEuler.Y) > MathUtil.ZeroTolerance)
+                float M11 = 1.0f - (2.0f * (yy + zz));
+                float M12 = 2.0f * (xy + zw);
+                float M13 = 2.0f * (zx - yw);
+                //float M21 = 2.0f * (xy - zw);
+                float M22 = 1.0f - (2.0f * (zz + xx));
+                float M23 = 2.0f * (yz + xw);
+                //float M31 = 2.0f * (zx + yw);
+                float M32 = 2.0f * (yz - xw);
+                float M33 = 1.0f - (2.0f * (yy + xx));
+
+                /*** Refer to Matrix.DecomposeXYZ(out Vector3 rotation) for code and license ***/
+                if (MathUtil.IsOne(Math.Abs(M13)))
                 {
-                    rotationEuler.Z = MathF.Atan2(2.0f * (xy + zw), 1.0f - (2.0f * (yy + zz)));
-                    rotationEuler.X = MathF.Atan2(2.0f * (yz + xw), 1.0f - (2.0f * (yy + xx)));
+                    if (M13 >= 0)
+                    {
+                        // Edge case where M13 == +1
+                        rotationEuler.Y = -MathUtil.PiOverTwo;
+                        rotationEuler.Z = MathF.Atan2(-M32, M22);
+                        rotationEuler.X = 0;
+                    }
+                    else
+                    {
+                        // Edge case where M13 == -1
+                        rotationEuler.Y = MathUtil.PiOverTwo;
+                        rotationEuler.Z = -MathF.Atan2(-M32, M22);
+                        rotationEuler.X = 0;
+                    }
                 }
                 else
                 {
-                    rotationEuler.Z = MathF.Atan2(2.0f * (zw - xy), 2.0f * (zx + yw));
-                    rotationEuler.X = 0.0f;
+                    // Common case
+                    rotationEuler.Y = MathF.Asin(-M13);
+                    rotationEuler.Z = MathF.Atan2(M12, M11);
+                    rotationEuler.X = MathF.Atan2(M23, M33);
                 }
                 return rotationEuler;
             }
             set
             {
-                // Equilvalent to:
+                // Equivalent to:
                 //  Quaternion quatX, quatY, quatZ;
-                //  
+                //
                 //  Quaternion.RotationX(value.X, out quatX);
                 //  Quaternion.RotationY(value.Y, out quatY);
                 //  Quaternion.RotationZ(value.Z, out quatZ);
-                //  
+                //
                 //  rotation = quatX * quatY * quatZ;
 
                 var halfAngles = value * 0.5f;
@@ -203,7 +227,7 @@ namespace Stride.Engine
                 var oldParent = Parent;
                 if (oldParent == value)
                     return;
-                
+
                 // SceneValue must be null if we have a parent
                 if( Entity.SceneValue != null )
                     Entity.Scene = null;
@@ -349,7 +373,7 @@ namespace Stride.Engine
                 Entity?.EntityManager?.OnHierarchyChanged(item.Entity);
                 Entity?.EntityManager?.GetProcessor<TransformProcessor>().NotifyChildrenCollectionChanged(item, false);
             }
-            
+
             /// <inheritdoc/>
             protected override void InsertItem(int index, TransformComponent item)
             {

--- a/sources/presentation/Stride.Core.Presentation/Controls/RotationEditor.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/RotationEditor.cs
@@ -58,9 +58,9 @@ namespace Stride.Core.Presentation.Controls
 
                 var rotationMatrix = Matrix.RotationQuaternion(value.Value);
                 rotationMatrix.Decompose(out decomposedRotation.Y, out decomposedRotation.X, out decomposedRotation.Z);
-                SetCurrentValue(XProperty, MathUtil.RadiansToDegrees(decomposedRotation.X));
-                SetCurrentValue(YProperty, MathUtil.RadiansToDegrees(decomposedRotation.Y));
-                SetCurrentValue(ZProperty, MathUtil.RadiansToDegrees(decomposedRotation.Z));
+                SetCurrentValue(XProperty, GetDisplayValue(decomposedRotation.X));
+                SetCurrentValue(YProperty, GetDisplayValue(decomposedRotation.Y));
+                SetCurrentValue(ZProperty, GetDisplayValue(decomposedRotation.Z));
             }
         }
 
@@ -96,6 +96,19 @@ namespace Stride.Core.Presentation.Controls
         private static Quaternion Recompose(ref Vector3 vector)
         {
             return Quaternion.RotationYawPitchRoll(vector.Y, vector.X, vector.Z);
+        }
+
+        private static float GetDisplayValue(float angleRadians)
+        {
+            var degrees = MathUtil.RadiansToDegrees(angleRadians);
+            if (degrees == 0 && float.IsNegative(degrees))
+            {
+                // Matrix.DecomposeXYZ can give -0 when MathF.Asin(-0) == -0,
+                // whereas previously Math.Asin(-0) == +0 (ie. did not respect the sign value at zero).
+                // This shows up in the editor but we don't want to see this.
+                degrees = 0;
+            }
+            return degrees;
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fixes the edge cases of the yaw/pitch/roll method variants of `Matrix.Decompose` & `Quaternion.RotationYawPitchRoll` and `Matrix.DecomposeXYZ` where pitch (or yaw) is 90 degrees, but not being handled by the correct edge case logic.

Also fixed a minor bug in the editor where rotation X displays `-0` instead of `0`.


## Description

<!--- Describe your changes in detail -->
Had to fish through google to try and track down what formulas are being used.
The closest I found was ['Euler Angle Formulas' by David Eberly](https://www.geometrictools.com/Documentation/EulerAngles.pdf)
The existing code checked for the +/- 1 edge cases using Asin and Cos, however the loss of precision in operating on Pi/2 when constructing the rotation matrix meant it'd never hit Cos(Angle) == 0, even with ZeroTolerance check. According to Eberly's pdf, just checking `M32` (or `M13` for DecomposeXYZ) directly is enough (and this won't degrade by going through Asin then Cos like the existing code).
Also +1 and -1 changes signs, which the current code doesn't handle (it incorrectly treated both cases as the +1 case).

For `Matrix.Decompose`, the matrix fields used for the common case & edge cases were consistent with Eberly's formula (except the -1 case)

For `Matrix.DecomposeXYZ`, the matrix fields used for the common case was consistent with Eberly's, but the edge case used different fields, ie.
Existing: `rotation.Z = MathF.Atan2(-M21, M31);`
New: `rotation.Z = MathF.Atan2(-M32, M22);`

Unfortunately I don't know where those fields came from, so just changed it to match Eberly's version.

The unit tests confirms the new code is working (though that assumes the tests themselves are correct...)

Not sure if `RotationCurveViewModel` is actually used anywhere. I've changed back it to use `Matrix.DecomposeXYZ`, as I suspect the 'better precision' version actually isn't better because the problem already starts with the incoming matrix.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1528
Partial fix to #174 (to some extent)

## Other Notes
Even though this also fixes the immediate problem of #174 (since it'll detect 90 degrees better now), there is still a potential for loss of precision because we're dealing with floats (probably not really solvable).
Also a hidden 'issue' is that we don't save the user's XYZ rotation value, so it is possible the editor may reload the rotation (orientation) with different XYZ values (because multiple XYZ combinations can achieve the same final rotation, eg. `X: 90, Y: 90, Z: 0` is the same orientation as `X: 90, Y: 0, Z: -90`) - this is beyond the scope of this pull.

---

Please advise if the attribution to Eberly's pdf & license needs to be changed, as I'm not sure of the right way to do it.

Also, the tests generates ~3800 tests each (due to trying to test many different combinations of yaw/pitch/roll). Not sure if that's an issue or if there's a better way to code this (though there's no performance problem since they're all simple calculations).

---

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.