### PR TITLE
Fix missing Utilities.CopyMemory for other graphics APIs

### DIFF
--- a/sources/engine/Stride.Graphics/OpenGL/Texture.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/Texture.OpenGL.cs
@@ -2,8 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 #if STRIDE_GRAPHICS_API_OPENGL
 using System;
-using System.Runtime.InteropServices;
-using Stride.Core;
+using System.Runtime.CompilerServices;
 using Stride.Core.Mathematics;
 
 namespace Stride.Graphics
@@ -29,16 +28,10 @@ namespace Stride.Graphics
         internal bool IsDepthBuffer { get; private set; }   // TODO: Isn't this redundant? This gets set to the same value as IsDepthStencil...
         internal bool HasStencil { get; private set; }
         internal bool IsRenderbuffer { get; private set; }
-        
-        internal uint PixelBufferObjectId
-        {
-            get { return pixelBufferObjectId; }
-        }
 
-        internal uint StencilId
-        {
-            get { return stencilId; }
-        }
+        internal uint PixelBufferObjectId => pixelBufferObjectId;
+
+        internal uint StencilId => stencilId;
 
         public static bool IsDepthStencilReadOnlySupported(GraphicsDevice device)
         {
@@ -48,39 +41,29 @@ namespace Stride.Graphics
 
         internal void SwapInternal(Texture other)
         {
-            var tmp = DepthPitch;
-            DepthPitch = other.DepthPitch;
-            other.DepthPitch = tmp;
-            //
-            tmp = RowPitch;
-            RowPitch = other.RowPitch;
-            other.RowPitch = tmp;
-            //
-            var tmp2 = IsDepthBuffer;
-            IsDepthBuffer = other.IsDepthBuffer;
-            other.IsDepthBuffer = tmp2;
-            //
-            tmp2 = HasStencil;
-            HasStencil = other.HasStencil;
-            other.HasStencil = tmp2;
-            //
-            tmp2 = IsRenderbuffer;
-            HasStencil = other.IsRenderbuffer;
-            other.IsRenderbuffer = tmp2;
-            //
-            Utilities.Swap(ref BoundSamplerState, ref other.BoundSamplerState);
-            Utilities.Swap(ref PixelBufferFrame, ref other.PixelBufferFrame);
-            Utilities.Swap(ref TextureTotalSize, ref other.TextureTotalSize);
-            Utilities.Swap(ref pixelBufferObjectId, ref other.pixelBufferObjectId);
-            Utilities.Swap(ref stencilId, ref other.stencilId);
-            //
-            Utilities.Swap(ref DiscardNextMap, ref other.DiscardNextMap);
-            Utilities.Swap(ref TextureId, ref other.TextureId);
-            Utilities.Swap(ref TextureTarget, ref other.TextureTarget);
-            Utilities.Swap(ref TextureInternalFormat, ref other.TextureInternalFormat);
-            Utilities.Swap(ref TextureFormat, ref other.TextureFormat);
-            Utilities.Swap(ref TextureType, ref other.TextureType);
-            Utilities.Swap(ref TexturePixelSize, ref other.TexturePixelSize);
+            (other.DepthPitch, DepthPitch) = (DepthPitch, other.DepthPitch);
+
+            (other.RowPitch, RowPitch) = (RowPitch, other.RowPitch);
+
+            (other.IsDepthBuffer, IsDepthBuffer) = (IsDepthBuffer, other.IsDepthBuffer);
+
+            (other.HasStencil, HasStencil) = (HasStencil, other.HasStencil);
+
+            (other.IsRenderbuffer, IsRenderbuffer) = (IsRenderbuffer, other.IsRenderbuffer);
+
+            (BoundSamplerState, other.BoundSamplerState)     = (other.BoundSamplerState, BoundSamplerState);
+            (PixelBufferFrame, other.PixelBufferFrame)       = (other.PixelBufferFrame, PixelBufferFrame);
+            (TextureTotalSize, other.TextureTotalSize)       = (other.TextureTotalSize, TextureTotalSize);
+            (pixelBufferObjectId, other.pixelBufferObjectId) = (other.pixelBufferObjectId, pixelBufferObjectId);
+            (stencilId, other.stencilId)                     = (other.stencilId, stencilId);
+
+            (DiscardNextMap, other.DiscardNextMap)               = (other.DiscardNextMap, DiscardNextMap);
+            (TextureId, other.TextureId)                         = (other.TextureId, TextureId);
+            (TextureTarget, other.TextureTarget)                 = (other.TextureTarget, TextureTarget);
+            (TextureInternalFormat, other.TextureInternalFormat) = (other.TextureInternalFormat, TextureInternalFormat);
+            (TextureFormat, other.TextureFormat)                 = (other.TextureFormat, TextureFormat);
+            (TextureType, other.TextureType)                     = (other.TextureType, TextureType);
+            (TexturePixelSize, other.TexturePixelSize)           = (other.TexturePixelSize, TexturePixelSize);
         }
 
         public void Recreate(DataBox[] dataBoxes = null)
@@ -121,9 +104,9 @@ namespace Stride.Graphics
                 //Android.Opengl.GLES20.GlBindTexture(Android.Opengl.GLES11Ext.GlTextureExternalOes, TextureId);
 
                 //Any "proper" way to do this? (GLES20 could directly accept it, not GLES30 anymore)
-                TextureTarget = (TextureTarget)Android.Opengl.GLES11Ext.GlTextureExternalOes;
+                TextureTarget = (TextureTarget) Android.Opengl.GLES11Ext.GlTextureExternalOes;
                 GL.BindTexture(TextureTarget, TextureId);
-                
+
                 //GL.BindTexture(TextureTarget, 0);
             }
         }
