### PR TITLE
Update NuGet dependencies to 6.4.0 (temporary fix for ScriptEditor issues)

### DIFF
--- a/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
+++ b/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
@@ -7,10 +7,10 @@
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-    <PackageReference Include="NuGet.Resolver" Version="6.0.0" />
-    <PackageReference Include="NuGet.Commands" Version="6.0.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.4.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
+    <PackageReference Include="NuGet.Resolver" Version="6.4.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.4.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
+    <PackageReference Include="NuGet.Configuration" Version="6.4.0" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>

--- a/sources/tools/Stride.NuGetLoader/Stride.NuGetLoader.csproj
+++ b/sources/tools/Stride.NuGetLoader/Stride.NuGetLoader.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-    <PackageReference Include="NuGet.Resolver" Version="6.0.0" />
-		<PackageReference Include="NuGet.Commands" Version="6.0.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
+    <PackageReference Include="NuGet.Resolver" Version="6.4.0" />
+		<PackageReference Include="NuGet.Commands" Version="6.4.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -34,7 +34,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.Commands" Version="6.0.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.4.0" />
 
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating NuGet dependencies to version `6.4.0`.
Removing legacy C# language check which no longer applies. Putting instead something for diagnosing issues in the future.

## Related Issue

Temporary patch for #1453 

## Motivation and Context

See https://github.com/stride3d/stride/issues/1453#issuecomment-1433729780

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / **dependency upgrade**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.