### PR TITLE
Check to see if the .NET 6.0 SDK is Installed When Launching Stride

### DIFF
--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -38,7 +38,7 @@ namespace Stride.Core.Assets
                 // Detect either .NET Core SDK or Visual Studio depending on current runtime
                 var isNETCore = !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
                 MSBuildInstance = MSBuildLocator.QueryVisualStudioInstances().FirstOrDefault(x => isNETCore
-                    ? x.DiscoveryType == DiscoveryType.DotNetSdk && x.Version.Major >= 3
+                    ? x.DiscoveryType == DiscoveryType.DotNetSdk && x.Version.Major == 6
                     : (x.DiscoveryType == DiscoveryType.VisualStudioSetup || x.DiscoveryType == DiscoveryType.DeveloperConsole) && x.Version.Major >= 16);
                 
                 if (MSBuildInstance == null)

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -225,6 +225,19 @@ namespace Stride.GameStudio
                 InitializeLanguageSettings();
                 var serviceProvider = InitializeServiceProvider();
 
+                //Check to see that the required .NET SDK is available, otherwise Stride will launch with an older version of the SDK
+                if (StrideGameStudio.EditorVersionMajor == "4.1" && !RuntimeInformation.FrameworkDescription.ToString().StartsWith(".NET 6"))
+                {
+                    var message = "Could not find required .NET 6.0 SDK.\r\n\r\n" +
+                                  "Check that you have a valid installation with the required workloads, or go to [https://dotnet.microsoft.com/en-us/download](https://dotnet.microsoft.com/en-us/download) and install.\r\n\r\n" +
+                                  "Detected SDK: " + RuntimeInformation.FrameworkDescription.ToString() + "\r\n";
+
+                    await serviceProvider.Get<IEditorDialogService>().MessageBox(message, Core.Presentation.Services.MessageBoxButton.OK, Core.Presentation.Services.MessageBoxImage.Error);
+                    app.Shutdown();
+                    return;
+
+                }
+
                 try
                 {
                     PackageSessionPublicHelper.FindAndSetMSBuildVersion();

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -48,7 +48,6 @@ using EditorSettings = Stride.Core.Assets.Editor.Settings.EditorSettings;
 using MessageBox = System.Windows.MessageBox;
 using MessageBoxButton = System.Windows.MessageBoxButton;
 using MessageBoxImage = System.Windows.MessageBoxImage;
-using Microsoft.Build.Locator;
 
 namespace Stride.GameStudio
 {

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -48,6 +48,7 @@ using EditorSettings = Stride.Core.Assets.Editor.Settings.EditorSettings;
 using MessageBox = System.Windows.MessageBox;
 using MessageBoxButton = System.Windows.MessageBoxButton;
 using MessageBoxImage = System.Windows.MessageBoxImage;
+using Microsoft.Build.Locator;
 
 namespace Stride.GameStudio
 {
@@ -225,19 +226,6 @@ namespace Stride.GameStudio
                 InitializeLanguageSettings();
                 var serviceProvider = InitializeServiceProvider();
 
-                //Check to see that the required .NET SDK is available, otherwise Stride will launch with an older version of the SDK
-                if (StrideGameStudio.EditorVersionMajor == "4.1" && !RuntimeInformation.FrameworkDescription.ToString().StartsWith(".NET 6"))
-                {
-                    var message = "Could not find required .NET 6.0 SDK.\r\n\r\n" +
-                                  "Check that you have a valid installation with the required workloads, or go to [https://dotnet.microsoft.com/en-us/download](https://dotnet.microsoft.com/en-us/download) and install.\r\n\r\n" +
-                                  "Detected SDK: " + RuntimeInformation.FrameworkDescription.ToString() + "\r\n";
-
-                    await serviceProvider.Get<IEditorDialogService>().MessageBox(message, Core.Presentation.Services.MessageBoxButton.OK, Core.Presentation.Services.MessageBoxImage.Error);
-                    app.Shutdown();
-                    return;
-
-                }
-
                 try
                 {
                     PackageSessionPublicHelper.FindAndSetMSBuildVersion();
@@ -247,6 +235,7 @@ namespace Stride.GameStudio
                     var message = "Could not find a compatible version of MSBuild.\r\n\r\n" +
                                   "Check that you have a valid installation with the required workloads, or go to [www.visualstudio.com/downloads](https://www.visualstudio.com/downloads) to install a new one.\r\n" +
                                   "Also make sure you have the latest [.NET 6 SDK](https://dotnet.microsoft.com/) \r\n\r\n" +
+                                  "Detected SDK: " + RuntimeInformation.FrameworkDescription.ToString() + "\r\n\r\n" +
                                   e;
                     await serviceProvider.Get<IEditorDialogService>().MessageBox(message, Core.Presentation.Services.MessageBoxButton.OK, Core.Presentation.Services.MessageBoxImage.Error);
                     app.Shutdown();

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -234,7 +234,6 @@ namespace Stride.GameStudio
                     var message = "Could not find a compatible version of MSBuild.\r\n\r\n" +
                                   "Check that you have a valid installation with the required workloads, or go to [www.visualstudio.com/downloads](https://www.visualstudio.com/downloads) to install a new one.\r\n" +
                                   "Also make sure you have the latest [.NET 6 SDK](https://dotnet.microsoft.com/) \r\n\r\n" +
-                                  "Detected SDK: " + RuntimeInformation.FrameworkDescription.ToString() + "\r\n\r\n" +
                                   e;
                     await serviceProvider.Get<IEditorDialogService>().MessageBox(message, Core.Presentation.Services.MessageBoxButton.OK, Core.Presentation.Services.MessageBoxImage.Error);
                     app.Shutdown();


### PR DESCRIPTION
# PR Details
Stride 4.1 requires the .NET 6.0 SDK. The existing FindAndSetMSBuildVersion() method can be bypassed if an older version of the SDK is installed (i.e., 5.0) because the method is checking for .NET Core 3 or above.

After bypassing this prerequisite check, Stride will function normally until the user attempts to build their project.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The _x.Version.Major_ requirement was raised in Stride.Core.Assets\PackageSessionPublicHelper.cs, the check is performed when the user opens Stride 4.1.x. If the SDK is missing the user is prompted to install it, the detected SDK version is provided to help with troubleshooting.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Prompted by discussion in issue https://github.com/stride3d/stride/issues/1753

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.