### PR TITLE
parse numbers in NumericTextBox using CurrentCulture

### DIFF
--- a/sources/presentation/Stride.Core.Presentation/Controls/NumericTextBox.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/NumericTextBox.cs
@@ -312,7 +312,7 @@ namespace Stride.Core.Presentation.Controls
         protected sealed override void OnValidated()
         {
             double? value;
-            if (double.TryParse(Text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsedValue))
+            if (double.TryParse(Text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out var parsedValue))
             {
                 value = parsedValue;
             }
@@ -328,7 +328,7 @@ namespace Stride.Core.Presentation.Controls
 
         protected override bool IsTextCompatibleWithValueBinding(string text)
         {
-            return double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out _);
+            return double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out _);
         }
 
         /// <inheritdoc/>
@@ -337,7 +337,7 @@ namespace Stride.Core.Presentation.Controls
         {
             baseValue = base.CoerceTextForValidation(baseValue);
             double? value;
-            if (double.TryParse(baseValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsedValue))
+            if (double.TryParse(baseValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out var parsedValue))
             {
                 value = parsedValue;
 
@@ -366,7 +366,7 @@ namespace Stride.Core.Presentation.Controls
 
             var decimalPlaces = DecimalPlaces;
             var coercedValue = decimalPlaces < 0 ? value.Value : Math.Round(value.Value, decimalPlaces);
-            return coercedValue.ToString(CultureInfo.InvariantCulture);
+            return coercedValue.ToString(CultureInfo.CurrentCulture);
         }
 
         private void RepeatButtonIsPressedChanged(object sender, EventArgs e)

--- a/sources/presentation/Stride.Core.Presentation/Controls/NumericTextBox.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/NumericTextBox.cs
@@ -312,7 +312,7 @@ namespace Stride.Core.Presentation.Controls
         protected sealed override void OnValidated()
         {
             double? value;
-            if (double.TryParse(Text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out var parsedValue))
+            if (TryParseValue(Text, out var parsedValue))
             {
                 value = parsedValue;
             }
@@ -328,7 +328,7 @@ namespace Stride.Core.Presentation.Controls
 
         protected override bool IsTextCompatibleWithValueBinding(string text)
         {
-            return double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out _);
+            return TryParseValue(text, out _);
         }
 
         /// <inheritdoc/>
@@ -337,7 +337,7 @@ namespace Stride.Core.Presentation.Controls
         {
             baseValue = base.CoerceTextForValidation(baseValue);
             double? value;
-            if (double.TryParse(baseValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out var parsedValue))
+            if (TryParseValue(baseValue, out var parsedValue))
             {
                 value = parsedValue;
 
@@ -366,7 +366,7 @@ namespace Stride.Core.Presentation.Controls
 
             var decimalPlaces = DecimalPlaces;
             var coercedValue = decimalPlaces < 0 ? value.Value : Math.Round(value.Value, decimalPlaces);
-            return coercedValue.ToString(CultureInfo.CurrentCulture);
+            return coercedValue.ToString(CultureInfo.InvariantCulture);
         }
 
         private void RepeatButtonIsPressedChanged(object sender, EventArgs e)
@@ -411,6 +411,38 @@ namespace Stride.Core.Presentation.Controls
             {
                 SetCurrentValue(ValueProperty, value);
             }
+        }
+
+        /// <summary>
+        /// tries to parse the value of the textbox into a double, accommodating various cultural settings and preferences
+        /// </summary>
+        /// <param name="value">text value of the textbox</param>
+        /// <param name="result">the resulting numeric value if parsing is successful</param>
+        /// <returns>whether parsing the value was successful</returns>
+        private static bool TryParseValue(string value, out double result)
+        {
+            //thousands are disallowed as they might lead to decimal seperators falsely being interpreted as thousands
+            const NumberStyles numberStyle = NumberStyles.Any & ~NumberStyles.AllowThousands;
+
+            //try parsing a hex string
+            var x = value.TrimStart('0').ToLower();
+            if (x.StartsWith("x") || x.StartsWith("#"))
+            {
+                x = x.TrimStart('x', '#');
+                if (double.TryParse(x, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out result))
+                    return true;
+            }
+            //Try parsing in the current culture
+            else if (double.TryParse(value, numberStyle, CultureInfo.CurrentCulture, out result) ||
+                //or in neutral culture
+                double.TryParse(value, numberStyle, CultureInfo.InvariantCulture, out result) ||
+                //or as fallback a culture that has ',' as comma separator
+                double.TryParse(value, numberStyle, CultureInfo.GetCultureInfo("de-DE"), out result))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static void OnValuePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
enables numpad usage for cultures that use comma for decimals

# PR Details

Changes parsing and formatting culture in the NumericTextBox from InvariantCulture to CurrentCulture. Therefore decimal numbers in the property grid will be displayed using the current culture of the user and can be input using that same culture. Most importantly this enables culture settings like mine('en-AT') to use the numpad to input decimals with the comma key.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.