### PR TITLE
[Graphics] Fixes Vsync off when using new flip model

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -73,25 +73,41 @@ namespace Stride.Graphics
 
             static bool CheckFlipModelSupport(GraphicsDevice device)
             {
-                // From https://github.com/walbourn/directx-vs-templates/blob/main/d3d11game_win32_dr/DeviceResources.cpp#L138
-                using var dxgiDevice = device.NativeDevice.QueryInterface<SharpDX.DXGI.Device>();
-                using var dxgiAdapter = dxgiDevice.Adapter;
-                using var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory4>();
-                return dxgiFactory != null;
+                try
+                {
+                    // From https://github.com/walbourn/directx-vs-templates/blob/main/d3d11game_win32_dr/DeviceResources.cpp#L138
+                    using var dxgiDevice = device.NativeDevice.QueryInterface<SharpDX.DXGI.Device>();
+                    using var dxgiAdapter = dxgiDevice.Adapter;
+                    using var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory4>();
+                    return dxgiFactory != null;
+                }
+                catch
+                {
+                    // The requested interfaces need at least Windows 8
+                    return false;
+                }
             }
 
             static unsafe bool CheckTearingSupport(GraphicsDevice device)
             {
-                // From https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/variable-refresh-rate-displays
-                using var dxgiDevice = device.NativeDevice.QueryInterface<SharpDX.DXGI.Device>();
-                using var dxgiAdapter = dxgiDevice.Adapter;
-                using var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory5>();
-                if (dxgiFactory is null)
-                    return false;
+                try
+                {
+                    // From https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/variable-refresh-rate-displays
+                    using var dxgiDevice = device.NativeDevice.QueryInterface<SharpDX.DXGI.Device>();
+                    using var dxgiAdapter = dxgiDevice.Adapter;
+                    using var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory5>();
+                    if (dxgiFactory is null)
+                        return false;
 
-                int allowTearing = 0;
-                dxgiFactory.CheckFeatureSupport(Feature.PresentAllowTearing, new IntPtr(&allowTearing), sizeof(int));
-                return allowTearing != 0;
+                    int allowTearing = 0;
+                    dxgiFactory.CheckFeatureSupport(Feature.PresentAllowTearing, new IntPtr(&allowTearing), sizeof(int));
+                    return allowTearing != 0;
+                }
+                catch
+                {
+                    // The requested interfaces need at least Windows 10
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Vsync off was no longer working since we use the new flip model (#1594).
This PR re-enables that feature, taking most of the code from https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/variable-refresh-rate-displays

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.