### PR TITLE
Silk.NET bump to 2.16.0. Suggestion for fix issue 1597

### DIFF
--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -51,11 +51,11 @@
     <PackageReference Include="SharpDX.Direct3D12" Version="4.2.0" Condition="'$(TargetFramework)' == '$(StrideFramework)'" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" Condition="'$(TargetFramework)' == '$(StrideFramework)' Or '$(TargetFramework)' == '$(StrideFrameworkUWP)'" />
     <PackageReference Include="Vortice.Vulkan" Version="1.2.167" Condition="'$(TargetFramework)' == '$(StrideFramework)'" />
-    <PackageReference Include="Silk.NET.OpenGL" Version="2.10.1" Condition="'$(TargetFramework)' == '$(StrideFramework)'" />
-    <PackageReference Include="Silk.NET.OpenGLES" Version="2.10.1" />
-    <PackageReference Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.10.1" />
-    <PackageReference Include="Silk.NET.Sdl" Version="2.10.1" />
-    <PackageReference Include="Silk.NET.Windowing.Sdl" Version="2.10.1" Condition="'$(TargetFramework)' == '$(StrideFrameworkAndroid)' Or '$(TargetFramework)' == '$(StrideFrameworkiOS)'" />
+    <PackageReference Include="Silk.NET.OpenGL" Version="2.16.0" Condition="'$(TargetFramework)' == '$(StrideFramework)'" />
+    <PackageReference Include="Silk.NET.OpenGLES" Version="2.16.0" />
+    <PackageReference Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.16.0" />
+    <PackageReference Include="Silk.NET.Sdl" Version="2.16.0" />
+    <PackageReference Include="Silk.NET.Windowing.Sdl" Version="2.16.0" Condition="'$(TargetFramework)' == '$(StrideFrameworkAndroid)' Or '$(TargetFramework)' == '$(StrideFrameworkiOS)'" />
     <PackageReference Include="Stride.SharpFont" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -46,7 +46,7 @@
     <ProjectReference Include="..\Stride.Native\Stride.Native.csproj" />
     <ProjectReference Include="..\Stride.Shaders\Stride.Shaders.csproj" />
     <ProjectReference Include="..\Stride\Stride.csproj" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" Condition="'$(TargetFramework)' == '$(StrideFramework)' Or '$(TargetFramework)' == '$(StrideFrameworkUWP)'" />
     <PackageReference Include="SharpDX.Direct3D12" Version="4.2.0" Condition="'$(TargetFramework)' == '$(StrideFramework)'" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" Condition="'$(TargetFramework)' == '$(StrideFramework)' Or '$(TargetFramework)' == '$(StrideFrameworkUWP)'" />


### PR DESCRIPTION
# PR Details

I created a PR that bumps Silk.NET dependency to 2.16.0 where crash issue is fixed. However, I could not test this PR because I could not get all of the android toolchain to work.

## Description

Bump Silk.NET to 2.16.0.

## Related Issue

See [Issue 1597](https://github.com/stride3d/stride/issues/1597)

## Motivation and Context

Android build crashes.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.