### PR TITLE
Added the ability to copy imported assets automatically to the Resources dir

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -538,8 +538,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
         private async Task<string> GetAssetCopyDirectory(DirectoryBaseViewModel directory, UFile file)
         {
             string path = directory.Path;
-            var message = Tr._p("Message", "Do you want to place the resource in the default location ?").ToFormat(file.FullPath);
-            string finalPath = directory.Package.Package.ResourceFolders[0] + "/" + path + file.GetFileName();
+            var message = Tr._p("Message", "Do you want to place the resource in the default location ?");
+            string finalPath = Path.Combine(directory.Package.Package.ResourceFolders[0],path,file.GetFileName());
             var pathResult = await Dialogs.MessageBox(message, MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (pathResult == MessageBoxResult.No)
             {
@@ -548,7 +548,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 {
                     var fileDialog = Dialogs.CreateFileSaveModalDialog();
                     fileDialog.Filters = new List<FileDialogFilter>() { new FileDialogFilter("", file.GetFileExtension()) };
-                    fileDialog.InitialDirectory = directory.Package.Package.ResourceFolders.FirstOrDefault().FullPath.Replace("/", "\\");
+                    fileDialog.InitialDirectory = Path.GetFullPath(directory.Package.Package.ResourceFolders.FirstOrDefault().FullPath);
                     fileDialog.DefaultFileName = file.GetFileName();
                     DialogResult result = await fileDialog.ShowModal();
 
@@ -559,9 +559,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     }
                     else
                     {
-                        var fullPath = Path.GetFullPath(fileDialog.FilePath).Replace("\\", "/");
+                        var fullPath = Path.GetFullPath(fileDialog.FilePath);
 
-                        bool inResource = directory.Package.Package.ResourceFolders.Any(x => fullPath.StartsWith(x.FullPath));
+                        bool inResource = directory.Package.Package.ResourceFolders.Any(x => fullPath.StartsWith(Path.GetFullPath(x.FullPath)));
                         if (inResource)
                         {
                             finalPath = fullPath;
@@ -613,10 +613,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
                                     {
                                         return newAssets;
                                     }
-                                    File.Delete(finalPath);
                                 }                                
                                 
-                                File.Copy(file.FullPath, finalPath);
+                                File.Copy(file.FullPath, finalPath,true);
                                 files[i] = new UFile(finalPath);
                             }
                             catch (Exception ex)

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -32,8 +32,6 @@ using Stride.Core.Presentation.Interop;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Presentation.ViewModel;
 using Stride.Core.Translation;
-using MessageBoxButton = Stride.Core.Presentation.Services.MessageBoxButton;
-using MessageBoxImage = Stride.Core.Presentation.Services.MessageBoxImage;
 
 namespace Stride.Core.Assets.Editor.ViewModel
 {
@@ -228,7 +226,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             AddAssetFilterCommand = new AnonymousCommand<AssetFilterViewModel>(serviceProvider, AddAssetFilter);
             ClearAssetFiltersCommand = new AnonymousCommand(serviceProvider, ClearAssetFilters);
             RefreshAssetFilterCommand = new AnonymousCommand<AssetFilterViewModel>(serviceProvider, RefreshAssetFilter);
-            currentAssetFilters.CollectionChanged += (s,e) => RefreshFilters();
+            currentAssetFilters.CollectionChanged += (s, e) => RefreshFilters();
             SelectedLocations.CollectionChanged += SelectedLocationCollectionChanged;
             filteredAssets.CollectionChanged += FilteredAssetsCollectionChanged;
             selectedContent.CollectionChanged += SelectedContentCollectionChanged;
@@ -473,7 +471,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             base.Destroy();
         }
 
-        public async Task<List<AssetViewModel>> RunAssetTemplate(ITemplateDescriptionViewModel template, IEnumerable<UFile> files, PropertyContainer? customParameters = null)
+        public async Task<List<AssetViewModel>> RunAssetTemplate(ITemplateDescriptionViewModel template, IList<UFile> files, PropertyContainer? customParameters = null)
         {
             if (template == null)
                 return new List<AssetViewModel>();
@@ -537,31 +535,99 @@ namespace Stride.Core.Assets.Editor.ViewModel
             }
         }
 
-        private async Task<List<AssetViewModel>> InvokeAddAssetTemplate(LoggerResult logger, string name, DirectoryBaseViewModel directory, TemplateAssetDescription templateDescription, IEnumerable<UFile> files, PropertyContainer? customParameters)
+        private async Task<string> GetAssetCopyDirectory(DirectoryBaseViewModel directory, UFile file)
+        {
+            string path = directory.Path;
+            var message = Tr._p("Message", "Do you want to place the resource in the default location ?").ToFormat(file.FullPath);
+            string finalPath = directory.Package.Package.ResourceFolders[0] + "/" + path + file.GetFileName();
+            var pathResult = await Dialogs.MessageBox(message, MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (pathResult == MessageBoxResult.No)
+            {
+                bool done = false;
+                do
+                {
+                    var fileDialog = Dialogs.CreateFileSaveModalDialog();
+                    fileDialog.Filters = new List<FileDialogFilter>() { new FileDialogFilter("", file.GetFileExtension()) };
+                    fileDialog.InitialDirectory = directory.Package.Package.ResourceFolders.FirstOrDefault().FullPath.Replace("/", "\\");
+                    fileDialog.DefaultFileName = file.GetFileName();
+                    DialogResult result = await fileDialog.ShowModal();
+
+                    // If the user closes the dialog, assume that they want to use the default directory
+                    if (result != DialogResult.Ok)
+                    {
+                        done = true;
+                    }
+                    else
+                    {
+                        var fullPath = Path.GetFullPath(fileDialog.FilePath).Replace("\\", "/");
+
+                        bool inResource = directory.Package.Package.ResourceFolders.Any(x => fullPath.StartsWith(x.FullPath));
+                        if (inResource)
+                        {
+                            finalPath = fullPath;
+                            done = true;
+                        }
+                        else
+                        {
+                            message = Tr._p("Message", "The selected directory is not a subdirectory of the resources folder!");
+                            await Dialogs.MessageBox(message, MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+
+                } while (!done);
+            }
+            return finalPath;
+        }
+
+        private async Task<List<AssetViewModel>> InvokeAddAssetTemplate(LoggerResult logger, string name, DirectoryBaseViewModel directory, TemplateAssetDescription templateDescription, IList<UFile> files, PropertyContainer? customParameters)
         {
             List<AssetViewModel> newAssets = new List<AssetViewModel>();
             if (files is not null)
             {
-                foreach (var file in files)
+                for (int i = 0; i < files.Count(); i++)
                 {
-                    bool inResourceFolder = false;
-                    foreach (var resourceFolder in directory.Package.Package.ResourceFolders)
-                    {
-                        if (file.FullPath.StartsWith(resourceFolder.FullPath))
-                        {
-                            inResourceFolder = true;
-                            break;
-                        }
-                    }
+                    var file = files[i];
+                    bool inResourceFolder = directory.Package.Package.ResourceFolders.Any(x => file.FullPath.StartsWith(x.FullPath));
 
                     if (inResourceFolder == false)
                     {
-                        var message = Tr._p("Message", "Source file '{0}' is not inside any of your project's resource folders, import anyway ?");
-                        message = string.Format(message, file.FullPath);
+                        var message = Tr._p("Message", "Source file '{0}' is not inside of your project's resource folders, do you want to copy it?").ToFormat(file.FullPath);
 
-                        var result = await Dialogs.MessageBox(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
-                        if (result == MessageBoxResult.No)
-                            return newAssets;
+                        var copyResult = await Dialogs.MessageBox(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
+
+                        if (copyResult == MessageBoxResult.Yes)
+                        {
+                            string finalPath = await GetAssetCopyDirectory(directory, file);
+
+                            try
+                            {
+                                Directory.CreateDirectory(Path.GetDirectoryName(finalPath));
+                                if (File.Exists(finalPath))
+                                {
+                                    message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(file.FullPath);
+
+                                    copyResult = await Dialogs.MessageBox(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                                    
+                                    // Abort if the user says no or closes the prompt
+                                    if (copyResult != MessageBoxResult.Yes)
+                                    {
+                                        return newAssets;
+                                    }
+                                    File.Delete(finalPath);
+                                }                                
+                                
+                                File.Copy(file.FullPath, finalPath);
+                                files[i] = new UFile(finalPath);
+                            }
+                            catch (Exception ex)
+                            {
+                                message = Tr._p("Message", $"An error occurred while copying the asset to the resources folder : {ex.Message}");
+                                await Dialogs.MessageBox(message, MessageBoxButton.OK, MessageBoxImage.Error);
+                                return newAssets;
+                            }
+
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION
# PR Details

This pull request adds a prompt to copy imported assets to the Resources directory directly from the editor.

## Description
- I added a prompt asking if the user wishes to copy the file they imported to the Resources directory.
- If they say yes, another prompt asks them if they want to copy it to the default directory, if they say yes, it will copy it to the default Resources directory following the structure of the Assets dir (if they import the file TheSong.mp3 in Assets/Music the resource would get copied to Resources/Music/TheSong.mp3), else, a save file dialog will appear allowing them to choose where in the resources directory they want to place the file.
- If they say no, the file will get imported as is.
- If the resource already exists, a prompt will appear allowing them to either override the file, either cancel the operation.

## Related Issue
#1633 

## Motivation and Context

This change will avoid new users breaking their projects by incorrectly importing their assets. This improvement makes the workflow more intuitive.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My change requires a change to the documentation. 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.