### PR TITLE
Adds touch support to Winforms based GameForm

### DIFF
--- a/sources/engine/Stride.Games/Desktop/GameForm.cs
+++ b/sources/engine/Stride.Games/Desktop/GameForm.cs
@@ -51,6 +51,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using static Stride.Games.TouchUtils;
 
 namespace Stride.Games
 {
@@ -165,6 +166,11 @@ namespace Stride.Games
         public bool IsProcessingKeys { get; set; }
 
         internal bool IsFullScreen { get; set; }
+
+        internal delegate void TouchFingerDelegate(POINTER_TOUCH_INFO e);
+        internal event TouchFingerDelegate FingerMoveActions;
+        internal event TouchFingerDelegate FingerPressActions;
+        internal event TouchFingerDelegate FingerReleaseActions;
 
         /// <summary>
         /// Raises the <see cref="E:System.Windows.Forms.Form.ResizeBegin"/> event.
@@ -412,6 +418,27 @@ namespace Stride.Games
                         if (!enableFullscreenToggle) return;
                         OnFullscreenToggle(new EventArgs()); //we handle alt enter manually
                         isSwitchingFullScreen = false;
+                    }
+                    break;
+                // https://devblogs.microsoft.com/oldnewthing/20210728-00/?p=105487
+                case TouchUtils.WM_POINTERDOWN:
+                case TouchUtils.WM_POINTERUPDATE:
+                case TouchUtils.WM_POINTERUP:
+                    var pointerId = TouchUtils.GET_POINTERID_WPARAM((ulong)m.WParam);
+                    if (TouchUtils.GetPointerType(pointerId, out var type) && type == TouchUtils.PointerInputType.PT_TOUCH)
+                    {
+                        TouchUtils.GetPointerTouchInfo(pointerId, out var touchInfo);
+
+                        if (m.Msg == TouchUtils.WM_POINTERDOWN)
+                            FingerPressActions?.Invoke(touchInfo);
+                        else if (m.Msg == TouchUtils.WM_POINTERUP)
+                            FingerReleaseActions?.Invoke(touchInfo);
+                        else
+                            FingerMoveActions?.Invoke(touchInfo);
+
+                        //to signal that there should not be a mouse event created
+                        m.Result = new IntPtr(1);
+                        return;
                     }
                     break;
             }

--- a/sources/engine/Stride.Games/Desktop/Win32Native.cs
+++ b/sources/engine/Stride.Games/Desktop/Win32Native.cs
@@ -208,6 +208,135 @@ namespace Stride.Games
 
         public const int PM_REMOVE = 0x0001;
     }
