### PR TITLE
Fix Samples.Tests and SamplesTestServer to auto-resolve packages

### DIFF
--- a/samples/Tests/Stride.Samples.Tests.csproj
+++ b/samples/Tests/Stride.Samples.Tests.csproj
@@ -27,5 +27,6 @@
     <ProjectReference Include="..\..\sources\tools\Stride.ConnectionRouter\Stride.ConnectionRouter.csproj" />
     <ProjectReference Include="..\..\sources\tools\Stride.SamplesTestServer\Stride.SamplesTestServer.csproj" />
   </ItemGroup>
+  <Import Project="..\..\sources\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="..\..\sources\targets\Stride.UnitTests.targets" />
 </Project>

--- a/samples/Tests/TestServerResolver.cs
+++ b/samples/Tests/TestServerResolver.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Reflection;
+using Stride.Core;
+using Stride.Core.Assets;
+
+namespace Stride.Samples.Tests
+{
+    internal class TestServerResolver
+    {
+        [ModuleInitializer(-100)]
+        public static void ResolveReferences() =>
+            NuGetAssemblyResolver.SetupNuGet("Stride.SamplesTestServer", StrideVersion.NuGetVersion, Assembly.GetCallingAssembly());
+    }
+}

--- a/sources/editor/Stride.Assets.Presentation/StrideDefaultAssetsPlugin.cs
+++ b/sources/editor/Stride.Assets.Presentation/StrideDefaultAssetsPlugin.cs
@@ -93,6 +93,8 @@ namespace Stride.Assets.Presentation
             {
                 var logger = new LoggerResult();
                 var packageFile = PackageStore.Instance.GetPackageFileName(packageInfo.Name, new PackageVersionRange(new PackageVersion(packageInfo.Version)));
+                if (packageFile is null)
+                    throw new InvalidOperationException($"Could not find package {packageInfo.Name} {packageInfo.Version}. Ensure packages have been resolved.");
                 var package = Package.Load(logger, packageFile.ToWindowsPath());
                 if (logger.HasErrors)
                     throw new InvalidOperationException($"Could not load package {packageInfo.Name}:{Environment.NewLine}{logger.ToText()}");

--- a/sources/engine/Stride.Games.Testing/GameTestingClient.cs
+++ b/sources/engine/Stride.Games.Testing/GameTestingClient.cs
@@ -82,7 +82,7 @@ namespace Stride.Games.Testing
 
             var runTask = Task.Run(() => socketMessageLayer.MessageLoop());
 
-            var cmd = platform == PlatformType.Windows ? Path.Combine(Environment.CurrentDirectory, gamePath, "Bin\\Windows\\Debug", gameName + ".Windows.exe") : "";
+            var cmd = platform == PlatformType.Windows ? Path.Combine(Environment.CurrentDirectory, gamePath, "Bin\\Windows\\Debug\\win-x64", gameName + ".Windows.exe") : "";
 
             socketMessageLayer.Send(new TestRegistrationRequest
             {

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -36,8 +36,15 @@ namespace Stride.Core.Assets
             assembliesResolved = true;
         }
 
-        internal static void SetupNuGet(string packageName, string packageVersion)
+        /// <summary>
+        /// Set up an Assembly resolver which on first missing Assembly runs Nuget resolver over <paramref name="packageName"/>.
+        /// </summary>
+        /// <param name="packageName">Name of the root package for NuGet resolution.</param>
+        /// <param name="packageVersion">Package version.</param>
+        /// <param name="metadataAssembly">Assembly for getting target framrwork and platform.</param>
+        internal static void SetupNuGet(string packageName, string packageVersion, Assembly metadataAssembly = null)
         {
+            metadataAssembly ??= Assembly.GetEntryAssembly();
             // Make sure our nuget local store is added to nuget config
             var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string strideFolder = null;
@@ -123,15 +130,14 @@ namespace Stride.Core.Assets
                             SynchronizationContext.SetSynchronizationContext(null);
 
                             // Determine current TFM
-                            var framework = Assembly
-                                .GetEntryAssembly()?
+                            var framework = metadataAssembly
                                 .GetCustomAttribute<TargetFrameworkAttribute>()?
                                 .FrameworkName ?? ".NETFramework,Version=v4.7.2";
                             var nugetFramework = NuGetFramework.ParseFrameworkName(framework, DefaultFrameworkNameProvider.Instance);
 
 #if NETCOREAPP
                             // Add TargetPlatform to net6.0 TFM (i.e. net6.0 to net6.0-windows7.0)
-                            var platform = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetPlatformAttribute>()?.PlatformName ?? string.Empty;
+                            var platform = metadataAssembly?.GetCustomAttribute<TargetPlatformAttribute>()?.PlatformName ?? string.Empty;
                             if (framework.StartsWith(FrameworkConstants.FrameworkIdentifiers.NetCoreApp) && platform != string.Empty)
                             {
                                 var platformParseResult = Regex.Match(platform, @"([a-zA-Z]+)(\d+.*)");

--- a/sources/tools/Stride.SamplesTestServer/Stride.SamplesTestServer.csproj
+++ b/sources/tools/Stride.SamplesTestServer/Stride.SamplesTestServer.csproj
@@ -17,6 +17,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\engine\Stride.Games.Testing\Stride.Games.Testing.csproj" />
     <ProjectReference Include="..\Stride.ConnectionRouter\Stride.ConnectionRouter.csproj" />
+
+    <!-- Ensure GameStudio is built and referenced as a NuGet dependency, it shouldn't be used though -->
+    <ProjectReference Include="..\..\editor\Stride.GameStudio\Stride.GameStudio.csproj">
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
# PR Details

## Description
The Stride.Samples.Tests is a project that allows us to test more complex game scenarios, by executing the actual sample game completely and simulating user input. It has been broken for a while and during my debugging session of Eric's changes to modernize Stride I encountered this problem and tried to fix it ad hoc. Now I was able to put some more time into it.

The issues:
- [x] Incorrect path to the game's executable - we had a change such that binaries are one level deeper - `win-x64`  for Windows.
    - Fixed by modifying the static path
- [x] Missing resolution of asset packages - could be fixed ad hoc by running GameStudio on the machine before running tests
- [x] Missing resolution of SamplesTestServer
    - Fixed by integrating Stride.NuGetResolver and asking it to resolve the test server, to which I added a reference to GameStudio. This way you can build solution, run Stride.Samples.Tests and in one step it works.

## Related Issue

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.