### PR TITLE
Improve documentation of ListFiles and add tests for DatabaseFileProvider implementation

### DIFF
--- a/sources/core/Stride.Core.IO/IVirtualFileProvider.cs
+++ b/sources/core/Stride.Core.IO/IVirtualFileProvider.cs
@@ -53,8 +53,14 @@ namespace Stride.Core.IO
         /// Returns the list of files from the specified path.
         /// </summary>
         /// <param name="path">The path.</param>
-        /// <param name="searchPattern">The search pattern.</param>
-        /// <param name="searchOption">The search option.</param>
+        /// <param name="searchPattern">
+        /// The search string to match against the names of files in <paramref name="path"/>.
+        /// This parameter can contain a combination of valid literal path and wildcard (* and ?) characters,
+        /// but it doesn't support regular expressions.
+        /// </param>
+        /// <param name="searchOption">
+        /// One of the enumeration values that specifies whether the search operation should include all subdirectories or only the current directory.
+        /// </param>
         /// <returns>A list of files from the specified path</returns>
         string[] ListFiles(string path, string searchPattern, VirtualSearchOption searchOption);
 

--- a/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
+++ b/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
@@ -149,7 +149,7 @@ namespace Stride.Core.IO
             url = Regex.Escape(url);
             searchPattern = Regex.Escape(searchPattern).Replace(@"\*", "[^/]*").Replace(@"\?", "[^/]");
             string recursivePattern = searchOption == VirtualSearchOption.AllDirectories ? "(.*/)*" : "/?";
-            return new Regex("^" + url + recursivePattern + searchPattern + "$");
+            return new Regex($"^{url}{recursivePattern}{searchPattern}$");
         }
 
         private abstract class DatabaseFileStream : VirtualFileStream, IDatabaseStream

--- a/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
+++ b/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
@@ -89,12 +89,14 @@ namespace Stride.Core.IO
             throw new ArgumentException("mode");
         }
 
+        /// <inheritdoc />
+        /// <param name="url">The url (without preceding slash).</param>
+        /// <remarks>
+        /// Example: to get all files within a directory <c>ListFiles("path/to/folder", "*", VirtualSearchOption.TopDirectoryOnly)</c>
+        /// </remarks>
         public override string[] ListFiles(string url, string searchPattern, VirtualSearchOption searchOption)
         {
-            url = Regex.Escape(url);
-            searchPattern = Regex.Escape(searchPattern).Replace(@"\*", "[^/]*").Replace(@"\?", "[^/]");
-            string recursivePattern = searchOption == VirtualSearchOption.AllDirectories ? "(.*/)*" : "/?";
-            var regex = new Regex("^" + url + recursivePattern + searchPattern + "$");
+            var regex = CreateRegexForFileSearch(url, searchPattern, searchOption);
 
             return contentIndexMap.SearchValues(x => regex.IsMatch(x.Key)).Select(x => x.Key).ToArray();
         }
@@ -140,6 +142,14 @@ namespace Stride.Core.IO
                 return null;
             }
             return provider.ContentIndexMap.TryGetValue(resolveProviderResult.Path, out objectId) ? provider : null;
+        }
+
+        public static Regex CreateRegexForFileSearch(string url, string searchPattern, VirtualSearchOption searchOption)
+        {
+            url = Regex.Escape(url);
+            searchPattern = Regex.Escape(searchPattern).Replace(@"\*", "[^/]*").Replace(@"\?", "[^/]");
+            string recursivePattern = searchOption == VirtualSearchOption.AllDirectories ? "(.*/)*" : "/?";
+            return new Regex("^" + url + recursivePattern + searchPattern + "$");
         }
 
         private abstract class DatabaseFileStream : VirtualFileStream, IDatabaseStream

--- a/sources/core/Stride.Core.Tests/IO/DatabaseFileProviderTests.cs
+++ b/sources/core/Stride.Core.Tests/IO/DatabaseFileProviderTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Stride.Core.IO;
+using Xunit;
+
+namespace Stride.Core.Tests.IO
+{
+    public class DatabaseFileProviderTests
+    {
+        [Theory]
+        [InlineData("Root/A", "Root", "A", VirtualSearchOption.TopDirectoryOnly)]
+        [InlineData("Root/A", "Root", "A", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/A", "Root/", "A", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/A", "Root", "*", VirtualSearchOption.TopDirectoryOnly)]
+        [InlineData("Root/A", "Root", "*", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/A", "Root/", "*", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Dir/A", "Root", "A", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Dir/A", "Root", "*", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/A", "Root", "?", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Abc", "Root", "A?c", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Abbc", "Root", "A*c", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Abbc", "Root", "A*", VirtualSearchOption.AllDirectories)]
+        public void ListFilesRegex_Matches(string url, string pathPrefix, string fileNamePattern, VirtualSearchOption options)
+        {
+            var regex = DatabaseFileProvider.CreateRegexForFileSearch(pathPrefix, fileNamePattern, options);
+            Assert.Matches(regex, url);
+        }
+
+        [Theory]
+        [InlineData("Root/A", "Root", "B", VirtualSearchOption.TopDirectoryOnly)]
+        [InlineData("Root/A", "Root", "B", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Dir/A", "Root", "B", VirtualSearchOption.AllDirectories)]
+        [InlineData("Root/Dir/A", "Root", "*", VirtualSearchOption.TopDirectoryOnly)]
+        [InlineData("Root/Abbc", "Root", "A?c", VirtualSearchOption.AllDirectories)]
+        // if path starts with / it won't match because URLs in DatabaseFileProvider don't have a preceding /
+        [InlineData("Root/A", "/Root", "A", VirtualSearchOption.AllDirectories)]
+        public void ListFilesRegex_DoesNotMatch(string url, string pathPrefix, string fileNamePattern, VirtualSearchOption options)
+        {
+            var regex = DatabaseFileProvider.CreateRegexForFileSearch(pathPrefix, fileNamePattern, options);
+            Assert.DoesNotMatch(regex, url);
+        }
+    }
+}


### PR DESCRIPTION
# PR Details

## Description

Make it more obvious via intellisense on how to use the `ListFiles` method of `IVirtualFileProvider`. For actual file system the behavior corresponds to `Directory.GetFiles()` and I've copied parameter comments from that method. Additionally I added an example specific to URL of `DatabaseFileProvider` and written a unit test of its Regex implementation.

## Related Issue

N/A

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.