@@ -135,9 +118,9 @@ namespace Stride.Graphics
         	{
                 case TextureDimension.Texture1D:
 #if !STRIDE_GRAPHICS_API_OPENGLES
-                        if (ArraySize > 1)
-                            throw new PlatformNotSupportedException("Texture1DArray is not implemented under OpenGL");
-                        return TextureTarget.Texture1D;
+                    if (ArraySize > 1)
+                        throw new PlatformNotSupportedException("Texture1DArray is not implemented under OpenGL");
+                    return TextureTarget.Texture1D;
 #endif
                 case TextureDimension.Texture2D:
                     return ArraySize > 1 ? TextureTarget.Texture2DArray : TextureTarget.Texture2D;
@@ -181,8 +164,7 @@ namespace Stride.Graphics
             {
                 TextureTarget = GetTextureTarget(Dimension);
 
-                bool compressed;
-                OpenGLConvertExtensions.ConvertPixelFormat(GraphicsDevice, ref textureDescription.Format, out TextureInternalFormat, out TextureFormat, out TextureType, out TexturePixelSize, out compressed);
+                OpenGLConvertExtensions.ConvertPixelFormat(GraphicsDevice, ref textureDescription.Format, out TextureInternalFormat, out TextureFormat, out TextureType, out TexturePixelSize, out var compressed);
 
                 DepthPitch = Description.Width * Description.Height * TexturePixelSize;
                 RowPitch = Description.Width * TexturePixelSize;
@@ -297,7 +279,7 @@ namespace Stride.Graphics
             {
                 ConvertDepthFormat(GraphicsDevice, Description.Format, out var depthRenderbufferFormat);
 
-                CreateRenderbuffer(Width, Height, (int)Description.MultisampleCount, depthRenderbufferFormat, out TextureId);
+                CreateRenderbuffer(Width, Height, (int) Description.MultisampleCount, depthRenderbufferFormat, out TextureId);
 
                 if (HasStencil)    // If depth and stencil are stored inside the same renderbuffer:
                 {
@@ -306,7 +288,7 @@ namespace Stride.Graphics
             }
             else if (Description.IsRenderTarget)    // If it is a color attachment:
             {
-                CreateRenderbuffer(Width, Height, (int)Description.MultisampleCount, TextureInternalFormat, out TextureId);
+                CreateRenderbuffer(Width, Height, (int) Description.MultisampleCount, TextureInternalFormat, out TextureId);
             }
             else
             {
@@ -321,10 +303,10 @@ namespace Stride.Graphics
             if (Description.IsDepthStencil || Description.IsRenderTarget)   // Set the filtering mode of depth, stencil and color FBO attachments:
             {
                 // Disable filtering on FBO attachments:
-                GL.TexParameter(TextureTarget, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);   // TODO: Do we enter this for MSAA buffers too? Is this an issue?
-                GL.TexParameter(TextureTarget, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);   // TODO: Why would we force the filter to "nearest"?
-                GL.TexParameter(TextureTarget, TextureParameterName.TextureWrapS, (int)TextureWrapMode.ClampToEdge);
-                GL.TexParameter(TextureTarget, TextureParameterName.TextureWrapT, (int)TextureWrapMode.ClampToEdge);
+                GL.TexParameter(TextureTarget, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Nearest);   // TODO: Do we enter this for MSAA buffers too? Is this an issue?
+                GL.TexParameter(TextureTarget, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);   // TODO: Why would we force the filter to "nearest"?
+                GL.TexParameter(TextureTarget, TextureParameterName.TextureWrapS, (int) TextureWrapMode.ClampToEdge);
+                GL.TexParameter(TextureTarget, TextureParameterName.TextureWrapT, (int) TextureWrapMode.ClampToEdge);
                 BoundSamplerState = GraphicsDevice.SamplerStates.PointClamp;
 
                 if (HasStencil)
@@ -336,8 +318,8 @@ namespace Stride.Graphics
 #if STRIDE_GRAPHICS_API_OPENGLES
             else if (Description.MipLevels <= 1)
             {
-                GL.TexParameter(TextureTarget, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);   // TODO: Why does this use the nearest filter for minification? Using Linear filtering would result in a smoother appearance for minified textures.
-                GL.TexParameter(TextureTarget, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+                GL.TexParameter(TextureTarget, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Nearest);   // TODO: Why does this use the nearest filter for minification? Using Linear filtering would result in a smoother appearance for minified textures.
+                GL.TexParameter(TextureTarget, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Linear);
             }
 #endif
 
@@ -354,12 +336,12 @@ namespace Stride.Graphics
             {
 #if !STRIDE_PLATFORM_IOS
                 // MSAA is not supported on iOS currently because OpenTK doesn't expose "GL.BlitFramebuffer()" on iOS for some reason.
-                GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, (uint)multisampleCount, internalFormat, (uint)width, (uint)height);
+                GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, (uint) multisampleCount, internalFormat, (uint) width, (uint) height);
 #endif
             }
             else
             {
-                GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, internalFormat, (uint)width, (uint)height);
+                GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, internalFormat, (uint) width, (uint) height);
             }
         }
 
@@ -369,11 +351,11 @@ namespace Stride.Graphics
 #if !STRIDE_GRAPHICS_API_OPENGLES
             if (compressed)
             {
-                GL.CompressedTexImage1D(TextureTarget, mipLevel, TextureInternalFormat, (uint)width, 0, (uint)dataBox.SlicePitch, (void*)dataBox.DataPointer);
+                GL.CompressedTexImage1D(TextureTarget, mipLevel, TextureInternalFormat, (uint) width, border: 0, (uint) dataBox.SlicePitch, (void*) dataBox.DataPointer);
             }
             else
             {
-                GL.TexImage1D(TextureTarget, mipLevel, TextureInternalFormat, (uint)width, 0, TextureFormat, TextureType, (void*)dataBox.DataPointer);
+                GL.TexImage1D(TextureTarget, mipLevel, TextureInternalFormat, (uint) width, border: 0, TextureFormat, TextureType, (void*) dataBox.DataPointer);
             }
 #endif
         }
@@ -387,14 +369,14 @@ namespace Stride.Graphics
 
                 if (IsRenderbuffer)
                 {
-                    GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, (uint)Description.MultisampleCount, TextureInternalFormat, (uint)width, (uint)height);
+                    GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, (uint) Description.MultisampleCount, TextureInternalFormat, (uint) width, (uint) height);
                 }
                 else
                 {
 #if STRIDE_GRAPHICS_API_OPENGLES
                     throw new NotSupportedException("Multisample textures are not supported on OpenGL ES.");
 #else
-                    GL.TexImage2DMultisample(TextureTarget.Texture2DMultisample, (uint)Description.MultisampleCount, TextureInternalFormat, (uint)width, (uint)height, false);
+                    GL.TexImage2DMultisample(TextureTarget.Texture2DMultisample, (uint) Description.MultisampleCount, TextureInternalFormat, (uint) width, (uint) height, fixedsamplelocations: false);
 #endif
                 }
             }
@@ -403,11 +385,11 @@ namespace Stride.Graphics
                 var dataSetTarget = GetTextureTargetForDataSet2D(TextureTarget, arrayIndex);
                 if (compressed)
                 {
-                    GL.CompressedTexImage2D(dataSetTarget, mipLevel, TextureInternalFormat, (uint)width, (uint)height, 0, (uint)dataBox.SlicePitch, (void*)dataBox.DataPointer);
+                    GL.CompressedTexImage2D(dataSetTarget, mipLevel, TextureInternalFormat, (uint) width, (uint) height, border: 0, (uint) dataBox.SlicePitch, (void*) dataBox.DataPointer);
                 }
                 else
                 {
-                    GL.TexImage2D(dataSetTarget, mipLevel, TextureInternalFormat, (uint)width, (uint)height, 0, TextureFormat, TextureType, (void*)dataBox.DataPointer);
+                    GL.TexImage2D(dataSetTarget, mipLevel, TextureInternalFormat, (uint) width, (uint) height, border: 0, TextureFormat, TextureType, (void*) dataBox.DataPointer);
                 }
             }
         }
@@ -416,11 +398,11 @@ namespace Stride.Graphics
         {
             if (compressed)
             {
-                GL.CompressedTexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint)width, (uint)height, (uint)depth, 0, (uint)dataBox.SlicePitch, (void*)dataBox.DataPointer);
+                GL.CompressedTexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint) width, (uint) height, (uint) depth, border: 0, (uint) dataBox.SlicePitch, (void*) dataBox.DataPointer);
             }
             else
             {
-                GL.TexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint)width, (uint)height, (uint)depth, 0, TextureFormat, TextureType, (void*)dataBox.DataPointer);
+                GL.TexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint) width, (uint) height, (uint) depth, border: 0, TextureFormat, TextureType, (void*) dataBox.DataPointer);
             }
         }
 
@@ -431,11 +413,11 @@ namespace Stride.Graphics
             {
                 if (compressed)
                 {
-                    GL.CompressedTexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint)width, (uint)height, (uint)ArraySize, 0, 0, IntPtr.Zero);
+                    GL.CompressedTexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint) width, (uint) height, (uint) ArraySize, border: 0, imageSize: 0, data: IntPtr.Zero);
                 }
                 else
                 {
-                    GL.TexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint)width, (uint)height, (uint)ArraySize, 0, TextureFormat, TextureType, IntPtr.Zero);
+                    GL.TexImage3D(TextureTarget, mipLevel, TextureInternalFormat, (uint) width, (uint) height, (uint) ArraySize, border: 0, TextureFormat, TextureType, IntPtr.Zero);
                 }
             }
 
