### PR TITLE
[Editor] Add dynamic snapping for selected objects

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/SceneEditor/SceneEditorSettings.cs
+++ b/sources/editor/Stride.Assets.Presentation/SceneEditor/SceneEditorSettings.cs
@@ -52,6 +52,10 @@ namespace Stride.Assets.Presentation.SceneEditor
             {
                 DisplayName = $"{SceneEditor}/{KeyBindings}/{Tr._p("Settings", "Snap selection to the grid")}"
             };
+            ControlDynamicSnapSelectionToGrid = new SettingsKey<Keys>("SceneEditor/KeyBindings/ControlDynamicSnapSelectionToGrid", Stride.Core.Assets.Editor.Settings.EditorSettings.SettingsContainer, Keys.LeftShift)
+            {
+                DisplayName = $"{SceneEditor}/{KeyBindings}/{Tr._p("Settings", "Use snapping while selection is beeing manipulated")}"
+            };
             TranslationGizmo = new SettingsKey<Keys>("SceneEditor/KeyBindings/TranslationGizmo", Stride.Core.Assets.Editor.Settings.EditorSettings.SettingsContainer, Keys.W)
             {
                 DisplayName = $"{SceneEditor}/{KeyBindings}/{Tr._p("Settings", "Switch to translation mode")}"
@@ -111,6 +115,8 @@ namespace Stride.Assets.Presentation.SceneEditor
         public static SettingsKey<Keys> CenterViewOnSelection { get; }
 
         public static SettingsKey<Keys> SnapSelectionToGrid { get; }
+
+        public static SettingsKey<Keys> ControlDynamicSnapSelectionToGrid { get; }
 
         public static SettingsKey<Keys> TranslationGizmo { get; }
 


### PR DESCRIPTION
# PR Details

Implements a dynamic snapping used while holding down a key (default: Left Shift) on manipulating (rotating/moving/scaling) an object/entity. It is possible to use STRG + Shift to duplicate with snapping, too.

## Description

* New: Add new Hotkey Setting for dynamic snapping
* New: Add Method to handle dynamic snapping

## Motivation and Context

To prevent from having to toggle the snapping on in the first place before manipulating an object, it is now possible to quickly (de)activate it, when it is (not) needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.