### PR TITLE
[Graphics] Fix expected image size for OpenGL textures.

### DIFF
--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -2,17 +2,17 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 //
 // Copyright (c) 2010-2012 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,51 +25,51 @@
 // -----------------------------------------------------------------------------
 // Microsoft Public License (Ms-PL)
 //
-// This license governs use of the accompanying software. If you use the 
+// This license governs use of the accompanying software. If you use the
 // software, you accept this license. If you do not accept the license, do not
 // use the software.
 //
 // 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and 
+// The terms "reproduce," "reproduction," "derivative works," and
 // "distribution" have the same meaning here as under U.S. copyright law.
-// A "contribution" is the original software, or any additions or changes to 
+// A "contribution" is the original software, or any additions or changes to
 // the software.
-// A "contributor" is any person that distributes its contribution under this 
+// A "contributor" is any person that distributes its contribution under this
 // license.
-// "Licensed patents" are a contributor's patent claims that read directly on 
+// "Licensed patents" are a contributor's patent claims that read directly on
 // its contribution.
 //
 // 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the 
-// license conditions and limitations in section 3, each contributor grants 
+// (A) Copyright Grant- Subject to the terms of this license, including the
+// license conditions and limitations in section 3, each contributor grants
 // you a non-exclusive, worldwide, royalty-free copyright license to reproduce
-// its contribution, prepare derivative works of its contribution, and 
+// its contribution, prepare derivative works of its contribution, and
 // distribute its contribution or any derivative works that you create.
 // (B) Patent Grant- Subject to the terms of this license, including the license
-// conditions and limitations in section 3, each contributor grants you a 
+// conditions and limitations in section 3, each contributor grants you a
 // non-exclusive, worldwide, royalty-free license under its licensed patents to
 // make, have made, use, sell, offer for sale, import, and/or otherwise dispose
-// of its contribution in the software or derivative works of the contribution 
+// of its contribution in the software or derivative works of the contribution
 // in the software.
 //
 // 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any 
+// (A) No Trademark License- This license does not grant you rights to use any
 // contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that 
-// you claim are infringed by the software, your patent license from such 
+// (B) If you bring a patent claim against any contributor over patents that
+// you claim are infringed by the software, your patent license from such
 // contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all 
+// (C) If you distribute any portion of the software, you must retain all
 // copyright, patent, trademark, and attribution notices that are present in the
 // software.
-// (D) If you distribute any portion of the software in source code form, you 
-// may do so only under this license by including a complete copy of this 
+// (D) If you distribute any portion of the software in source code form, you
+// may do so only under this license by including a complete copy of this
 // license with your distribution. If you distribute any portion of the software
-// in compiled or object code form, you may only do so under a license that 
+// in compiled or object code form, you may only do so under a license that
 // complies with this license.
 // (E) The software is licensed "as-is." You bear the risk of using it. The
 // contributors give no express warranties, guarantees or conditions. You may
-// have additional consumer rights under your local laws which this license 
-// cannot change. To the extent permitted under your local laws, the 
+// have additional consumer rights under your local laws which this license
+// cannot change. To the extent permitted under your local laws, the
 // contributors exclude the implied warranties of merchantability, fitness for a
 // particular purpose and non-infringement.
 using System;
@@ -102,7 +102,7 @@ namespace Stride.Graphics
         private int zBufferCountPerArraySlice;
         private MipMapDescription[] mipmapDescriptions;
         private static List<LoadSaveDelegate> loadSaveDelegates = new List<LoadSaveDelegate>();
-        
+
         /// <summary>
         /// Provides access to all pixel buffers.
         /// </summary>
@@ -229,7 +229,7 @@ namespace Stride.Graphics
                 // For 3D textures
                 return GetPixelBufferUnsafe(0, arrayOrZSliceIndex, mipmap);
             }
-            
+
             if (arrayOrZSliceIndex > Description.ArraySize)
             {
                 throw new ArgumentException("Invalid array slice index", "arrayOrZSliceIndex");
@@ -685,7 +685,7 @@ namespace Stride.Graphics
                     if (image != null)
                     {
                         if (loadAsSRGB)
-                            image.ConvertFormatToSRgb();                     
+                            image.ConvertFormatToSRgb();
 
                         return image;
                     }
@@ -869,6 +869,8 @@ namespace Stride.Graphics
                     case PixelFormat.BC4_UNorm:
                     case PixelFormat.BC4_SNorm:
                     case PixelFormat.ETC1:
+                    case PixelFormat.ETC2_RGB:
+                    case PixelFormat.ETC2_RGB_SRgb:
                         bpb = 8;
                         break;
                     default:
@@ -983,8 +985,8 @@ namespace Stride.Graphics
             {
                 int w = imageDesc.Width;
                 int h = imageDesc.Height;
-                int d = imageDesc.Depth; 
-                
+                int d = imageDesc.Depth;
+
                 for (int i = 0; i < imageDesc.MipLevels; i++)
                 {
                     int rowPitch, slicePitch;
@@ -1034,7 +1036,7 @@ namespace Stride.Graphics
         }
 
         /// <summary>
-        /// Allocates PixelBuffers 
+        /// Allocates PixelBuffers
         /// </summary>
         /// <param name="buffer"></param>
         /// <param name="pixelSize"></param>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fixes "Image size different than expected." in the Asset Compiler when compiling for Android with graphics level 10+.

## Description

<!--- Describe your changes in detail -->
Gets the correct 'bpb' value for certain ETC2 pixel formats.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Solves the first part of #1600 however my machine isn't set up correctly to fix the other ETC2 issues.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.