@@ -443,11 +425,11 @@ namespace Stride.Graphics
             {
                 if (compressed)
                 {
-                    GL.CompressedTexSubImage3D(TextureTarget, mipLevel, 0, 0, arrayIndex, (uint)width, (uint)height, 1, TextureInternalFormat, (uint)dataBox.SlicePitch, (void*)dataBox.DataPointer);
+                    GL.CompressedTexSubImage3D(TextureTarget, mipLevel, xoffset: 0, yoffset: 0, arrayIndex, (uint) width, (uint) height, depth: 1, TextureInternalFormat, (uint) dataBox.SlicePitch, (void*) dataBox.DataPointer);
                 }
                 else
                 {
-                    GL.TexSubImage3D(TextureTarget, mipLevel, 0, 0, arrayIndex, (uint)width, (uint)height, 1, TextureFormat, TextureType, (void*)dataBox.DataPointer);
+                    GL.TexSubImage3D(TextureTarget, mipLevel, xoffset: 0, yoffset: 0, arrayIndex, (uint) width, (uint) height, depth: 1, TextureFormat, TextureType, (void*) dataBox.DataPointer);
                 }
             }
         }
@@ -594,7 +576,7 @@ namespace Stride.Graphics
             if (PixelBufferObjectId != 0)
             {
                 GL.BindBuffer(bufferTarget, PixelBufferObjectId);
-                bufferData = (IntPtr)GL.MapBufferRange(bufferTarget, IntPtr.Zero, (UIntPtr)TextureTotalSize, MapBufferAccessMask.MapWriteBit | MapBufferAccessMask.MapUnsynchronizedBit);
+                bufferData = (IntPtr) GL.MapBufferRange(bufferTarget, IntPtr.Zero, (UIntPtr) TextureTotalSize, MapBufferAccessMask.MapWriteBit | MapBufferAccessMask.MapUnsynchronizedBit);
             }
 
             if (bufferData != IntPtr.Zero)
@@ -604,10 +586,11 @@ namespace Stride.Graphics
                     var offsetArray = arrayIndex * Description.MipLevels;
                     for (int i = 0; i < Description.MipLevels; ++i)
                     {
-                        IntPtr data = IntPtr.Zero;
-                        var width = CalculateMipSize(Description.Width, i);
-                        var height = CalculateMipSize(Description.Height, i);
-                        var depth = CalculateMipSize(Description.Depth, i);
+                        var data = IntPtr.Zero;
+
+                        var width = CalculateMipSize(Description.Width, mipLevel: i);
+                        var height = CalculateMipSize(Description.Height, mipLevel: i);
+                        var depth = CalculateMipSize(Description.Depth, mipLevel: i);
                         if (dataBoxes != null && i < dataBoxes.Length)
                         {
                             data = dataBoxes[offsetArray + i].DataPointer;
@@ -615,7 +598,7 @@ namespace Stride.Graphics
 
                         if (data != IntPtr.Zero)
                         {
-                            Utilities.CopyMemory(bufferData + offset, data, width * height * depth * TexturePixelSize);
+                            Unsafe.CopyBlockUnaligned((void*) (bufferData + offset), (void*) data, (uint) (width * height * depth * TexturePixelSize));
                         }
 
                         offset += width*height*TexturePixelSize;
@@ -632,13 +615,12 @@ namespace Stride.Graphics
 
         internal uint GeneratePixelBufferObject(BufferTargetARB target, PixelStoreParameter alignment, BufferUsageARB bufferUsage, int totalSize)
         {
-            uint result;
 
-            GL.GenBuffers(1, out result);
+            GL.GenBuffers(1, out uint result);
             GL.BindBuffer(target, result);
             if (RowPitch < 4)
                 GL.PixelStore(alignment, 1);
-            GL.BufferData(target, (UIntPtr)totalSize, IntPtr.Zero, bufferUsage);
+            GL.BufferData(target, (UIntPtr) totalSize, IntPtr.Zero, bufferUsage);
             GL.BindBuffer(target, 0);
 
             return result;

--- a/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
@@ -2,11 +2,9 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 #if STRIDE_GRAPHICS_API_VULKAN
 using System;
-using System.Collections.Generic;
-
+using System.Runtime.CompilerServices;
 using Vortice.Vulkan;
 using static Vortice.Vulkan.Vulkan;
-using Stride.Core;
 
 namespace Stride.Graphics
 {
@@ -28,7 +26,7 @@ namespace Stride.Graphics
             bufferDescription = description;
             //nativeDescription = ConvertToNativeDescription(Description);
             ViewFlags = viewFlags;
-            InitCountAndViewFormat(out this.elementCount, ref viewFormat);
+            InitCountAndViewFormat(out elementCount, ref viewFormat);
             ViewFormat = viewFormat;
             Recreate(dataPointer);
 
@@ -90,8 +88,8 @@ namespace Stride.Graphics
             var createInfo = new VkBufferCreateInfo
             {
                 sType = VkStructureType.BufferCreateInfo,
-                size = (ulong)bufferDescription.SizeInBytes,
-                flags = VkBufferCreateFlags.None,
+                size = (ulong) bufferDescription.SizeInBytes,
+                flags = VkBufferCreateFlags.None
             };
 
             createInfo.usage |= VkBufferUsageFlags.TransferSrc;
@@ -148,7 +146,7 @@ namespace Stride.Graphics
             // Allocate memory
             var memoryProperties = VkMemoryPropertyFlags.DeviceLocal;
             if (bufferDescription.Usage == GraphicsResourceUsage.Staging || Usage == GraphicsResourceUsage.Dynamic)
-            { 
+            {
                 memoryProperties = VkMemoryPropertyFlags.HostVisible | VkMemoryPropertyFlags.HostCoherent;
             }
 
@@ -184,41 +182,39 @@ namespace Stride.Graphics
                     if (Usage == GraphicsResourceUsage.Dynamic)
                     {
                         void* uploadMemory;
-                        vkMapMemory(GraphicsDevice.NativeDevice, NativeMemory, 0, (ulong)SizeInBytes, VkMemoryMapFlags.None, &uploadMemory);
-                        Utilities.CopyMemory((IntPtr)uploadMemory, dataPointer, SizeInBytes);
+                        vkMapMemory(GraphicsDevice.NativeDevice, NativeMemory, 0, (ulong) SizeInBytes, VkMemoryMapFlags.None, &uploadMemory);
+                        Unsafe.CopyBlockUnaligned(uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
                         vkUnmapMemory(GraphicsDevice.NativeDevice, NativeMemory);
                     }
                     else
                     {
                         var sizeInBytes = bufferDescription.SizeInBytes;
-                        VkBuffer uploadResource;
-                        int uploadOffset;
-                        var uploadMemory = GraphicsDevice.AllocateUploadBuffer(sizeInBytes, out uploadResource, out uploadOffset);
+                        var uploadMemory = GraphicsDevice.AllocateUploadBuffer(sizeInBytes, out var uploadResource, out var uploadOffset);
 
-                        Utilities.CopyMemory(uploadMemory, dataPointer, sizeInBytes);
+                        Unsafe.CopyBlockUnaligned((void*) uploadMemory, (void*) dataPointer, (uint) sizeInBytes);
 
                         // Barrier
-                        var memoryBarrier = new VkBufferMemoryBarrier(uploadResource, VkAccessFlags.HostWrite, VkAccessFlags.TransferRead, (ulong)uploadOffset, (ulong)sizeInBytes);
-                        vkCmdPipelineBarrier(commandBuffer, VkPipelineStageFlags.Host, VkPipelineStageFlags.Transfer, VkDependencyFlags.None, 0, null, 1, &memoryBarrier, 0, null);
+                        var memoryBarrier = new VkBufferMemoryBarrier(uploadResource, VkAccessFlags.HostWrite, VkAccessFlags.TransferRead, (ulong) uploadOffset, (ulong) sizeInBytes);
+                        vkCmdPipelineBarrier(commandBuffer, VkPipelineStageFlags.Host, VkPipelineStageFlags.Transfer, VkDependencyFlags.None, memoryBarrierCount: 0, memoryBarriers: null, bufferMemoryBarrierCount: 1, &memoryBarrier, imageMemoryBarrierCount: 0, imageMemoryBarriers: null);
 
                         // Copy
                         var bufferCopy = new VkBufferCopy
                         {
-                            srcOffset = (uint)uploadOffset,
+                            srcOffset = (uint) uploadOffset,
                             dstOffset = 0,
-                            size = (uint)sizeInBytes
+                            size = (uint) sizeInBytes
                         };
                         vkCmdCopyBuffer(commandBuffer, uploadResource, NativeBuffer, 1, &bufferCopy);
                     }
                 }
                 else
                 {
-                    vkCmdFillBuffer(commandBuffer, NativeBuffer, 0, (uint)bufferDescription.SizeInBytes, 0);
+                    vkCmdFillBuffer(commandBuffer, NativeBuffer, 0, (uint) bufferDescription.SizeInBytes, 0);
                 }
 
                 // Barrier
                 var bufferMemoryBarrier = new VkBufferMemoryBarrier(NativeBuffer, VkAccessFlags.TransferWrite, NativeAccessMask);
-                vkCmdPipelineBarrier(commandBuffer, VkPipelineStageFlags.Transfer, VkPipelineStageFlags.AllCommands, VkDependencyFlags.None, 0, null, 1, &bufferMemoryBarrier, 0, null);
+                vkCmdPipelineBarrier(commandBuffer, VkPipelineStageFlags.Transfer, VkPipelineStageFlags.AllCommands, VkDependencyFlags.None, memoryBarrierCount: 0, memoryBarriers: null, bufferMemoryBarrierCount: 1, &bufferMemoryBarrier, imageMemoryBarrierCount: 0, imageMemoryBarriers: null);
 
                 // Close and submit
                 vkEndCommandBuffer(commandBuffer);
@@ -227,7 +223,7 @@ namespace Stride.Graphics
                 {
                     sType = VkStructureType.SubmitInfo,
                     commandBufferCount = 1,
-                    pCommandBuffers = &commandBuffer,
+                    pCommandBuffers = &commandBuffer
                 };
 
                 lock (GraphicsDevice.QueueLock)
@@ -237,7 +233,7 @@ namespace Stride.Graphics
                     //commandBuffer.Reset(VkCommandBufferResetFlags.None);
                 }
 
-                vkFreeCommandBuffers(GraphicsDevice.NativeDevice, GraphicsDevice.NativeCopyCommandPools.Value, 1, &commandBuffer);
+                vkFreeCommandBuffers(GraphicsDevice.NativeDevice, GraphicsDevice.NativeCopyCommandPools.Value, commandBufferCount: 1, &commandBuffer);
 
                 InitializeViews();
             }
@@ -268,11 +264,11 @@ namespace Stride.Graphics
                 sType = VkStructureType.BufferViewCreateInfo,
                 buffer = NativeBuffer,
                 format = viewFormat == PixelFormat.None ? VkFormat.Undefined : VulkanConvertExtensions.ConvertPixelFormat(viewFormat),
-                range = (ulong)SizeInBytes, // this.ElementCount
+                range = (ulong) SizeInBytes, // this.ElementCount
                 //view = (Description.BufferFlags & BufferFlags.RawBuffer) != 0 ? VkBufferViewType.Raw : VkBufferViewType.Formatted,
             };
 
-            vkCreateBufferView(GraphicsDevice.NativeDevice, &createInfo, null, out var bufferView);
+            vkCreateBufferView(GraphicsDevice.NativeDevice, &createInfo, allocator: null, out var bufferView);
             return bufferView;
         }
 
@@ -302,5 +298,5 @@ namespace Stride.Graphics
             }
         }
     }
