### PR TITLE
[Asset] Show warning message when importing assets that are not inside of the resource folder

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -541,6 +541,29 @@ namespace Stride.Core.Assets.Editor.ViewModel
         {
             List<AssetViewModel> newAssets = new List<AssetViewModel>();
 
+            foreach (var file in files)
+            {
+                bool inResourceFolder = false;
+                foreach (var resourceFolder in directory.Package.Package.ResourceFolders)
+                {
+                    if (file.FullPath.StartsWith(resourceFolder.FullPath))
+                    {
+                        inResourceFolder = true;
+                        break;
+                    }
+                }
+
+                if (inResourceFolder == false)
+                {
+                    var message = Tr._p("Message", "Source file '{0}' is not inside any of your project's resource folders, import anyway ?");
+                    message = string.Format(message, file.FullPath);
+
+                    var result = await Dialogs.MessageBox(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                    if (result == MessageBoxResult.No)
+                        return newAssets;
+                }
+            }
+
             var parameters = new AssetTemplateGeneratorParameters(directory.Path, files)
             {
                 Name = name,


### PR DESCRIPTION
# PR Details
![image](https://github.com/stride3d/stride/assets/5742236/e91c8934-48d5-4f06-be3c-229efd1f54b1)

## Related Issue
Could extend to cover issue #1633 depending on what we want ?

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.