### PR TITLE
Update README.md - Bullet point fixed in Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Ask for help or report issues:
 
 1. **Latest** [Git](https://git-scm.com/downloads) **with Large File Support** selected in the setup on the components dialog.
 2. [DotNet SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
-  * Run 'dotnet --info' in a console or powershell window to see which versions you have installed  
+   - Run `dotnet --info` in a console or powershell window to see which versions you have installed  
 3. [Visual Studio 2022](https://www.visualstudio.com/downloads/) with the following workloads:
-  * `.NET desktop development` with `.NET Framework 4.7.2 targeting pack`
-  * `Desktop development with C++` with
-    * `Windows 10 SDK (10.0.18362.0)` (it's currently enabled by default but it might change)
-    * `MSVC v143 - VS2022 C++ x64/x86 build tools (v14.30)` or later version (should be enabled by default)
-    * `C++/CLI support for v143 build tools (v14.30)` or later version **(not enabled by default)**
-  * Optional (to target iOS/Android): `Mobile development with .NET` and `Android SDK setup (API level 27)` individual component, then in Visual Studio go to `Tools > Android > Android SDK Manager` and install `NDK` (version 19+) from `Tools` tab.
+   - `.NET desktop development` with `.NET Framework 4.7.2 targeting pack`
+   - `Desktop development with C++` with
+     - `Windows 10 SDK (10.0.18362.0)` (it's currently enabled by default but it might change)
+     - `MSVC v143 - VS2022 C++ x64/x86 build tools (v14.30)` or later version (should be enabled by default)
+     - `C++/CLI support for v143 build tools (v14.30)` or later version **(not enabled by default)**
+   - Optional (to target iOS/Android): `Mobile development with .NET` and `Android SDK setup (API level 27)` individual component, then in Visual Studio go to `Tools > Android > Android SDK Manager` and install `NDK` (version 19+) from `Tools` tab.
 4. **[FBX SDK 2019.0 VS2015](https://www.autodesk.com/developer-network/platform-technologies/fbx-sdk-2019-0)**
 
 ### Build Stride


### PR DESCRIPTION
Bullet points alignment fixed from:
<img width="576" alt="image" src="https://github.com/stride3d/stride/assets/4528464/6d47f839-666e-4866-939c-6fd0c30e6e67">

to:
<img width="586" alt="image" src="https://github.com/stride3d/stride/assets/4528464/cefb6d11-8754-4edd-9096-709dc1e732d2">