-} 
-#endif 
+}
+#endif

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -995,6 +995,8 @@ namespace Stride.Graphics
 
         public unsafe void CopyRegion(GraphicsResource source, int sourceSubresource, ResourceRegion? sourceRegion, GraphicsResource destination, int destinationSubResource, int dstX = 0, int dstY = 0, int dstZ = 0)
         {
+            // TODO VULKAN: One copy per mip level
+
             if (source is Texture sourceTexture && destination is Texture destinationTexture)
             {
                 CleanupRenderPass();

--- a/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Vortice.Vulkan;
 using static Vortice.Vulkan.Vulkan;
-using Stride.Core;
-using Stride.Core.Collections;
-using Stride.Core.Serialization;
 using Stride.Shaders;
 using Encoding = System.Text.Encoding;
 
@@ -33,7 +31,7 @@ namespace Stride.Graphics
             VkDynamicState.Viewport,
             VkDynamicState.Scissor,
             VkDynamicState.BlendConstants,
-            VkDynamicState.StencilReference,
+            VkDynamicState.StencilReference
         };
 
         // GLSL converter always outputs entry point main()
@@ -86,18 +84,18 @@ namespace Stride.Graphics
                     inputAttributes[inputAttributeCount++] = new VkVertexInputAttributeDescription
                     {
                         format = format,
-                        offset = (uint)inputElement.AlignedByteOffset,
-                        binding = (uint)inputElement.InputSlot,
-                        location = (uint)location.Key
+                        offset = (uint) inputElement.AlignedByteOffset,
+                        binding = (uint) inputElement.InputSlot,
+                        location = (uint) location.Key
                     };
                 }
 
-                inputBindings[slotIndex].binding = (uint)slotIndex;
+                inputBindings[slotIndex].binding = (uint) slotIndex;
                 inputBindings[slotIndex].inputRate = inputElement.InputSlotClass == InputClassification.Vertex ? VkVertexInputRate.Vertex : VkVertexInputRate.Instance;
 
                 // TODO VULKAN: This is currently an argument to Draw() overloads.
                 if (inputBindings[slotIndex].stride < inputElement.AlignedByteOffset + size)
-                    inputBindings[slotIndex].stride = (uint)(inputElement.AlignedByteOffset + size);
+                    inputBindings[slotIndex].stride = (uint) (inputElement.AlignedByteOffset + size);
 
                 if (inputElement.InputSlot >= inputBindingCount)
                     inputBindingCount = inputElement.InputSlot + 1;
