### PR TITLE
Fix DX11 shared textures

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
@@ -175,25 +175,26 @@ namespace Stride.Graphics
             NativeRenderTargetView = GetRenderTargetView(ViewType, ArraySlice, MipLevel);
             NativeDepthStencilView = GetDepthStencilView(out HasStencil);
 
-            switch (textureDescription.Options)
+            if (textureDescription.Options == TextureOptions.None)
             {
-                case TextureOptions.None:
-                    SharedHandle = IntPtr.Zero;
-                    break;
-                case TextureOptions.Shared:
-                    var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
-                    SharedHandle = sharedResource.SharedHandle;
-                    break;
+                SharedHandle = IntPtr.Zero;
+            }
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-                case TextureOptions.SharedNthandle | TextureOptions.SharedKeyedmutex:
-                    var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
-                    var uniqueName = "Stride:" + Guid.NewGuid().ToString();
-                    SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
-                    SharedNtHandleName = uniqueName;
-                    break; 
+            else if ((textureDescription.Options & TextureOptions.SharedNthandle) != 0)
+            {
+                var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
+                var uniqueName = "Stride:" + Guid.NewGuid().ToString();
+                SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
+                SharedNtHandleName = uniqueName;
+            }
 #endif
-                default:
-                    throw new ArgumentOutOfRangeException("textureDescription.Options");
+            else if ((textureDescription.Options & TextureOptions.Shared) != 0) {
+                var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
+                SharedHandle = sharedResource.SharedHandle;
+            }
+            else
+            { 
+                throw new ArgumentOutOfRangeException("textureDescription.Options");
             }
         }
 


### PR DESCRIPTION
Re-do of #1759 as it was lost in a force push.

# PR Details

Right now creating a texture from a native texture with D3D11_RESOURCE_MISC_SHARED_NTHANDLE  will fail unless it is also D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX. This combination is recomended but not mandatory acording to the specification: https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_resource_misc_flag

## Description

The PR changes the code that checks for shared handles from a switch/case to an if/else where the check is done for flags using a bitwise and instead of comparing the full flag to an specific value. Shared NT is checked first as Shared & SharedNT can be set at the same time.

## Related Issue

https://github.com/stride3d/stride/issues/1758

## Motivation and Context

Allows to use DX11 textures with an NT handle but no keyed mutex

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.