### PR TITLE
Translations fix

### DIFF
--- a/deps/Gettext.Net/GNU.Getopt.dll
+++ b/deps/Gettext.Net/GNU.Getopt.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62e1f16bcd420c181885df74fc203b43846b81b61328634f446a3e7a1749534c
-size 13312
+oid sha256:bc7cb994a2abd32af8a721a9639be77f8cc54fcc5d2c75eecc519406a9a26e85
+size 13824

--- a/deps/Gettext.Net/GNU.Gettext.Msgfmt.dll.config
+++ b/deps/Gettext.Net/GNU.Gettext.Msgfmt.dll.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<appSettings>
+		<add key="Gnu.PosixlyCorrect" value="true"/>
+	</appSettings>
+</configuration>

--- a/deps/Gettext.Net/GNU.Gettext.Msgfmt.exe
+++ b/deps/Gettext.Net/GNU.Gettext.Msgfmt.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f148923a83a4e14026636502698ece332d843776d221f38c7dafaff8b868273
-size 22016
+oid sha256:ce1eedcf4d2a6e251505c603307e8c7663c98e2434bf04b2e6ef9a11abebcda8
+size 18121955

--- a/deps/Gettext.Net/GNU.Gettext.Msgfmt.exe.config
+++ b/deps/Gettext.Net/GNU.Gettext.Msgfmt.exe.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
-  </startup>
-</configuration>

--- a/deps/Gettext.Net/GNU.Gettext.dll
+++ b/deps/Gettext.Net/GNU.Gettext.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6f0b66ebefc9bc1460f6e3e76d9d9134aad71da94bfc2ee6c81056afb62c78e
-size 67584
+oid sha256:6b3d95bfe85fb6162c8b4f5621eabc0473910ecc421eb436e743af80e9d6a475
+size 68096

--- a/deps/Gettext.Net/System.Configuration.ConfigurationManager.dll
+++ b/deps/Gettext.Net/System.Configuration.ConfigurationManager.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:370fa504e5766c703ddef43abddbbe3e373362207a1704d7baa67206c888c51c
-size 83528

--- a/deps/Gettext.Net/System.Security.AccessControl.dll
+++ b/deps/Gettext.Net/System.Security.AccessControl.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aced52254a8c3cb6ad30f99f8b745296926c49373cab00824c2c4c10ad325b10
-size 30792

--- a/deps/Gettext.Net/System.Security.Permissions.dll
+++ b/deps/Gettext.Net/System.Security.Permissions.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50653deedf757fd1669f54c1cbac2c2d1403d5864b73f63454ac4adc9619d831
-size 25464

--- a/deps/Gettext.Net/System.Security.Principal.Windows.dll
+++ b/deps/Gettext.Net/System.Security.Principal.Windows.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3ae599b5218516915f6542779ef577d5ad5de3d84a116e671c09e15e4591285
-size 15224

--- a/sources/core/Stride.Core.Translation/Stride.Core.Translation.csproj
+++ b/sources/core/Stride.Core.Translation/Stride.Core.Translation.csproj
@@ -12,7 +12,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Stride.GNU.Gettext" Version="1.0.0.0" />
+    <PackageReference Include="Stride.GNU.Gettext" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">

--- a/sources/targets/Stride.Core.targets
+++ b/sources/targets/Stride.Core.targets
@@ -169,7 +169,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Stride.AutoPack.targets"/>
 
   <!-- Generate localization satellite assemblies -->
-  <Target Name="StrideGenerateLocalizationSatelliteDlls" BeforeTargets="SatelliteDllsProjectOutputGroup" Returns="@(SatelliteDllsProjectOutputGroupOutput)" Condition="'$(StrideLocalized)' == 'true' And '$(Configuration)' == 'Release'">
+  <Target Name="StrideGenerateLocalizationSatelliteDlls" BeforeTargets="SatelliteDllsProjectOutputGroup" Returns="@(SatelliteDllsProjectOutputGroupOutput)" Condition="'$(StrideLocalized)' == 'true'" AfterTargets="Build">
     <ItemGroup>
       <!-- Current list of languages to try to generate -->
       <StrideTraductions Include="fr;ja;es;de;ru;it;ko"/>
@@ -182,8 +182,7 @@
       </_StrideTraductions>
     </ItemGroup>
     <Message Importance="High" Text="Generating traduction for %(_StrideTraductions.Identity) %(_StrideTraductions.SourceFolder)"/>
-    <Exec Condition="Exists('$(SolutionDir)..\sources\localization\%(_StrideTraductions.Source)\$(TargetName).%(_StrideTraductions.Source).po')" Command="Path=$(RoslynTargetsPath);$(Path)
-&quot;$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe&quot; --lib-dir &quot;$(SolutionDir)..\deps\Gettext.Net&quot; --resource $(TargetName) -d &quot;$(TargetDir).&quot; --locale %(_StrideTraductions.Identity) &quot;$(MSBuildThisFileDirectory)..\localization\%(_StrideTraductions.Source)\$(TargetName).%(_StrideTraductions.Source).po&quot; --verbose" />
+    <Exec Condition="Exists('$(SolutionDir)..\sources\localization\%(_StrideTraductions.Source)\$(TargetName).%(_StrideTraductions.Source).po')" Command="$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe -r $(TargetName) -d $(TargetDir) -l %(_StrideTraductions.Identity) -L $(SolutionDir)..\deps\Gettext.Net\ $(MSBuildThisFileDirectory)..\localization\%(_StrideTraductions.Source)\$(TargetName).%(_StrideTraductions.Source).po" />
     <ItemGroup>
       <SatelliteDllsProjectOutputGroupOutputIntermediate Include="$(OutDir)%(_StrideTraductions.Identity)\$(TargetName).Messages.resources.dll" Condition="Exists('$(OutDir)%(_StrideTraductions.Identity)\$(TargetName).Messages.resources.dll')">
         <TargetPath>%(_StrideTraductions.Identity)\$(TargetName).Messages.resources.dll</TargetPath>

--- a/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
+++ b/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
@@ -14,8 +14,8 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Stride.GNU.Getopt" Version="1.0.0.0" />
-    <PackageReference Include="Stride.GNU.Gettext" Version="1.0.0.0" />
+    <PackageReference Include="Stride.GNU.Getopt" Version="2.0.0" />
+    <PackageReference Include="Stride.GNU.Gettext" Version="2.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# PR Details

## Description

PR fixes translations by using dlls and updated code from my gettext fork : https://github.com/Jklawreszuk/gettextnet.

![image](https://github.com/stride3d/stride/assets/31008367/cbac6395-6a97-4aaf-a7ce-63e17540d88b)

# Additional context 

Although, It works correct and imho it could be merged I would say that is only temporary fix.
There are couple things need to do in the future:
- [x] Merge PR: https://github.com/stride3d/gettextnet/pull/2
	- [x] Publish nuget packages: GNU.Getopt, GNU.Gettext
	- [ ] _optional_: Publish nuget tools: GNU.Gettext.Msgfmt nad GNU.Gettext.Xgettext
		- [ ] Remove unnecessary dlls in deps/gettext.net folder 
		- [ ] Update teamcity pipeline or force to install required dotnet tools through msbuild if missing
	- [x] Consume packages in Stride repo

## Related Issue

#1714 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)