### PR TITLE
fix #1703 Changing the comparison project related and not UPath related

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
@@ -216,7 +216,7 @@ namespace Stride.Assets.Presentation.AssetEditors
                 if (needProjectReload == false
                     && (e.ChangeType == FileEventChangeType.Deleted || e.ChangeType == FileEventChangeType.Renamed || e.ChangeType == FileEventChangeType.Created)
                     && Path.GetExtension(changedFile)?.ToLowerInvariant() == ".cs"
-                    && !UPath.Combine(new UFile(trackedAssembly.Project.FilePath).GetFullDirectory(), new UDirectory("obj")).Contains(new UFile(changedFile)))
+                    && trackedAssembly.Project.Documents.Any(x => x.FilePath.Equals(changedFile,StringComparison.OrdinalIgnoreCase)))
                 {
                     needProjectReload = true;
                 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
@@ -202,7 +202,7 @@ namespace Stride.Assets.Presentation.AssetEditors
             string changedFile;
             var renameEvent = e as FileRenameEvent;
             changedFile = renameEvent?.OldFullPath ?? e.FullPath;
-
+            
             foreach (var trackedAssembly in trackedAssemblies)
             {
                 // Report change of the assembly binary
@@ -214,9 +214,9 @@ namespace Stride.Assets.Presentation.AssetEditors
                 // Also check for .cs file changes (DefaultItems auto import *.cs, with some excludes such as obj subfolder)
                 // TODO: Check actual unevaluated .csproj to get the auto includes/excludes?
                 if (needProjectReload == false
-                    && (e.ChangeType == FileEventChangeType.Deleted || e.ChangeType == FileEventChangeType.Renamed || e.ChangeType == FileEventChangeType.Created)
+                    && ((e.ChangeType == FileEventChangeType.Deleted ||e.ChangeType == FileEventChangeType.Renamed ||  e.ChangeType == FileEventChangeType.Created)
                     && Path.GetExtension(changedFile)?.ToLowerInvariant() == ".cs"
-                    && trackedAssembly.Project.Documents.Any(x => x.FilePath.Equals(changedFile,StringComparison.OrdinalIgnoreCase)))
+                    && changedFile.StartsWith(Path.GetDirectoryName(trackedAssembly.Project.FilePath),StringComparison.OrdinalIgnoreCase)))
                 {
                     needProjectReload = true;
                 }


### PR DESCRIPTION
# PR Details
The Comparison was wrong as the UPath always fits the main Project.
It will never reach the other Projects
So i changed the Comparison to be Project related and not UPath related

## Description



## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

that bug was annoying.
Each change in a sub project didnt get reloaded.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