@@ -107,19 +105,19 @@ namespace Stride.Graphics
             {
                 sType = VkStructureType.PipelineInputAssemblyStateCreateInfo,
                 topology = VulkanConvertExtensions.ConvertPrimitiveType(Description.PrimitiveType),
-                primitiveRestartEnable = VulkanConvertExtensions.ConvertPrimitiveRestart(Description.PrimitiveType),
+                primitiveRestartEnable = VulkanConvertExtensions.ConvertPrimitiveRestart(Description.PrimitiveType)
             };
 
             // TODO VULKAN: Tessellation and multisampling
             var multisampleState = new VkPipelineMultisampleStateCreateInfo
             {
                 sType = VkStructureType.PipelineMultisampleStateCreateInfo,
-                rasterizationSamples = VkSampleCountFlags.Count1,
+                rasterizationSamples = VkSampleCountFlags.Count1
             };
 
             var tessellationState = new VkPipelineTessellationStateCreateInfo
             {
-                sType = VkStructureType.PipelineTessellationStateCreateInfo,
+                sType = VkStructureType.PipelineTessellationStateCreateInfo
             };
 
             var rasterizationState = CreateRasterizationState(Description.RasterizerState);
@@ -143,7 +141,7 @@ namespace Stride.Graphics
                     dstColorBlendFactor = VulkanConvertExtensions.ConvertBlend(renderTargetBlendState->ColorDestinationBlend),
                     srcAlphaBlendFactor = VulkanConvertExtensions.ConvertBlend(renderTargetBlendState->AlphaSourceBlend),
                     srcColorBlendFactor = VulkanConvertExtensions.ConvertBlend(renderTargetBlendState->ColorSourceBlend),
-                    colorWriteMask = VulkanConvertExtensions.ConvertColorWriteChannels(renderTargetBlendState->ColorWriteChannels),
+                    colorWriteMask = VulkanConvertExtensions.ConvertColorWriteChannels(renderTargetBlendState->ColorWriteChannels)
                 };
 
                 if (description.IndependentBlendEnable)
@@ -154,7 +152,7 @@ namespace Stride.Graphics
             {
                 sType = VkStructureType.PipelineViewportStateCreateInfo,
                 scissorCount = 1,
-                viewportCount = 1,
+                viewportCount = 1
             };
 
             // fixed yields null if array is empty or null
@@ -167,31 +165,31 @@ namespace Stride.Graphics
                 var vertexInputState = new VkPipelineVertexInputStateCreateInfo
                 {
                     sType = VkStructureType.PipelineVertexInputStateCreateInfo,
-                    vertexAttributeDescriptionCount = (uint)inputAttributeCount,
+                    vertexAttributeDescriptionCount = (uint) inputAttributeCount,
                     pVertexAttributeDescriptions = fInputAttributes,
-                    vertexBindingDescriptionCount = (uint)inputBindingCount,
-                    pVertexBindingDescriptions = fInputBindings,
+                    vertexBindingDescriptionCount = (uint) inputBindingCount,
+                    pVertexBindingDescriptions = fInputBindings
                 };
 
                 var colorBlendState = new VkPipelineColorBlendStateCreateInfo
                 {
                     sType = VkStructureType.PipelineColorBlendStateCreateInfo,
-                    attachmentCount = (uint)renderTargetCount,
-                    pAttachments = fColorBlendAttachments,
+                    attachmentCount = (uint) renderTargetCount,
+                    pAttachments = fColorBlendAttachments
                 };
 
                 var dynamicState = new VkPipelineDynamicStateCreateInfo
                 {
                     sType = VkStructureType.PipelineDynamicStateCreateInfo,
-                    dynamicStateCount = (uint)dynamicStates.Length,
-                    pDynamicStates = dynamicStatesPointer,
+                    dynamicStateCount = (uint) dynamicStates.Length,
+                    pDynamicStates = dynamicStatesPointer
                 };
 
                 var createInfo = new VkGraphicsPipelineCreateInfo
                 {
                     sType = VkStructureType.GraphicsPipelineCreateInfo,
                     layout = NativeLayout,
-                    stageCount = (uint)stages.Length,
+                    stageCount = (uint) stages.Length,
                     pStages = stages.Length > 0 ? fStages : null,
                     //tessellationState = &tessellationState,
                     pVertexInputState = &vertexInputState,
@@ -203,16 +201,16 @@ namespace Stride.Graphics
                     pDynamicState = &dynamicState,
                     pViewportState = &viewportState,
                     renderPass = NativeRenderPass,
-                    subpass = 0,
+                    subpass = 0
                 };
                 fixed (VkPipeline* nativePipelinePtr = &NativePipeline)
-                    vkCreateGraphicsPipelines(GraphicsDevice.NativeDevice, VkPipelineCache.Null, 1, &createInfo, null, nativePipelinePtr);
+                    vkCreateGraphicsPipelines(GraphicsDevice.NativeDevice, VkPipelineCache.Null, createInfoCount: 1, &createInfo, allocator: null, nativePipelinePtr);
             }
 
             // Cleanup shader modules
             foreach (var stage in stages)
             {
-                vkDestroyShaderModule(GraphicsDevice.NativeDevice, stage.module, null);
+                vkDestroyShaderModule(GraphicsDevice.NativeDevice, stage.module, allocator: null);
             }
         }
 
@@ -252,13 +250,13 @@ namespace Stride.Graphics
                         stencilLoadOp = VkAttachmentLoadOp.DontCare,
                         stencilStoreOp = VkAttachmentStoreOp.DontCare,
                         initialLayout = VkImageLayout.ColorAttachmentOptimal,
-                        finalLayout = VkImageLayout.ColorAttachmentOptimal,
+                        finalLayout = VkImageLayout.ColorAttachmentOptimal
                     };
 
                     colorAttachmentReferences[i] = new VkAttachmentReference
                     {
-                        attachment = (uint)i,
-                        layout = VkImageLayout.ColorAttachmentOptimal,
+                        attachment = (uint) i,
+                        layout = VkImageLayout.ColorAttachmentOptimal
                     };
                 }
             }
@@ -274,7 +272,7 @@ namespace Stride.Graphics
                     stencilLoadOp = VkAttachmentLoadOp.DontCare, // TODO VULKAN: Handle stencil
                     stencilStoreOp = VkAttachmentStoreOp.DontCare,
                     initialLayout = VkImageLayout.DepthStencilAttachmentOptimal,
-                    finalLayout = VkImageLayout.DepthStencilAttachmentOptimal,
+                    finalLayout = VkImageLayout.DepthStencilAttachmentOptimal
                 };
             }
 
@@ -283,27 +281,27 @@ namespace Stride.Graphics
             fixed (VkAttachmentDescription* fAttachments = attachments) {
                 var depthAttachmentReference = new VkAttachmentReference
                 {
-                    attachment = (uint)attachments.Length - 1,
-                    layout = VkImageLayout.DepthStencilAttachmentOptimal,
+                    attachment = (uint) attachments.Length - 1,
+                    layout = VkImageLayout.DepthStencilAttachmentOptimal
                 };
 
                 var subpass = new VkSubpassDescription
                 {
                     pipelineBindPoint = VkPipelineBindPoint.Graphics,
-                    colorAttachmentCount = (uint)renderTargetCount,
+                    colorAttachmentCount = (uint) renderTargetCount,
                     pColorAttachments = fColorAttachmentReferences,
-                    pDepthStencilAttachment = hasDepthStencilAttachment ? &depthAttachmentReference : null,
+                    pDepthStencilAttachment = hasDepthStencilAttachment ? &depthAttachmentReference : null
                 };
 
                 var renderPassCreateInfo = new VkRenderPassCreateInfo
                 {
                     sType = VkStructureType.RenderPassCreateInfo,
-                    attachmentCount = (uint)attachmentCount,
+                    attachmentCount = (uint) attachmentCount,
                     pAttachments = fAttachments,
                     subpassCount = 1,
-                    pSubpasses = &subpass,
+                    pSubpasses = &subpass
                 };
-                vkCreateRenderPass(GraphicsDevice.NativeDevice, &renderPassCreateInfo, null, out NativeRenderPass);
+                vkCreateRenderPass(GraphicsDevice.NativeDevice, &renderPassCreateInfo, allocator: null, out NativeRenderPass);
             }
         }
 
