### PR TITLE
Update the forum link with Github discussions link

### DIFF
--- a/sources/editor/Stride.GameStudio/StrideGameStudio.cs
+++ b/sources/editor/Stride.GameStudio/StrideGameStudio.cs
@@ -35,7 +35,7 @@ namespace Stride.GameStudio
         public static string DocumentationUrl => $"https://doc.stride3d.net/{EditorVersionMajor}/";
 
         [NotNull]
-        public static string ForumsUrl => "https://forums.stride3d.net/";
+        public static string ForumsUrl => "https://github.com/stride3d/stride/discussions";
 
         [NotNull]
         public static string ReportIssueUrl => "https://github.com/stride3d/stride/issues/";


### PR DESCRIPTION
# PR Details
## Description

Update the link used in the editor from the closed Stride forums to Github community.

## Motivation and Context

Use the GitHub community as forum, since `https://forums.stride3d.net/` is marked as read only. I didn't consider creating a issue since this change is trivial to implement.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- **N/A** Bug fix (non-breaking change which fixes an issue)
- **N/A** New feature (non-breaking change which adds functionality)
- **N/A** Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- **N/A** My change requires a change to the documentation.
- **N/A** I have added tests to cover my changes.
- [x] All new and existing tests passed. (there's no behavior that affects any test units)