### PR TITLE
Use Path.Combine() to concatenate MSBuild paths

### DIFF
--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -85,9 +85,9 @@ namespace Stride.Core.Assets
 
             var variables = new Dictionary<string, string>
             {
-                [MSBUILD_EXE_PATH] = dotNetSdkPath + "MSBuild.dll",
+                [MSBUILD_EXE_PATH] = Path.Combine(dotNetSdkPath, "MSBuild.dll"),
                 [MSBuildExtensionsPath] = dotNetSdkPath,
-                [MSBuildSDKsPath] = dotNetSdkPath + "Sdks"
+                [MSBuildSDKsPath] = Path.Combine(dotNetSdkPath, "Sdks")
             };
 
             foreach (var kvp in variables)


### PR DESCRIPTION
# PR Details

When building Stride myself I have encountered several times errors in Assets.CompilerApp where the MSBuild.Locator returns the .NET SDK paths without the trailing slash. When concatenating this paths with the MSBuild DLL or any other things, the resulting path is incorrect.

This PR is an easy fix that uses `Path.Combine()` instead of string concatenation to resolve the issue.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.