### PR TITLE
Adds sRGB and Gamma conversions to ColorUtility.sdsl

### DIFF
--- a/sources/engine/Stride.Graphics/Shaders/ColorUtility.sdsl
+++ b/sources/engine/Stride.Graphics/Shaders/ColorUtility.sdsl
@@ -21,4 +21,62 @@ shader ColorUtility
         float3 sRGB = sRGBa.rgb;
         return float4(sRGB * (sRGB * (sRGB * 0.305306011 + 0.682171111) + 0.012522878), sRGBa.a);
     }
+
+    // simple screen gamma conversion
+    float4 GammaToLinear (float4 RGBa, float Gamma = 2.2)
+    {
+        RGBa.rgb = pow(RGBa.rgb, 1.0/Gamma);
+        return RGBa;
+    }
+
+    float4 LinearToGamma (float4 RGBa, float Gamma = 2.2)
+    {
+        RGBa.rgb = pow(RGBa.rgb, Gamma);
+        return RGBa;
+    }
+
+    //https://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
+    // Converts an sRGB color to linear space
+    float4 SRgbToLinear(float4 sRGBa)
+    {
+        float3 sRGB = sRGBa.rgb;
+        return float4(sRGB * (sRGB * (sRGB * 0.305306011 + 0.682171111) + 0.012522878), sRGBa.a);
+    }
+
+    // Converts an linear color to sRGB space
+    float4 LinearToSRgb(float4 RGBa)
+    {
+        float3 RGB = RGBa.rgb;
+
+        float3 S1 = sqrt(RGB);
+        float3 S2 = sqrt(S1);
+        float3 S3 = sqrt(S2);
+
+        return float4(0.662002687f * S1 + 0.684122060f * S2 - 0.323583601f * S3 - 0.0225411470f * RGB, RGBa.a);
+    }
+
+    //https://github.com/vvvv/VL.Stride/pull/395#issuecomment-760253956
+    // Converts a color from linear to sRGB
+    float4 LinearToSRgbPrecise(float4 RGBa)
+    {
+        float3 rgb = RGBa.rgb;
+        float3 higher = 1.055 * pow(rgb, 1.0/2.4) - 0.055;
+        float3 lower = rgb * 12.92f;
+
+        float3 cutoff = step(rgb, 0.0031308);
+        RGBa.rgb = lerp(higher, lower, cutoff);
+        return RGBa;
+    }
+
+    // Converts a color from sRGB to linear
+    float4 SRgbToLinearPrecise(float4 sRGBa)
+    {
+        float3 srgb = sRGBa.rgb;
+        float3 higher = pow((srgb + 0.055) / 1.055, 2.4);
+        float3 lower = srgb / 12.92;
+
+        float3 cutoff = step(srgb, 0.04045);
+        sRGBa.rgb = lerp(higher, lower, cutoff);
+        return sRGBa;
+    }
 };


### PR DESCRIPTION
# PR Details

Adds the basic conversion methods for sRGB, and screen gamma.

Stride already has `ToLinear` methods, which are there same as `SRgbToLinear`, I could not remove them because it could potentially break existing shaders. Stride also has additional methods for single `float` and `float3`, which I have not provided, but I am open to adding this if requested.

## Related Issue

We had this in a temporary file in the vvvv code, but it would be better to put this into the official ColorUtility of Stride:
https://github.com/vvvv/VL.Stride/pull/395#issuecomment-760253956

## Motivation and Context

Getting color issues right when working with designers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)