+
+    internal static class TouchUtils
+    {
+        public const int WM_POINTERDOWN = 0x0246;
+        public const int WM_POINTERUP = 0x0247;
+        public const int WM_POINTERUPDATE = 0x0245;
+        public const int WM_POINTERWHEEL = 0x024E;
+        public const int WM_POINTERHWHEEL = 0x024F;
+        public const int WM_POINTERCAPTURECHANGED = 0x024C;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool GetPointerType(uint pointerId, out PointerInputType pointerType);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool GetPointerTouchInfo(uint pointerId, out POINTER_TOUCH_INFO touchInfo);
+
+        [Flags]
+        public enum TouchFlags
+        {
+            TOUCH_FLAG_NONE = 0x00000000
+        }
+
+        [Flags]
+        public enum TouchMask
+        {
+            TOUCH_MASK_NONE = 0x00000000,
+            TOUCH_MASK_CONTACTAREA = 0x00000001,
+            TOUCH_MASK_ORIENTATION = 0x00000002,
+            TOUCH_MASK_PRESSURE = 0x00000004,
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct POINTER_TOUCH_INFO
+        {
+            public POINTER_INFO pointerInfo;
+            public TouchFlags touchFlags;
+            public TouchMask touchMask;
+            public int rcContactLeft;
+            public int rcContactTop;
+            public int rcContactRight;
+            public int rcContactBottom;
+            public int rcContactRawLeft;
+            public int rcContactRawTop;
+            public int rcContactRawRight;
+            public int rcContactRawBottom;
+            public uint orientation;
+            public uint pressure;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct POINTER_INFO
+        {
+            public PointerInputType pointerType;
+            public uint pointerId;
+            public uint frameId;
+            public PointerFlags pointerFlags;
+            public IntPtr sourceDevice;
+            public IntPtr hwndTarget;
+            public int ptPixelLocationX;
+            public int ptPixelLocationY;
+            public int ptHimetricLocationX;
+            public int ptHimetricLocationY;
+            public int ptPixelLocationRawX;
+            public int ptPixelLocationRawY;
+            public int ptHimetricLocationRawX;
+            public int ptHimetricLocationRawY;
+            public uint dwTime;
+            public uint historyCount;
+            public int inputData;
+            public uint dwKeyStates;
+            public ulong PerformanceCount;
+            public PointerButtonChangeType ButtonChangeType;
+        }
+
+        public enum PointerInputType
+        {
+            PT_NONE = 0x00000000,
+            PT_POINTER = 0x00000001,
+            PT_TOUCH = 0x00000002,
+            PT_PEN = 0x00000003,
+            PT_MOUSE = 0x00000004,
+            PT_TOUCHPAD = 0x00000005
+        }
+
+        [Flags]
+        public enum PointerFlags
+        {
+            POINTER_FLAG_NONE = 0x00000000,
+            POINTER_FLAG_NEW = 0x00000001,
+            POINTER_FLAG_INRANGE = 0x00000002,
+            POINTER_FLAG_INCONTACT = 0x00000004,
+            POINTER_FLAG_FIRSTBUTTON = 0x00000010,
+            POINTER_FLAG_SECONDBUTTON = 0x00000020,
+            POINTER_FLAG_THIRDBUTTON = 0x00000040,
+            POINTER_FLAG_FOURTHBUTTON = 0x00000080,
+            POINTER_FLAG_FIFTHBUTTON = 0x00000100,
+            POINTER_FLAG_PRIMARY = 0x00002000,
+            POINTER_FLAG_CONFIDENCE = 0x00000400,
+            POINTER_FLAG_CANCELED = 0x00000800,
+            POINTER_FLAG_DOWN = 0x00010000,
+            POINTER_FLAG_UPDATE = 0x00020000,
+            POINTER_FLAG_UP = 0x00040000,
+            POINTER_FLAG_WHEEL = 0x00080000,
+            POINTER_FLAG_HWHEEL = 0x00100000,
+            POINTER_FLAG_CAPTURECHANGED = 0x00200000,
+            POINTER_FLAG_HASTRANSFORM = 0x00400000
+        }
+
+        public enum PointerButtonChangeType : ulong
+        {
+            POINTER_CHANGE_NONE,
+            POINTER_CHANGE_FIRSTBUTTON_DOWN,
+            POINTER_CHANGE_FIRSTBUTTON_UP,
+            POINTER_CHANGE_SECONDBUTTON_DOWN,
+            POINTER_CHANGE_SECONDBUTTON_UP,
+            POINTER_CHANGE_THIRDBUTTON_DOWN,
+            POINTER_CHANGE_THIRDBUTTON_UP,
+            POINTER_CHANGE_FOURTHBUTTON_DOWN,
+            POINTER_CHANGE_FOURTHBUTTON_UP,
+            POINTER_CHANGE_FIFTHBUTTON_DOWN,
+            POINTER_CHANGE_FIFTHBUTTON_UP
+        }
+
+        public static ushort LOWORD(ulong l) { return (ushort)(l & 0xFFFF); }
+        public static ushort HIWORD(ulong l) { return (ushort)((l >> 16) & 0xFFFF); }
+        public static ushort GET_POINTERID_WPARAM(ulong wParam) { return LOWORD(wParam); }
+        public static ushort GET_X_LPARAM(ulong lp) { return LOWORD(lp); }
+        public static ushort GET_Y_LPARAM(ulong lp) { return HIWORD(lp); }
+    }
 }
 
 #endif

--- a/sources/engine/Stride.Input/SDL/PointerSDL.cs
+++ b/sources/engine/Stride.Input/SDL/PointerSDL.cs
@@ -21,8 +21,6 @@ namespace Stride.Input
         private static Sdl SDL = Window.SDL;
 
         private readonly Window uiControl;
-        private readonly Dictionary<(long touchId, long fingerId), int> touchFingerIndexMap = new Dictionary<(long touchId, long fingerId), int>();
-        private int touchCounter;
 
         public PointerSDL(InputSourceSDL source, Window uiControl)
         {
@@ -60,37 +58,6 @@ namespace Stride.Input
         private void OnSizeChanged(WindowEvent eventArgs)
         {
             SetSurfaceSize(new Vector2(uiControl.ClientSize.Width, uiControl.ClientSize.Height));
-        }
-
-        private int GetFingerId(long touchId, long fingerId, PointerEventType type)
-        {
-            // Assign finger index (starting at 0) to touch ID
-            int touchFingerIndex = 0;
-            var key = (touchId, fingerId);
-            if (type == PointerEventType.Pressed)
-            {
-                touchFingerIndex = touchCounter++;
-                touchFingerIndexMap[key] = touchFingerIndex;
-            }
-            else
-            {
-                touchFingerIndexMap.TryGetValue(key, out touchFingerIndex);
-            }
-
-            // Remove index
-            if (type == PointerEventType.Released && touchFingerIndexMap.Remove(key))
-            {
-                touchCounter = 0; // Reset touch counter
-
-                // Recalculate next finger index
-                if (touchFingerIndexMap.Count > 0)
-                {
-                    touchFingerIndexMap.ForEach(pair => touchCounter = Math.Max(touchCounter, pair.Value));
-                    touchCounter++; // next
-                }
-            }
-
-            return touchFingerIndex;
         }
 
         private void HandleFingerEvent(TouchFingerEvent e, PointerEventType type)

--- a/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
@@ -25,6 +25,7 @@ namespace Stride.Input
         
         private KeyboardWinforms keyboard;
         private MouseWinforms mouse;
+        private PointerWinforms pointer;
 
         private IntPtr defaultWndProc;
         private Win32Native.WndProc inputWndProc;
@@ -63,6 +64,9 @@ namespace Stride.Input
 
             mouse = new MouseWinforms(this, uiControl);
             RegisterDevice(mouse);
+
+            pointer = new PointerWinforms(this, uiControl);
+            RegisterDevice(pointer);
         }
 
         /// <summary>

--- a/sources/engine/Stride.Input/Windows/PointerWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/PointerWinforms.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#if STRIDE_UI_WINFORMS
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Stride.Core.Extensions;
+using Stride.Core.Mathematics;
+using Stride.Games;
+using static Stride.Games.TouchUtils;
+
+namespace Stride.Input
+{
+    /// <summary>
+    /// Class handling finger touch inputs using the Winforms backend
+    /// </summary>
+    internal class PointerWinforms : PointerDeviceBase, IDisposable
+    {
+        private readonly GameForm uiControl;
+
+        public PointerWinforms(InputSourceWinforms source, Control uiControl)
+        {
+            Source = source;
+            this.uiControl = uiControl as GameForm;
+
+            this.uiControl.FingerMoveActions += OnFingerMoveEvent;
+            this.uiControl.FingerPressActions += OnFingerPressEvent;
+            this.uiControl.FingerReleaseActions += OnFingerReleaseEvent;
+
+            uiControl.Resize += OnSizeChanged;
+            OnSizeChanged(uiControl, EventArgs.Empty);
+
+            Id = InputDeviceUtils.DeviceNameToGuid(uiControl.Handle.ToString() + Name);
+        }
+
+        public override string Name => "Winforms Pointer";
+
+        public override Guid Id { get; }
+
+        public override IInputSource Source { get; }
+
+        public void Dispose()
+        {
+            uiControl.FingerMoveActions -= OnFingerMoveEvent;
+            uiControl.FingerPressActions -= OnFingerPressEvent;
+            uiControl.FingerReleaseActions -= OnFingerReleaseEvent;
+
+            uiControl.Resize -= OnSizeChanged;
+        }
+
+        private void OnSizeChanged(object sender, EventArgs eventArgs)
+        {
+            SetSurfaceSize(new Vector2(uiControl.ClientSize.Width, uiControl.ClientSize.Height));
+        }
+
+        private void HandleFingerEvent(POINTER_TOUCH_INFO e, PointerEventType type)
+        {
+            var pointerInfo = e.pointerInfo;
+            var point = uiControl.PointToClient(new System.Drawing.Point(pointerInfo.ptPixelLocationX, pointerInfo.ptPixelLocationY));
+            var newPosition = new Vector2(point.X, point.Y);
+            var id = GetFingerId(pointerInfo.sourceDevice.ToInt64(), pointerInfo.pointerId, type);
+
+            PointerState.PointerInputEvents.Add(new PointerDeviceState.InputEvent { Type = type, Position = newPosition, Id = id });
+        }
+
+        private void OnFingerMoveEvent(POINTER_TOUCH_INFO e)
+        {
+            HandleFingerEvent(e, PointerEventType.Moved);
+        }
+
+        private void OnFingerPressEvent(POINTER_TOUCH_INFO e)
+        {
+            HandleFingerEvent(e, PointerEventType.Pressed);
+        }
+
+        private void OnFingerReleaseEvent(POINTER_TOUCH_INFO e)
+        {
+            HandleFingerEvent(e, PointerEventType.Released);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
# PR Details

Similar to https://github.com/stride3d/stride/pull/504, this adds touch support to the Winforms based GameForm.

## Description

Adds a PointerWinfoms class (corresponding to the PointerSDL class) and adds FingerPress/Move/Release events to the GameForm class. The GameForm in its WndProc() listens to the WM_POINTER messages and fires the finger-events accordingly.

The GetFingerId() method is now shared by PointerSDL and PointerWinforms by having it moved to their baseclass: PointerDeviceBase.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The SDL based GameForm had touch support for a while now but it turned out that at least on Windows it has issues (probably due to the SDL2 touch implementation being based on the obsolete WM_TOUCH api). Sometimes touches would not be released, simple to reproduce by pressing ALT+Tab while having a finger on the screen. 

This PR adds touch support based on the WM_POINTER api and does not show the same issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.