### PR TITLE
Feature: Add Support for F# and VB Project Types

### DIFF
--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -596,7 +596,7 @@ namespace Stride.Core.Assets
 
         public static PackageContainer LoadProject(ILogger log, string filePath)
         {
-            if (Path.GetExtension(filePath).ToLowerInvariant() == ".csproj")
+            if (SupportedProgrammingLanguages.IsSupportedByExtension(Path.GetExtension(filePath).ToLowerInvariant()))
             {
                 var projectPath = filePath;
                 var packagePath = Path.ChangeExtension(filePath, Package.PackageFileExtension);

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -596,7 +596,7 @@ namespace Stride.Core.Assets
 
         public static PackageContainer LoadProject(ILogger log, string filePath)
         {
-            if (SupportedProgrammingLanguages.IsSupportedByExtension(Path.GetExtension(filePath).ToLowerInvariant()))
+            if (SupportedProgrammingLanguages.IsProjectExtensionSupported(Path.GetExtension(filePath).ToLowerInvariant()))
             {
                 var projectPath = filePath;
                 var packagePath = Path.ChangeExtension(filePath, Package.PackageFileExtension);

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -258,7 +258,7 @@ namespace Stride.Core.Assets
                     switch (projectDependency.Type)
                     {
                         case DependencyType.Project:
-                            if (Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant() == ".csproj")
+                            if (SupportedProgrammingLanguages.IsSupportedByExtension(Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant()))
                                 file = UPath.Combine(project.FullPath.GetFullDirectory(), (UFile)projectDependency.MSBuildProject);
                             break;
                         case DependencyType.Package:

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -258,7 +258,7 @@ namespace Stride.Core.Assets
                     switch (projectDependency.Type)
                     {
                         case DependencyType.Project:
-                            if (SupportedProgrammingLanguages.IsSupportedByExtension(Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant()))
+                            if (SupportedProgrammingLanguages.IsProjectExtensionSupported(Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant()))
                                 file = UPath.Combine(project.FullPath.GetFullDirectory(), (UFile)projectDependency.MSBuildProject);
                             break;
                         case DependencyType.Package:

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -832,7 +832,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
 
                         session.LoadMissingDependencies(sessionResult, loadParameters);
                     }
-                    else if (SupportedProgrammingLanguages.IsSupportedByExtension(Path.GetExtension(filePath).ToLowerInvariant())
+                    else if (SupportedProgrammingLanguages.IsProjectExtensionSupported(Path.GetExtension(filePath).ToLowerInvariant())
                         || Path.GetExtension(filePath).ToLowerInvariant() == Package.PackageFileExtension)
                     {
                         var project = session.LoadProject(sessionResult, filePath, loadParameters);

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -832,7 +832,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
 
                         session.LoadMissingDependencies(sessionResult, loadParameters);
                     }
-                    else if (Path.GetExtension(filePath).ToLowerInvariant() == ".csproj"
+                    else if (SupportedProgrammingLanguages.IsSupportedByExtension(Path.GetExtension(filePath).ToLowerInvariant())
                         || Path.GetExtension(filePath).ToLowerInvariant() == Package.PackageFileExtension)
                     {
                         var project = session.LoadProject(sessionResult, filePath, loadParameters);
@@ -841,7 +841,11 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
                     }
                     else
                     {
-                        sessionResult.Error($"Unsupported file extension (only .sln, .csproj and .sdpkg are supported)");
+                        var supportedExtensions = SupportedProgrammingLanguages.Languages
+                            .Select(lang => lang.Extension)
+                            .ToArray();
+
+                        sessionResult.Error($"Unsupported file extension (only .sln, {string.Join(", ", supportedExtensions)} and .sdpkg are supported)");
                         return;
                     }
 

--- a/sources/assets/Stride.Core.Assets/SupportedProgrammingLanguage.cs
+++ b/sources/assets/Stride.Core.Assets/SupportedProgrammingLanguage.cs
@@ -38,7 +38,7 @@ namespace Stride.Core.Assets
         /// </summary>
         /// <param name="extension">The project file extension to check.</param>
         /// <returns>True if the extension is supported, otherwise false.</returns>
-        public static bool IsSupportedByExtension(string extension)
+        public static bool IsProjectExtensionSupported(string extension)
         {
             return Languages.Any(lang => string.Equals(lang.Extension, extension, StringComparison.InvariantCultureIgnoreCase));
         }

--- a/sources/assets/Stride.Core.Assets/SupportedProgrammingLanguage.cs
+++ b/sources/assets/Stride.Core.Assets/SupportedProgrammingLanguage.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Stride.Core.Assets
+{
+    /// <summary>
+    /// Represents a programming language supported by the system.
+    /// </summary>
+    /// <param name="Name">The name of the programming language.</param>
+    /// <param name="Extension">The associated project file extension.</param>
+    public record SupportedProgrammingLanguage(string Name, string Extension);
+
+    /// <summary>
+    /// Provides a list of programming languages supported by the system.
+    /// </summary>
+    public static class SupportedProgrammingLanguages
+    {
+        /// <summary>
+        /// Gets the list of supported programming languages.
+        /// </summary>
+        /// <value>
+        /// A list of <see cref="SupportedProgrammingLanguage"/> objects.
+        /// </value>
+        /// <remarks>
+        /// Use this list to check for supported programming languages when needed.
+        /// The list is initialized with common programming languages and their respective project file extensions.
+        /// </remarks>
+        public static IReadOnlyList<SupportedProgrammingLanguage> Languages { get; } = new List<SupportedProgrammingLanguage>
+        {
+            new SupportedProgrammingLanguage("C#", ".csproj"),
+            new SupportedProgrammingLanguage("F#", ".fsproj"),
+            new SupportedProgrammingLanguage("VB", ".vbproj"),
+        };
+
+        /// <summary>
+        /// Determines if a given project file extension is supported.
+        /// </summary>
+        /// <param name="extension">The project file extension to check.</param>
+        /// <returns>True if the extension is supported, otherwise false.</returns>
+        public static bool IsSupportedByExtension(string extension)
+        {
+            return Languages.Any(lang => string.Equals(lang.Extension, extension, StringComparison.InvariantCultureIgnoreCase));
+        }
+    }
+}


### PR DESCRIPTION
# PR Details

This PR adds support for additional project types: `.fsproj` and `.vbproj`, enabling **F#** and **Visual Basic** coding in Stride's code-only approach. Further work may be required to integrate F# and Visual Basic into the Stride Game Studio, which I will leave to more experienced contributors.

## Description

This PR serves as a follow-up to the incomplete https://github.com/stride3d/stride/pull/1078. I've implemented the changes necessary for a "code-only" approach, as I'm currently not familiar with Stride Game Studio.

To accommodate these changes, I've introduced a `SupportedProgrammingLanguage` record and a `SupportedProgrammingLanguages` class. I opted for these names as `SupportedLanguage` is already used within the codebase for a different purpose.

I'm open to feedback on the naming conventions and the overall implementation. The core change involves extending the existing logic to account for `.fsproj` and `.vbproj` in addition to `.csproj`.

## Related Issue

https://github.com/stride3d/stride/pull/1078

**Typical error when using other project types**

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	0.157s	[AssetCompiler] Unsupported file extension (only .sln, .csproj and .sdpkg are supported)	Example06_VBasic_Basic3DScene	D:\Projects\GitHub\stride-community-toolkit\examples\code-only\Example06_VBasic_Basic3DScene\EXEC	1

```

## Motivation and Context

Allowing to use other .NET languages as they should be working.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation - announcing this feature
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.