### PR TITLE
Added implicit conversion of equivalent ValueTuples for vector structs

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Color.cs
+++ b/sources/core/Stride.Core.Mathematics/Color.cs
@@ -1125,5 +1125,12 @@ namespace Stride.Core.Mathematics
             var value = (int)(component * 255.0f);
             return (byte)(value < 0 ? 0 : value > 255 ? 255 : value);
         }
+
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Color((byte R, byte G, byte B, byte A) values) => new Color(values.R, values.G, values.B, values.A);
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Color3.cs
+++ b/sources/core/Stride.Core.Mathematics/Color3.cs
@@ -831,6 +831,13 @@ namespace Stride.Core.Mathematics
             b = B;
         }
 
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Color3((float R, float G, float B) values) => new Color3(values.R, values.G, values.B);
+
+
 #if SlimDX1xInterop
         /// <summary>
         /// Performs an implicit conversion from <see cref="Stride.Core.Mathematics.Color3"/> to <see cref="SlimDX.Color3"/>.

--- a/sources/core/Stride.Core.Mathematics/Color4.cs
+++ b/sources/core/Stride.Core.Mathematics/Color4.cs
@@ -1012,6 +1012,12 @@ namespace Stride.Core.Mathematics
             b = B;
             a = A;
         }
+        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Color4((float R, float G, float B, float A) values) => new Color4(values.R, values.G, values.B, values.A);
 
     }
 }

--- a/sources/core/Stride.Core.Mathematics/ColorBGRA.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorBGRA.cs
@@ -1109,6 +1109,5 @@ namespace Stride.Core.Mathematics
             b = B;
             a = A;
         }
-
     }
 }

--- a/sources/core/Stride.Core.Mathematics/ColorHSV.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorHSV.cs
@@ -214,5 +214,10 @@ namespace Stride.Core.Mathematics
             a = A;
         }
 
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator ColorHSV((float H, float S, float V, float A) values) => new ColorHSV(values.H, values.S, values.V, values.A);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Double2.cs
+++ b/sources/core/Stride.Core.Mathematics/Double2.cs
@@ -1448,6 +1448,12 @@ namespace Stride.Core.Mathematics
             x = X;
             y = Y;
         }
+        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Double2((double X, double Y) values) => new Double2(values.X, values.Y);
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Double3.cs
+++ b/sources/core/Stride.Core.Mathematics/Double3.cs
@@ -1728,7 +1728,12 @@ namespace Stride.Core.Mathematics
             y = Y;
             z = Z;
         }
-
+                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Double3((double X, double Y, double Z) values) => new Double3(values.X, values.Y, values.Z);
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Double4.cs
+++ b/sources/core/Stride.Core.Mathematics/Double4.cs
@@ -1402,6 +1402,12 @@ namespace Stride.Core.Mathematics
             z = Z;
             w = W;
         }
+                        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Double4((double X, double Y, double Z, double W) values) => new Double4(values.X, values.Y, values.Z, values.W);
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Half2.cs
+++ b/sources/core/Stride.Core.Mathematics/Half2.cs
@@ -240,5 +240,12 @@ namespace Stride.Core.Mathematics
             x = X;
             y = Y;
         }
+                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Half2((Half X, Half Y) values) => new Half2(values.X, values.Y);
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Half3.cs
+++ b/sources/core/Stride.Core.Mathematics/Half3.cs
@@ -260,5 +260,11 @@ namespace Stride.Core.Mathematics
             y = Y;
             z = Z;
         }
+
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Half3((Half X, Half Y, Half Z) values) => new Half3(values.X, values.Y, values.Z);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Half4.cs
+++ b/sources/core/Stride.Core.Mathematics/Half4.cs
@@ -280,5 +280,11 @@ namespace Stride.Core.Mathematics
             z = Z;
             w = W;
         }
+        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Half4((Half X, Half Y, Half Z, Half W) values) => new Half4(values.X, values.Y, values.Z, values.W);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Int2.cs
+++ b/sources/core/Stride.Core.Mathematics/Int2.cs
@@ -728,6 +728,12 @@ namespace Stride.Core.Mathematics
             x = X;
             y = Y;
         }
+                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Int2((int X, int Y) values) => new Int2(values.X, values.Y);
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Int3.cs
+++ b/sources/core/Stride.Core.Mathematics/Int3.cs
@@ -771,6 +771,12 @@ namespace Stride.Core.Mathematics
             y = Y;
             z = Z;
         }
