### PR TITLE
Added deconstructors to most of the structs in Stride.Mathematics

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Color3.cs
+++ b/sources/core/Stride.Core.Mathematics/Color3.cs
@@ -817,6 +817,19 @@ namespace Stride.Core.Mathematics
 
             return Equals((Color3)value);
         }
+                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="r">The R component</param>
+        /// <param name="g">The G component</param>
+        /// <param name="b">The B component</param>
+        public void Deconstruct(out float r, out float g, out float b)
+        {
+            r = R;
+            g = G;
+            b = B;
+        }
 
 #if SlimDX1xInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Color4.cs
+++ b/sources/core/Stride.Core.Mathematics/Color4.cs
@@ -996,6 +996,22 @@ namespace Stride.Core.Mathematics
                 return false;
 
             return Equals((Color4)value);
+        }           
+        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="r">The R component</param>
+        /// <param name="g">The G component</param>
+        /// <param name="b">The B component</param>
+        /// <param name="a">The A component</param>
+        public void Deconstruct(out float r, out float g, out float b, out float a)
+        {
+            r = R;
+            g = G;
+            b = B;
+            a = A;
         }
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/ColorBGRA.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorBGRA.cs
@@ -1093,6 +1093,22 @@ namespace Stride.Core.Mathematics
         {
             var value = (int)(component * 255.0f);
             return (byte)(value < 0 ? 0 : value > 255 ? 255 : value);
+        }        
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="r">The R component</param>
+        /// <param name="g">The G component</param>
+        /// <param name="b">The B component</param>
+        /// <param name="a">The A component</param>
+        public void Deconstruct(out byte r, out byte g, out byte b, out byte a)
+        {
+            r = R;
+            g = G;
+            b = B;
+            a = A;
         }
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/ColorHSV.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorHSV.cs
@@ -197,6 +197,22 @@ namespace Stride.Core.Mathematics
                                  S.ToString(format, formatProvider),
                                  V.ToString(format, formatProvider),
                                  A.ToString(format, formatProvider));
+        }     
+        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="h">The H component</param>
+        /// <param name="s">The S component</param>
+        /// <param name="v">The V component</param>
+        /// <param name="a">The A component</param>
+        public void Deconstruct(out float h, out float s, out float v, out float a)
+        {
+            h = H;
+            s = S;
+            v = V;
+            a = A;
         }
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Double2.cs
+++ b/sources/core/Stride.Core.Mathematics/Double2.cs
@@ -1437,6 +1437,17 @@ namespace Stride.Core.Mathematics
 
             return Equals((Double2)value);
         }
+                                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        public void Deconstruct(out double x, out double y)
+        {
+            x = X;
+            y = Y;
+        }
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Double3.cs
+++ b/sources/core/Stride.Core.Mathematics/Double3.cs
@@ -1715,6 +1715,19 @@ namespace Stride.Core.Mathematics
 
             return Equals((Double3)value);
         }
+                        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        public void Deconstruct(out double x, out double y, out double z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
 
 
 #if WPFInterop

--- a/sources/core/Stride.Core.Mathematics/Double4.cs
+++ b/sources/core/Stride.Core.Mathematics/Double4.cs
@@ -1387,6 +1387,21 @@ namespace Stride.Core.Mathematics
 
             return Equals((Double4)value);
         }
+                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        /// <param name="w">The W component</param>
+        public void Deconstruct(out double x, out double y, out double z, out double w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
+        }
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Half2.cs
+++ b/sources/core/Stride.Core.Mathematics/Half2.cs
@@ -235,7 +235,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="x">The X component</param>
         /// <param name="y">The Y component</param>
-        public void Deconstruct(out float x, out float y)
+        public void Deconstruct(out Half x, out Half y)
         {
             x = X;
             y = Y;

--- a/sources/core/Stride.Core.Mathematics/Half2.cs
+++ b/sources/core/Stride.Core.Mathematics/Half2.cs
@@ -229,5 +229,16 @@ namespace Stride.Core.Mathematics
         {
             return new Vector2(value.X, value.Y);
         }
+                                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        public void Deconstruct(out float x, out float y)
+        {
+            x = X;
+            y = Y;
+        }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Half3.cs
+++ b/sources/core/Stride.Core.Mathematics/Half3.cs
@@ -247,5 +247,18 @@ namespace Stride.Core.Mathematics
             }
             return this.Equals((Half3)obj);
         }
