### PR TITLE
Possible fix for the animation importer crashing

### DIFF
--- a/sources/tools/Stride.Importer.FBX/AnimationConverter.h
+++ b/sources/tools/Stride.Importer.FBX/AnimationConverter.h
@@ -315,6 +315,12 @@ namespace Stride {
 					const float framerate = static_cast<float>(FbxTime::GetFrameRate(scene->GetGlobalSettings().GetTimeMode()));
 					auto oneFrame = FbxTime::GetOneFrameValue(scene->GetGlobalSettings().GetTimeMode());
 
+					//FIX: If scene->GetGlobalSettings().GetTimeMode() returns FbxTime::eFrames30Drop then oneFrame is going to be 0.
+					// This is (propably) undesired since time will increment by 0 in the next second loop, resulting in a infinite loop 
+					// that finally leads to a out-of-memory exception.
+					if (oneFrame == 0)
+						oneFrame = FbxTime::GetOneFrameValue(FbxTime::eFrames1000); // See https://github.com/stride3d/stride/issues/1567 why this was chosen.
+
 					// Step1: Pregenerate curve with discontinuities
 					int currentKeyIndices[4];
 					int currentEvaluationIndices[4];

--- a/sources/tools/Stride.Importer.FBX/AnimationConverter.h
+++ b/sources/tools/Stride.Importer.FBX/AnimationConverter.h
@@ -318,8 +318,11 @@ namespace Stride {
 					//FIX: If scene->GetGlobalSettings().GetTimeMode() returns FbxTime::eFrames30Drop then oneFrame is going to be 0.
 					// This is (propably) undesired since time will increment by 0 in the next second loop, resulting in a infinite loop 
 					// that finally leads to a out-of-memory exception.
-					if (oneFrame == 0)
-						oneFrame = FbxTime::GetOneFrameValue(FbxTime::eFrames1000); // See https://github.com/stride3d/stride/issues/1567 why this was chosen.
+
+					if (oneFrame == 0) 
+						oneFrame = FbxTime::GetOneFrameValue(FbxTime::eNTSCDropFrame); // FbxTime::eNTSCDropFrame is equivalent to FbxTime::eFrames30Drop.
+					//Source: (FBX Docs : http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_time.html,topicNumber=cpp_ref_class_fbx_time_html29087af6-8c2c-4e9d-aede-7dc5a1c2436c)
+					//Refer to: enum EMode
 
 					// Step1: Pregenerate curve with discontinuities
 					int currentKeyIndices[4];

--- a/sources/tools/Stride.Importer.FBX/AnimationConverter.h
+++ b/sources/tools/Stride.Importer.FBX/AnimationConverter.h
@@ -319,7 +319,7 @@ namespace Stride {
 					// This is (propably) undesired since time will increment by 0 in the next second loop, resulting in a infinite loop 
 					// that finally leads to a out-of-memory exception.
 
-					if (oneFrame == 0) 
+					if (oneFrame <= 0) 
 						oneFrame = FbxTime::GetOneFrameValue(FbxTime::eNTSCDropFrame); // FbxTime::eNTSCDropFrame is equivalent to FbxTime::eFrames30Drop.
 					//Source: (FBX Docs : http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_time.html,topicNumber=cpp_ref_class_fbx_time_html29087af6-8c2c-4e9d-aede-7dc5a1c2436c)
 					//Refer to: enum EMode


### PR DESCRIPTION
# PR Details

This is a (possible) fix for https://github.com/stride3d/stride/issues/1567 and https://github.com/stride3d/stride/issues/1584 .

## Description
Due to a possible bug in FBX SDK:
```cpp
FbxTime::GetOneFrameValue(FbxTime::eFrames30Drop)
```
returns `0`. While the documentation says it returns the same value as  (citation: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_time.html,topicNumber=cpp_ref_class_fbx_time_html29087af6-8c2c-4e9d-aede-7dc5a1c2436c )
```cpp
FbxTime::GetOneFrameValue(FbxTime::eNTSCDropFrame)
```

The smallest numerical values of the `GetOneFrameValue function` were determined with this short C++ program:
```cpp
#include <iostream>
#include <vector>
#include <algorithm>
#include <unordered_map>
#include <string>

#include <fbxsdk/core/base/fbxtime.h>

using namespace fbxsdk;

auto main() -> int
{
	std::unordered_map<std::string, FbxLongLong> valueNames;

	valueNames["default mode :"] = FbxTime::GetOneFrameValue(FbxTime::eDefaultMode);
	valueNames["custom :"] = FbxTime::GetOneFrameValue(FbxTime::eCustom);
	valueNames["film full frame :"] = FbxTime::GetOneFrameValue(FbxTime::eFilmFullFrame) ;
	valueNames["frames 100 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames100) ;
	valueNames["frames 1000 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames1000) ;
	valueNames["frames 120 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames120) ;
	valueNames["frames 24 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames24) ;
	valueNames["frames 30 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames30) ;
	valueNames["frames 30 drop :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames30Drop) ;
	valueNames["frames 48 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames48) ;
	valueNames["frames 50 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames50) ;
	valueNames["frames 50.94 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames59dot94) ;
	valueNames["frames 60 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames60) ;
	valueNames["frames 72 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames72) ;
	valueNames["frames 96 :"] = FbxTime::GetOneFrameValue(FbxTime::eFrames96) ;
	valueNames["modes count :"] = FbxTime::GetOneFrameValue(FbxTime::eModesCount) ;
	valueNames["NTSCD drop frame :"] = FbxTime::GetOneFrameValue(FbxTime::eNTSCDropFrame) ;
	valueNames["NTSCD full frame :"] = FbxTime::GetOneFrameValue(FbxTime::eNTSCFullFrame) ;
	valueNames["PAL :"] = FbxTime::GetOneFrameValue(FbxTime::ePAL) ;
        valueNames["Undefined:"] = FbxTime::GetOneFrameValue(static_cast<FbxTime::EMode>(100));

	std::vector<std::pair<std::string, FbxLongLong>> values;

	for (auto p : valueNames)
	{
		values.push_back(p);
	}

	std::sort(values.begin(), values.end(),
		[](std::pair<std::string, FbxLongLong> a, std::pair<std::string, FbxLongLong> b) -> bool
		{
			return a.second > b.second;
		}
	);

	for (auto& p : values)
	{
		std::cout << p.first << ' ' << p.second << "\r\n";
	}

	return 0;
}
```
With outputs
```
custom : 3694892640
film full frame : 1926347673
frames 24 : 1924423250
PAL : 1847446320
NTSCD drop frame : 1541078138
NTSCD full frame : 1541078138
default mode : 1539538600
frames 30 : 1539538600
frames 48 : 962211625
frames 50 : 923723160
frames 50.94 : 770539069
frames 60 : 769769300
frames 72 : 641474416
frames 96 : 481105812
frames 100 : 461861580
frames 120 : 384884650
frames 1000 : 46186158
frames 30 drop : 0
modes count : 0
Undefined: 0
```

The fix is checking if `0` was returned, then using the value returned by 
```cpp
 FbxTime::GetOneFrameValue(FbxTime::eNTSCDropFrame)
 ```
 to make sure the loop that's iterating time is not infinite. (this is the loop I'm refering to https://github.com/stride3d/stride/blob/3d218db080d31ce9283a1053c82123e394741217/sources/tools/Stride.Importer.FBX/AnimationConverter.h#LL338C18-L338C27 )
 
 The FBX documentation says that the return value of ` FbxTime::GetOneFrameValue(FbxTime::eNTSCDropFrame)` should be same as ` FbxTime::GetOneFrameValue(FbxTime::eFrames30Drop)`
 
> - eFrames30Drop 30 frames/s (use when display in frame is selected, equivalent to NTSC drop)
> - eNTSCDropFrame ~29.97 frames/s drop color NTSC

Source: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_time.html,topicNumber=cpp_ref_class_fbx_time_html29087af6-8c2c-4e9d-aede-7dc5a1c2436c

Showcase that the fix is working:

https://user-images.githubusercontent.com/20599225/235382525-bf761ee6-f9fd-4b2d-80da-f2eb9f9f230a.mov

(The model was previously used in https://github.com/stride3d/stride/issues/1567 )

## Related Issues
 https://github.com/stride3d/stride/issues/1567 and https://github.com/stride3d/stride/issues/1584

## Motivation and Context
I wasn't able to load FBX models exported from Blender. I struggled with this in MONTHS. :(

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.