### PR TITLE
iOS Project Template Updated to Support .NET 6

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.iOS/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.iOS/$ProjectName$.csproj.t4
@@ -1,51 +1,28 @@
 <#@ template inherits="ProjectTemplateTransformation" language="C#" #>
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{<#= ProjectGuid.ToString().ToUpperInvariant() #>}</ProjectGuid>
-    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFramework><#= Properties.TargetFramework #></TargetFramework>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <RootNamespace><#= Properties.Namespace #></RootNamespace>
-    <AssemblyName><#= Properties.PackageNameCode #></AssemblyName>
-    <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+    
+    <OutputPath>..\Bin\iOS\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <ApplicationId><#= Properties.PackageGameName #></ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+	  
     <!-- Force msbuild to check to rebuild this assembly instead of letting VS IDE guess -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  
+    <!-- Let Stride generate Properties/AssemblyInfo.cs instead -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-<#@ include file="..\Common.PropertyGroups.targets.t4" #>
+  
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Xamarin.iOS" />
+    <ProjectReference Include="..\<#= Properties.ProjectGameRelativePath #>" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\<#= Properties.ProjectGameRelativePath #>">
-      <Project>{<#= Properties.ProjectGameGuid #>}</Project>
-      <Name><#= Properties.PackageGameAssemblyName #></Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="<#= Properties.PackageGameNameShort #>AppDelegate.cs" />
-    <None Include="Info.plist" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BundleResource Include="Resources\Icon.png" />
-    <BundleResource Include="Resources\Icon@2x.png" />
-    <BundleResource Include="Resources\Icon-60@2x.png" />
-    <BundleResource Include="Resources\Default-568h@2x.png" />
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-    Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

The iOS .csproj template does not support .NET Core, this results in various exceptions when generating iOS projects with Stride 4.1.

## Description

<!--- Describe your changes in detail -->
The template file was updated to support .NET Core/6.0, GenerateAssemblyInfo is false to avoid build conflicts with the Stride generated AssemblyInfo file.

## Related Issue
https://github.com/stride3d/stride/issues/1414

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.