@@ -312,11 +310,11 @@ namespace Stride.Graphics
         {
             if (NativePipeline != VkPipeline.Null)
             {
-                vkDestroyRenderPass(GraphicsDevice.NativeDevice, NativeRenderPass, null);
-                vkDestroyPipeline(GraphicsDevice.NativeDevice, NativePipeline, null);
-                vkDestroyPipelineLayout(GraphicsDevice.NativeDevice, NativeLayout, null);
+                vkDestroyRenderPass(GraphicsDevice.NativeDevice, NativeRenderPass, allocator: null);
+                vkDestroyPipeline(GraphicsDevice.NativeDevice, NativePipeline, allocator: null);
+                vkDestroyPipelineLayout(GraphicsDevice.NativeDevice, NativeLayout, allocator: null);
 
-                vkDestroyDescriptorSetLayout(GraphicsDevice.NativeDevice, NativeDescriptorSetLayout, null);
+                vkDestroyDescriptorSetLayout(GraphicsDevice.NativeDevice, NativeDescriptorSetLayout, allocator: null);
             }
 
             base.OnDestroyed();
@@ -344,7 +342,7 @@ namespace Stride.Graphics
 
             // Get binding indices used by the shader
             var destinationBindings = pipelineStateDescription.EffectBytecode.Stages
-                .SelectMany(x => BinarySerialization.Read<ShaderInputBytecode>(x.Data).ResourceBindings)
+                .SelectMany(x => ReadShaderBytecode(x.Data).ResourceBindings)
                 .GroupBy(x => x.Key, x => x.Value)
                 .ToDictionary(x => x.Key, x => x.First());
 
@@ -384,7 +382,7 @@ namespace Stride.Graphics
                             SourceBinding = sourceBinding,
                             DestinationBinding = destinationBinding,
                             DescriptorType = VulkanConvertExtensions.ConvertDescriptorType(sourceEntry.Class, sourceEntry.Type),
-                            ResourceElementIsInteger = sourceEntry.ElementType != EffectParameterType.Float && sourceEntry.ElementType != EffectParameterType.Double,
+                            ResourceElementIsInteger = sourceEntry.ElementType != EffectParameterType.Float && sourceEntry.ElementType != EffectParameterType.Double
                         });
                     }
                 }
@@ -396,7 +394,7 @@ namespace Stride.Graphics
                 Class = EffectParameterClass.Sampler,
                 Type = EffectParameterType.Sampler,
                 ImmutableSampler = GraphicsDevice.SamplerStates.PointWrap,
-                ArraySize = 1,
+                ArraySize = 1
             };
 
             // Create descriptor set layout
@@ -408,9 +406,9 @@ namespace Stride.Graphics
             {
                 sType = VkStructureType.PipelineLayoutCreateInfo,
                 setLayoutCount = 1,
-                pSetLayouts = &nativeDescriptorSetLayout,
+                pSetLayouts = &nativeDescriptorSetLayout
             };
-            vkCreatePipelineLayout(GraphicsDevice.NativeDevice, &pipelineLayoutCreateInfo, null, out NativeLayout);
+            vkCreatePipelineLayout(GraphicsDevice.NativeDevice, &pipelineLayoutCreateInfo, allocator: null, out NativeLayout);
         }
 
         private unsafe VkPipelineShaderStageCreateInfo[] CreateShaderStages(PipelineStateDescription pipelineStateDescription, out Dictionary<int, string> inputAttributeNames)
@@ -422,7 +420,7 @@ namespace Stride.Graphics
 
             for (int i = 0; i < stages.Length; i++)
             {
-                var shaderBytecode = BinarySerialization.Read<ShaderInputBytecode>(stages[i].Data);
+                var shaderBytecode = ReadShaderBytecode(stages[i].Data);
                 if (stages[i].Stage == ShaderStage.Vertex)
                     inputAttributeNames = shaderBytecode.InputAttributeNames;
 
@@ -433,13 +431,21 @@ namespace Stride.Graphics
                     {
                         sType = VkStructureType.PipelineShaderStageCreateInfo,
                         stage = VulkanConvertExtensions.Convert(stages[i].Stage),
-                        pName = entryPointPointer,
+                        pName = entryPointPointer
                     };
-                    vkCreateShaderModule(GraphicsDevice.NativeDevice, shaderBytecode.Data, null, out nativeStages[i].module);
+                    vkCreateShaderModule(GraphicsDevice.NativeDevice, shaderBytecode.Data, allocator: null, out nativeStages[i].module);
                 }
             };
 
             return nativeStages;
+        }
+
+        //
+        // Reads the ShaderInputBytecode structure from a byte[].
+        //
+        private unsafe static ShaderInputBytecode ReadShaderBytecode(byte[] data)
+        {
+            return Unsafe.Read<ShaderInputBytecode>(Unsafe.AsPointer(ref data[0]));
         }
 
         private VkPipelineRasterizationStateCreateInfo CreateRasterizationState(RasterizerStateDescription description)
@@ -456,7 +462,7 @@ namespace Stride.Graphics
                 depthBiasClamp = description.DepthBiasClamp,
                 lineWidth = 1.0f,
                 depthClampEnable = !description.DepthClipEnable,
-                rasterizerDiscardEnable = false,
+                rasterizerDiscardEnable = false
             };
         }
 

--- a/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
@@ -440,9 +440,9 @@ namespace Stride.Graphics
             return nativeStages;
         }
 
