### PR TITLE
[Core] Enable multiple profiler consumers and add a timeline/tracing profiler

### DIFF
--- a/sources/core/Stride.Core.Tests/TestProfiler.cs
+++ b/sources/core/Stride.Core.Tests/TestProfiler.cs
@@ -1,12 +1,16 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Xunit;
-using Stride.Core.Diagnostics;
 using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Stride.Core.Diagnostics;
+using Xunit;
 
 namespace Stride.Core.Tests
 {
@@ -107,7 +111,7 @@ namespace Stride.Core.Tests
 
 
         [Fact]
-        public void TestWitAttributes()
+        public void TestWithAttributes()
         {
             Profiler.Reset();
             const int timeToWait = 10;
@@ -131,6 +135,78 @@ namespace Stride.Core.Tests
             watcher.Finish();
         }
 
+        [Fact]
+        public async void TestSubscribersReceiveEvents()
+        {
+            const int subscriberCount = 5;
+            const int eventCount = 5;
+
+            var subscribers = new TestEventReader[subscriberCount];
+
+            Profiler.DisableAll();
+
+            for(int i = 0; i < subscriberCount; i++)
+            {
+                // EventReaders will Unsubscribe themselves after reading 'eventCount' events.
+                subscribers[i] = new TestEventReader(eventsToRead: eventCount);
+                subscribers[i].Subscribe();
+            }
+
+            Profiler.MinimumProfileDuration = TimeSpan.Zero;
+            Profiler.EnableAll();
+
+            for(int i = 0; i < eventCount; i++)
+            {
+                using var _ = Profiler.Begin(TestKey);
+            }
+
+            var results = await Task.WhenAll(subscribers.Select(async x => await x.ReadAll()));            
+
+            Assert.All(results, x => Assert.Equal(eventCount, x.Count));
+        }
+
+        [Fact]
+        public async void TestConcurrentUse()
+        {
+            const int subscriberCount = 100;
+            const int eventCount = 5;
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+
+            Task[] eventGenerators = Enumerable.Range(0, 4).Select(x => Task.Run(() =>
+            {
+                while (true)
+                {
+                    if (cts.IsCancellationRequested)
+                        return;
+
+                    using var _ = Profiler.Begin(TestKey);
+                    Thread.Sleep(1);
+                }
+            })).ToArray();
+
+            Profiler.MinimumProfileDuration = TimeSpan.Zero;
+            Profiler.EnableAll();
+
+            var subscribers = new ConcurrentBag<TestEventReader>();
+
+            Parallel.For(0, subscriberCount, (i) =>
+            {
+                // EventReaders will Unsubscribe themselves after reading 'eventCount' events.
+                var reader = new TestEventReader(eventsToRead: eventCount);
+                reader.Subscribe();
+                subscribers.Add(reader);
+                Thread.Sleep(1);
+            });
+            
+            var results = await Task.WhenAll(subscribers.Select(async x => await x.ReadAll()));            
+            
+            cts.Cancel();
+
+            Task.WaitAll(eventGenerators);
+
+            Assert.All(results, x => Assert.Equal(eventCount, x.Count));
+        }
 
         private static Regex matchElapsed = new Regex(@"Elapsed = ([\d.]+)", RegexOptions.CultureInvariant);
 
@@ -221,6 +297,47 @@ namespace Stride.Core.Tests
             };
             GlobalLogger.GlobalMessageLogged += watcher.LogAction;
             return watcher;
+        }
+
+        private class TestEventReader
+        { 
+
+            ChannelReader<ProfilingEvent> reader;
+
+            public List<ProfilingEvent> Events;
+            private int eventsToRead;
+
+            public TestEventReader(int eventsToRead)
+            {
+                this.eventsToRead = eventsToRead;
+            }
+
+            public void Subscribe()
+            {
+                Events = new List<ProfilingEvent>();
+                reader = Profiler.Subscribe();
+            }
+
+            public void Unsubscribe()
+            {
+                Profiler.Unsubscribe(reader);
+            }
+
+            public async Task<List<ProfilingEvent>> ReadAll()
+            {
+                await foreach (var item in reader.ReadAllAsync())
+                {
+                    Events.Add(item);
+                    if (Events.Count == eventsToRead)
+                    {
+                        Unsubscribe();
+                        break;
+                    }
+                }
+
+                return Events;
+            }
+
         }
     }
 }

--- a/sources/core/Stride.Core.Tests/TestProfiler.cs
+++ b/sources/core/Stride.Core.Tests/TestProfiler.cs
@@ -132,7 +132,7 @@ namespace Stride.Core.Tests
         }
 
 
-        private static Regex matchElapsed = new Regex(@"Elapsed = ([\d\.]+)");
+        private static Regex matchElapsed = new Regex(@"Elapsed = ([\d.,]+)");
 
         // Maximum time difference accepted between elapsed time
         private const double ElapsedTimeEpsilon = 10;

--- a/sources/core/Stride.Core.Tests/TestProfiler.cs
+++ b/sources/core/Stride.Core.Tests/TestProfiler.cs
@@ -132,7 +132,7 @@ namespace Stride.Core.Tests
         }
 
 
-        private static Regex matchElapsed = new Regex(@"Elapsed = ([\d.,]+)");
+        private static Regex matchElapsed = new Regex(@"Elapsed = ([\d.]+)", RegexOptions.CultureInvariant);
 
         // Maximum time difference accepted between elapsed time
         private const double ElapsedTimeEpsilon = 10;

--- a/sources/core/Stride.Core/Diagnostics/ChromeTracingProfileWriter.cs
+++ b/sources/core/Stride.Core/Diagnostics/ChromeTracingProfileWriter.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Stride.Core.Diagnostics
+{
+    public class ChromeTracingProfileWriter
+    {
+        public void Start(string outputPath, bool indentOutput = false)
+        {
+            eventReader = Profiler.Subscribe();
+            writerTask = Task.Run(async () =>
+            {
+                var pid = Process.GetCurrentProcess().Id;
+
+                using FileStream fs = File.Create(outputPath);
+                using var writer = new Utf8JsonWriter(fs, options: new JsonWriterOptions { Indented = indentOutput });
+
+                JsonObject root = new JsonObject();
+
+                writer.WriteStartObject();
+                writer.WriteStartArray("traceEvents");
+  
+                writer.WriteStartObject();
+                writer.WriteString("name", "thread_name");
+                writer.WriteString("ph", "M");
+                writer.WriteNumber("pid", pid);
+                writer.WriteNumber("tid", int.MaxValue);
+                writer.WriteStartObject("args");
+                writer.WriteString("name", "GPU");
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+                writer.WriteStartObject();
+                writer.WriteString("name", "thread_sort_index");
+                writer.WriteString("ph", "M");
+                writer.WriteNumber("pid", pid);
+                writer.WriteNumber("tid", int.MaxValue);
+                writer.WriteStartObject("args");
+                writer.WriteNumber("sort_index", int.MaxValue);
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+
+                await foreach (var e in eventReader.ReadAllAsync())
+                {                    
+                    //gc scopes currently start at negative timestamps and should be filtered out,
+                    //because they don't represent durations.
+                    if (e.TimeStamp.Ticks < 0)
+                        continue;
+
+                    double startTimeInMicroseconds = e.TimeStamp.TotalMilliseconds * 1000.0;
+                    double durationInMicroseconds = e.ElapsedTime.TotalMilliseconds * 1000.0;
+
+                    Debug.Assert(durationInMicroseconds >= 0);
+
+                    writer.WriteStartObject();
+                    writer.WriteString("name", e.Key.Name);
+                    if (e.Key.Parent != null)
+                        writer.WriteString("cat", e.Key.Parent.Name);
+                    writer.WriteString("ph", "X");
+                    writer.WriteNumber("ts", startTimeInMicroseconds);
+                    writer.WriteNumber("dur", durationInMicroseconds);
+                    writer.WriteNumber("tid", e.ThreadId>=0?e.ThreadId: int.MaxValue);
+                    writer.WriteNumber("pid", pid);
+                    if (e.Attributes.Count > 0)
+                    {
+                        writer.WriteStartObject("args");
+                        foreach (var (k,v) in e.Attributes)
+                        {
+                            writer.WriteString(k, v.ToString());
+                        }                        
+                        writer.WriteEndObject();
+                    }
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+                writer.Flush();
+            });
+        }
+
+        public void Stop()
+        {
+            if (eventReader != null)
+            {
+                Profiler.Unsubscribe(eventReader);
+                writerTask?.Wait();
+            }
+        }
+#nullable enable
+        ChannelReader<ProfilingEvent>? eventReader;
+        Task? writerTask;
+#nullable disable
+    }
+
+}

--- a/sources/core/Stride.Core/Diagnostics/ProfilingEvent.cs
+++ b/sources/core/Stride.Core/Diagnostics/ProfilingEvent.cs
@@ -37,6 +37,11 @@ namespace Stride.Core.Diagnostics
         public readonly TimeSpan ElapsedTime;
 
         /// <summary>
+        /// The thread id.
+        /// </summary>
+        public readonly int ThreadId;
+
+        /// <summary>
         /// The message.
         /// </summary>
         public readonly ProfilingEventMessage? Message;
@@ -62,6 +67,7 @@ namespace Stride.Core.Diagnostics
             ProfilingMessageType profilingType, 
             TimeSpan timeStamp, 
             TimeSpan elapsedTime, 
+            int threadId,
             ProfilingEventMessage? message,
             TagList attributes)
         {
@@ -70,8 +76,11 @@ namespace Stride.Core.Diagnostics
             Type = profilingType;
             TimeStamp = timeStamp;
             ElapsedTime = elapsedTime;
+            ThreadId = threadId;
             Message = message;
             Attributes = attributes;
         }
+
+        public bool IsGPUEvent() => ThreadId == Profiler.GpuThreadId;
     }
 }

--- a/sources/core/Stride.Core/Diagnostics/ProfilingState.cs
+++ b/sources/core/Stride.Core/Diagnostics/ProfilingState.cs
@@ -4,6 +4,8 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 
+using static Stride.Core.Extensions.TimeSpanExtensions;
+
 namespace Stride.Core.Diagnostics
 {
     /// <summary>
@@ -115,7 +117,7 @@ namespace Stride.Core.Diagnostics
             eventType = ProfilingEventType.GpuProfilingEvent;
             //TODO: Map GPU queues to thread ids
             threadId = Profiler.GpuThreadId;
-            EmitEventCore(ProfilingMessageType.Begin, TimeSpanFromTimeStamp(timeStamp));
+            EmitEventCore(ProfilingMessageType.Begin, FromTimeStamp(timeStamp, tickFrequency));
         }
 
         /// <summary>
@@ -168,7 +170,7 @@ namespace Stride.Core.Diagnostics
             // Perform event only if the profiling is running (to save on time calculations)
             if (!isEnabled) return;
 
-            EmitEventCore(ProfilingMessageType.End, TimeSpanFromTimeStamp(timeStamp));
+            EmitEventCore(ProfilingMessageType.End, FromTimeStamp(timeStamp, tickFrequency));
         }
 
         private void EmitEventCore(ProfilingMessageType profilingType, TimeSpan timeStamp, ProfilingEventMessage? message = null)
@@ -218,12 +220,7 @@ namespace Stride.Core.Diagnostics
             if (!isEnabled) return;
 
             var timeStamp = Stopwatch.GetTimestamp();
-            EmitEventCore(profilingType, TimeSpanFromTimeStamp(timeStamp), message);
-        }
-
-        private TimeSpan TimeSpanFromTimeStamp(long timeStamp)
-        {
-            return new TimeSpan((long)(timeStamp * ((double)10_000_000 / tickFrequency)));
+            EmitEventCore(profilingType, FromTimeStamp(timeStamp, tickFrequency), message);
         }
     }
 }

--- a/sources/core/Stride.Core/Diagnostics/ProfilingState.cs
+++ b/sources/core/Stride.Core/Diagnostics/ProfilingState.cs
@@ -172,6 +172,8 @@ namespace Stride.Core.Diagnostics
             // Perform event only if the profiling is running
             if (!isEnabled) return;
 
+            TimeSpan deltaTime = TimeSpan.Zero;
+
             if (profilingType == ProfilingMessageType.Begin)
             {
                 startTime = timeStamp;
@@ -182,15 +184,15 @@ namespace Stride.Core.Diagnostics
                 if (message == null)
                     message = beginMessage;
 
+                deltaTime = timeStamp - startTime;
+
+                // Send profiler measurement to Histogram Meter
+                ProfilingKey.PerformanceMeasurement.Record(deltaTime.TotalMilliseconds, Attributes);
+
                 // upon end we disable this state
                 // one of the reasons is that we can call End(message) inside the `using() { }` and by disabling we prevent another End event to be emitted.
                 isEnabled = false;
             }
