### PR TITLE
[Serialization][Editor] Reference type support on interface fields and properties

### DIFF
--- a/sources/assets/Stride.Core.Assets/Serializers/IdentifiableObjectSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/IdentifiableObjectSerializer.cs
@@ -97,8 +97,10 @@ namespace Stride.Core.Assets.Serializers
                 // Return default(T)
                 //return !context.Descriptor.Type.IsValueType ? null : Activator.CreateInstance(context.Descriptor.Type);
                 // Return temporary proxy instance
-                var proxy = (IIdentifiable)AbstractObjectInstantiator.CreateConcreteInstance(context.Descriptor.Type);
-                proxy.Id = identifier;
+                var proxy = AbstractObjectInstantiator.CreateConcreteInstance(context.Descriptor.Type);
+                // Filtering out interface and abstracts here as they're using a proxy type which doesn't have Id implemented
+                if (context.Descriptor.Type.IsInterface == false && context.Descriptor.Type.IsAbstract == false && proxy is IIdentifiable identifiable)
+                    identifiable.Id = identifier;
                 return proxy;
             }
 

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityPickerWindow.xaml.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityPickerWindow.xaml.cs
@@ -72,7 +72,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Views
             if (editor == null) throw new ArgumentNullException(nameof(editor));
 
             InitializeComponent();
-            if (targetType != null && typeof(EntityComponent).IsAssignableFrom(targetType))
+            if (targetType != null && (typeof(EntityComponent).IsAssignableFrom(targetType) || targetType.IsAbstract))
             {
                 ComponentType = targetType;
                 Width *= 2;
@@ -120,7 +120,8 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Views
 
             if (ComponentType != null)
             {
-                return ComponentType.IsInstanceOfType(((EntityHierarchyItemViewModelWrapper)SelectedEntity).SelectedComponent?.Item2);
+                // Do not use IsInstanceOfType, it will fail when 'ComponentType' is an interface
+                return ComponentType.IsAssignableFrom(((EntityHierarchyItemViewModelWrapper)SelectedEntity).SelectedComponent?.Item2.GetType());
             }
 
             return true;

--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Commands/PickupEntityComponentCommand.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Commands/PickupEntityComponentCommand.cs
@@ -6,7 +6,7 @@ using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Presentation.Quantum.Presenters;
 using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewModels;
 using Stride.Assets.Presentation.SceneEditor.Services;
-using Stride.Assets.Presentation.ViewModel.Commands;
+using Stride.Core.Extensions;
 using Stride.Engine;
 
 namespace Stride.Assets.Presentation.NodePresenters.Commands
@@ -33,7 +33,10 @@ namespace Stride.Assets.Presentation.NodePresenters.Commands
         /// <inheritdoc/>
         public override bool CanAttach(INodePresenter nodePresenter)
         {
-            return typeof(EntityComponent).IsAssignableFrom(nodePresenter.Type);
+            if (typeof(EntityComponent).IsAssignableFrom(nodePresenter.Type))
+                return true;
+
+            return nodePresenter.Type.IsInterface && nodePresenter.Type.IsImplementedOnAny<EntityComponent>();
         }
 
         /// <inheritdoc/>

--- a/sources/editor/Stride.Assets.Presentation/SceneEditor/Services/StrideDialogService.cs
+++ b/sources/editor/Stride.Assets.Presentation/SceneEditor/Services/StrideDialogService.cs
@@ -25,7 +25,7 @@ namespace Stride.Assets.Presentation.SceneEditor.Services
         public IEntityPickerDialog CreateEntityComponentPickerDialog(EntityHierarchyEditorViewModel editor, Type componentType)
         {
             if (editor == null) throw new ArgumentNullException(nameof(editor));
-            if (!typeof(EntityComponent).IsAssignableFrom(componentType))
+            if (!typeof(EntityComponent).IsAssignableFrom(componentType) && componentType.IsAbstract == false)
                 throw new ArgumentException(@"The given component type does not inherit from EntityComponent.", nameof(componentType));
 
             var picker = new EntityPickerWindow(editor, componentType);

--- a/sources/editor/Stride.Assets.Presentation/TemplateProviders/EntityComponentReferenceTemplateProvider.cs
+++ b/sources/editor/Stride.Assets.Presentation/TemplateProviders/EntityComponentReferenceTemplateProvider.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Extensions;
 using Stride.Engine;
 using Stride.Core.Presentation.Quantum;
 using Stride.Core.Presentation.Quantum.View;
@@ -13,7 +15,13 @@ namespace Stride.Assets.Presentation.TemplateProviders
 
         public override bool MatchNode(NodeViewModel node)
         {
-            return typeof(EntityComponent).IsAssignableFrom(node.Type) && node.Parent?.Type != typeof(EntityComponentCollection);
+            if (node.Parent?.Type == typeof(EntityComponentCollection))
+                return false;
+
+            if (typeof(EntityComponent).IsAssignableFrom(node.Type))
+                return true;
+
+            return node.Type.IsInterface && node.Type.IsImplementedOnAny<EntityComponent>();
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
@@ -60,7 +60,7 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
         protected override void UpdateNode(IAssetNodePresenter node)
         {
             var type = node.Descriptor.GetInnerCollectionType();
-            if (type.IsAbstract && !IsReferenceType(type) && !node.IsObjectReference(node.Value) && IsInstantiable(type))
+            if (type.IsAbstract && !IsReferenceType(type) && IsInstantiable(type))
             {
                 var abstractNodeEntries = FillDefaultAbstractNodeEntry(node);
                 node.AttachedProperties.Add(AbstractNodeEntryData.Key, abstractNodeEntries);

--- a/sources/presentation/Stride.Core.Presentation/View/TemplateProviderSelector.cs
+++ b/sources/presentation/Stride.Core.Presentation/View/TemplateProviderSelector.cs
@@ -141,7 +141,7 @@ namespace Stride.Core.Presentation.View
 
             lastContainers.Remove(item);
 
-            var availableSelectors = templateProviders.Where(x => x.Match(item)).ToList();
+            var availableSelectors = templateProviders.Where(x => x.Match(item));
 
             var result = availableSelectors.FirstOrDefault(x => !usedProvidersForItem.Contains(x.Name));
 


### PR DESCRIPTION
# PR Details
Previously, interface fields and properties were treated as value types in the editor, having such a field would show a combo box where the user could select the type of field they wanted to create.
Now components marked with an interface can be assigned to a field of that interface type on another component, enabling more complex gameplay architecture.

https://github.com/stride3d/stride/assets/5742236/b3081938-e9d7-42df-9dc9-e3c1ad85d464

The serialization already mostly supported this feature, just had to change how `IdentifiableObjectSerializer` operates slightly.

## Related Issue
Fixes #764

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.