### PR TITLE
[Editor] Log viewer shows stacktrace by default

### DIFF
--- a/sources/presentation/Stride.Core.Presentation/Controls/TextLogViewer.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/TextLogViewer.cs
@@ -148,7 +148,7 @@ namespace Stride.Core.Presentation.Controls
         /// <summary>
         /// Identifies the <see cref="ShowStacktrace"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty ShowStacktraceProperty = DependencyProperty.Register("ShowStacktrace", typeof(bool), typeof(TextLogViewer), new PropertyMetadata(BooleanBoxes.FalseBox, TextPropertyChanged));
+        public static readonly DependencyProperty ShowStacktraceProperty = DependencyProperty.Register("ShowStacktrace", typeof(bool), typeof(TextLogViewer), new PropertyMetadata(BooleanBoxes.TrueBox, TextPropertyChanged));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextLogViewer"/> class.


### PR DESCRIPTION
# PR Details
Stacktrace are always hidden by default in the editor logger, UX is not there yet to properly convey to the user that they should press on the `(...)` button to show it, so let's turn it on by default.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.