### PR TITLE
Fix BoxColliderShape by creating Box2D shape when is2D

### DIFF
--- a/sources/engine/Stride.Physics/Shapes/BoxColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/BoxColliderShape.cs
@@ -37,7 +37,7 @@ namespace Stride.Physics
 
             if (Is2D)
             {
-                InternalShape = new BulletSharp.Convex2DShape(shape) { LocalScaling = cachedScaling };
+                InternalShape = new BulletSharp.Box2DShape(size / 2) { LocalScaling = cachedScaling };
             }
             else
             {

--- a/sources/engine/Stride.Physics/Shapes/BoxColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/BoxColliderShape.cs
@@ -30,11 +30,6 @@ namespace Stride.Physics
 
             if (is2D) size.Z = 0.001f;
 
-            var shape = new BulletSharp.BoxShape(size / 2)
-            {
-                LocalScaling = cachedScaling,
-            };
-
             // Note: Creating Convex 2D Shape from (3D) BoxShape, causes weird behaviour, 
             // better to instantiate Box2DShape directly (see issue #1707)
             if (Is2D)
@@ -43,7 +38,7 @@ namespace Stride.Physics
             }
             else
             {
-                InternalShape = shape;
+                InternalShape = new BulletSharp.BoxShape(size / 2) { LocalScaling = cachedScaling };
             }
 
             DebugPrimitiveMatrix = Matrix.Scaling(size * DebugScaling);

--- a/sources/engine/Stride.Physics/Shapes/BoxColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/BoxColliderShape.cs
@@ -35,6 +35,8 @@ namespace Stride.Physics
                 LocalScaling = cachedScaling,
             };
 
+            // Note: Creating Convex 2D Shape from (3D) BoxShape, causes weird behaviour, 
+            // better to instantiate Box2DShape directly (see issue #1707)
             if (Is2D)
             {
                 InternalShape = new BulletSharp.Box2DShape(size / 2) { LocalScaling = cachedScaling };


### PR DESCRIPTION
# PR Details

## Description

This PR fixes incorrect BoxCollider detection when the is2D checkbox is selected, simply by creating a 2D BoxShape version.

## Related Issue

#1707 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.