-
-            TimeSpan deltaTime = timeStamp - startTime;
-
-            // Send profiler measurement to Histogram Meter
-            ProfilingKey.PerformanceMeasurement.Record(deltaTime.TotalMilliseconds, Attributes);
 
             // Create profiler event
             var profilerEvent = new ProfilingEvent(ProfilingId, ProfilingKey, profilingType, timeStamp, deltaTime, message, Attributes);

--- a/sources/core/Stride.Core/Diagnostics/ProfilingState.cs
+++ b/sources/core/Stride.Core/Diagnostics/ProfilingState.cs
@@ -183,6 +183,10 @@ namespace Stride.Core.Diagnostics
                 startTime = timeStamp;
                 beginMessage = message;
             }
+            else if(profilingType == ProfilingMessageType.Mark)
+            {
+                deltaTime = timeStamp - startTime;
+            }
             else if (profilingType == ProfilingMessageType.End)
             {
                 if (message == null)

--- a/sources/core/Stride.Core/Extensions/TimeSpanExtensions.cs
+++ b/sources/core/Stride.Core/Extensions/TimeSpanExtensions.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Diagnostics;
 
-namespace Stride.Audio
+namespace Stride.Core.Extensions
 {
     public static class TimeSpanExtensions
     {
         private const long TicksPerMicroSecond = TimeSpan.TicksPerMillisecond / 1000L;
+        private static readonly double timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 
         public static TimeSpan FromMicroSeconds(long microSeconds)
         {
@@ -14,6 +16,16 @@ namespace Stride.Audio
         public static long TotalMicroSeconds(this TimeSpan timeSpan)
         {
             return timeSpan.Ticks / TicksPerMicroSecond;
+        }
+
+        public static TimeSpan FromTimeStamp(long timestamp)
+        {
+            return new TimeSpan((long)(timestamp * timestampToTicks));
+        }
+
+        public static TimeSpan FromTimeStamp(long timestamp, long frequency)
+        {
+            return new TimeSpan((long)(timestamp * (TimeSpan.TicksPerSecond / (double)frequency)));
         }
 
         public static TimeSpan Min(TimeSpan left, TimeSpan right)

--- a/sources/core/Stride.Core/Threading/ConcurrentCollector.cs
+++ b/sources/core/Stride.Core/Threading/ConcurrentCollector.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using Stride.Core.Annotations;
+using Stride.Core.Diagnostics;
 
 namespace Stride.Core.Threading
 {
@@ -64,7 +65,7 @@ namespace Stride.Core.Threading
     public class ConcurrentCollector<T> : IReadOnlyList<T>
     {
         private const int DefaultCapacity = 16;
-
+        private static readonly ProfilingKey CloseKey = new ProfilingKey($"ConcurrentCollector<{typeof(T).Name}>.Close");
         private class Segment
         {
             public T[] Items;
@@ -99,6 +100,7 @@ namespace Stride.Core.Threading
         /// </summary>
         public void Close()
         {
+            using var _ = Profiler.Begin(CloseKey);
             if (head.Next != null)
             {
                 var newItems = new T[tail.Offset + tail.Items.Length];

--- a/sources/core/Stride.Core/Threading/Dispatcher.cs
+++ b/sources/core/Stride.Core/Threading/Dispatcher.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Stride.Core.Annotations;
 using Stride.Core.Collections;
+using Stride.Core.Diagnostics;
 
 namespace Stride.Core.Threading
 {
@@ -22,6 +23,8 @@ namespace Stride.Core.Threading
 #else
         public static int MaxDegreeOfParallelism = Environment.ProcessorCount;
 #endif
+
+        private static readonly ProfilingKey DispatcherSortKey = new ProfilingKey("Dispatcher.Sort");
 
         public delegate void ValueAction<T>(ref T obj);
 
@@ -527,6 +530,8 @@ namespace Stride.Core.Threading
 
         public static void Sort<T>(T[] collection, int index, int length, IComparer<T> comparer)
         {
+            using var _ = Profiler.Begin(DispatcherSortKey);
+
             if (length <= 0)
                 return;
 

--- a/sources/core/Stride.Core/Threading/ThreadPool.cs
+++ b/sources/core/Stride.Core/Threading/ThreadPool.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Stride.Core.Annotations;
+using Stride.Core.Diagnostics;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -24,7 +25,9 @@ namespace Stride.Core.Threading
         private static bool isWorkedThread;
         /// <summary> Is the thread reading this property a worker thread </summary>
         public static bool IsWorkedThread => isWorkedThread;
-        
+
+        private static readonly ProfilingKey ProcessWorkItemKey = new ProfilingKey("Process Work Item");
+
         private readonly ConcurrentQueue<Action> workItems = new ConcurrentQueue<Action>();
         private readonly SemaphoreW semaphore;
         
@@ -103,6 +106,7 @@ namespace Stride.Core.Threading
                 Interlocked.Decrement(ref workScheduled);
                 try
                 {
+                    using var _ = Profiler.Begin(ProcessWorkItemKey);
                     workItem.Invoke();
                 }
                 finally

--- a/sources/core/Stride.Core/Threading/ThreadPool.cs
+++ b/sources/core/Stride.Core/Threading/ThreadPool.cs
@@ -26,7 +26,7 @@ namespace Stride.Core.Threading
         /// <summary> Is the thread reading this property a worker thread </summary>
         public static bool IsWorkedThread => isWorkedThread;
 
-        private static readonly ProfilingKey ProcessWorkItemKey = new ProfilingKey("Process Work Item");
+        private static readonly ProfilingKey ProcessWorkItemKey = new ProfilingKey($"{nameof(ThreadPool)}.ProcessWorkItem");
 
         private readonly ConcurrentQueue<Action> workItems = new ConcurrentQueue<Action>();
         private readonly SemaphoreW semaphore;

--- a/sources/editor/Stride.Assets.Presentation/SceneEditor/MaterialFilterRenderFeature.cs
+++ b/sources/editor/Stride.Assets.Presentation/SceneEditor/MaterialFilterRenderFeature.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Stride.Core.Diagnostics;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
 using Stride.Shaders;

--- a/sources/editor/Stride.Assets.Presentation/SceneEditor/MaterialFilterRenderFeature.cs
+++ b/sources/editor/Stride.Assets.Presentation/SceneEditor/MaterialFilterRenderFeature.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Stride.Core.Diagnostics;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
 using Stride.Shaders;

--- a/sources/engine/Stride.Audio/StreamedBufferSoundSource.cs
+++ b/sources/engine/Stride.Audio/StreamedBufferSoundSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 
 using Stride.Core;
+using Stride.Core.Extensions;
 using Stride.Media;
 
 namespace Stride.Audio

--- a/sources/engine/Stride.Engine/Engine/EntityManager.cs
+++ b/sources/engine/Stride.Engine/Engine/EntityManager.cs
@@ -24,6 +24,7 @@ namespace Stride.Engine
     public abstract class EntityManager : ComponentBase, Core.Collections.IReadOnlySet<Entity>
     {
         // TODO: Make this class threadsafe (current locks aren't sufficients)
+        private static readonly ProfilingKey DrawKey = new ProfilingKey("EntityManager.Draw");
 
         public ExecutionMode ExecutionMode { get; protected set; } = ExecutionMode.Runtime;
 
@@ -186,6 +187,7 @@ namespace Stride.Engine
         /// <param name="context">The render context.</param>
         public virtual void Draw(RenderContext context)
         {
+            using var _ = Profiler.Begin(DrawKey);
             foreach (var processor in processors)
             {
                 if (processor.Enabled)

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSorting.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSorting.cs
@@ -6,6 +6,9 @@ namespace Stride.Profiling
 {
     public enum GameProfilingSorting
     {
+        [Display("Average time")]
+        ByAverageTime,
+
         [Display("Total time")]
         ByTime,
 

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -18,7 +18,7 @@ namespace Stride.Profiling
 {
     public class GameProfilingSystem : GameSystemBase
     {
-        private static readonly ProfilingKey UpdateStringsKey = new ProfilingKey("Update Profiling Strings");
+        private static readonly ProfilingKey UpdateStringsKey = new ProfilingKey($"{nameof(GameProfilingSystem)}.UpdateStrings");
 
         private readonly Point textDrawStartOffset = new Point(5, 10);
         private const int TextRowHeight = 16;
@@ -428,11 +428,12 @@ namespace Stride.Profiling
                 }
             }
 
-            Profiler.Init(MinimumProfileDuration);
-
             gcProfiler.Enable();
 
-            stringBuilderTask = Task.Run(ReadEventsAsync);
+            if (stringBuilderTask == null || stringBuilderTask.IsCompleted)
+            {
+                stringBuilderTask = Task.Run(ReadEventsAsync);
+            }
         }
 
         /// <summary>
@@ -483,6 +484,8 @@ namespace Stride.Profiling
             get => filteringMode;
             set
             {
+                // Only Cpu and Gpu modes need to subscribe to profiling events, so we
+                // subscribe when switching away from Fps mode and unsubscribe when switching to it.
                 if (filteringMode != value)
                 {
                     if (filteringMode == GameProfilingResults.Fps)
@@ -504,7 +507,5 @@ namespace Stride.Profiling
         /// Sets or gets the profiling result page to display.
         /// </summary>
         public uint CurrentResultPage { get; set; } = 1;
-
-        public TimeSpan MinimumProfileDuration => Profiler.MinimumProfileDuration;
     }
 }

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -75,7 +75,8 @@ namespace Stride.Profiling
 
             public int Compare(ProfilingResult x, ProfilingResult y)
             {
-                return TimeSpan.Compare(x.AccumulatedTime, y.AccumulatedTime);
+                //Flip sign so we get descending order.
+                return -TimeSpan.Compare(x.AccumulatedTime, y.AccumulatedTime);
             }
         }
 

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Stride.Core;
 using Stride.Core.Diagnostics;
@@ -17,6 +18,8 @@ namespace Stride.Profiling
 {
     public class GameProfilingSystem : GameSystemBase
     {
+        private static readonly ProfilingKey UpdateStringsKey = new ProfilingKey("Update Profiling Strings");
+
         private readonly Point textDrawStartOffset = new Point(5, 10);
         private const int TextRowHeight = 16;
         private const int TopRowHeight = TextRowHeight + 2;
@@ -47,6 +50,10 @@ namespace Stride.Profiling
 
         private Color4 textColor = Color.LightGreen;
 
+        private GameProfilingResults filteringMode;
+        private Task stringBuilderTask;
+        private Size2 renderTargetSize;
+        private ChannelReader<ProfilingEvent> profilerChannel;
         private PresentInterval? userPresentInterval;
         private bool userMinimizedState = true;
 
@@ -95,25 +102,10 @@ namespace Stride.Profiling
         }
 
         private readonly Stopwatch dumpTiming = Stopwatch.StartNew();
+        
 
-        private Task stringBuilderTask;
-        private Size2 renderTargetSize;
 
-        /// <inheritdoc/>
-        public override void Update(GameTime gameTime)
-        {
-            if (dumpTiming.ElapsedMilliseconds < RefreshTime || FilteringMode == GameProfilingResults.GpuEvents)
-                return;
-
-            dumpTiming.Restart();
-
-            if (stringBuilderTask != null && !stringBuilderTask.IsCompleted) return;
-
-            stringBuilderTask = new Task(UpdateProfilingStrings);
-            stringBuilderTask.Start();
-        }
-
-        private void UpdateProfilingStrings()
+        private void UpdateProfilingStrings(bool containsMarks)
         {
             profilersStringBuilder.Clear();
             fpsStatStringBuilder.Clear();
@@ -128,18 +120,112 @@ namespace Stride.Profiling
             var elapsedFrames = newDraw - lastFrame;
             lastFrame = newDraw;
 
-            // Get events from the profiler ( this will also clean up the profiler )
-            var events = Profiler.GetEvents(FilteringMode == GameProfilingResults.CpuEvents ? ProfilingEventType.CpuProfilingEvent : ProfilingEventType.GpuProfilingEvent);
+            profilersStringBuilder.Clear();
+            profilingResults.Clear();
 
-            if (FilteringMode != GameProfilingResults.Fps)
+            foreach (var profilingResult in profilingResultsDictionary)
             {
-                var containsMarks = false;
+                if (!profilingResult.Value.Event.HasValue) continue;
+                profilingResults.Add(profilingResult.Value);
+            }
+            profilingResultsDictionary.Clear();
 
-                const float kb = 1 << 10;
-                const float mb = 1 << 20;
-                //update strings that need update
-                foreach (var e in events)
+            if (SortingMode == GameProfilingSorting.ByTime)
+            {
+                profilingResults.Sort((x, y) => x.Compare(x, y));
+            }
+            else
+            {
+                // Can't be null because we skip those events without values
+                // ReSharper disable PossibleInvalidOperationException
+                profilingResults.Sort((x1, x2) => string.Compare(x1.Event.Value.Key.Name, x2.Event.Value.Key.Name, StringComparison.Ordinal));
+                // ReSharper restore PossibleInvalidOperationException
+            }
+
+            var availableDisplayHeight = viewportHeight - 2 * TextRowHeight - 3 * TopRowHeight;
+            var elementsPerPage = (int)Math.Floor(availableDisplayHeight / TextRowHeight);
+            numberOfPages = (uint)Math.Ceiling(profilingResults.Count / (float)elementsPerPage);
+            CurrentResultPage = Math.Min(CurrentResultPage, numberOfPages);
+
+            profilersStringBuilder.AppendFormat("TOTAL     | AVG/CALL  | MIN/CALL  | MAX/CALL  | CALLS | ");
+            if (containsMarks)
+                profilersStringBuilder.AppendFormat("MARKS | ");
+            profilersStringBuilder.AppendFormat("PROFILING KEY / EXTRA INFO\n");
+
+            for (int i = 0; i < Math.Min(profilingResults.Count - (CurrentResultPage - 1) * elementsPerPage, elementsPerPage); i++)
+            {
+                AppendEvent(profilingResults[((int)CurrentResultPage - 1) * elementsPerPage + i], elapsedFrames, containsMarks);
+            }
+            profilingResults.Clear();
+
+            if (numberOfPages > 1)
+                profilersStringBuilder.AppendFormat("PAGE {0} OF {1}", CurrentResultPage, numberOfPages);
+
+            const float mb = 1 << 20;
+
+            gpuInfoStringBuilder.Clear();
+            gpuInfoStringBuilder.AppendFormat("Drawn triangles: {0:0.0}k, Draw calls: {1}, Buffer memory: {2:0.00}[MB], Texture memory: {3:0.00}[MB]", trianglesCount / 1000f, drawCallsCount, GraphicsDevice.BuffersMemory / mb, GraphicsDevice.TextureMemory / mb);
+
+            gpuGeneralInfoStringBuilder.Clear();
+            //Note: renderTargetSize gets set in Draw(), without synchronization, so might be temporarily incorrect.
+            gpuGeneralInfoStringBuilder.AppendFormat("Device: {0}, Platform: {1}, Profile: {2}, Resolution: {3}", GraphicsDevice.Adapter.Description, GraphicsDevice.Platform, GraphicsDevice.ShaderProfile, renderTargetSize);
+
+            fpsStatStringBuilder.Clear();
+            fpsStatStringBuilder.AppendFormat("Displaying: {0}, Frame: {1}, Update: {2:0.00}ms, Draw: {3:0.00}ms, FPS: {4:0.00}", FilteringMode, Game.DrawTime.FrameCount, Game.UpdateTime.TimePerFrame.TotalMilliseconds, Game.DrawTime.TimePerFrame.TotalMilliseconds, Game.DrawTime.FramePerSecond);
+
+            lock (stringLock)
+            {
+                gcCollectionsString = gcCollectionsStringBuilder.ToString();
+                gcMemoryString = gcMemoryStringBuilder.ToString();
+                profilersString = profilersStringBuilder.ToString();
+                fpsStatString = fpsStatStringBuilder.ToString();
+                gpuInfoString = gpuInfoStringBuilder.ToString();
+                gpuGeneralInfoString = gpuGeneralInfoStringBuilder.ToString();
+            }
+        }
+
+        private async Task ReadEventsAsync()
+        {
+            var containsMarks = false;
+
+            //TODO: Untangle this a bit. Currently fps display (FilteringMode == GameProfilingResults.Fps)
+            //      depends on the timer/update logic, but it does not actually need the profiling events.
+            
+            while (Enabled)
+            {
+                if (dumpTiming.ElapsedMilliseconds > RefreshTime)
                 {
+                    using (Profiler.Begin(UpdateStringsKey))
+                    {
+                        UpdateProfilingStrings(containsMarks);
+                        dumpTiming.Restart();
+                        containsMarks = false;
+                    }
+                }
+
+                if (profilerChannel == null)
+                    continue;
+
+                await foreach (var e in profilerChannel.ReadAllAsync())
+                {
+                    if (dumpTiming.ElapsedMilliseconds > RefreshTime)
+                    {
+                        using (Profiler.Begin(UpdateStringsKey))
+                        {
+                            UpdateProfilingStrings(containsMarks);
+                            dumpTiming.Restart();
+                            containsMarks = false;
+                        }
+                    }
+
+                    if (FilteringMode == GameProfilingResults.Fps)
+                        continue;
+
+                    if (e.IsGPUEvent() && FilteringMode != GameProfilingResults.GpuEvents)
+                        continue;
+                    if (!e.IsGPUEvent() && FilteringMode != GameProfilingResults.CpuEvents)
+                        continue;
+
                     //gc profiling is a special case
                     if (e.Key == GcProfiling.GcMemoryKey)
                     {
@@ -184,66 +270,6 @@ namespace Stride.Profiling
 
                     profilingResultsDictionary[e.Key] = profilingResult;
                 }
-
-                profilersStringBuilder.Clear();
-                profilingResults.Clear();
-
-                foreach (var profilingResult in profilingResultsDictionary)
-                {
-                    if (!profilingResult.Value.Event.HasValue) continue;
-                    profilingResults.Add(profilingResult.Value);
-                }
-                profilingResultsDictionary.Clear();
-
-                if (SortingMode == GameProfilingSorting.ByTime)
-                {
-                    profilingResults.Sort((x,y) => x.Compare(x,y));
-                }
-                else
-                {
-                    // Can't be null because we skip those events without values
-                    // ReSharper disable PossibleInvalidOperationException
-                    profilingResults.Sort((x1, x2) => string.Compare(x1.Event.Value.Key.Name, x2.Event.Value.Key.Name, StringComparison.Ordinal));
-                    // ReSharper restore PossibleInvalidOperationException
-                }
-
-                var availableDisplayHeight = viewportHeight - 2 * TextRowHeight - 3 * TopRowHeight;
-                var elementsPerPage = (int)Math.Floor(availableDisplayHeight / TextRowHeight);
-                numberOfPages = (uint)Math.Ceiling(profilingResults.Count / (float)elementsPerPage);
-                CurrentResultPage = Math.Min(CurrentResultPage, numberOfPages);
-
-                profilersStringBuilder.AppendFormat("TOTAL     | AVG/CALL  | MIN/CALL  | MAX/CALL  | CALLS | ");
-                if (containsMarks)
-                    profilersStringBuilder.AppendFormat("MARKS | ");
-                profilersStringBuilder.AppendFormat("PROFILING KEY / EXTRA INFO\n");
-
-                for (int i = 0; i < Math.Min(profilingResults.Count - (CurrentResultPage - 1) * elementsPerPage, elementsPerPage); i++)
-                {
-                    AppendEvent(profilingResults[((int)CurrentResultPage - 1) * elementsPerPage + i], elapsedFrames, containsMarks);
-                }
-                profilingResults.Clear();
-
-                if (numberOfPages > 1)
-                    profilersStringBuilder.AppendFormat("PAGE {0} OF {1}", CurrentResultPage, numberOfPages);
-
-                gpuInfoStringBuilder.Clear();
-                gpuInfoStringBuilder.AppendFormat("Drawn triangles: {0:0.0}k, Draw calls: {1}, Buffer memory: {2:0.00}[MB], Texture memory: {3:0.00}[MB]", trianglesCount / 1000f, drawCallsCount, GraphicsDevice.BuffersMemory / mb, GraphicsDevice.TextureMemory / mb);
-
-                gpuGeneralInfoStringBuilder.Clear();
-                gpuGeneralInfoStringBuilder.AppendFormat("Device: {0}, Platform: {1}, Profile: {2}, Resolution: {3}", GraphicsDevice.Adapter.Description, GraphicsDevice.Platform, GraphicsDevice.ShaderProfile, renderTargetSize);
-            }
-
-            fpsStatStringBuilder.Clear();
-            fpsStatStringBuilder.AppendFormat("Displaying: {0}, Frame: {1}, Update: {2:0.00}ms, Draw: {3:0.00}ms, FPS: {4:0.00}", FilteringMode, Game.DrawTime.FrameCount, Game.UpdateTime.TimePerFrame.TotalMilliseconds, Game.DrawTime.TimePerFrame.TotalMilliseconds, Game.DrawTime.FramePerSecond);
-
-            lock (stringLock)
-            {
-                gcCollectionsString = gcCollectionsStringBuilder.ToString();
-                gcMemoryString = gcMemoryStringBuilder.ToString();
-                profilersString = profilersStringBuilder.ToString();
-                fpsStatString = fpsStatStringBuilder.ToString();
-                gpuInfoString = gpuInfoStringBuilder.ToString();
-                gpuGeneralInfoString = gpuGeneralInfoStringBuilder.ToString();
             }
         }
 
@@ -286,6 +312,8 @@ namespace Stride.Profiling
             Enabled = false;
             Visible = false;
 
+            Profiler.Unsubscribe(profilerChannel);
+
             if (stringBuilderTask != null && !stringBuilderTask.IsCompleted)
             {
                 stringBuilderTask.Wait();
@@ -304,17 +332,9 @@ namespace Stride.Profiling
             drawCallsCount = GraphicsDevice.FrameDrawCalls;
             trianglesCount = GraphicsDevice.FrameTriangleCount;
 
-            if (dumpTiming.ElapsedMilliseconds > RefreshTime && FilteringMode == GameProfilingResults.GpuEvents)
+            if (FilteringMode == GameProfilingResults.GpuEvents && renderTargetSize != new Size2(renderTarget.Width, renderTarget.Height))
             {
-                dumpTiming.Restart();
-
                 renderTargetSize = new Size2(renderTarget.Width, renderTarget.Height);
-
-                if (stringBuilderTask == null || stringBuilderTask.IsCompleted)
-                {
-                    stringBuilderTask = new Task(UpdateProfilingStrings);
-                    stringBuilderTask.Start();
-                }
             }
 
             var renderContext = RenderContext.GetShared(Services);
@@ -408,7 +428,11 @@ namespace Stride.Profiling
                 }
             }
 
+            Profiler.Init(MinimumProfileDuration);
+
             gcProfiler.Enable();
+
+            stringBuilderTask = Task.Run(ReadEventsAsync);
         }
 
         /// <summary>
@@ -428,6 +452,8 @@ namespace Stride.Profiling
 
             Profiler.DisableAll();
             gcProfiler.Disable();
+
+            FilteringMode = GameProfilingResults.Fps;
         }
 
         /// <summary>
@@ -452,7 +478,22 @@ namespace Stride.Profiling
         /// <summary>
         /// Sets or gets which data should be displayed on screen.
         /// </summary>
-        public GameProfilingResults FilteringMode { get; set; } = GameProfilingResults.Fps;
+        public GameProfilingResults FilteringMode
+        {
+            get => filteringMode;
+            set
+            {
+                if (filteringMode != value)
+                {
+                    if (filteringMode == GameProfilingResults.Fps)
+                        profilerChannel = Profiler.Subscribe();
+                    else if (value == GameProfilingResults.Fps)
+                        Profiler.Unsubscribe(profilerChannel);
+
+                    filteringMode = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Sets or gets the refreshing time of the profiling information in milliseconds.
@@ -463,5 +504,7 @@ namespace Stride.Profiling
         /// Sets or gets the profiling result page to display.
         /// </summary>
         public uint CurrentResultPage { get; set; } = 1;
+
+        public TimeSpan MinimumProfileDuration => Profiler.MinimumProfileDuration;
     }
 }

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -282,6 +282,8 @@ namespace Stride.Profiling
 
         private void AppendEvent(ProfilingResult profilingResult, int elapsedFrames, bool displayMarkCount)
         {
+            elapsedFrames = Math.Max(elapsedFrames, 1);
+
             var profilingEvent = profilingResult.Event.Value;
 
             Profiler.AppendTime(profilersStringBuilder, profilingResult.AccumulatedTime / elapsedFrames);

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -134,6 +134,10 @@ namespace Stride.Profiling
             {
                 profilingResults.Sort((x, y) => x.Compare(x, y));
             }
+            else if(SortingMode == GameProfilingSorting.ByAverageTime)
+            {
+                profilingResults.Sort((x, y) => -TimeSpan.Compare(x.AccumulatedTime / x.Count, y.AccumulatedTime / y.Count));
+            }
             else
             {
                 // Can't be null because we skip those events without values
@@ -147,7 +151,10 @@ namespace Stride.Profiling
             numberOfPages = (uint)Math.Ceiling(profilingResults.Count / (float)elementsPerPage);
             CurrentResultPage = Math.Min(CurrentResultPage, numberOfPages);
 
-            profilersStringBuilder.AppendFormat("TOTAL     | AVG/CALL  | MIN/CALL  | MAX/CALL  | CALLS | ");
+            char sortByTimeIndicator = SortingMode == GameProfilingSorting.ByTime ? 'v' : ' ';
+            char sortByAvgTimeIndicator = SortingMode == GameProfilingSorting.ByAverageTime ? 'v' : ' ';
+
+            profilersStringBuilder.AppendFormat("TOTAL    {0}| AVG/CALL {1}| MIN/CALL  | MAX/CALL  | CALLS  | ", sortByTimeIndicator, sortByAvgTimeIndicator);
             if (containsMarks)
                 profilersStringBuilder.AppendFormat("MARKS | ");
             profilersStringBuilder.AppendFormat("PROFILING KEY / EXTRA INFO\n");
@@ -285,7 +292,7 @@ namespace Stride.Profiling
             profilersStringBuilder.Append(" | ");
             Profiler.AppendTime(profilersStringBuilder, profilingResult.MaxTime);
             profilersStringBuilder.Append(" | ");
-            profilersStringBuilder.AppendFormat("{0:00.00}", profilingResult.Count / (double)elapsedFrames);
+            profilersStringBuilder.AppendFormat("{0,6:#00.00}", profilingResult.Count / (double)elapsedFrames);
             profilersStringBuilder.Append(" | ");
 
             if (displayMarkCount)

--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -26,6 +26,9 @@ namespace Stride.Rendering.Compositing
     [Display("Forward renderer")]
     public partial class ForwardRenderer : SceneRendererBase, ISharedRenderer
     {
+        private static readonly ProfilingKey CollectCoreKey = new ProfilingKey("ForwardRenderer.CollectCore");
+        private static readonly ProfilingKey DrawCoreKey = new ProfilingKey("ForwardRenderer.DrawCore");
+
         // TODO: should we use GraphicsDeviceManager.PreferredBackBufferFormat?
         public const PixelFormat DepthBufferFormat = PixelFormat.D24_UNorm_S8_UInt;
 
@@ -293,6 +296,8 @@ namespace Stride.Rendering.Compositing
 
         protected override unsafe void CollectCore(RenderContext context)
         {
+            using var _ = Profiler.Begin(CollectCoreKey);
+
             var camera = context.GetCurrentCamera();
 
             if (context.RenderView == null)
@@ -614,6 +619,8 @@ namespace Stride.Rendering.Compositing
 
         protected override void DrawCore(RenderContext context, RenderDrawContext drawContext)
         {
+            using var _ = Profiler.Begin(DrawCoreKey);
+
             var viewport = drawContext.CommandList.Viewport;
 
             using (drawContext.PushRenderTargetsAndRestore())

--- a/sources/engine/Stride.Engine/Rendering/Compositing/SceneCameraRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/SceneCameraRenderer.cs
@@ -37,6 +37,8 @@ namespace Stride.Rendering.Compositing
         private bool cameraSlotResolutionFailed;
         private bool cameraResolutionFailed;
 
+        private static readonly ProfilingKey CollectInnerKey = new ProfilingKey("SceneCameraRenderer.CollectInner");
+
         protected override void CollectCore(RenderContext context)
         {
             base.CollectCore(context);
@@ -94,6 +96,8 @@ namespace Stride.Rendering.Compositing
 
         protected virtual void CollectInner(RenderContext renderContext)
         {
+            using var _ = Profiler.Begin(CollectInnerKey);
+
             RenderView.CullingMask = RenderMask;
 
             Child?.Collect(renderContext);

--- a/sources/engine/Stride.Rendering/Rendering/Compositing/SceneRendererCollection.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Compositing/SceneRendererCollection.cs
@@ -3,6 +3,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 
 namespace Stride.Rendering.Compositing
 {
@@ -11,6 +12,8 @@ namespace Stride.Rendering.Compositing
     /// </summary>
     public partial class SceneRendererCollection : SceneRendererBase, IEnumerable<ISceneRenderer>
     {
+        private static readonly ProfilingKey DrawChildKey = new ProfilingKey("SceneRendererCollection.DrawChild");
+
         [Display(Expand = ExpandRule.Always)]
         public List<ISceneRenderer> Children { get; } = new List<ISceneRenderer>();
 
@@ -25,7 +28,12 @@ namespace Stride.Rendering.Compositing
         protected override void DrawCore(RenderContext context, RenderDrawContext drawContext)
         {
             foreach (var child in Children)
-                child.Draw(drawContext);
+            {
+                using (Profiler.Begin(DrawChildKey, $"{child.GetType().Name}.Draw"))
+                {
+                    child.Draw(drawContext);
+                }
+            }
         }
 
         public void Add(ISceneRenderer child)

--- a/sources/engine/Stride.Rendering/Rendering/Compositing/SceneRendererCollection.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Compositing/SceneRendererCollection.cs
@@ -12,8 +12,6 @@ namespace Stride.Rendering.Compositing
     /// </summary>
     public partial class SceneRendererCollection : SceneRendererBase, IEnumerable<ISceneRenderer>
     {
-        private static readonly ProfilingKey DrawChildKey = new ProfilingKey("SceneRendererCollection.DrawChild");
-
         [Display(Expand = ExpandRule.Always)]
         public List<ISceneRenderer> Children { get; } = new List<ISceneRenderer>();
 
@@ -29,10 +27,7 @@ namespace Stride.Rendering.Compositing
         {
             foreach (var child in Children)
             {
-                using (Profiler.Begin(DrawChildKey, $"{child.GetType().Name}.Draw"))
-                {
-                    child.Draw(drawContext);
-                }
+                child.Draw(drawContext);
             }
         }
 

--- a/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Core.Threading;
 using Stride.Graphics;
@@ -30,6 +31,8 @@ namespace Stride.Rendering
     {
         [DataMemberIgnore]
         public static readonly PropertyKey<Dictionary<RenderModel, RenderInstancing>> ModelToInstancingMap = new PropertyKey<Dictionary<RenderModel, RenderInstancing>>("InstancingRenderFeature.ModelToInstancingMap", typeof(InstancingRenderFeature));
+
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("InstancingRenderFeature.PrepareEffectPermutations");
 
         private StaticObjectPropertyKey<InstancingData> renderObjectInstancingDataInfoKey;
 
@@ -107,6 +110,7 @@ namespace Stride.Rendering
 
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareEffectPermutationsKey);
             var renderObjectInstancingData = RootRenderFeature.RenderData.GetData(renderObjectInstancingDataInfoKey);
 
             var renderEffects = RootRenderFeature.RenderData.GetData(renderEffectKey);

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Stride.Core;
 using Stride.Core.Annotations;
 using Stride.Core.Collections;
+using Stride.Core.Diagnostics;
 using Stride.Core.Storage;
 using Stride.Core.Threading;
 using Stride.Graphics;
@@ -91,6 +92,9 @@ namespace Stride.Rendering.Lights
 
         private static readonly string[] DirectLightGroupsCompositionNames;
         private static readonly string[] EnvironmentLightGroupsCompositionNames;
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("ForwardLightingRenderFeature.PrepareEffectPermutations");
+        private static readonly ProfilingKey PrepareKey = new ProfilingKey("ForwardLightingRenderFeature.Prepare");
+        private static readonly ProfilingKey DrawKey = new ProfilingKey("ForwardLightingRenderFeature.Draw");
 
         private readonly HashSet<int> ignoredEffectSlots = new HashSet<int>();
 
@@ -193,6 +197,7 @@ namespace Stride.Rendering.Lights
         /// <inheritdoc/>
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareEffectPermutationsKey);
             var renderEffects = RootRenderFeature.RenderData.GetData(renderEffectKey);
             int effectSlotCount = ((RootEffectRenderFeature)RootRenderFeature).EffectPermutationSlotCount;
 
@@ -328,6 +333,7 @@ namespace Stride.Rendering.Lights
         /// <inheritdoc/>
         public override void Prepare(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareKey);
             foreach (var view in RenderSystem.Views)
             {
                 var viewFeature = view.Features[RootRenderFeature.Index];
@@ -454,6 +460,7 @@ namespace Stride.Rendering.Lights
 
         public override void Draw(RenderDrawContext context, RenderView renderView, RenderViewStage renderViewStage)
         {
+            using var _ = Profiler.Begin(DrawKey);
             // Update per-view resources only when view changes
             if (currentRenderView == renderView)
                 return;

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Threading;
 using Stride.Extensions;
 using Stride.Graphics;
@@ -28,6 +29,8 @@ namespace Stride.Rendering.Materials
 
         // Material instantiated
         private readonly Dictionary<MaterialPass, MaterialInfo> allMaterialInfos = new Dictionary<MaterialPass, MaterialInfo>();
+        
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("MaterialRenderFeature.PrepareEffectPermutations");
 
         public class MaterialInfoBase
         {
@@ -106,6 +109,7 @@ namespace Stride.Rendering.Materials
         /// <inheritdoc/>
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareEffectPermutationsKey);
             var renderEffects = RootRenderFeature.RenderData.GetData(renderEffectKey);
             var tessellationStates = RootRenderFeature.RenderData.GetData(tessellationStateKey);
             int effectSlotCount = ((RootEffectRenderFeature)RootRenderFeature).EffectPermutationSlotCount;

--- a/sources/engine/Stride.Rendering/Rendering/MeshVelocityRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshVelocityRenderFeature.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Stride.Core;
 using Stride.Core.Annotations;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Core.Threading;
 using Stride.Rendering.Compositing;
@@ -32,6 +33,8 @@ namespace Stride.Rendering
         private int usageCounter = 0;
 
         private HashSet<RenderView> updatedViews = new HashSet<RenderView>();
+        
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("MeshVelocityRenderFeature.PrepareEffectPermutations");
 
         protected override void InitializeCore()
         {
@@ -51,6 +54,7 @@ namespace Stride.Rendering
 
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareEffectPermutationsKey);
             base.PrepareEffectPermutations(context);
 
             var rootEffectRenderFeature = ((RootEffectRenderFeature)RootRenderFeature);

--- a/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
@@ -29,18 +29,18 @@ namespace Stride.Rendering
 
         private readonly Dictionary<Type, List<RootRenderFeature>> renderFeaturesByType = new Dictionary<Type, List<RootRenderFeature>>();
 
-        private static readonly ProfilingKey CreateObjectNodesKey = new ProfilingKey("Create Object Nodes");
-        private static readonly ProfilingKey SortRenderObjectsKey = new ProfilingKey("Sort Render Objects");
-        private static readonly ProfilingKey CollectObjectKey = new ProfilingKey("Collect Object");
-        private static readonly ProfilingKey SortRenderNodesKey = new ProfilingKey("Sort Render Nodes");
-        private static readonly ProfilingKey RenderFeatureExtractKey = new ProfilingKey("RenderFeature.Extract");
-        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("PrepareEffectPermutations");
-        private static readonly ProfilingKey PrepareSortKey = new ProfilingKey("Prepare.Sort");
-        private static readonly ProfilingKey UpdateRenderViewsKey = new ProfilingKey("UpdateRenderViews");
-        private static readonly ProfilingKey DrawRootRenderFeaturesKey = new ProfilingKey("DrawRootRenderFeatures");
-        private static readonly ProfilingKey DrawRenderFeatureChunksKey = new ProfilingKey("DrawRenderFeatureChunks");
-        private static readonly ProfilingKey DrawKey = new ProfilingKey("RenderSystem.Draw");
-        private static readonly ProfilingKey PrepareDataArraysKey = new ProfilingKey("RenderSystem.PrepareDataArrays");
+        private static readonly ProfilingKey CreateObjectNodesKey = new ProfilingKey($"{nameof(RenderSystem)}.CreateObjectNodes");
+        private static readonly ProfilingKey SortRenderObjectsKey = new ProfilingKey($"{nameof(RenderSystem)}.Sort Render Objects");
+        private static readonly ProfilingKey CollectObjectKey = new ProfilingKey($"{nameof(RenderSystem)}.CollectObject");
+        private static readonly ProfilingKey SortRenderNodesKey = new ProfilingKey($"{nameof(RenderSystem)}.SortRenderNodes");
+        private static readonly ProfilingKey RenderFeatureExtractKey = new ProfilingKey($"{nameof(RenderSystem)}.RenderFeature.Extract");
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey($"{nameof(RenderSystem)}.PrepareEffectPermutations");
+        private static readonly ProfilingKey PrepareSortKey = new ProfilingKey($"{nameof(RenderSystem)}.Prepare.Sort");
+        private static readonly ProfilingKey UpdateRenderViewsKey = new ProfilingKey($"{nameof(RenderSystem)}.UpdateRenderViews");
+        private static readonly ProfilingKey DrawRootRenderFeaturesKey = new ProfilingKey($"{nameof(RenderSystem)}.DrawRootRenderFeatures");
+        private static readonly ProfilingKey DrawRenderFeatureChunksKey = new ProfilingKey($"{nameof(RenderSystem)}.DrawRenderFeatureChunks");
+        private static readonly ProfilingKey DrawKey = new ProfilingKey($"{nameof(RenderSystem)}.Draw");
+        private static readonly ProfilingKey PrepareDataArraysKey = new ProfilingKey($"{nameof(RenderSystem)}.PrepareDataArrays");
 
         private IServiceRegistry registry;
 
@@ -199,7 +199,7 @@ namespace Stride.Rendering
 
                 // Also sort view|stage per render feature
                 foreach (var renderViewStage in view.RenderStages)
-                {                    
+                {
                     renderViewStage.RenderNodes.Close();
                     using (Profiler.Begin(SortRenderNodesKey))
                     {
@@ -221,7 +221,7 @@ namespace Stride.Rendering
             foreach (var renderFeature in RenderFeatures)
             // We might be able to parallelize too as long as we resepect render feature dependency graph (probably very few dependencies in practice)
             {
-                using(Profiler.Begin(RenderFeatureExtractKey))
+                using var _ = Profiler.Begin(RenderFeatureExtractKey);
                 // Divide into task chunks for parallelism
                 renderFeature.Extract();
             }

--- a/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Stride.Core;
 using Stride.Core.Collections;
 using Stride.Core.Threading;
+using Stride.Core.Diagnostics;
 using Stride.Graphics;
 
 namespace Stride.Rendering
@@ -27,6 +28,20 @@ namespace Stride.Rendering
         private Texture[] renderTargets;
 
         private readonly Dictionary<Type, List<RootRenderFeature>> renderFeaturesByType = new Dictionary<Type, List<RootRenderFeature>>();
+
+        private static readonly ProfilingKey CreateObjectNodesKey = new ProfilingKey("Create Object Nodes");
+        private static readonly ProfilingKey SortRenderObjectsKey = new ProfilingKey("Sort Render Objects");
+        private static readonly ProfilingKey CollectObjectKey = new ProfilingKey("Collect Object");
+        private static readonly ProfilingKey SortRenderNodesKey = new ProfilingKey("Sort Render Nodes");
+        private static readonly ProfilingKey RenderFeatureExtractKey = new ProfilingKey("RenderFeature.Extract");
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("PrepareEffectPermutations");
+        private static readonly ProfilingKey PrepareSortKey = new ProfilingKey("Prepare.Sort");
+        private static readonly ProfilingKey UpdateRenderViewsKey = new ProfilingKey("UpdateRenderViews");
+        private static readonly ProfilingKey DrawRootRenderFeaturesKey = new ProfilingKey("DrawRootRenderFeatures");
+        private static readonly ProfilingKey DrawRenderFeatureChunksKey = new ProfilingKey("DrawRenderFeatureChunks");
+        private static readonly ProfilingKey DrawKey = new ProfilingKey("RenderSystem.Draw");
+        private static readonly ProfilingKey PrepareDataArraysKey = new ProfilingKey("RenderSystem.PrepareDataArrays");
+
         private IServiceRegistry registry;
 
         // TODO GRAPHICS REFACTOR should probably be controlled by graphics compositor?
@@ -127,9 +142,13 @@ namespace Stride.Rendering
             // Create nodes for objects to render
             Dispatcher.ForEach(Views, view =>
             {
+                using var _ = Profiler.Begin(CreateObjectNodesKey);
                 // Sort per render feature (used for later sorting)
                 // We'll be able to process data more efficiently for the next steps
-                Dispatcher.Sort(view.RenderObjects, RenderObjectFeatureComparer.Default);
+                using (Profiler.Begin(SortRenderObjectsKey, "Sorting {0} RenderObjects", view.RenderObjects.Count))
+                {
+                    Dispatcher.Sort(view.RenderObjects, RenderObjectFeatureComparer.Default);
+                }
 
                 Dispatcher.ForEach(view.RenderObjects, () => extractThreadLocals.Value, (renderObject, batch) =>
                 {
@@ -146,28 +165,31 @@ namespace Stride.Rendering
                     // Collect object
                     // TODO: Check which stage it belongs to (and skip everything if it doesn't belong to any stage)
                     // TODO: For now, we build list and then copy. Another way would be to count and then fill (might be worse, need to check)
-                    var activeRenderStages = renderObject.ActiveRenderStages;
-                    foreach (var renderViewStage in view.RenderStages)
+
+                    using (Profiler.Begin(CollectObjectKey))
                     {
-                        // Check if this RenderObject wants to be rendered for this render stage
-                        var renderStageIndex = renderViewStage.Index;
-                        if (!activeRenderStages[renderStageIndex].Active)
-                            continue;
+                        var activeRenderStages = renderObject.ActiveRenderStages;
+                        foreach (var renderViewStage in view.RenderStages)
+                        {
+                            // Check if this RenderObject wants to be rendered for this render stage
+                            var renderStageIndex = renderViewStage.Index;
+                            if (!activeRenderStages[renderStageIndex].Active)
+                                continue;
 
-                        var renderStage = RenderStages[renderStageIndex];
-                        if (renderStage.Filter != null && !renderStage.Filter.IsVisible(renderObject, view, renderViewStage))
-                            continue;
+                            var renderStage = RenderStages[renderStageIndex];
+                            if (renderStage.Filter != null && !renderStage.Filter.IsVisible(renderObject, view, renderViewStage))
+                                continue;
 
-                        var renderNode = renderFeature.CreateRenderNode(renderObject, view, renderViewNode, renderStage);
+                            var renderNode = renderFeature.CreateRenderNode(renderObject, view, renderViewNode, renderStage);
 
-                        // Note: Used mostly during updating
-                        viewFeature.RenderNodes.Add(renderNode, batch.ViewFeatureRenderNodeCache);
+                            // Note: Used mostly during updating
+                            viewFeature.RenderNodes.Add(renderNode, batch.ViewFeatureRenderNodeCache);
 
-                        // Note: Used mostly during rendering
-                        renderViewStage.RenderNodes.Add(new RenderNodeFeatureReference(renderFeature, renderNode, renderObject), batch.ViewStageRenderNodeCache);
+                            // Note: Used mostly during rendering
+                            renderViewStage.RenderNodes.Add(new RenderNodeFeatureReference(renderFeature, renderNode, renderObject), batch.ViewStageRenderNodeCache);
+                        }
                     }
-                }, batch => batch.Flush());
-
+                }, batch => batch.Flush());            
                 // Finish collectin of view feature nodes
                 foreach (var viewFeature in view.Features)
                 {
@@ -177,10 +199,12 @@ namespace Stride.Rendering
 
                 // Also sort view|stage per render feature
                 foreach (var renderViewStage in view.RenderStages)
-                {
+                {                    
                     renderViewStage.RenderNodes.Close();
-
-                    Dispatcher.Sort(renderViewStage.RenderNodes, RenderNodeFeatureReferenceComparer.Default);
+                    using (Profiler.Begin(SortRenderNodesKey))
+                    {
+                        Dispatcher.Sort(renderViewStage.RenderNodes, RenderNodeFeatureReferenceComparer.Default);
+                    }                    
                 }
             });
 
@@ -197,6 +221,7 @@ namespace Stride.Rendering
             foreach (var renderFeature in RenderFeatures)
             // We might be able to parallelize too as long as we resepect render feature dependency graph (probably very few dependencies in practice)
             {
+                using(Profiler.Begin(RenderFeatureExtractKey))
                 // Divide into task chunks for parallelism
                 renderFeature.Extract();
             }
@@ -225,12 +250,15 @@ namespace Stride.Rendering
         {
             // Sync point: after extract, before prepare (game simulation could resume now)
 
-            // Generate and execute prepare effect jobs
-            foreach (var renderFeature in RenderFeatures)
-            // We might be able to parallelize too as long as we resepect render feature dependency graph (probably very few dependencies in practice)
+            using (Profiler.Begin(PrepareEffectPermutationsKey))
             {
-                // Divide into task chunks for parallelism
-                renderFeature.PrepareEffectPermutations(context);
+                // Generate and execute prepare effect jobs
+                foreach (var renderFeature in RenderFeatures)
+                // We might be able to parallelize too as long as we resepect render feature dependency graph (probably very few dependencies in practice)
+                {
+                    // Divide into task chunks for parallelism
+                    renderFeature.PrepareEffectPermutations(context);
+                }
             }
 
             // Generate and execute prepare jobs
@@ -241,51 +269,54 @@ namespace Stride.Rendering
                 renderFeature.Prepare(context);
             }
 
-            // Sort
-            Dispatcher.ForEach(Views, view =>
+            using (Profiler.Begin(PrepareSortKey))
             {
-                Dispatcher.For(0, view.RenderStages.Count, () => prepareThreadLocals.Acquire(), (index, local) =>
+                // Sort
+                Dispatcher.ForEach(Views, view =>
                 {
-                    var renderViewStage = view.RenderStages[index];
-
-                    var renderNodes = renderViewStage.RenderNodes;
-                    if (renderNodes.Count == 0)
-                        return;
-
-                    var renderStage = RenderStages[renderViewStage.Index];
-                    var sortedRenderNodes = renderViewStage.SortedRenderNodes;
-
-                    // Fast clear, since it's cleared properly in Reset()
-                    sortedRenderNodes.Resize(renderViewStage.RenderNodes.Count, true);
-
-                    if (renderStage.SortMode != null)
+                    Dispatcher.For(0, view.RenderStages.Count, () => prepareThreadLocals.Acquire(), (index, local) =>
                     {
-                        // Make sure sortKeys is big enough
-                        if (local.SortKeys == null || local.SortKeys.Length < renderNodes.Count)
-                            Array.Resize(ref local.SortKeys, renderNodes.Count);
+                        var renderViewStage = view.RenderStages[index];
 
-                        // renderNodes[start..end] belongs to the same render feature
-                        fixed (SortKey* sortKeysPtr = local.SortKeys)
-                            renderStage.SortMode.GenerateSortKey(view, renderViewStage, sortKeysPtr);
+                        var renderNodes = renderViewStage.RenderNodes;
+                        if (renderNodes.Count == 0)
+                            return;
 
-                        Dispatcher.Sort(local.SortKeys, 0, renderNodes.Count, Comparer<SortKey>.Default);
+                        var renderStage = RenderStages[renderViewStage.Index];
+                        var sortedRenderNodes = renderViewStage.SortedRenderNodes;
 
-                        // Reorder list
-                        for (int i = 0; i < renderNodes.Count; ++i)
+                        // Fast clear, since it's cleared properly in Reset()
+                        sortedRenderNodes.Resize(renderViewStage.RenderNodes.Count, true);                        
+
+                        if (renderStage.SortMode != null)
                         {
-                            sortedRenderNodes[i] = renderNodes[local.SortKeys[i].Index];
+                            // Make sure sortKeys is big enough
+                            if (local.SortKeys == null || local.SortKeys.Length < renderNodes.Count)
+                                Array.Resize(ref local.SortKeys, renderNodes.Count);
+
+                            // renderNodes[start..end] belongs to the same render feature
+                            fixed (SortKey* sortKeysPtr = local.SortKeys)
+                                renderStage.SortMode.GenerateSortKey(view, renderViewStage, sortKeysPtr);
+
+                            Dispatcher.Sort(local.SortKeys, 0, renderNodes.Count, Comparer<SortKey>.Default);
+
+                            // Reorder list
+                            for (int i = 0; i < renderNodes.Count; ++i)
+                            {
+                                sortedRenderNodes[i] = renderNodes[local.SortKeys[i].Index];
+                            }
                         }
-                    }
-                    else
-                    {
-                        // No sorting, copy as is
-                        for (int i = 0; i < renderNodes.Count; ++i)
+                        else
                         {
-                            sortedRenderNodes[i] = renderNodes[i];
+                            // No sorting, copy as is
+                            for (int i = 0; i < renderNodes.Count; ++i)
+                            {
+                                sortedRenderNodes[i] = renderNodes[i];
+                            }
                         }
-                    }
-                }, state => prepareThreadLocals.Release(state));
-            });
+                    }, state => prepareThreadLocals.Release(state));
+                });
+            }
 
             // Flush the resources uploaded during Prepare
             context.ResourceGroupAllocator.Flush();
@@ -294,6 +325,7 @@ namespace Stride.Rendering
 
         public void Draw(RenderDrawContext renderDrawContext, RenderView renderView, RenderStage renderStage)
         {
+            using var _ = Profiler.Begin(DrawKey);
             // Sync point: draw (from now, we should execute with a graphics device context to perform rendering)
 
             // Look for the RenderViewStage corresponding to this RenderView | RenderStage combination
@@ -312,10 +344,13 @@ namespace Stride.Rendering
                 throw new InvalidOperationException("Requested RenderView|RenderStage combination doesn't exist. Please add it to RenderView.RenderStages.");
             }
 
-            // Perform updates once per change of RenderView
-            foreach (var renderFeature in RenderFeatures)
+            using (Profiler.Begin(UpdateRenderViewsKey))
             {
-                renderFeature.Draw(renderDrawContext, renderView, renderViewStage);
+                // Perform updates once per change of RenderView
+                foreach (var renderFeature in RenderFeatures)
+                {
+                    renderFeature.Draw(renderDrawContext, renderView, renderViewStage);
+                }
             }
 
             // Generate and execute draw jobs
@@ -327,18 +362,21 @@ namespace Stride.Rendering
 
             if (!GraphicsDevice.IsDeferred)
             {
-                int currentStart, currentEnd;
-                for (currentStart = 0; currentStart < renderNodeCount; currentStart = currentEnd)
+                using (Profiler.Begin(DrawRootRenderFeaturesKey))
                 {
-                    var currentRenderFeature = renderNodes[currentStart].RootRenderFeature;
-                    currentEnd = currentStart + 1;
-                    while (currentEnd < renderNodeCount && renderNodes[currentEnd].RootRenderFeature == currentRenderFeature)
+                    int currentStart, currentEnd;
+                    for (currentStart = 0; currentStart < renderNodeCount; currentStart = currentEnd)
                     {
-                        currentEnd++;
-                    }
+                        var currentRenderFeature = renderNodes[currentStart].RootRenderFeature;
+                        currentEnd = currentStart + 1;
+                        while (currentEnd < renderNodeCount && renderNodes[currentEnd].RootRenderFeature == currentRenderFeature)
+                        {
+                            currentEnd++;
+                        }
 
-                    // Divide into task chunks for parallelism
-                    currentRenderFeature.Draw(renderDrawContext, renderView, renderViewStage, currentStart, currentEnd);
+                        // Divide into task chunks for parallelism
+                        currentRenderFeature.Draw(renderDrawContext, renderView, renderViewStage, currentStart, currentEnd);
+                    }
                 }
             }
             else
@@ -367,6 +405,7 @@ namespace Stride.Rendering
 
                 Dispatcher.For(0, batchCount, () => renderDrawContext.RenderContext.GetThreadContext(), (batchIndex, threadContext) =>
                 {
+                    using var _ = Profiler.Begin(DrawRenderFeatureChunksKey);
                     threadContext.CommandList.Reset();
                     threadContext.CommandList.ClearState();
 
@@ -534,6 +573,7 @@ namespace Stride.Rendering
 
         private void PrepareDataArrays()
         {
+            using var _ = Profiler.Begin(PrepareDataArraysKey);
             // Also do it for each render feature
             foreach (var renderFeature in RenderFeatures)
             {

--- a/sources/engine/Stride.Rendering/Rendering/RendererBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RendererBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Rendering.Compositing;
 
 namespace Stride.Rendering
@@ -13,6 +14,8 @@ namespace Stride.Rendering
     [DataContract]
     public abstract class RendererBase : RendererCoreBase, IGraphicsRenderer
     {
+        private static readonly ProfilingKey DrawKey = new ProfilingKey("RendererBase.Draw");
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RendererBase"/> class.
         /// </summary>
@@ -45,6 +48,7 @@ namespace Stride.Rendering
         {
             if (Enabled)
             {
+                using var _ = Profiler.Begin(DrawKey, $"{GetType().Name}.Draw");
                 PreDrawCoreInternal(context);
                 DrawCore(context);
                 PostDrawCoreInternal(context);

--- a/sources/engine/Stride.Rendering/Rendering/RendererBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RendererBase.cs
@@ -14,8 +14,6 @@ namespace Stride.Rendering
     [DataContract]
     public abstract class RendererBase : RendererCoreBase, IGraphicsRenderer
     {
-        private static readonly ProfilingKey DrawKey = new ProfilingKey("RendererBase.Draw");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="RendererBase"/> class.
         /// </summary>
@@ -48,7 +46,7 @@ namespace Stride.Rendering
         {
             if (Enabled)
             {
-                using var _ = Profiler.Begin(DrawKey, $"{GetType().Name}.Draw");
+                using var _ = Profiler.Begin(CPUProfilingKey);
                 PreDrawCoreInternal(context);
                 DrawCore(context);
                 PostDrawCoreInternal(context);

--- a/sources/engine/Stride.Rendering/Rendering/RendererCoreBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RendererCoreBase.cs
@@ -21,7 +21,8 @@ namespace Stride.Rendering
     public abstract class RendererCoreBase : ComponentBase, IGraphicsRendererCore
     {
         private bool isInDrawCore;
-        private ProfilingKey profilingKey;
+        private ProfilingKey gpuProfilingKey;
+        private ProfilingKey cpuProfilingKey;
         private readonly List<GraphicsResource> scopedResources = new List<GraphicsResource>();
         private readonly List<IGraphicsRendererCore> subRenderersToUnload;
 
@@ -58,7 +59,10 @@ namespace Stride.Rendering
         public bool Profiling { get; set; }
 
         [DataMemberIgnore]
-        public ProfilingKey ProfilingKey => profilingKey ?? (profilingKey = new ProfilingKey(Name));
+        public ProfilingKey GPUProfilingKey => gpuProfilingKey ??= new ProfilingKey(Name);
+
+        [DataMemberIgnore]
+        public ProfilingKey CPUProfilingKey => cpuProfilingKey ??= new ProfilingKey($"{Name}.Draw");
 
         [DataMemberIgnore]
         protected RenderContext Context { get; private set; }
@@ -225,9 +229,9 @@ namespace Stride.Rendering
 
             EnsureContext(context.RenderContext);
 
-            if (ProfilingKey.Name != null && Profiling)
+            if (GPUProfilingKey.Name != null && Profiling)
             {
-                context.QueryManager.BeginProfile(Color.Green, ProfilingKey);
+                context.QueryManager.BeginProfile(Color.Green, GPUProfilingKey);
             }
 
             PreDrawCore(context);
@@ -257,9 +261,9 @@ namespace Stride.Rendering
 
             PostDrawCore(context);
 
-            if (ProfilingKey.Name != null && Profiling)
+            if (GPUProfilingKey.Name != null && Profiling)
             {
-                context.QueryManager.EndProfile(ProfilingKey);
+                context.QueryManager.EndProfile(GPUProfilingKey);
             }
         }
     }

--- a/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Stride.Core;
 using Stride.Core.Annotations;
+using Stride.Core.Diagnostics;
 using Stride.Core.Storage;
 using Stride.Core.Threading;
 using Stride.Graphics;
@@ -54,6 +55,10 @@ namespace Stride.Rendering
 
         private readonly List<NamedSlotDefinition> viewLogicalGroups = new List<NamedSlotDefinition>();
         private readonly List<NamedSlotDefinition> drawLogicalGroups = new List<NamedSlotDefinition>();
+
+        private static readonly ProfilingKey CompileEffectsKey = new ProfilingKey("Compile Effects");
+        private static readonly ProfilingKey UpdateReflectionInfosKey = new ProfilingKey("Update Reflection Infos");
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("RootEffectRenderFeature.PrepareEffectPermutations");
 
         // Common slots
         private EffectDescriptorSetReference perFrameDescriptorSetSlot;
@@ -391,6 +396,7 @@ namespace Stride.Rendering
         /// <inheritdoc/>
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareEffectPermutationsKey);
             base.PrepareEffectPermutations(context);
 
             // TODO: Temporary until we have a better system for handling permutations
@@ -435,213 +441,219 @@ namespace Stride.Rendering
             var currentTime = DateTime.UtcNow;
 
             // Step2: Compile effects
-            Dispatcher.ForEach(RenderObjects, renderObject =>
+            using (Profiler.Begin(CompileEffectsKey))
             {
-                //var renderObject = RenderObjects[index];
-                var staticObjectNode = renderObject.StaticObjectNode;
-
-                for (int i = 0; i < effectSlotCount; ++i)
+                Dispatcher.ForEach(RenderObjects, renderObject =>
                 {
-                    var staticEffectObjectNode = staticObjectNode * effectSlotCount + i;
-                    var renderEffect = renderEffects[staticEffectObjectNode];
+                    //var renderObject = RenderObjects[index];
+                    var staticObjectNode = renderObject.StaticObjectNode;
 
-                    // Skip if not used
-                    if (renderEffect == null)
-                        continue;
-
-                    // Skip reflection update unless a state change requires it
-                    renderEffect.IsReflectionUpdateRequired = false;
-
-                    if (!renderEffect.IsUsedDuringThisFrame(RenderSystem))
-                        continue;
-
-                    // Skip if nothing changed
-                    if (renderEffect.EffectValidator.ShouldSkip)
+                    for (int i = 0; i < effectSlotCount; ++i)
                     {
-                        // Reset pending effect, as it is now obsolete anyway
-                        renderEffect.Effect = null;
-                        renderEffect.State = RenderEffectState.Skip;
-                    }
-                    else if (renderEffect.EffectValidator.EndEffectValidation() && (renderEffect.Effect == null || !renderEffect.Effect.SourceChanged) && !(renderEffect.State == RenderEffectState.Error && currentTime >= renderEffect.RetryTime))
-                    {
-                        InvalidateEffectPermutation(renderObject, renderEffect);
+                        var staticEffectObjectNode = staticObjectNode * effectSlotCount + i;
+                        var renderEffect = renderEffects[staticEffectObjectNode];
 
-                        // Still, let's check if there is a pending effect compiling
-                        var pendingEffect = renderEffect.PendingEffect;
-                        if (pendingEffect == null || !pendingEffect.IsCompleted)
+                        // Skip if not used
+                        if (renderEffect == null)
                             continue;
 
-                        renderEffect.ClearFallbackParameters();
-                        if (pendingEffect.IsFaulted)
+                        // Skip reflection update unless a state change requires it
+                        renderEffect.IsReflectionUpdateRequired = false;
+
+                        if (!renderEffect.IsUsedDuringThisFrame(RenderSystem))
+                            continue;
+
+                        // Skip if nothing changed
+                        if (renderEffect.EffectValidator.ShouldSkip)
                         {
-                            // The effect can fail compilation asynchronously
-                            renderEffect.State = RenderEffectState.Error;
-                            renderEffect.Effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Error);
+                            // Reset pending effect, as it is now obsolete anyway
+                            renderEffect.Effect = null;
+                            renderEffect.State = RenderEffectState.Skip;
+                        }
+                        else if (renderEffect.EffectValidator.EndEffectValidation() && (renderEffect.Effect == null || !renderEffect.Effect.SourceChanged) && !(renderEffect.State == RenderEffectState.Error && currentTime >= renderEffect.RetryTime))
+                        {
+                            InvalidateEffectPermutation(renderObject, renderEffect);
+
+                            // Still, let's check if there is a pending effect compiling
+                            var pendingEffect = renderEffect.PendingEffect;
+                            if (pendingEffect == null || !pendingEffect.IsCompleted)
+                                continue;
+
+                            renderEffect.ClearFallbackParameters();
+                            if (pendingEffect.IsFaulted)
+                            {
+                                // The effect can fail compilation asynchronously
+                                renderEffect.State = RenderEffectState.Error;
+                                renderEffect.Effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Error);
+                            }
+                            else
+                            {
+                                renderEffect.State = RenderEffectState.Normal;
+                                renderEffect.Effect = pendingEffect.Result;
+                            }
+                            renderEffect.PendingEffect = null;
                         }
                         else
                         {
+                            // Reset pending effect, as it is now obsolete anyway
+                            renderEffect.PendingEffect = null;
                             renderEffect.State = RenderEffectState.Normal;
-                            renderEffect.Effect = pendingEffect.Result;
+
+                            // CompilerParameters are ThreadStatic
+                            if (staticCompilerParameters == null)
+                                staticCompilerParameters = new CompilerParameters();
+
+                            foreach (var effectValue in renderEffect.EffectValidator.EffectValues)
+                            {
+                                staticCompilerParameters.SetObject(effectValue.Key, effectValue.Value);
+                            }
+
+                            TaskOrResult<Effect> asyncEffect;
+                            try
+                            {
+                                // The effect can fail compilation synchronously
+                                asyncEffect = RenderSystem.EffectSystem.LoadEffect(renderEffect.EffectSelector.EffectName, staticCompilerParameters);
+                                staticCompilerParameters.Clear();
+                            }
+                            catch
+                            {
+                                staticCompilerParameters.Clear();
+                                renderEffect.ClearFallbackParameters();
+                                renderEffect.State = RenderEffectState.Error;
+                                renderEffect.Effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Error);
+                                continue;
+                            }
+
+                            renderEffect.Effect = asyncEffect.Result;
+                            if (renderEffect.Effect == null)
+                            {
+                                // Effect still compiling, let's find if there is a fallback
+                                renderEffect.ClearFallbackParameters();
+                                renderEffect.PendingEffect = asyncEffect.Task;
+                                renderEffect.State = RenderEffectState.Compiling;
+                                renderEffect.Effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Compiling);
+                            }
                         }
-                        renderEffect.PendingEffect = null;
+
+                        renderEffect.IsReflectionUpdateRequired = true;
                     }
-                    else
-                    {
-                        // Reset pending effect, as it is now obsolete anyway
-                        renderEffect.PendingEffect = null;
-                        renderEffect.State = RenderEffectState.Normal;
+                });
+            }
 
-                        // CompilerParameters are ThreadStatic
-                        if (staticCompilerParameters == null)
-                            staticCompilerParameters = new CompilerParameters();
-
-                        foreach (var effectValue in renderEffect.EffectValidator.EffectValues)
-                        {
-                            staticCompilerParameters.SetObject(effectValue.Key, effectValue.Value);
-                        }
-
-                        TaskOrResult<Effect> asyncEffect;
-                        try
-                        {
-                            // The effect can fail compilation synchronously
-                            asyncEffect = RenderSystem.EffectSystem.LoadEffect(renderEffect.EffectSelector.EffectName, staticCompilerParameters);
-                            staticCompilerParameters.Clear();
-                        }
-                        catch
-                        {
-                            staticCompilerParameters.Clear();
-                            renderEffect.ClearFallbackParameters();
-                            renderEffect.State = RenderEffectState.Error;
-                            renderEffect.Effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Error);
-                            continue;
-                        }
-
-                        renderEffect.Effect = asyncEffect.Result;
-                        if (renderEffect.Effect == null)
-                        {
-                            // Effect still compiling, let's find if there is a fallback
-                            renderEffect.ClearFallbackParameters();
-                            renderEffect.PendingEffect = asyncEffect.Task;
-                            renderEffect.State = RenderEffectState.Compiling;
-                            renderEffect.Effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Compiling);
-                        }
-                    }
-
-                    renderEffect.IsReflectionUpdateRequired = true;
-                }
-            });
-
-            // Step3: Uupdate reflection infos (offset, etc...)
-            foreach (var renderObject in RenderObjects)
+            // Step3: Update reflection infos (offset, etc...)
+            using (Profiler.Begin(UpdateReflectionInfosKey))
             {
-                var staticObjectNode = renderObject.StaticObjectNode;
-
-                for (int i = 0; i < effectSlotCount; ++i)
+                foreach (var renderObject in RenderObjects)
                 {
-                    var staticEffectObjectNode = staticObjectNode * effectSlotCount + i;
-                    var renderEffect = renderEffects[staticEffectObjectNode];
+                    var staticObjectNode = renderObject.StaticObjectNode;
 
-                    // Skip if not used
-                    if (renderEffect == null || !renderEffect.IsReflectionUpdateRequired)
-                        continue;
-
-                    var effect = renderEffect.Effect;
-                    if (effect == null && renderEffect.State == RenderEffectState.Compiling)
+                    for (int i = 0; i < effectSlotCount; ++i)
                     {
-                        // Need to wait for completion because we have nothing else
-                        renderEffect.PendingEffect.Wait();
+                        var staticEffectObjectNode = staticObjectNode * effectSlotCount + i;
+                        var renderEffect = renderEffects[staticEffectObjectNode];
 
-                        if (!renderEffect.PendingEffect.IsFaulted)
+                        // Skip if not used
+                        if (renderEffect == null || !renderEffect.IsReflectionUpdateRequired)
+                            continue;
+
+                        var effect = renderEffect.Effect;
+                        if (effect == null && renderEffect.State == RenderEffectState.Compiling)
                         {
-                            renderEffect.Effect = effect = renderEffect.PendingEffect.Result;
-                            renderEffect.State = RenderEffectState.Normal;
+                            // Need to wait for completion because we have nothing else
+                            renderEffect.PendingEffect.Wait();
+
+                            if (!renderEffect.PendingEffect.IsFaulted)
+                            {
+                                renderEffect.Effect = effect = renderEffect.PendingEffect.Result;
+                                renderEffect.State = RenderEffectState.Normal;
+                            }
+                            else
+                            {
+                                renderEffect.ClearFallbackParameters();
+                                renderEffect.State = RenderEffectState.Error;
+                                renderEffect.Effect = effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Error);
+                            }
+                        }
+
+                        var effectHashCode = effect != null ? (uint)effect.GetHashCode() : 0;
+
+                        // Effect is last 16 bits
+                        renderObject.StateSortKey = (renderObject.StateSortKey & 0xFFFF0000) | (effectHashCode & 0x0000FFFF);
+
+                        if (effect != null)
+                        {
+                            RenderEffectReflection renderEffectReflection;
+                            if (!InstantiatedEffects.TryGetValue(effect, out renderEffectReflection))
+                            {
+                                renderEffectReflection = new RenderEffectReflection();
+
+                                // Build root signature automatically from reflection
+                                renderEffectReflection.DescriptorReflection = EffectDescriptorSetReflection.New(RenderSystem.GraphicsDevice, effect.Bytecode, effectDescriptorSetSlots, "PerFrame");
+                                renderEffectReflection.ResourceGroupDescriptions = new ResourceGroupDescription[renderEffectReflection.DescriptorReflection.Layouts.Count];
+
+                                // Compute ResourceGroup hashes
+                                for (int index = 0; index < renderEffectReflection.DescriptorReflection.Layouts.Count; index++)
+                                {
+                                    var descriptorSet = renderEffectReflection.DescriptorReflection.Layouts[index];
+                                    if (descriptorSet.Layout == null)
+                                        continue;
+
+                                    var constantBufferReflection = effect.Bytecode.Reflection.ConstantBuffers.FirstOrDefault(x => x.Name == descriptorSet.Name);
+
+                                    renderEffectReflection.ResourceGroupDescriptions[index] = new ResourceGroupDescription(descriptorSet.Layout, constantBufferReflection);
+                                }
+
+                                renderEffectReflection.RootSignature = RootSignature.New(RenderSystem.GraphicsDevice, renderEffectReflection.DescriptorReflection);
+                                renderEffectReflection.BufferUploader.Compile(RenderSystem.GraphicsDevice, renderEffectReflection.DescriptorReflection, effect.Bytecode);
+
+                                // Prepare well-known descriptor set layouts
+                                renderEffectReflection.PerDrawLayout = CreateDrawResourceGroupLayout(renderEffectReflection.ResourceGroupDescriptions[perDrawDescriptorSetSlot.Index], renderEffect.State);
+                                renderEffectReflection.PerFrameLayout = CreateFrameResourceGroupLayout(renderEffectReflection.ResourceGroupDescriptions[perFrameDescriptorSetSlot.Index], renderEffect.State);
+                                renderEffectReflection.PerViewLayout = CreateViewResourceGroupLayout(renderEffectReflection.ResourceGroupDescriptions[perViewDescriptorSetSlot.Index], renderEffect.State);
+
+                                InstantiatedEffects.Add(effect, renderEffectReflection);
+
+                                // Notify a new effect has been compiled
+                                EffectCompiled?.Invoke(RenderSystem, effect, renderEffectReflection);
+                            }
+
+                            // Setup fallback parameters
+                            if (renderEffect.State != RenderEffectState.Normal && renderEffectReflection.FallbackUpdaterLayout == null)
+                            {
+                                // Process all "non standard" layouts
+                                var layoutMapping = new int[renderEffectReflection.DescriptorReflection.Layouts.Count - 3];
+                                var layouts = new DescriptorSetLayoutBuilder[renderEffectReflection.DescriptorReflection.Layouts.Count - 3];
+                                int layoutMappingIndex = 0;
+                                for (int index = 0; index < renderEffectReflection.DescriptorReflection.Layouts.Count; index++)
+                                {
+                                    var layout = renderEffectReflection.DescriptorReflection.Layouts[index];
+
+                                    // Skip well-known layouts (already handled)
+                                    if (layout.Name == "PerDraw" || layout.Name == "PerFrame" || layout.Name == "PerView")
+                                        continue;
+
+                                    layouts[layoutMappingIndex] = layout.Layout;
+                                    layoutMapping[layoutMappingIndex++] = index;
+                                }
+
+                                renderEffectReflection.FallbackUpdaterLayout = new EffectParameterUpdaterLayout(RenderSystem.GraphicsDevice, effect, layouts);
+                                renderEffectReflection.FallbackResourceGroupMapping = layoutMapping;
+                            }
+
+                            // Update effect
+                            renderEffect.Effect = effect;
+                            renderEffect.Reflection = renderEffectReflection;
+
+                            // Invalidate pipeline state (new effect)
+                            renderEffect.PipelineState = null;
+
+                            renderEffects[staticEffectObjectNode] = renderEffect;
                         }
                         else
                         {
-                            renderEffect.ClearFallbackParameters();
-                            renderEffect.State = RenderEffectState.Error;
-                            renderEffect.Effect = effect = ComputeFallbackEffect?.Invoke(renderObject, renderEffect, RenderEffectState.Error);
+                            renderEffect.Reflection = RenderEffectReflection.Empty;
+                            renderEffect.PipelineState = null;
                         }
-                    }
-
-                    var effectHashCode = effect != null ? (uint)effect.GetHashCode() : 0;
-
-                    // Effect is last 16 bits
-                    renderObject.StateSortKey = (renderObject.StateSortKey & 0xFFFF0000) | (effectHashCode & 0x0000FFFF);
-
-                    if (effect != null)
-                    {
-                        RenderEffectReflection renderEffectReflection;
-                        if (!InstantiatedEffects.TryGetValue(effect, out renderEffectReflection))
-                        {
-                            renderEffectReflection = new RenderEffectReflection();
-
-                            // Build root signature automatically from reflection
-                            renderEffectReflection.DescriptorReflection = EffectDescriptorSetReflection.New(RenderSystem.GraphicsDevice, effect.Bytecode, effectDescriptorSetSlots, "PerFrame");
-                            renderEffectReflection.ResourceGroupDescriptions = new ResourceGroupDescription[renderEffectReflection.DescriptorReflection.Layouts.Count];
-
-                            // Compute ResourceGroup hashes
-                            for (int index = 0; index < renderEffectReflection.DescriptorReflection.Layouts.Count; index++)
-                            {
-                                var descriptorSet = renderEffectReflection.DescriptorReflection.Layouts[index];
-                                if (descriptorSet.Layout == null)
-                                    continue;
-
-                                var constantBufferReflection = effect.Bytecode.Reflection.ConstantBuffers.FirstOrDefault(x => x.Name == descriptorSet.Name);
-
-                                renderEffectReflection.ResourceGroupDescriptions[index] = new ResourceGroupDescription(descriptorSet.Layout, constantBufferReflection);
-                            }
-
-                            renderEffectReflection.RootSignature = RootSignature.New(RenderSystem.GraphicsDevice, renderEffectReflection.DescriptorReflection);
-                            renderEffectReflection.BufferUploader.Compile(RenderSystem.GraphicsDevice, renderEffectReflection.DescriptorReflection, effect.Bytecode);
-
-                            // Prepare well-known descriptor set layouts
-                            renderEffectReflection.PerDrawLayout = CreateDrawResourceGroupLayout(renderEffectReflection.ResourceGroupDescriptions[perDrawDescriptorSetSlot.Index], renderEffect.State);
-                            renderEffectReflection.PerFrameLayout = CreateFrameResourceGroupLayout(renderEffectReflection.ResourceGroupDescriptions[perFrameDescriptorSetSlot.Index], renderEffect.State);
-                            renderEffectReflection.PerViewLayout = CreateViewResourceGroupLayout(renderEffectReflection.ResourceGroupDescriptions[perViewDescriptorSetSlot.Index], renderEffect.State);
-
-                            InstantiatedEffects.Add(effect, renderEffectReflection);
-
-                            // Notify a new effect has been compiled
-                            EffectCompiled?.Invoke(RenderSystem, effect, renderEffectReflection);
-                        }
-
-                        // Setup fallback parameters
-                        if (renderEffect.State != RenderEffectState.Normal && renderEffectReflection.FallbackUpdaterLayout == null)
-                        {
-                            // Process all "non standard" layouts
-                            var layoutMapping = new int[renderEffectReflection.DescriptorReflection.Layouts.Count - 3];
-                            var layouts = new DescriptorSetLayoutBuilder[renderEffectReflection.DescriptorReflection.Layouts.Count - 3];
-                            int layoutMappingIndex = 0;
-                            for (int index = 0; index < renderEffectReflection.DescriptorReflection.Layouts.Count; index++)
-                            {
-                                var layout = renderEffectReflection.DescriptorReflection.Layouts[index];
-
-                                // Skip well-known layouts (already handled)
-                                if (layout.Name == "PerDraw" || layout.Name == "PerFrame" || layout.Name == "PerView")
-                                    continue;
-
-                                layouts[layoutMappingIndex] = layout.Layout;
-                                layoutMapping[layoutMappingIndex++] = index;
-                            }
-
-                            renderEffectReflection.FallbackUpdaterLayout = new EffectParameterUpdaterLayout(RenderSystem.GraphicsDevice, effect, layouts);
-                            renderEffectReflection.FallbackResourceGroupMapping = layoutMapping;
-                        }
-
-                        // Update effect
-                        renderEffect.Effect = effect;
-                        renderEffect.Reflection = renderEffectReflection;
-
-                        // Invalidate pipeline state (new effect)
-                        renderEffect.PipelineState = null;
-
-                        renderEffects[staticEffectObjectNode] = renderEffect;
-                    }
-                    else
-                    {
-                        renderEffect.Reflection = RenderEffectReflection.Empty;
-                        renderEffect.PipelineState = null;
                     }
                 }
             }

--- a/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
@@ -56,9 +56,9 @@ namespace Stride.Rendering
         private readonly List<NamedSlotDefinition> viewLogicalGroups = new List<NamedSlotDefinition>();
         private readonly List<NamedSlotDefinition> drawLogicalGroups = new List<NamedSlotDefinition>();
 
-        private static readonly ProfilingKey CompileEffectsKey = new ProfilingKey("Compile Effects");
-        private static readonly ProfilingKey UpdateReflectionInfosKey = new ProfilingKey("Update Reflection Infos");
-        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("RootEffectRenderFeature.PrepareEffectPermutations");
+        private static readonly ProfilingKey CompileEffectsKey = new ProfilingKey($"{nameof(RootEffectRenderFeature)}.CompileEffects");
+        private static readonly ProfilingKey UpdateReflectionInfosKey = new ProfilingKey($"{nameof(RootEffectRenderFeature)}.UpdateReflectionInfos");
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey($"{nameof(RootEffectRenderFeature)}.PrepareEffectPermutations");
 
         // Common slots
         private EffectDescriptorSetReference perFrameDescriptorSetSlot;

--- a/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
@@ -24,7 +24,7 @@ namespace Stride.Rendering
         private readonly ConcurrentCollector<ViewObjectNode> viewObjectNodes = new ConcurrentCollector<ViewObjectNode>();
         private readonly ConcurrentCollector<ObjectNode> objectNodes = new ConcurrentCollector<ObjectNode>();
         
-        private static readonly ProfilingKey GetOrCreateObjectNodeKey = new ProfilingKey("GetOrCreateObjectNode");
+        private static readonly ProfilingKey GetOrCreateObjectNodeKey = new ProfilingKey($"{nameof(RootRenderFeature)}.GetOrCreateObjectNode");
 
         // storage for properties (struct of arrays)
         public RenderDataHolder RenderData;

--- a/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Stride.Core;
 using Stride.Core.Annotations;
 using Stride.Core.Collections;
+using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
 using Stride.Core.Threading;
 
@@ -22,6 +23,8 @@ namespace Stride.Rendering
     {
         private readonly ConcurrentCollector<ViewObjectNode> viewObjectNodes = new ConcurrentCollector<ViewObjectNode>();
         private readonly ConcurrentCollector<ObjectNode> objectNodes = new ConcurrentCollector<ObjectNode>();
+        
+        private static readonly ProfilingKey GetOrCreateObjectNodeKey = new ProfilingKey("GetOrCreateObjectNode");
 
         // storage for properties (struct of arrays)
         public RenderDataHolder RenderData;
@@ -137,6 +140,7 @@ namespace Stride.Rendering
 
         internal unsafe ObjectNodeReference GetOrCreateObjectNode(RenderObject renderObject)
         {
+            using var _ = Profiler.Begin(GetOrCreateObjectNodeKey);
             fixed (ObjectNodeReference* objectNodeRef = &renderObject.ObjectNode)
             {
                 var oldValue = Interlocked.CompareExchange(ref *(int*)objectNodeRef, -2, -1);

--- a/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapRenderer.cs
@@ -32,6 +32,9 @@ namespace Stride.Rendering.Shadows
 
         private readonly List<LightShadowMapTexture> shadowMaps = new List<LightShadowMapTexture>();
         
+        private static readonly ProfilingKey CollectKey = new ProfilingKey("ShadowMapRenderer.Collect");
+        private static readonly ProfilingKey DrawKey = new ProfilingKey("ShadowMapRenderer.Draw");
+
         public ShadowMapRenderer()
         {
             atlases = new FastListStruct<ShadowMapAtlasTexture>(16);
@@ -71,6 +74,7 @@ namespace Stride.Rendering.Shadows
 
         public void Collect(RenderContext context, Dictionary<RenderView, ForwardLightingRenderFeature.RenderViewLightData> renderViewLightDatas)
         {
+            using var _ = Profiler.Begin(CollectKey);
             // Reset the state of renderers
             foreach (var renderer in Renderers)
             {
@@ -152,6 +156,7 @@ namespace Stride.Rendering.Shadows
 
         public void Draw(RenderDrawContext drawContext)
         {
+            using var _ = Profiler.Begin(DrawKey);
             var renderSystem = drawContext.RenderContext.RenderSystem;
 
             // Clear atlases

--- a/sources/engine/Stride.Rendering/Rendering/SkinningRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/SkinningRenderFeature.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Core.Threading;
 using Stride.Rendering.Materials;
@@ -19,6 +20,8 @@ namespace Stride.Rendering
         private ObjectPropertyKey<Matrix[]> renderModelObjectInfoKey;
 
         private ConstantBufferOffsetReference blendMatrices;
+
+        private static readonly ProfilingKey PrepareEffectPermutationsKey = new ProfilingKey("SkinningRenderFeature.PrepareEffectPermutations");
 
         // Good number for low profiles?
         public int MaxBones { get; set; } = 56;
@@ -46,6 +49,7 @@ namespace Stride.Rendering
         /// <inheritdoc/>
         public override void PrepareEffectPermutations(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareEffectPermutationsKey);
             var skinningInfos = RootRenderFeature.RenderData.GetData(skinningInfoKey);
 
             var renderEffects = RootRenderFeature.RenderData.GetData(renderEffectKey);

--- a/sources/engine/Stride.Rendering/Rendering/TransformRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/TransformRenderFeature.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Core.Threading;
 using Stride.Graphics;
@@ -23,6 +24,9 @@ namespace Stride.Rendering
         private ConstantBufferOffsetReference world;
         private ConstantBufferOffsetReference worldInverse;
         private ConstantBufferOffsetReference camera;
+        
+        private static readonly ProfilingKey ExtractKey = new ProfilingKey("TransformRenderFeature.Extract");
+        private static readonly ProfilingKey PrepareKey = new ProfilingKey("TransformRenderFeature.Prepare");
 
         internal struct RenderModelFrameInfo
         {
@@ -53,6 +57,7 @@ namespace Stride.Rendering
         /// <inheritdoc/>
         public override void Extract()
         {
+            using var _ = Profiler.Begin(ExtractKey);
             var renderModelObjectInfo = RootRenderFeature.RenderData.GetData(RenderModelObjectInfoKey);
 
             //for (int index = 0; index < RootRenderFeature.ObjectNodeReferences.Count; index++)
@@ -70,6 +75,7 @@ namespace Stride.Rendering
         /// <inheritdoc/>
         public override unsafe void Prepare(RenderDrawContext context)
         {
+            using var _ = Profiler.Begin(PrepareKey);
             // Compute WorldView, WorldViewProj
             var renderModelObjectInfoData = RootRenderFeature.RenderData.GetData(RenderModelObjectInfoKey);
             var renderModelViewInfoData = RootRenderFeature.RenderData.GetData(RenderModelViewInfoKey);

--- a/sources/engine/Stride.Rendering/Rendering/VisibilityGroup.cs
+++ b/sources/engine/Stride.Rendering/Rendering/VisibilityGroup.cs
@@ -12,6 +12,7 @@ using Stride.Core.Collections;
 using Stride.Core.Extensions;
 using Stride.Core.Mathematics;
 using Stride.Core.Threading;
+using Stride.Core.Diagnostics;
 using Stride.Engine;
 using Stride.Rendering.Shadows;
 
@@ -24,6 +25,8 @@ namespace Stride.Rendering
     {
         private readonly List<RenderObject> renderObjectsWithoutFeatures = new List<RenderObject>();
         private readonly ThreadLocal<ConcurrentCollectorCache<RenderObject>> collectorCache = new ThreadLocal<ConcurrentCollectorCache<RenderObject>>(() => new ConcurrentCollectorCache<RenderObject>(32));
+
+        private static readonly ProfilingKey TryCollectKey = new ProfilingKey("VisibilityGroup.Collect");
 
         private int stageMaskMultiplier;
 
@@ -91,6 +94,7 @@ namespace Stride.Rendering
         /// <param name="view"></param>
         public void TryCollect(RenderView view)
         {
+            using var _ = Profiler.Begin(TryCollectKey);
             // Already colleted this frame?
             if (view.LastFrameCollected == RenderSystem.FrameCounter)
                 return;

--- a/sources/engine/Stride.Video/VideoInstance.cs
+++ b/sources/engine/Stride.Video/VideoInstance.cs
@@ -5,13 +5,13 @@ using System;
 using System.Runtime.CompilerServices;
 using Stride.Core;
 using Stride.Core.Annotations;
+using Stride.Core.Extensions;
 using Stride.Core.Serialization.Contents;
 using Stride.Core.Storage;
 using Stride.Graphics;
 using Stride.Streaming;
 using Stride.Core.Diagnostics;
 using Stride.Media;
-using Stride.Audio;
 using Stride.Core.IO;
 using Stride.Games;
 


### PR DESCRIPTION
# PR Details

## Description

This PR adds a profiler outputting data in chrome://tracing format (for now) and changes `Profiler` to make that possible.

`ChromeTracingProfileWriter` consumes events and dumps them to a file which can then be analyzed with tools like chrome://tracing, [perfetto](https://ui.perfetto.dev) or [speedscope](https://speedscope.app).

### Usage
```cs
//Start
ChromeTracingProfileWriter.Start(string outputPath, bool indentOutput = false)
//Stop
ChromeTracingProfiler.Stop()

//To add another output format/client and receive events use
Profiler.Subscribe() and Profiler.Unsubscribe()
```

## Related Issue

N/A

## Motivation and Context

I had trouble pinpointing performance issues with both the existing Profiler and external tools like dotTrace, so I started experimenting with adding something in the vein of chrome://tracing or [tracy](https://github.com/wolfpld/tracy). In particular the exisiting `Profiler` is quite heavy-weight and doesn't play well with multithreading, while everything happening inside the `ThreadPool` / `Dispatcher` is difficult to understand with sampling profilers as a lot of work happens in anonymous functions.

The `TraceProfiler` lets you see work on all threads and lets you look at individual frames to analyze spikes instead of just averages. For me this was also very helpful in understanding the structure of the engine.

An example trace from a rendering stresstest opened in [perfetto](https://ui.perfetto.dev):
![grafik](https://github.com/stride3d/stride/assets/8515865/f1953a3a-ec19-4cf0-9866-497e2a04a0cb)

The example trace:
[tracing_example.json.gz](https://github.com/stride3d/stride/files/12643239/tracing_example.json.gz)

## Open Questions / Todo

- [x] Decide what to do with this. I've already found this very useful compared with the existing Profiler, so I'd like to see it added, but of course having multiple internal profilers is not ideal. Merging it with `Profiler` seemed quite challenging, but maybe it's a bit easier after the refactoring in #1774 and I should take another look.
- [x] Add tests.
- [x] Update outdated comments and add new ones where needed.
- [x] Verify performance.
- [ ] Update docs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.