### PR TITLE
[Build] Show useful error message and directions for users lacking requirements to run Stride.Core.Tasks

### DIFF
--- a/sources/core/Stride.Core.Tasks/Program.cs
+++ b/sources/core/Stride.Core.Tasks/Program.cs
@@ -27,7 +27,7 @@ namespace Stride.Core.Tasks
                 // The following ensures that a clear message is logged before the stuff above is shown.
                 // Do note that the 'error' word in the message is essential for it to be logged,
                 // direct any message about this peculiar 'feature' over to Microsoft, thanks !
-                Console.Error.WriteLine($@"error {typeof(Program).Namespace}: No supported instance of MSBuild could be detected, make sure you have .Net SDK {Environment.Version.Major} {Environment.Version.Minor} installed");
+                Console.Error.WriteLine($@"error {typeof(Program).Namespace}: No supported instance of MSBuild could be detected, make sure you have .Net SDK {Environment.Version.Major}.{Environment.Version.Minor} installed");
                 throw;
             }
             return RealMain(args);

--- a/sources/core/Stride.Core.Tasks/Program.cs
+++ b/sources/core/Stride.Core.Tasks/Program.cs
@@ -16,7 +16,20 @@ namespace Stride.Core.Tasks
     {
         public static int Main(string[] args)
         {
-            MSBuildLocator.RegisterDefaults();
+            try
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+            catch (InvalidOperationException e) when (e.Message.StartsWith("No instances of MSBuild could be detected."))
+            {
+                // When tasks running through build tools throw, it logs an obtuse 'The command [...]/Stride.Core.Tasks.exe [...] exited with code - x'
+                // message requiring the user to dig in the output to figure out what happened.
+                // The following ensures that a clear message is logged before the stuff above is shown.
+                // Do note that the 'error' word in the message is essential for it to be logged,
+                // direct any message about this peculiar 'feature' over to Microsoft, thanks !
+                Console.Error.WriteLine($@"error {typeof(Program).Namespace}: No supported instance of MSBuild could be detected, make sure you have .Net SDK {Environment.Version.Major} {Environment.Version.Minor} installed");
+                throw;
+            }
             return RealMain(args);
         }
 


### PR DESCRIPTION
# PR Details
Here's how it looks now when building without the right SDK installed:
![image](https://github.com/stride3d/stride/assets/5742236/56c85bea-3a26-40ff-a00f-2456cd3bfeb5)

## Related Issue
None logged in github as far as I could find

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.