### PR TITLE
rebased branch

### DIFF
--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -40,9 +40,15 @@ namespace Stride.Core.Assets
                 MSBuildInstance = MSBuildLocator.QueryVisualStudioInstances().FirstOrDefault(x => isNETCore
                     ? x.DiscoveryType == DiscoveryType.DotNetSdk && x.Version.Major >= 3
                     : (x.DiscoveryType == DiscoveryType.VisualStudioSetup || x.DiscoveryType == DiscoveryType.DeveloperConsole) && x.Version.Major >= 16);
+                
+                if (MSBuildInstance == null)
+                {
+                    throw new InvalidOperationException("Could not find a MSBuild installation (expected 16.0 or later) " +
+                        "Please ensure you have the .NET 6 SDK installed from Microsoft's website");
+                }
 
                 // Make sure it is not already loaded (otherwise MSBuildLocator.RegisterDefaults() throws an exception)
-                if (MSBuildInstance != null && !AppDomain.CurrentDomain.GetAssemblies().Any(IsMSBuildAssembly))
+                if (!AppDomain.CurrentDomain.GetAssemblies().Any(IsMSBuildAssembly))
                 {
                     // We can't use directly RegisterInstance because we want to avoid NuGet verison conflicts (between MSBuild/dotnet one and ours).
                     // More details at https://github.com/microsoft/MSBuildLocator/issues/127
@@ -65,9 +71,6 @@ namespace Stride.Core.Assets
                     };
                 }
             }
-
-            if (MSBuildInstance == null)
-                throw new InvalidOperationException("Could not find a MSBuild installation (expected 16.0 or later)");
 
             SetupMSBuildCurrentHostForOutOfProc(MSBuildInstance.MSBuildPath);
             CheckMSBuildToolset();

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -244,7 +244,8 @@ namespace Stride.GameStudio
                 catch (Exception e)
                 {
                     var message = "Could not find a compatible version of MSBuild.\r\n\r\n" +
-                                  "Check that you have a valid installation with the required workloads, or go to [www.visualstudio.com/downloads](https://www.visualstudio.com/downloads) to install a new one.\r\n\r\n" +
+                                  "Check that you have a valid installation with the required workloads, or go to [www.visualstudio.com/downloads](https://www.visualstudio.com/downloads) to install a new one.\r\n" +
+                                  "Also make sure you have the latest [.NET 6 SDK](https://dotnet.microsoft.com/) \r\n\r\n" +
                                   e;
                     await serviceProvider.Get<IEditorDialogService>().MessageBox(message, Core.Presentation.Services.MessageBoxButton.OK, Core.Presentation.Services.MessageBoxImage.Error);
                     app.Shutdown();


### PR DESCRIPTION
# PR Details
Remade from https://github.com/stride3d/stride/pull/1641 because I broke my master branch.
This PR should make the readabilty of a common error easier to understand.

## Description

I added references to the .NET 6 package in 2 places where an error describes needing MSBuild 16.0. I added these because even the VS2022 installation does not solve this error and user need to manually install the .NET 6 SDK in order for gamestudio 4.1 to run.

I also did a little bit of code clean up with some if statements.

## Related Issue

https://github.com/stride3d/stride/issues/1612
also at least one question about this problem a week in the discord.

## Motivation and Context

There are a lot of new Stride user coming in that have not manually installed the .NET 6 SDK. I am hoping this error message will be a bit more friendly to read. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