-        //
-        // Reads the ShaderInputBytecode structure from a byte[].
-        //
+        /// <summary>
+        ///   Reads the ShaderInputBytecode structure from a byte[].
+        /// </summary>
         private unsafe static ShaderInputBytecode ReadShaderBytecode(byte[] data)
         {
             return Unsafe.Read<ShaderInputBytecode>(Unsafe.AsPointer(ref data[0]));

--- a/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
@@ -3,11 +3,12 @@
 #if STRIDE_GRAPHICS_API_VULKAN
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Vortice.Vulkan;
 using static Vortice.Vulkan.Vulkan;
 using Stride.Shaders;
+using Stride.Core.Serialization;
 using Encoding = System.Text.Encoding;
 
 namespace Stride.Graphics
@@ -443,9 +444,13 @@ namespace Stride.Graphics
         /// <summary>
         ///   Reads the ShaderInputBytecode structure from a byte[].
         /// </summary>
-        private unsafe static ShaderInputBytecode ReadShaderBytecode(byte[] data)
+        private static unsafe ShaderInputBytecode ReadShaderBytecode(byte[] data)
         {
-            return Unsafe.Read<ShaderInputBytecode>(Unsafe.AsPointer(ref data[0]));
+            using var dataStream = new MemoryStream(data);
+
+            var reader = new BinarySerializationReader(dataStream);
+
+            return reader.Read<ShaderInputBytecode>();
         }
 
         private VkPipelineRasterizationStateCreateInfo CreateRasterizationState(RasterizerStateDescription description)

--- a/sources/targets/Stride.props
+++ b/sources/targets/Stride.props
@@ -12,6 +12,11 @@
 
   <!-- Default GraphicsApi -->
   <PropertyGroup>
+    <!-- When working in a specific API in the Stride Runtime or in the Stride solution (not in a game or app),
+         you can uncomment this property and set its value to the name of that graphics API so it becomes
+         the active one that Visual Studio and IntelliSense takes into account -->
+    <!--<StrideDefaultGraphicsApiDesignTime>Vulkan</StrideDefaultGraphicsApiDesignTime>-->
+
     <StrideGraphicsApis Condition="('$(StrideGraphicsApis)' == '' Or '$(StrideGraphicsApiDependentBuildAll)' == 'true') And ('$(TargetFramework)' == '$(StrideFramework)' Or '$(TargetFramework)' == '$(StrideFrameworkWindows)')">Direct3D11;Direct3D12;OpenGL;OpenGLES;Vulkan</StrideGraphicsApis>
 
     <StrideDefaultGraphicsApi Condition="'$(StrideGraphicsApis)' != ''">$(StrideGraphicsApis.Split(';', StringSplitOptions.RemoveEmptyEntries)[0])</StrideDefaultGraphicsApi>
@@ -33,7 +38,7 @@
     <StrideGraphicsApi Condition="'$(StrideGraphicsApi)' == ''">$(StrideDefaultGraphicsApi)</StrideGraphicsApi>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     Settings StrideGraphicsApi specific
   -->
   <PropertyGroup Condition=" '$(StrideGraphicsApi)' == 'Direct3D11' ">
@@ -60,14 +65,14 @@
     <StrideGraphicsApiDefines>STRIDE_GRAPHICS_API_VULKAN</StrideGraphicsApiDefines>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     Settings TargetFramework specific
   -->
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(StrideFrameworkUWP)' ">
     <ProjectLockFile Condition="'$(ProjectLockFile)' == ''">$(MSBuildThisFileDirectory)..\build\project.lock.json</ProjectLockFile>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     Global Defines
   -->
   <PropertyGroup>

--- a/sources/tools/Stride.TextureConverter.Wrappers/FreeImage.Net/Classes/Palette.cs
+++ b/sources/tools/Stride.TextureConverter.Wrappers/FreeImage.Net/Classes/Palette.cs
@@ -5,9 +5,10 @@ using System.Collections.Generic;
 using System.Text;
 using System.Drawing;
 using System.IO;
-using FreeImageAPI.Metadata;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using FreeImageAPI.Metadata;
 
 namespace FreeImageAPI
 {
@@ -397,16 +398,16 @@ namespace FreeImageAPI
 		public void Load(BinaryReader reader)
 		{
 			EnsureNotDisposed();
-			unsafe
-			{
-				int size = length * sizeof(RGBQUAD);
-				byte[] data = reader.ReadBytes(size);
-				fixed (byte* src = data)
-				{
-					CopyMemory(baseAddress, src, data.Length);
-				}
-			}
-		}
+            unsafe
+            {
+                int size = length * sizeof(RGBQUAD);
+                byte[] data = reader.ReadBytes(size);
+
+                ref byte dst = ref Unsafe.AsRef<byte>(baseAddress);
+                ref byte src = ref data[0];
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) data.Length);
+            }
+        }
 
 		/// <summary>
 		/// Releases allocated handles associated with this instance.

--- a/sources/tools/Stride.TextureConverter.Wrappers/FreeImage.Net/Structs/FIICCPROFILE.cs
+++ b/sources/tools/Stride.TextureConverter.Wrappers/FreeImage.Net/Structs/FIICCPROFILE.cs
@@ -35,6 +35,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace FreeImageAPI
 {
@@ -113,9 +114,14 @@ namespace FreeImageAPI
 		{
 			get
 			{
-				byte[] result;
-				FreeImage.CopyMemory(result = new byte[size], data.ToPointer(), size);
-				return result;
+				byte[] result = new byte[size];
+
+                ref byte dst = ref result[0];
+                ref byte src = ref Unsafe.AsRef<byte>((void*) data);
+
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, size);
+
+                return result;
 			}
 		}
 

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MemoryArray.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MemoryArray.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -100,7 +101,7 @@ namespace FreeImageAPI
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="MemoryArray&lt;T&gt;"/> class. 
+		/// Initializes a new instance of the <see cref="MemoryArray&lt;T&gt;"/> class.
 		/// </summary>
 		/// <param name="baseAddress">Address of the memory block.</param>
 		/// <param name="length">Length of the array.</param>
@@ -116,7 +117,7 @@ namespace FreeImageAPI
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="MemoryArray&lt;T&gt;"/> class. 
+		/// Initializes a new instance of the <see cref="MemoryArray&lt;T&gt;"/> class.
 		/// </summary>
 		/// <param name="baseAddress">Address of the memory block.</param>
 		/// <param name="length">Length of the array.</param>
@@ -246,8 +247,8 @@ namespace FreeImageAPI
 			}
 			else
 			{
-				CopyMemory(ptr, baseAddress + (index * size), size);
-				return buffer[0];
+                Unsafe.CopyBlockUnaligned(ptr, baseAddress + (index * size), (uint) size);
+                return buffer[0];
 			}
 		}
 
@@ -297,8 +298,8 @@ namespace FreeImageAPI
 			else
 			{
 				buffer[0] = value;
-				CopyMemory(baseAddress + (index * size), ptr, size);
-			}
+                Unsafe.CopyBlockUnaligned(baseAddress + (index * size), ptr, (uint) size);
+            }
 		}
 
 		/// <summary>
@@ -335,10 +336,9 @@ namespace FreeImageAPI
 			}
 			else
 			{
-				GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
-				byte* dst = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(data, 0);
-				CopyMemory(dst, baseAddress + (size * index), size * length);
-				handle.Free();
+				ref byte dst = ref Unsafe.As<T, byte>(ref data[0]);
+                ref byte src = ref Unsafe.AsRef<byte>(baseAddress + (size * index));
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
 			}
 			return data;
 		}
@@ -380,11 +380,10 @@ namespace FreeImageAPI
 			}
 			else
 			{
-				GCHandle handle = GCHandle.Alloc(values, GCHandleType.Pinned);
-				byte* src = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(values, 0);
-				CopyMemory(baseAddress + (index * size), src, size * length);
-				handle.Free();
-			}
+                ref byte dst = ref Unsafe.AsRef<byte>(baseAddress + (index * size));
+                ref byte src = ref Unsafe.As<T, byte>(ref values[0]);
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+            }
 		}
 
 		/// <summary>
@@ -450,11 +449,10 @@ namespace FreeImageAPI
 			}
 			else
 			{
-				GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
-				byte* dst = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(array, destinationIndex);
-				CopyMemory(dst, baseAddress + (size * sourceIndex), size * length);
-				handle.Free();
-			}
+                ref byte dst = ref Unsafe.As<T, byte>(ref array[destinationIndex]);
+                ref byte src = ref Unsafe.AsRef<byte>(baseAddress + (size * sourceIndex));
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+            }
 		}
 
 		/// <summary>
@@ -494,11 +492,10 @@ namespace FreeImageAPI
 			}
 			else
 			{
-				GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
-				byte* src = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(array, sourceIndex);
-				CopyMemory(baseAddress + (size * destinationIndex), src, size * length);
-				handle.Free();
-			}
+                ref byte dst = ref Unsafe.AsRef<byte>(baseAddress + (size * destinationIndex));
+                ref byte src = ref Unsafe.As<T, byte>(ref array[sourceIndex]);
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+            }
 		}
 
 		/// <summary>