+                        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Int3((int X, int Y, int Z) values) => new Int3(values.X, values.Y, values.Z);
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Int4.cs
+++ b/sources/core/Stride.Core.Mathematics/Int4.cs
@@ -709,6 +709,5 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="values"></param>
         public static implicit operator Int4((int X, int Y, int Z, int W) values) => new Int4(values.X, values.Y, values.Z, values.W);
-
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Int4.cs
+++ b/sources/core/Stride.Core.Mathematics/Int4.cs
@@ -702,6 +702,13 @@ namespace Stride.Core.Mathematics
             y = Y;
             z = Z;
             w = W;
-        }
+        }   
+        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Int4((int X, int Y, int Z, int W) values) => new Int4(values.X, values.Y, values.Z, values.W);
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Point.cs
+++ b/sources/core/Stride.Core.Mathematics/Point.cs
@@ -153,6 +153,11 @@ namespace Stride.Core.Mathematics
             x = X;
             y = Y;
         }
-
+                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Point((int X, int Y) values) => new Point(values.X, values.Y);
    }
 }

--- a/sources/core/Stride.Core.Mathematics/Size2.cs
+++ b/sources/core/Stride.Core.Mathematics/Size2.cs
@@ -138,5 +138,11 @@ namespace Stride.Core.Mathematics
             width = Width;
             height = Height;
         }
+                        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Size2((int Width, int Height) values) => new Size2(values.Width, values.Height);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Size2F.cs
+++ b/sources/core/Stride.Core.Mathematics/Size2F.cs
@@ -138,5 +138,12 @@ namespace Stride.Core.Mathematics
             width = Width;
             height = Height;
         }
+                                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Size2F((float Width, float Height) values) => new Size2F(values.Width, values.Height);
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Size3.cs
+++ b/sources/core/Stride.Core.Mathematics/Size3.cs
@@ -245,5 +245,12 @@ namespace Stride.Core.Mathematics
             height = Height;
             depth = Depth;
         }
+                                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Size3((int Width, int Height, int Depth) values) => new Size3(values.Width, values.Height, values.Depth);
+
     }
 }

--- a/sources/core/Stride.Core.Mathematics/UInt4.cs
+++ b/sources/core/Stride.Core.Mathematics/UInt4.cs
@@ -651,5 +651,11 @@ namespace Stride.Core.Mathematics
             z = Z;
             w = W;
         }
+                        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator UInt4((uint X, uint Y, uint Z, uint W) values) => new UInt4(values.X, values.Y, values.Z, values.W);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -1441,6 +1441,12 @@ namespace Stride.Core.Mathematics
             x = X;
             y = Y;
         }
+                
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Vector2((float X, float Y) values) => new Vector2(values.X, values.Y);
 
 #if WPFInterop
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -1775,6 +1775,12 @@ namespace Stride.Core.Mathematics
             z = Z;
         }
 
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Vector3((float X, float Y, float Z) values) => new Vector3(values.X, values.Y, values.Z);
+
 #if WPFInterop
         /// <summary>
         /// Performs an implicit conversion from <see cref="Stride.Core.Mathematics.Vector3"/> to <see cref="System.Windows.Media.Media3D.Vector3D"/>.

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -1399,6 +1399,12 @@ namespace Stride.Core.Mathematics
             z = Z;
             w = W;
         }
+        
+        /// <summary>
+        /// Implicitly convert equivalent ValueTuple.
+        /// </summary>
+        /// <param name="values"></param>
+        public static implicit operator Vector4((float X, float Y, float Z, float W) values) => new Vector4(values.X, values.Y, values.Z, values.W);
 
 #if WPFInterop
         /// <summary>


### PR DESCRIPTION
More syntactic sugar.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds implicit conversion from ValueTuples to the equivalent vector struct.
(int, int) -> Int2 
(float, float, float) -> Vector3
etc..

## Motivation and Context

This was specifically to support cleaner data inlining such as:
```
public readonly ReadOnlyMemory<Int2> Corners = new Int2[]
{   (0, 0)
,   (1, 0)
,   (0, 1)
,   (1, 1)
};
```
And operations like:
```
var x = corners[0] + (2, 1);
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (I have failing tests, but they are tests that have continuously failed on my workstation going back to last July. No new issues.)