+                        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        public void Deconstruct(out float x, out float y, out float z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Half3.cs
+++ b/sources/core/Stride.Core.Mathematics/Half3.cs
@@ -254,7 +254,7 @@ namespace Stride.Core.Mathematics
         /// <param name="x">The X component</param>
         /// <param name="y">The Y component</param>
         /// <param name="z">The Z component</param>
-        public void Deconstruct(out float x, out float y, out float z)
+        public void Deconstruct(out Half x, out Half y, out Half z)
         {
             x = X;
             y = Y;

--- a/sources/core/Stride.Core.Mathematics/Half4.cs
+++ b/sources/core/Stride.Core.Mathematics/Half4.cs
@@ -264,6 +264,21 @@ namespace Stride.Core.Mathematics
                 return false;
             }
             return this.Equals((Half4)obj);
+        }        
+                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        /// <param name="w">The W component</param>
+        public void Deconstruct(out float x, out float y, out float z, out float w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Half4.cs
+++ b/sources/core/Stride.Core.Mathematics/Half4.cs
@@ -273,7 +273,7 @@ namespace Stride.Core.Mathematics
         /// <param name="y">The Y component</param>
         /// <param name="z">The Z component</param>
         /// <param name="w">The W component</param>
-        public void Deconstruct(out float x, out float y, out float z, out float w)
+        public void Deconstruct(out Half x, out Half y, out Half z, out Half w)
         {
             x = X;
             y = Y;

--- a/sources/core/Stride.Core.Mathematics/Int2.cs
+++ b/sources/core/Stride.Core.Mathematics/Int2.cs
@@ -49,22 +49,22 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Int2"/> with all of its components set to zero.
         /// </summary>
-        public static readonly Int2 Zero = new Int2();
+        public static readonly Int2 Zero = new();
 
         /// <summary>
         /// The X unit <see cref="Stride.Core.Mathematics.Int2"/> (1, 0, 0).
         /// </summary>
-        public static readonly Int2 UnitX = new Int2(1, 0);
+        public static readonly Int2 UnitX = new(1, 0);
 
         /// <summary>
         /// The Y unit <see cref="Stride.Core.Mathematics.Int2"/> (0, 1, 0).
         /// </summary>
-        public static readonly Int2 UnitY = new Int2(0, 1);
+        public static readonly Int2 UnitY = new(0, 1);
 
         /// <summary>
         /// A <see cref="Stride.Core.Mathematics.Int2"/> with all of its components set to one.
         /// </summary>
-        public static readonly Int2 One = new Int2(1, 1);
+        public static readonly Int2 One = new(1, 1);
 
         /// <summary>
         /// The X component of the vector.
@@ -435,7 +435,7 @@ namespace Stride.Core.Mathematics
         public static void SmoothStep(ref Int2 start, ref Int2 end, float amount, out Int2 result)
         {
             amount = (amount > 1) ? 1 : ((amount < 0) ? 0 : amount);
-            amount = (amount * amount) * (3 - (2 * amount));
+            amount = amount * amount * (3 - (2 * amount));
 
             result.X = (int)(start.X + ((end.X - start.X) * amount));
             result.Y = (int)(start.Y + ((end.Y - start.Y) * amount));
@@ -696,8 +696,8 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public bool Equals(Int2 other)
         {
-            return (MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance);
+            return MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
+                MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance;
         }
 
         /// <summary>
@@ -717,6 +717,18 @@ namespace Stride.Core.Mathematics
 
             return Equals((Int2)value);
         }
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        public void Deconstruct(out int x, out int y)
+        {
+            x = X;
+            y = Y;
+        }
+
 #if WPFInterop
         /// <summary>
         /// Performs an implicit conversion from <see cref="Stride.Core.Mathematics.Int2"/> to <see cref="System.Windows.Media.Media3D.Int3D"/>.

--- a/sources/core/Stride.Core.Mathematics/Int3.cs
+++ b/sources/core/Stride.Core.Mathematics/Int3.cs
@@ -758,6 +758,20 @@ namespace Stride.Core.Mathematics
 
             return Equals((Int3)value);
         }
+        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        public void Deconstruct(out int x, out int y, out int z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
+
 #if WPFInterop
         /// <summary>
         /// Performs an implicit conversion from <see cref="Stride.Core.Mathematics.Int3"/> to <see cref="System.Windows.Media.Media3D.Int3D"/>.

--- a/sources/core/Stride.Core.Mathematics/Int4.cs
+++ b/sources/core/Stride.Core.Mathematics/Int4.cs
@@ -149,22 +149,14 @@ namespace Stride.Core.Mathematics
         /// <exception cref = "System.ArgumentOutOfRangeException">Thrown when the <paramref name = "index" /> is out of the range [0, 3].</exception>
         public int this[int index]
         {
-            get
+            get => index switch
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    case 3:
-                        return W;
-                }
-
-                throw new ArgumentOutOfRangeException("index", "Indices for Int4 run from 0 to 3, inclusive.");
-            }
+                0 => X,
+                1 => Y,
+                2 => Z,
+                3 => W,
+                _ => throw new ArgumentOutOfRangeException("index", "Indices for Int4 run from 0 to 3, inclusive."),
+            };
 
             set
             {
@@ -695,6 +687,21 @@ namespace Stride.Core.Mathematics
         public static implicit operator int[](Int4 input)
         {
             return input.ToArray();
+        }
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        /// <param name="w">The W component</param>
+        public void Deconstruct(out int x, out int y, out int z, out int w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Point.cs
+++ b/sources/core/Stride.Core.Mathematics/Point.cs
@@ -142,5 +142,17 @@ namespace Stride.Core.Mathematics
         {
             return new Vector2(value.X, value.Y);
         }
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        public void Deconstruct(out int x, out int y)
+        {
+            x = X;
+            y = Y;
+        }
+
    }
 }

