### PR TITLE
[Reflection] Fixes loading of mixed mode assemblies in .NET Core

### DIFF
--- a/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
+++ b/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
@@ -315,6 +315,11 @@ namespace Stride.Core.Reflection
                             // No way to load from byte array (see https://stackoverflow.com/questions/5005409/exception-with-resolving-assemblies-attempt-to-load-an-unverifiable-executable)
                             assembly = Assembly.LoadFrom(assemblyFullPath);
                         }
+                        catch (BadImageFormatException)
+                        {
+                            // It could be a mixed mode assembly (see https://stackoverflow.com/questions/2945080/how-do-i-dynamically-load-raw-assemblies-that-contains-unmanaged-codebypassing)
+                            assembly = Assembly.LoadFrom(assemblyFullPath);
+                        }
                         loadedAssembly = new LoadedAssembly(this, assemblyFullPath, assembly, dependenciesMapping);
                         loadedAssemblies.Add(loadedAssembly);
                         loadedAssembliesByName.Add(assemblyFullPath, loadedAssembly);


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

It seems .NET Core behaves slightly different in this regard, throwing a different kind of exception, so previous code no longer applies, even though it's the same assembly being loaded (irrKlang.NET4.dll)

## Related Issue

#1072 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.