### PR TITLE
[System] Fix binary path location when the dlls are run from an unexp…

### DIFF
--- a/sources/core/Stride.Core/PlatformFolders.cs
+++ b/sources/core/Stride.Core/PlatformFolders.cs
@@ -184,11 +184,10 @@ namespace Stride.Core
         [NotNull]
         private static string GetApplicationBinaryDirectory()
         {
-            var executablePath = GetApplicationExecutableDirectory();
 #if STRIDE_PLATFORM_ANDROID
-            return executablePath;
+            return GetApplicationExecutableDirectory();
 #else
-            return FindCoreAssemblyDirectory(executablePath);
+            return Path.GetDirectoryName(typeof(PlatformFolders).Assembly.Location);
 #endif
         }
 
@@ -210,30 +209,6 @@ namespace Stride.Core
 #else
             throw new NotImplementedException();
 #endif
-        }
-
-        static string FindCoreAssemblyDirectory(string entryDirectory)
-        {
-            //simple case
-            var corePath = Path.Combine(entryDirectory, "Stride.Core.dll");
-            if (File.Exists(corePath))
-            {
-                return entryDirectory;
-            }
-            else //search one level down
-            {
-                foreach (var subfolder in Directory.GetDirectories(entryDirectory))
-                {
-                    corePath = Path.Combine(subfolder, "Stride.Core.dll");
-                    if (File.Exists(corePath))
-                    {
-                        return subfolder;
-                    }
-                }
-            }
-
-            //if nothing found, return input
-            return entryDirectory;
         }
 
         [NotNull]


### PR DESCRIPTION
Re-do of #1764 as it was lost in a force push.

# PR Details
A user had an issue running tests from Rider, the folder returned from that function pointed next to the test runner executable instead of the dlls. Pinging @tebjan since this is his area.

## Related Issue
None logged

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.