--- a/sources/core/Stride.Core.Mathematics/Size2.cs
+++ b/sources/core/Stride.Core.Mathematics/Size2.cs
@@ -127,5 +127,16 @@ namespace Stride.Core.Mathematics
         {
             return string.Format("({0},{1})", Width, Height);
         }
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="height">The Height component</param>
+        /// <param name="width">The Width component</param>
+        public void Deconstruct(out int height, out int width)
+        {
+            height = Height;
+            width = Width;
+        }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Size2.cs
+++ b/sources/core/Stride.Core.Mathematics/Size2.cs
@@ -131,12 +131,12 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Deconstructs the vector's components into named variables.
         /// </summary>
-        /// <param name="height">The Height component</param>
         /// <param name="width">The Width component</param>
-        public void Deconstruct(out int height, out int width)
+        /// <param name="height">The Height component</param>
+        public void Deconstruct(out int width, out int height)
         {
-            height = Height;
             width = Width;
+            height = Height;
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Size2F.cs
+++ b/sources/core/Stride.Core.Mathematics/Size2F.cs
@@ -126,6 +126,17 @@ namespace Stride.Core.Mathematics
         public override string ToString()
         {
             return string.Format("({0},{1})", Width, Height);
+        }                
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="height">The Height component</param>
+        /// <param name="width">The Width component</param>
+        public void Deconstruct(out float height, out float width)
+        {
+            height = Height;
+            width = Width;
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Size2F.cs
+++ b/sources/core/Stride.Core.Mathematics/Size2F.cs
@@ -131,12 +131,12 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Deconstructs the vector's components into named variables.
         /// </summary>
-        /// <param name="height">The Height component</param>
         /// <param name="width">The Width component</param>
-        public void Deconstruct(out float height, out float width)
+        /// <param name="height">The Height component</param>
+        public void Deconstruct(out float width, out float height)
         {
-            height = Height;
             width = Width;
+            height = Height;
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Size3.cs
+++ b/sources/core/Stride.Core.Mathematics/Size3.cs
@@ -236,13 +236,13 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Deconstructs the vector's components into named variables.
         /// </summary>
-        /// <param name="height">The Height component</param>
         /// <param name="width">The Width component</param>
+        /// <param name="height">The Height component</param>
         /// <param name="depth">The Depth component</param>
-        public void Deconstruct(out int height, out int width, out int depth)
+        public void Deconstruct(out int width, out int height, out int depth)
         {
-            height = Height;
             width = Width;
+            height = Height;
             depth = Depth;
         }
     }

--- a/sources/core/Stride.Core.Mathematics/Size3.cs
+++ b/sources/core/Stride.Core.Mathematics/Size3.cs
@@ -232,5 +232,18 @@ namespace Stride.Core.Mathematics
         {
             return direction == 0 ? this : direction < 0 ? Down2() : Up2();
         }
+                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="height">The Height component</param>
+        /// <param name="width">The Width component</param>
+        /// <param name="depth">The Depth component</param>
+        public void Deconstruct(out int height, out int width, out int depth)
+        {
+            height = Height;
+            width = Width;
+            depth = Depth;
+        }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/UInt4.cs
+++ b/sources/core/Stride.Core.Mathematics/UInt4.cs
@@ -636,5 +636,21 @@ namespace Stride.Core.Mathematics
         {
             return input.ToArray();
         }
+
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        /// <param name="w">The W component</param>
+        public void Deconstruct(out uint x, out uint y, out uint z, out uint w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
+        }
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/UInt4.cs
+++ b/sources/core/Stride.Core.Mathematics/UInt4.cs
@@ -651,6 +651,5 @@ namespace Stride.Core.Mathematics
             z = Z;
             w = W;
         }
-
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -1430,6 +1430,17 @@ namespace Stride.Core.Mathematics
 
             return Equals((Vector2)value);
         }
+                        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        public void Deconstruct(out float x, out float y)
+        {
+            x = X;
+            y = Y;
+        }
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -1761,6 +1761,19 @@ namespace Stride.Core.Mathematics
 
             return Equals((Vector3)value);
         }
+                
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        public void Deconstruct(out float x, out float y, out float z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -1384,6 +1384,21 @@ namespace Stride.Core.Mathematics
 
             return Equals((Vector4)value);
         }
+        
+        /// <summary>
+        /// Deconstructs the vector's components into named variables.
+        /// </summary>
+        /// <param name="x">The X component</param>
+        /// <param name="y">The Y component</param>
+        /// <param name="z">The Z component</param>
+        /// <param name="w">The W component</param>
+        public void Deconstruct(out float x, out float y, out float z, out float w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
+        }
 
 #if WPFInterop
         /// <summary>


### PR DESCRIPTION
# PR Details

Just adding deconstructors to most of the basic struct types in Mathematics.

## Description

Pretty straight forward add. The only hiccup is I noticed I included a document format on Int2.cs. That change was immaterial so I didn't bother to revert it. 

for example: new Init2() became new();

## Related Issue

none

## Motivation and Context

I wanted my syntactic sugar high.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.