### PR TITLE
Change physics null exceptions

### DIFF
--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -26,7 +26,8 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                logger.Warning("Jump called on a CharacterComponent that is not attached to a PhysicsSystem");
+                return;
             }
             BulletSharp.Math.Vector3 bV3 = jumpDirection;
             KinematicCharacter.Jump(ref bV3);
@@ -39,7 +40,8 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                logger.Warning("Jump called on a CharacterComponent that is not attached to a PhysicsSystem");
+                return;
             }
             KinematicCharacter.Jump();
         }
@@ -209,7 +211,8 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                logger.Warning("Teleport called on a CharacterComponent that is not attached to a PhysicsSystem");
+                return;
             }
 
             //we assume that the user wants to teleport in world/entity space
@@ -230,7 +233,8 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                logger.Warning("Move called on a CharacterComponent that is not attached to a PhysicsSystem");
+                return;
             }
 
             KinematicCharacter.SetWalkDirection(movement);
@@ -246,7 +250,8 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is available only when the Entity has been already added to the Scene.");
+                logger.Warning("SetVelocity called on a CharacterComponent that is not attached to a PhysicsSystem");
+                return;
             }
 
             KinematicCharacter.SetWalkDirection(velocity * Simulation.FixedTimeStep);

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -365,7 +365,7 @@ namespace Stride.Physics
             LinkedConstraints.Clear();
             //~Remove constraints
 
-            Simulation.RemoveRigidBody(this);
+            Simulation?.RemoveRigidBody(this);
 
             InternalRigidBody = null;
 

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -341,8 +341,11 @@ namespace Stride.Physics
 
         protected override void OnDetach()
         {
-            MotionState.Dispose();
-            MotionState.Clear();
+            if (MotionState != null)
+            {
+                MotionState.Dispose();
+                MotionState.Clear();
+            }
 
             if (NativeCollisionObject == null)
                 return;


### PR DESCRIPTION
# PR Details

Added some null checks and changed from throwing errors to just returning the function and logging the error.

## Description

Obsdark and I were getting errors from trying to remove physics entities from a scene however there seems to be an issue with the components still trying to update with null data. 

I would love some input on this as I feel like this is 100% a bandaid fix for a larger issue with how Synced entities are removed from a Scene.

## Motivation and Context

This should prevent the engine from hard crashing due to null exceptions.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.