### PR TITLE
fix Crash when NativeDeviceContext is null

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/CommandList.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/CommandList.Direct3D.cs
@@ -81,7 +81,7 @@ namespace Stride.Graphics
 
         private void ClearStateImpl()
         {
-            NativeDeviceContext.ClearState();
+            NativeDeviceContext?.ClearState();
 
             for (int i = 0; i < samplerStates.Length; ++i)
                 samplerStates[i] = null;


### PR DESCRIPTION
# PR Details

I added a simple null check as when I was working with the source built version of stride this caused crashes about 3 times.

## Description

I am not 100% sure what causes this to be null since this seems to be called per frame but there were a few times when I added some new models that when I selected them the Gamestudio would pop up the crash message. 

I could not recreate this consistantly but after adding this I wasnt getting anymore issues.

## Motivation and Context

Should fix some crash issues when NativeDeviceContext is null

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.