### PR TITLE
fixed constructors in CsharpBeginner template

### DIFF
--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/InstantiatingPrefabsDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/InstantiatingPrefabsDemo.cs
@@ -24,7 +24,7 @@ namespace CSharpBeginner.Code
 
             // We add the entities to a new entity that we can use a parent
             // We can easily position and rotate the parent entity
-            var pileOfBoxesParent = new Entity(new Vector3(0, 0, -2), "PileOfBoxes2");
+            var pileOfBoxesParent = new Entity("PileOfBoxes2", new Vector3(0, 0, -2));
             pileOfBoxesParent.Transform.Rotation = Quaternion.RotationY(135);
             foreach (var entity in pileOfBoxesInstance2)
             {

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/LoadingContentDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/LoadingContentDemo.cs
@@ -68,7 +68,7 @@ namespace CSharpBeginner.Code
                 var randomPosition = new Vector3(random.Next(-2, 4), 0, random.Next(-2, 2));
 
                 // Create a new entity and attach a model component 
-                var entity = new Entity(randomPosition, "My new entity with a model component");
+                var entity = new Entity("My new entity with a model component", randomPosition);
                 entity.Add(modelComponent);
 
                 // Add the new entity to the current tutorial scene


### PR DESCRIPTION
# PR Details

an issue was found in the beginner csharp tutorial template. This PR should resolve the issue as it seems the Constructor may have changed its formatting in a previous release.

## Description

I only had to switch the location of the values in the constructor at the below locations:
InstantiatingPrefabsDemo line 28
LoadingContentDemo.cs line 71

## Related Issue

https://github.com/stride3d/stride/issues/1617

## Motivation and Context

makes sure new users can load the beginner templates without having to fix issues.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.