@@ -521,11 +518,12 @@ namespace FreeImageAPI
 			{
 				result = new byte[size * length];
 			}
-			fixed (byte* dst = result)
-			{
-				CopyMemory(dst, baseAddress, result.Length);
-			}
-			return result;
+
+            ref byte dst = ref result[0];
+            ref byte src = ref Unsafe.AsRef<byte>(baseAddress);
+            Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) result.Length);
+
+            return result;
 		}
 
 		/// <summary>
@@ -742,55 +740,6 @@ namespace FreeImageAPI
 		{
 			EnsureNotDisposed();
 			return (int)baseAddress ^ length;
-		}
-
-		/// <summary>
-		/// Copies a block of memory from one location to another.
-		/// </summary>
-		/// <param name="dest">Pointer to the starting address of the copy destination.</param>
-		/// <param name="src">Pointer to the starting address of the block of memory to be copied.</param>
-		/// <param name="len">Size of the block of memory to copy, in bytes.</param>
-		protected static unsafe void CopyMemory(byte* dest, byte* src, int len)
-		{
-			if (len >= 0x10)
-			{
-				do
-				{
-					*((int*)dest) = *((int*)src);
-					*((int*)(dest + 4)) = *((int*)(src + 4));
-					*((int*)(dest + 8)) = *((int*)(src + 8));
-					*((int*)(dest + 12)) = *((int*)(src + 12));
-					dest += 0x10;
-					src += 0x10;
-				}
-				while ((len -= 0x10) >= 0x10);
-			}
-			if (len > 0)
-			{
-				if ((len & 8) != 0)
-				{
-					*((int*)dest) = *((int*)src);
-					*((int*)(dest + 4)) = *((int*)(src + 4));
-					dest += 8;
-					src += 8;
-				}
-				if ((len & 4) != 0)
-				{
-					*((int*)dest) = *((int*)src);
-					dest += 4;
-					src += 4;
-				}
-				if ((len & 2) != 0)
-				{
-					*((short*)dest) = *((short*)src);
-					dest += 2;
-					src += 2;
-				}
-				if ((len & 1) != 0)
-				{
-					*dest = *src;
-				}
-			}
 		}
 	}
 }

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MetadataTag.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MetadataTag.cs
@@ -36,6 +36,7 @@
 using System;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -408,9 +409,12 @@ namespace FreeImageAPI.Metadata
 					}
 
 					Array array = Array.CreateInstance(idList[Type], Count);
-					void* src = (void*)FreeImage.GetTagValue(tag);
-					FreeImage.CopyMemory(array, src, Length);
-					return array;
+
+                    ref byte dst = ref MemoryMarshal.GetArrayDataReference(array);
+                    ref byte src = ref Unsafe.AsRef<byte>((void*) FreeImage.GetTagValue(tag));
+                    Unsafe.CopyBlockUnaligned(ref dst, ref src, Length);
+
+                    return array;
 				}
 			}
 			set
@@ -512,22 +516,25 @@ namespace FreeImageAPI.Metadata
 			}
 			else
 			{
-				Array array = value as Array;
-				if (array == null)
-				{
-					throw new ArgumentException("value");
-				}
+                if (value is not Array array)
+                {
+                    throw new ArgumentException(nameof(value));
+                }
 
-				if (array.Length != 0)
+                if (array.Length != 0)
 					if (!CheckType(array.GetValue(0).GetType(), type))
 						throw new ArgumentException("The type of value is incorrect.");
 
 				Type = type;
 				Count = (uint)array.Length;
 				Length = (uint)(array.Length * Marshal.SizeOf(idList[type]));
+
 				data = new byte[Length];
-				FreeImage.CopyMemory(data, array, Length);
-			}
+
+                ref byte dst = ref data[0];
+                ref byte src = ref MemoryMarshal.GetArrayDataReference(array);
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, Length);
+            }
 
 			return FreeImage.SetTagValue(tag, data);
 		}
@@ -617,8 +624,13 @@ namespace FreeImageAPI.Metadata
 			item.Id = ID;
 			item.Len = (int)Length;
 			item.Type = (short)Type;
-			FreeImage.CopyMemory(item.Value = new byte[item.Len], FreeImage.GetTagValue(tag), item.Len);
-			return item;
+            item.Value = new byte[item.Len];
+
+            ref byte dst = ref item.Value[0];
+            ref byte src = ref Unsafe.AsRef<byte>((void*) FreeImage.GetTagValue(tag));
+            Unsafe.CopyBlockUnaligned(ref dst, ref src, Length);
+
+            return item;
 		}
 
 		/// <summary>

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/Palette.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/Palette.cs
@@ -1,13 +1,12 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Drawing;
 using System.IO;
-using FreeImageAPI.Metadata;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using FreeImageAPI.Metadata;
 
 namespace FreeImageAPI
 {
@@ -400,11 +399,11 @@ namespace FreeImageAPI
 			{
 				int size = length * sizeof(RGBQUAD);
 				byte[] data = reader.ReadBytes(size);
-				fixed (byte* src = data)
-				{
-					CopyMemory(baseAddress, src, data.Length);
-				}
-			}
+
+                ref byte dst = ref Unsafe.AsRef<byte>(baseAddress);
+                ref byte src = ref data[0];
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) data.Length);
+            }
 		}
 
 		/// <summary>

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Structs/FIICCPROFILE.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Structs/FIICCPROFILE.cs
@@ -34,6 +34,7 @@
 // ==========================================================
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace FreeImageAPI
@@ -113,9 +114,14 @@ namespace FreeImageAPI
 		{
 			get
 			{
-				byte[] result;
-				FreeImage.CopyMemory(result = new byte[size], data.ToPointer(), size);
-				return result;
+                byte[] result = new byte[size];
+
+                ref byte dst = ref result[0];
+                ref byte src = ref Unsafe.AsRef<byte>((void*) data);
+
+                Unsafe.CopyBlockUnaligned(ref dst, ref src, size);
+
+                return result;
 			}
 		}
 


### PR DESCRIPTION
# PR Details

When building the runtime, the other graphics APIs that are not Direct3D 11 (OpenGL, Vulkan, Direct3D 12) results in errors stating that `Utilities.CopyMemory()` and `BinarySerialization.Read()` don't exist.

A previous PR replaced several many interop and IL weaved methods with the use of `ref`s, `Span<T>`, and `Unsafe` calls, but several of those for the other graphics APIs were not replaced.

This PR completes the replacement and fixes those errors when building `Stride.Runtime.sln`.

## Description

* Replaces several uses of `Utilities.CopyMemory()` with `Unsafe.CopyBlockUnaligned()`.
* Replaces several uses of `BinarySerialization.Read()` with `Unsafe.Read()`.
* Adds a small section in `Stride.props` where users can set the design-time graphics API to override the default one with so the proper `#define`s are set, Visual Studio can know what packages to restore, and IntelliSense can show the correct completions. This section is commented by default, but it's useful when working or modifying a specific graphics API.
* Small cleanups and use of modern C# syntax.

## Related Issue

This PR continues the work of [ericwj](https://github.com/ericwj)'s PR [#1469](https://github.com/stride3d/stride/pull/1469).
The original issue that motivated that PR was #1461.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODO

- [ ] Document in [stride-docs](https://github.com/stride3d/stride-docs) the way to set a specific graphics API at design-time.