### PR TITLE
[Core] Fix StringComparison across the project

### DIFF
--- a/samples/Tests/SampleTestFixture.cs
+++ b/samples/Tests/SampleTestFixture.cs
@@ -91,7 +91,7 @@ namespace Stride.Samples.Tests
             if (!generator.Run(parameters))
                 logger.Error("Run returned false for the TemplateSampleGenerator");
 
-            var updaterTemplate = strideTemplates.First(x => x.FullPath.ToString().EndsWith("UpdatePlatforms.sdtpl"));
+            var updaterTemplate = strideTemplates.First(x => x.FullPath.ToString().EndsWith("UpdatePlatforms.sdtpl", StringComparison.Ordinal));
             parameters.Description = updaterTemplate;
 
             if (logger.HasErrors)

--- a/sources/assets/Stride.Core.Assets.Yaml/DynamicYaml/DynamicYamlMapping.cs
+++ b/sources/assets/Stride.Core.Assets.Yaml/DynamicYaml/DynamicYamlMapping.cs
@@ -357,23 +357,23 @@ namespace Stride.Core.Yaml
                 var scalar = keyValue.Key as YamlScalarNode;
                 if (scalar?.Value != null)
                 {
-                    var isPostFixNew = scalar.Value.EndsWith(OverridePostfixes.PostFixNewText);
-                    var isPostFixSealed = scalar.Value.EndsWith(OverridePostfixes.PostFixSealedText);
+                    var isPostFixNew = scalar.Value.EndsWith(OverridePostfixes.PostFixNewText, StringComparison.Ordinal);
+                    var isPostFixSealed = scalar.Value.EndsWith(OverridePostfixes.PostFixSealedText, StringComparison.Ordinal);
                     if (isPostFixNew || isPostFixSealed)
                     {
                         var name = scalar.Value;
                         var type = isPostFixNew ? OverrideType.New : OverrideType.Sealed;
 
-                        var isPostFixNewSealedAlt = name.EndsWith(OverridePostfixes.PostFixNewSealedAlt);
-                        var isPostFixNewSealed = name.EndsWith(OverridePostfixes.PostFixNewSealed);
+                        var isPostFixNewSealedAlt = name.EndsWith(OverridePostfixes.PostFixNewSealedAlt, StringComparison.Ordinal);
+                        var isPostFixNewSealed = name.EndsWith(OverridePostfixes.PostFixNewSealed, StringComparison.Ordinal);
                         if (isPostFixNewSealed || isPostFixNewSealedAlt)
                         {
                             type = OverrideType.New | OverrideType.Sealed;
-                            name = name.Substring(0, name.Length - 2);
+                            name = name[..^2];
                         }
                         else
                         {
-                            name = name.Substring(0, name.Length - 1);
+                            name = name[..^1];
                         }
                         if (keyMapping == null)
                         {

--- a/sources/assets/Stride.Core.Assets/IO/FileExtensionCollection.cs
+++ b/sources/assets/Stride.Core.Assets/IO/FileExtensionCollection.cs
@@ -86,14 +86,14 @@ namespace Stride.Core.Assets.IO
             if (extension.Contains(";") || extension.Contains(","))
                 throw new ArgumentException("Expecting a single extension");
 
-            if (extension.StartsWith("*."))
+            if (extension.StartsWith("*.", StringComparison.Ordinal))
             {
-                extension = extension.Substring(1);
+                extension = extension[1..];
             }
             if (extension.Any(x => x != '*' & Path.GetInvalidFileNameChars().Contains(x)))
                 throw new ArgumentException("Extension contains invalid characters");
 
-            if (!extension.StartsWith("."))
+            if (!extension.StartsWith('.'))
             {
                 extension = $".{extension}";
             }

--- a/sources/assets/Stride.Core.Assets/IO/FileUtility.cs
+++ b/sources/assets/Stride.Core.Assets/IO/FileUtility.cs
@@ -66,7 +66,7 @@ namespace Stride.Core.Assets
             }
 
             fileExtension = fileExtension.ToLowerInvariant();
-            if (fileExtension.StartsWith("."))
+            if (fileExtension.StartsWith('.'))
             {
                 return fileExtension;
             }

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -511,14 +511,14 @@ namespace Stride.Core.Assets
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    if (line.StartsWith("!Package"))
+                    if (line.StartsWith("!Package", StringComparison.Ordinal))
                     {
                         hasPackage = true;
                     }
 
-                    if (hasPackage && line.StartsWith("Id:"))
+                    if (hasPackage && line.StartsWith("Id:", StringComparison.Ordinal))
                     {
-                        var id = line.Substring("Id:".Length).Trim();
+                        var id = line["Id:".Length..].Trim();
                         return Guid.Parse(id);
                     }
                 }
@@ -1220,7 +1220,7 @@ namespace Stride.Core.Assets
                     foreach (var filePath in files)
                     {
                         // Don't load package via this method
-                        if (filePath.FullName.EndsWith(PackageFileExtension))
+                        if (filePath.FullName.EndsWith(PackageFileExtension, StringComparison.Ordinal))
                         {
                             continue;
                         }

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -1220,7 +1220,7 @@ namespace Stride.Core.Assets
                     foreach (var filePath in files)
                     {
                         // Don't load package via this method
-                        if (filePath.FullName.EndsWith(PackageFileExtension, StringComparison.Ordinal))
+                        if (filePath.FullName.EndsWith(PackageFileExtension, StringComparison.OrdinalIgnoreCase))
                         {
                             continue;
                         }

--- a/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
+++ b/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
@@ -361,7 +361,7 @@ namespace Stride.Core.Assets
                 throw new ArgumentException("Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), "item");
             }
 
-            if (location.GetDirectory() != null && location.GetDirectory().StartsWith(".."))
+            if (location.GetDirectory() != null && location.GetDirectory().StartsWith("..", StringComparison.Ordinal))
             {
                 throw new ArgumentException("Asset location [{0}] cannot start with relative '..'".ToFormat(location), "item");
             }

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -355,7 +355,7 @@ namespace Stride.Core.Assets
                                 // Build list of assemblies
                                 foreach (var a in targetLibrary.RuntimeAssemblies)
                                 {
-                                    if (!a.Path.EndsWith("_._") && !a.Path.Contains("/native/"))
+                                    if (!a.Path.EndsWith("_._", StringComparison.Ordinal) && !a.Path.Contains("/native/"))
                                     {
                                         var assemblyFile = Path.Combine(libraryPath, a.Path.Replace('/', Path.DirectorySeparatorChar));
                                         projectDependency.Assemblies.Add(assemblyFile);
@@ -363,7 +363,7 @@ namespace Stride.Core.Assets
                                 }
                                 foreach (var a in targetLibrary.RuntimeTargets)
                                 {
-                                    if (!a.Path.EndsWith("_._") && !a.Path.Contains("/native/"))
+                                    if (!a.Path.EndsWith("_._", StringComparison.Ordinal) && !a.Path.Contains("/native/"))
                                     {
                                         var assemblyFile = Path.Combine(libraryPath, a.Path.Replace('/', Path.DirectorySeparatorChar));
                                         projectDependency.Assemblies.Add(assemblyFile);

--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -36,7 +36,7 @@ namespace Stride.Core.Assets
             if (MSBuildInstance == null && Interlocked.Increment(ref MSBuildLocatorCount) == 1)
             {
                 // Detect either .NET Core SDK or Visual Studio depending on current runtime
-                var isNETCore = !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
+                var isNETCore = !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.Ordinal);
                 MSBuildInstance = MSBuildLocator.QueryVisualStudioInstances().FirstOrDefault(x => isNETCore
                     ? x.DiscoveryType == DiscoveryType.DotNetSdk && x.Version.Major == 6
                     : (x.DiscoveryType == DiscoveryType.VisualStudioSetup || x.DiscoveryType == DiscoveryType.DeveloperConsole) && x.Version.Major >= 16);

--- a/sources/assets/Stride.Core.Assets/Serializers/IdentifiableObjectSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/IdentifiableObjectSerializer.cs
@@ -32,7 +32,7 @@ namespace Stride.Core.Assets.Serializers
             if (objectContext.Reader.Accept<Scalar>())
             {
                 var next = objectContext.Reader.Peek<Scalar>();
-                if (next.Value.StartsWith(Prefix))
+                if (next.Value.StartsWith(Prefix, StringComparison.Ordinal))
                 {
                     return scalarRedirectSerializer.ReadYaml(ref objectContext);
                 }
@@ -66,7 +66,7 @@ namespace Stride.Core.Assets.Serializers
 
         private static bool TryParse(string text, out Guid identifier)
         {
-            if (!text.StartsWith(Prefix))
+            if (!text.StartsWith(Prefix, StringComparison.Ordinal))
             {
                 identifier = Guid.Empty;
                 return false;

--- a/sources/assets/Stride.Core.Assets/XenkoToStrideRenameHelper.cs
+++ b/sources/assets/Stride.Core.Assets/XenkoToStrideRenameHelper.cs
@@ -64,7 +64,7 @@ namespace Stride.Core.Assets
 
             // Rename extension
             var extension = Path.GetExtension(filePath);
-            if (extension.StartsWith(".xk"))
+            if (extension.StartsWith(".xk", StringComparison.Ordinal))
             {
                 File.Move(filePath, filePath = filePath.Replace(".xk", ".sd"));
             }

--- a/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
@@ -336,7 +336,7 @@ namespace Stride.Core.Yaml
                 var overrideType = OverrideType.Base;
                 if (realName.Length != namePart.Length)
                 {
-                    if (namePart.Contains(OverridePostfixes.PostFixNewSealed) || namePart.EndsWith(OverridePostfixes.PostFixNewSealedAlt))
+                    if (namePart.Contains(OverridePostfixes.PostFixNewSealed) || namePart.EndsWith(OverridePostfixes.PostFixNewSealedAlt, StringComparison.Ordinal))
                     {
                         overrideType = OverrideType.New | OverrideType.Sealed;
                     }

--- a/sources/assets/Stride.Core.Assets/Yaml/ErrorRecoverySerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/ErrorRecoverySerializer.cs
@@ -100,7 +100,7 @@ namespace Stride.Core.Yaml
                     string assemblyName = null;
                     if (tag != null)
                     {
-                        var tagAsType = tag.StartsWith("!") ? tag.Substring(1) : tag;
+                        var tagAsType = tag.StartsWith('!') ? tag[1..] : tag;
                         objectContext.SerializerContext.ParseType(tagAsType, out typeName, out assemblyName);
                     }
 

--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -87,7 +87,7 @@ namespace Stride.Core.Packages
                 {
                     var path = packageSource.GetValueAsPath();
 
-                    if (packageSource.Key.StartsWith(prefixName))
+                    if (packageSource.Key.StartsWith(prefixName, StringComparison.Ordinal))
                     {
                         // Remove entry from packageSources
                         settings.Remove("packageSources", packageSource);
@@ -105,7 +105,7 @@ namespace Stride.Core.Packages
                 {
                     var path = packageSource.GetValueAsPath();
 
-                    if (packageSource.Key.StartsWith(prefixName)
+                    if (packageSource.Key.StartsWith(prefixName, StringComparison.Ordinal)
                         && Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.IsFile // make sure it's a valid file URI
                         && !Directory.Exists(path)) // detect if directory has been deleted
                     {
@@ -729,12 +729,12 @@ namespace Stride.Core.Packages
         {
             return package.Version < new PackageVersion(3, 1, 0, 0)
                 ? File.Exists(GetRedirectFile(package))
-                : (package.Version.SpecialVersion != null && package.Version.SpecialVersion.StartsWith("dev") && !package.Version.SpecialVersion.Contains('.'));
+                : (package.Version.SpecialVersion != null && package.Version.SpecialVersion.StartsWith("dev", StringComparison.Ordinal) && !package.Version.SpecialVersion.Contains('.'));
         }
 
         public bool IsDevRedirectPackage(NugetServerPackage package)
         {
-            return (package.Version.SpecialVersion != null && package.Version.SpecialVersion.StartsWith("dev") && !package.Version.SpecialVersion.Contains('.'));
+            return (package.Version.SpecialVersion != null && package.Version.SpecialVersion.StartsWith("dev", StringComparison.Ordinal) && !package.Version.SpecialVersion.Contains('.'));
         }
 
         private void OnPackageInstalled(object sender, PackageOperationEventArgs args)

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/AssemblyHash.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/AssemblyHash.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
@@ -57,7 +59,7 @@ namespace Stride.Core.BuildEngine
             {
                 // Avoid processing system assemblies
                 // TODO: Scan what is actually in framework folders (and unify it with ProcessDataSerializerGlobalAttributes)
-                if (referencedAssemblyName.Name == "mscorlib" || referencedAssemblyName.Name.StartsWith("System")
+                if (referencedAssemblyName.Name == "mscorlib" || referencedAssemblyName.Name.StartsWith("System", StringComparison.Ordinal)
                     || referencedAssemblyName.FullName.Contains("PublicKeyToken=31bf3856ad364e35")) // Signed with Microsoft public key (likely part of system libraries)
                     continue;
 

--- a/sources/core/Stride.Core.Design/IO/UPath.cs
+++ b/sources/core/Stride.Core.Design/IO/UPath.cs
@@ -61,7 +61,7 @@ namespace Stride.Core.IO
         /// <param name="isDirectory">if set to <c>true</c> the filePath is considered as a directory and not a filename.</param>
         internal UPath(string filePath, bool isDirectory)
         {
-            if (!isDirectory && filePath != null && (filePath.EndsWith(DirectorySeparatorString) || filePath.EndsWith(DirectorySeparatorStringAlt) || filePath.EndsWith(Path.VolumeSeparatorChar)))
+            if (!isDirectory && filePath != null && (filePath.EndsWith(DirectorySeparatorChar) || filePath.EndsWith(DirectorySeparatorCharAlt) || filePath.EndsWith(Path.VolumeSeparatorChar)))
             {
                 throw new ArgumentException("A file path cannot end with with directory char '\\' or '/', or a volume separator ':'.");
             }

--- a/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
+++ b/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
@@ -287,7 +287,7 @@ namespace Stride.Core.Reflection
                                         .Select(runtime => Path.Combine(globalPackagesFolder, library.Path, "runtimes", runtime))
                                         .Where(Directory.Exists)
                                         .SelectMany(folder => Directory.EnumerateDirectories(Path.Combine(folder, "lib")))
-                                        .FirstOrDefault(file => Path.GetFileName(file).StartsWith("net")); // Only consider framework netXX and netstandardX.X
+                                        .FirstOrDefault(file => Path.GetFileName(file).StartsWith("net", StringComparison.Ordinal)); // Only consider framework netXX and netstandardX.X
                                     if (runtimeFolder != null)
                                     {
                                         foreach (var runtimeFile in Directory.EnumerateFiles(runtimeFolder, "*.dll"))

--- a/sources/core/Stride.Core.Design/VisualStudio/Project.cs
+++ b/sources/core/Stride.Core.Design/VisualStudio/Project.cs
@@ -214,10 +214,10 @@ namespace Stride.Core.VisualStudio
                 // Example: "{GUID}|Infra.dll;{GUID2}|Services.dll;"
                 var propertyItem = sections["WebsiteProperties"].Properties["ProjectReferences"];
                 var value = propertyItem.Value;
-                if (value.StartsWith("\""))
-                    value = value.Substring(1);
-                if (value.EndsWith("\""))
-                    value = value.Substring(0, value.Length - 1);
+                if (value.StartsWith('\"'))
+                    value = value[1..];
+                if (value.EndsWith('\"'))
+                    value = value[..^1];
 
                 foreach (var dependency in value.Split(';'))
                 {

--- a/sources/core/Stride.Core.Design/VisualStudio/SolutionReader.cs
+++ b/sources/core/Stride.Core.Design/VisualStudio/SolutionReader.cs
@@ -237,7 +237,7 @@ namespace Stride.Core.VisualStudio
 
         private void ReadGlobal()
         {
-            for (var line = ReadLine(); !line.StartsWith("EndGlobal"); line = ReadLine())
+            for (var line = ReadLine(); !line.StartsWith("EndGlobal", StringComparison.Ordinal); line = ReadLine())
             {
                 ReadGlobalSection(line);
             }
@@ -297,7 +297,7 @@ namespace Stride.Core.VisualStudio
             {
                 var line = ReadLine();
                 solution.Headers.Add(line);
-                if (line.StartsWith("#"))
+                if (line.StartsWith('#'))
                 {
                     return;
                 }
@@ -332,7 +332,7 @@ namespace Stride.Core.VisualStudio
             var projectGuid = new Guid(match.Groups["PROJECTGUID"].Value.Trim());
 
             var projectSections = new List<Section>();
-            for (var line = ReadLine(); !line.StartsWith("EndProject"); line = ReadLine())
+            for (var line = ReadLine(); !line.StartsWith("EndProject", StringComparison.Ordinal); line = ReadLine())
             {
                 projectSections.Add(ReadProjectSection(line));
             }

--- a/sources/core/Stride.Core.IO/FileSystemProvider.cs
+++ b/sources/core/Stride.Core.IO/FileSystemProvider.cs
@@ -39,7 +39,7 @@ namespace Stride.Core.IO
                 localBasePath = localBasePath.Replace(AltDirectorySeparatorChar, DirectorySeparatorChar);
 
             // Ensure localBasePath ends with a \
-            if (localBasePath != null && !localBasePath.EndsWith(DirectorySeparatorChar.ToString()))
+            if (localBasePath != null && !localBasePath.EndsWith(DirectorySeparatorChar))
                 localBasePath = localBasePath + DirectorySeparatorChar;
         }
 

--- a/sources/core/Stride.Core.Mathematics/ColorExtensions.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorExtensions.cs
@@ -17,7 +17,7 @@ namespace Stride.Core.Mathematics
         /// <returns>True if the string can be converted, false otherwise.</returns>
         public static bool CanConvertStringToRgba([CanBeNull] string stringColor)
         {
-            return stringColor?.StartsWith("#") ?? false;
+            return stringColor?.StartsWith('#') ?? false;
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Stride.Core.Mathematics
             var intValue = 0xFF000000;
             if (stringColor != null)
             {
-                if (stringColor.StartsWith("#"))
+                if (stringColor.StartsWith('#'))
                 {
                     if (stringColor.Length == "#000".Length && uint.TryParse(stringColor.Substring(1, 3), NumberStyles.HexNumber, null, out intValue))
                     {

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
@@ -386,7 +386,7 @@ namespace Stride.Core.Reflection
         protected bool IsMemberToVisit(MemberInfo memberInfo)
         {
             // Remove all SyncRoot from members
-            if (memberInfo is PropertyInfo && memberInfo.Name == "SyncRoot" && memberInfo.DeclaringType != null && (memberInfo.DeclaringType.Namespace ?? string.Empty).StartsWith(SystemCollectionsNamespace))
+            if (memberInfo is PropertyInfo && memberInfo.Name == "SyncRoot" && memberInfo.DeclaringType != null && (memberInfo.DeclaringType.Namespace ?? string.Empty).StartsWith(SystemCollectionsNamespace, StringComparison.Ordinal))
             {
                 return false;
             }

--- a/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
+++ b/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
@@ -49,10 +49,10 @@ namespace Stride.Core.IO
             if (mode == VirtualFileMode.Open)
             {
                 ObjectId objectId;
-                if (url.StartsWith(ObjectIdUrl))
-                    ObjectId.TryParse(url.Substring(ObjectIdUrl.Length), out objectId);
+                if (url.StartsWith(ObjectIdUrl, StringComparison.Ordinal))
+                    ObjectId.TryParse(url[ObjectIdUrl.Length..], out objectId);
                 else if (!contentIndexMap.TryGetValue(url, out objectId))
-                    throw new FileNotFoundException(string.Format("Unable to find the file [{0}]", url));
+                    throw new FileNotFoundException($"Unable to find the file [{url}]");
 
                 var result = objectDatabase.OpenStream(objectId, mode, access, share);
 
@@ -69,7 +69,7 @@ namespace Stride.Core.IO
 
             if (mode == VirtualFileMode.Create)
             {
-                if (url.StartsWith(ObjectIdUrl))
+                if (url.StartsWith(ObjectIdUrl, StringComparison.Ordinal))
                     throw new NotSupportedException();
 
                 var stream = objectDatabase.CreateStream();

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentIndexMap.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentIndexMap.cs
@@ -111,7 +111,7 @@ namespace Stride.Core.Serialization.Contents
             while ((line = reader.ReadLine()) != null)
             {
                 line = line.Trim();
-                if (line == string.Empty || line.StartsWith("#"))
+                if (line == string.Empty || line.StartsWith('#'))
                     continue;
 
                 var match = RegexEntry.Match(line);

--- a/sources/core/Stride.Core.Serialization/Storage/BundleOdbBackend.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/BundleOdbBackend.cs
@@ -242,7 +242,7 @@ namespace Stride.Core.Storage
             BundleDescription bundle;
 
             // If there is a .bundle, add incremental id before it
-            var currentBundleExtensionUrl = bundleUrl.Length - (bundleUrl.EndsWith(BundleExtension) ? BundleExtension.Length : 0);
+            var currentBundleExtensionUrl = bundleUrl.Length - (bundleUrl.EndsWith(BundleExtension, StringComparison.Ordinal) ? BundleExtension.Length : 0);
 
             // Process incremental bundles one by one
             using (var packStream = VirtualFileSystem.OpenStream(bundleUrl, VirtualFileMode.Open, VirtualFileAccess.Read))
@@ -441,7 +441,7 @@ namespace Stride.Core.Storage
             var incrementalBundles = new List<ObjectId>();
 
             // If there is a .bundle, add incremental id before it
-            var bundleExtensionLength = (bundleUrl.EndsWith(BundleExtension) ? BundleExtension.Length : 0);
+            var bundleExtensionLength = (bundleUrl.EndsWith(BundleExtension, StringComparison.Ordinal) ? BundleExtension.Length : 0);
 
             // Early exit if package didn't change (header-check only)
             if (VirtualFileSystem.FileExists(bundleUrl))
@@ -967,7 +967,7 @@ namespace Stride.Core.Storage
                 // Remove incremental ID from bundle url
                 ObjectId incrementalId;
                 var filename = VirtualFileSystem.GetFileName(bundleUrl);
-                var bundleExtensionLength = filename.EndsWith(BundleExtension) ? BundleExtension.Length : 0;
+                var bundleExtensionLength = filename.EndsWith(BundleExtension, StringComparison.Ordinal) ? BundleExtension.Length : 0;
                 if (filename.Length - bundleExtensionLength >= ObjectId.HashStringLength + 1 && filename[filename.Length - bundleExtensionLength - ObjectId.HashStringLength - 1] == '.'
                     && ObjectId.TryParse(filename.Substring(filename.Length - bundleExtensionLength - ObjectId.HashStringLength, ObjectId.HashStringLength), out incrementalId))
                 {

--- a/sources/core/Stride.Core.Serialization/Storage/BundleOdbBackend.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/BundleOdbBackend.cs
@@ -242,7 +242,7 @@ namespace Stride.Core.Storage
             BundleDescription bundle;
 
             // If there is a .bundle, add incremental id before it
-            var currentBundleExtensionUrl = bundleUrl.Length - (bundleUrl.EndsWith(BundleExtension, StringComparison.Ordinal) ? BundleExtension.Length : 0);
+            var currentBundleExtensionUrl = bundleUrl.Length - (bundleUrl.EndsWith(BundleExtension, StringComparison.OrdinalIgnoreCase) ? BundleExtension.Length : 0);
 
             // Process incremental bundles one by one
             using (var packStream = VirtualFileSystem.OpenStream(bundleUrl, VirtualFileMode.Open, VirtualFileAccess.Read))
@@ -441,7 +441,7 @@ namespace Stride.Core.Storage
             var incrementalBundles = new List<ObjectId>();
 
             // If there is a .bundle, add incremental id before it
-            var bundleExtensionLength = (bundleUrl.EndsWith(BundleExtension, StringComparison.Ordinal) ? BundleExtension.Length : 0);
+            var bundleExtensionLength = (bundleUrl.EndsWith(BundleExtension, StringComparison.OrdinalIgnoreCase) ? BundleExtension.Length : 0);
 
             // Early exit if package didn't change (header-check only)
             if (VirtualFileSystem.FileExists(bundleUrl))
@@ -967,7 +967,7 @@ namespace Stride.Core.Storage
                 // Remove incremental ID from bundle url
                 ObjectId incrementalId;
                 var filename = VirtualFileSystem.GetFileName(bundleUrl);
-                var bundleExtensionLength = filename.EndsWith(BundleExtension, StringComparison.Ordinal) ? BundleExtension.Length : 0;
+                var bundleExtensionLength = filename.EndsWith(BundleExtension, StringComparison.OrdinalIgnoreCase) ? BundleExtension.Length : 0;
                 if (filename.Length - bundleExtensionLength >= ObjectId.HashStringLength + 1 && filename[filename.Length - bundleExtensionLength - ObjectId.HashStringLength - 1] == '.'
                     && ObjectId.TryParse(filename.Substring(filename.Length - bundleExtensionLength - ObjectId.HashStringLength, ObjectId.HashStringLength), out incrementalId))
                 {

--- a/sources/core/Stride.Core.Tasks/Program.cs
+++ b/sources/core/Stride.Core.Tasks/Program.cs
@@ -20,7 +20,7 @@ namespace Stride.Core.Tasks
             {
                 MSBuildLocator.RegisterDefaults();
             }
-            catch (InvalidOperationException e) when (e.Message.StartsWith("No instances of MSBuild could be detected."))
+            catch (InvalidOperationException e) when (e.Message.StartsWith("No instances of MSBuild could be detected.", StringComparison.Ordinal))
             {
                 // When tasks running through build tools throw, it logs an obtuse 'The command [...]/Stride.Core.Tasks.exe [...] exited with code - x'
                 // message requiring the user to dig in the output to figure out what happened.

--- a/sources/core/Stride.Core.Tests/TestProfiler.cs
+++ b/sources/core/Stride.Core.Tests/TestProfiler.cs
@@ -148,7 +148,7 @@ namespace Stride.Core.Tests
                     matchFunction(message);
                 }
 
-                return message.StartsWith(text);
+                return message.StartsWith(text, StringComparison.Ordinal);
             };
         }
 

--- a/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests2.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests2.cs
@@ -1127,7 +1127,7 @@ G_ListCustom: {Name: name4, ~Items: [1, 2, 3, 4, 5, 6, 7]}
             public override string ReadMemberName(ref ObjectContext objectContext, string memberName, out bool skipMember)
             {
                 skipMember = false;
-                if (memberName.EndsWith("!"))
+                if (memberName.EndsWith('!'))
                 {
                     memberName = memberName.Substring(0, memberName.Length - 1);
                     SpecialKeys.Add(new Tuple<object, object>(objectContext.Instance, objectContext.Descriptor[memberName]));
@@ -1138,9 +1138,9 @@ G_ListCustom: {Name: name4, ~Items: [1, 2, 3, 4, 5, 6, 7]}
             public override object ReadDictionaryKey(ref ObjectContext objectContext, Type keyType)
             {
                 var itemKey = base.ReadDictionaryKey(ref objectContext, keyType) as string;
-                if (itemKey != null && itemKey.EndsWith("!"))
+                if (itemKey != null && itemKey.EndsWith('!'))
                 {
-                    itemKey = itemKey.Substring(0, itemKey.Length - 1);
+                    itemKey = itemKey[..^1];
                     SpecialKeys.Add(new Tuple<object, object>(objectContext.Instance, itemKey));
                 }
                 return itemKey;

--- a/sources/core/Stride.Core.Yaml/Serialization/YamlAssemblyRegistry.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/YamlAssemblyRegistry.cs
@@ -159,18 +159,18 @@ namespace Stride.Core.Yaml.Serialization
 
             // Prefix all tags by !
             tag = Uri.EscapeUriString(tag);
-            if (tag.StartsWith("tag:"))
+            if (tag.StartsWith("tag:", StringComparison.Ordinal))
             {
                 // shorten tag
                 // TODO this is not really failsafe
-                var shortTag = "!!" + tag.Substring(tag.LastIndexOf(':') + 1);
+                var shortTag = "!!" + tag[(tag.LastIndexOf(':') + 1)..];
 
                 // Auto register tag to schema
                 schema.RegisterTag(shortTag, tag);
                 tag = shortTag;
             }
 
-            tag = tag.StartsWith("!") ? tag : "!" + tag;
+            tag = tag.StartsWith('!') ? tag : "!" + tag;
 
             lock (lockCache)
             {
@@ -194,7 +194,7 @@ namespace Stride.Core.Yaml.Serialization
             // Get the default schema type if there is any
             var shortTag = schema.ShortenTag(tag);
             Type type;
-            if (shortTag != tag || shortTag.StartsWith("!!"))
+            if (shortTag != tag || shortTag.StartsWith("!!", StringComparison.Ordinal))
             {
                 type = schema.GetTypeForDefaultTag(shortTag);
                 if (type != null)
@@ -217,7 +217,7 @@ namespace Stride.Core.Yaml.Serialization
                 }
 
                 // Else resolve type from assembly
-                var tagAsType = shortTag.StartsWith("!") ? shortTag.Substring(1) : shortTag;
+                var tagAsType = shortTag.StartsWith('!') ? shortTag[1..] : shortTag;
 
                 // Try to resolve the type from registered assemblies
                 type = ResolveType(tagAsType);

--- a/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
+++ b/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
@@ -112,7 +112,7 @@ namespace Stride.Core
                         LoadedLibraries.Add(libraryName, result);
                         return;
                     }
-                    else if (!libraryName.StartsWith(UNIX_LIB_PREFIX)
+                    else if (!libraryName.StartsWith(UNIX_LIB_PREFIX, StringComparison.Ordinal)
                         && NativeLibrary.TryLoad(UNIX_LIB_PREFIX + libraryNameWithExtension, out result))
                     {
                         LoadedLibraries.Add(libraryName, result);

--- a/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
+++ b/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
@@ -76,7 +76,7 @@ namespace Stride.Core.Reflection
         public static Type GetType([NotNull] string fullyQualifiedTypeName, bool throwOnError = true)
         {
             if (fullyQualifiedTypeName == null) throw new ArgumentNullException(nameof(fullyQualifiedTypeName));
-            var assemblyIndex = fullyQualifiedTypeName.IndexOf(",");
+            var assemblyIndex = fullyQualifiedTypeName.IndexOf(',');
             if (assemblyIndex < 0)
             {
                 throw new ArgumentException($"Invalid fulltype name [{fullyQualifiedTypeName}], expecting an assembly name", nameof(fullyQualifiedTypeName));

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameModelSelectionService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameModelSelectionService.cs
@@ -131,7 +131,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
                     {
                         var effectName = renderObject.ActiveRenderStages[index].EffectSelector.EffectName;
                         if (effectName == "StrideForwardShadingEffect"
-                            || effectName.StartsWith("StrideForwardShadingEffect."))
+                            || effectName.StartsWith("StrideForwardShadingEffect.", StringComparison.Ordinal))
                         {
                             effectName = effectName.Replace("StrideForwardShadingEffect", "StrideEditorForwardShadingEffect");
                             renderObject.ActiveRenderStages[index].EffectSelector = new EffectSelector(effectName);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EntityHierarchyEditorGame.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EntityHierarchyEditorGame.cs
@@ -179,8 +179,8 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
                 renderEffect.FallbackParameters = new ParameterCollection(renderMesh.MaterialPass.Parameters);
 
                 // Don't show selection wireframe/highlights as compiling
-                var ignoreState = renderEffect.EffectSelector.EffectName.EndsWith(".Wireframe") || renderEffect.EffectSelector.EffectName.EndsWith(".Highlight") ||
-                                  renderEffect.EffectSelector.EffectName.EndsWith(".Picking");
+                var ignoreState = renderEffect.EffectSelector.EffectName.EndsWith(".Wireframe", StringComparison.Ordinal) || renderEffect.EffectSelector.EffectName.EndsWith(".Highlight", StringComparison.Ordinal) ||
+                                  renderEffect.EffectSelector.EffectName.EndsWith(".Picking", StringComparison.Ordinal);
 
                 // Also set a value so that we know something is loading (green glowing FX) or error (red glowing FX)
                 if (!ignoreState)

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/SpriteEditor/Views/SpriteEditorView.xaml.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/SpriteEditor/Views/SpriteEditorView.xaml.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -21,12 +23,12 @@ namespace Stride.Assets.Presentation.AssetEditors.SpriteEditor.Views
         {
             var executingAssembly = Assembly.GetExecutingAssembly();
             var resources = executingAssembly.GetManifestResourceNames();
-            var stream = executingAssembly.GetManifestResourceStream(resources.First(x => x.EndsWith("ColorPicker.cur")));
+            var stream = executingAssembly.GetManifestResourceStream(resources.First(x => x.EndsWith("ColorPicker.cur", StringComparison.Ordinal)));
             if (stream != null)
             {
                 ColorPickerCursor = new Cursor(stream);
             }
-            stream = executingAssembly.GetManifestResourceStream(resources.First(x => x.EndsWith("MagicWand.cur")));
+            stream = executingAssembly.GetManifestResourceStream(resources.First(x => x.EndsWith("MagicWand.cur", StringComparison.Ordinal)));
             if (stream != null)
             {
                 MagicWandCursor = new Cursor(stream);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/VisualScriptEditorViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/VisualScriptEditorViewModel.cs
@@ -470,7 +470,7 @@ namespace Stride.Assets.Presentation.AssetEditors.VisualScriptEditor
                             if (assembly.Name.Contains("Stride"))
                                 return 1;
 
-                            if (assembly.Name == "mscorlib" || assembly.Name.StartsWith("System"))
+                            if (assembly.Name == "mscorlib" || assembly.Name.StartsWith("System", StringComparison.Ordinal))
                                 return 3;
 
                             return 2;

--- a/sources/editor/Stride.Assets.Presentation/Templates/AssetTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/AssetTemplateGenerator.cs
@@ -122,8 +122,9 @@ namespace Stride.Assets.Presentation.Templates
 
         private static UFile GenerateLocation(string assetName, AssetTemplateGeneratorParameters parameters)
         {
-            var location = assetName.StartsWith(parameters.TargetLocation) ? new UFile(assetName)
-                                    : UPath.Combine(parameters.TargetLocation, new UFile(assetName));
+            var location = assetName.StartsWith(parameters.TargetLocation, StringComparison.Ordinal)
+                ? new UFile(assetName)
+                : UPath.Combine(parameters.TargetLocation, new UFile(assetName));
 
             return NamingHelper.ComputeNewName(location, x => parameters.Package.Assets.Find(x) != null, "{0}_{1}");
         }

--- a/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
@@ -117,7 +117,7 @@ namespace Stride.Assets.Presentation.Templates
                 foreach (var file in directory.GetFiles())
                 {
                     // If the file is ending with the Template extension or a directory with the sample extension, don;t copy it
-                    if (file.FullName.EndsWith(TemplateDescription.FileExtension, StringComparison.Ordinal) ||
+                    if (file.FullName.EndsWith(TemplateDescription.FileExtension, StringComparison.OrdinalIgnoreCase) ||
                         string.Compare(directory.Name, TemplateDescription.FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         continue;
@@ -136,7 +136,7 @@ namespace Stride.Assets.Presentation.Templates
                     var outputFileDirectory = outputFile.GetParent();
 
                     // Determine if we are processing the main game project
-                    var isPackageFile = (projectOutputFile == null && Path.GetExtension(file.FullName).ToLowerInvariant() == ".csproj" && !Path.GetFileNameWithoutExtension(file.FullName).EndsWith(".Windows", StringComparison.Ordinal));
+                    var isPackageFile = (projectOutputFile == null && string.Equals(Path.GetExtension(file.FullName), ".csproj", StringComparison.OrdinalIgnoreCase) && !Path.GetFileNameWithoutExtension(file.FullName).EndsWith(".Windows", StringComparison.OrdinalIgnoreCase));
 
                     if (isPackageFile)
                     {
@@ -188,7 +188,7 @@ namespace Stride.Assets.Presentation.Templates
                         foreach (var file in directory.GetFiles())
                         {
                             // If the file is ending with the Template extension or a directory with the sample extension, don`t copy it
-                            if (file.FullName.EndsWith(TemplateDescription.FileExtension, StringComparison.Ordinal) ||
+                            if (file.FullName.EndsWith(TemplateDescription.FileExtension, StringComparison.OrdinalIgnoreCase) ||
                                 string.Compare(directory.Name, TemplateDescription.FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
                             {
                                 continue;

--- a/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
@@ -117,7 +117,7 @@ namespace Stride.Assets.Presentation.Templates
                 foreach (var file in directory.GetFiles())
                 {
                     // If the file is ending with the Template extension or a directory with the sample extension, don;t copy it
-                    if (file.FullName.EndsWith(TemplateDescription.FileExtension) ||
+                    if (file.FullName.EndsWith(TemplateDescription.FileExtension, StringComparison.Ordinal) ||
                         string.Compare(directory.Name, TemplateDescription.FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         continue;
@@ -136,7 +136,7 @@ namespace Stride.Assets.Presentation.Templates
                     var outputFileDirectory = outputFile.GetParent();
 
                     // Determine if we are processing the main game project
-                    var isPackageFile = (projectOutputFile == null && Path.GetExtension(file.FullName).ToLowerInvariant() == ".csproj" && !Path.GetFileNameWithoutExtension(file.FullName).EndsWith(".Windows"));
+                    var isPackageFile = (projectOutputFile == null && Path.GetExtension(file.FullName).ToLowerInvariant() == ".csproj" && !Path.GetFileNameWithoutExtension(file.FullName).EndsWith(".Windows", StringComparison.Ordinal));
 
                     if (isPackageFile)
                     {
@@ -188,7 +188,7 @@ namespace Stride.Assets.Presentation.Templates
                         foreach (var file in directory.GetFiles())
                         {
                             // If the file is ending with the Template extension or a directory with the sample extension, don`t copy it
-                            if (file.FullName.EndsWith(TemplateDescription.FileExtension) ||
+                            if (file.FullName.EndsWith(TemplateDescription.FileExtension, StringComparison.Ordinal) ||
                                 string.Compare(directory.Name, TemplateDescription.FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
                             {
                                 continue;

--- a/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/NewProjectTemplateCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/NewProjectTemplateCollectionViewModel.cs
@@ -48,8 +48,8 @@ namespace Stride.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels
         private bool IsAssetsOnlyTemplate(TemplateDescription template)
         {
             // TODO We only have two such template for now, so check directly, maybe improve later
-            return template.FullPath.FullPath.EndsWith("ProjectLibrary.sdtpl")
-                || template.FullPath.FullPath.EndsWith("ProjectExecutable.sdtpl");
+            return template.FullPath.FullPath.EndsWith("ProjectLibrary.sdtpl", StringComparison.Ordinal)
+                || template.FullPath.FullPath.EndsWith("ProjectExecutable.sdtpl", StringComparison.Ordinal);
         }
 
         public SessionViewModel Session { get; }

--- a/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/TemplateDescriptionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/TemplateDescriptionViewModel.cs
@@ -63,7 +63,7 @@ namespace Stride.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels
         {
             try
             {
-                if (!path.StartsWith("pack:") && !File.Exists(path))
+                if (!path.StartsWith("pack:", StringComparison.Ordinal) && !File.Exists(path))
                 {
                     return null;
                 }

--- a/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
@@ -112,7 +112,7 @@ namespace Stride.Core.Assets.Editor.Services
             foreach (var process in processes)
             {
                 // Get instances that have a solution with the same name currently open (The solution name is displayed in the title bar).
-                if (process.MainWindowTitle.ToLowerInvariant().StartsWith(solutionPath.GetFileNameWithoutExtension().ToLowerInvariant()))
+                if (process.MainWindowTitle.ToLowerInvariant().StartsWith(solutionPath.GetFileNameWithoutExtension().ToLowerInvariant(), StringComparison.Ordinal))
                 {
                     // If there is a matching instance, get its command line.
                     var query = $"SELECT CommandLine FROM Win32_Process WHERE ProcessId = {process.Id}";
@@ -120,7 +120,7 @@ namespace Stride.Core.Assets.Editor.Services
                     {
                         var managementObject = managementObjectSearcher.Get().Cast<ManagementObject>().First();
                         var commandLine = managementObject["CommandLine"].ToString();
-                        if (commandLine.ToLowerInvariant().Replace("/", "\\").Contains(solutionPath.ToString().ToLowerInvariant().Replace("/", "\\")))
+                        if (commandLine.ToLowerInvariant().Replace("/", "\\").Contains(solutionPath.ToString().ToLowerInvariant().Replace('/', '\\')))
                         {
                             return process;
                         }

--- a/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
@@ -112,7 +112,7 @@ namespace Stride.Core.Assets.Editor.Services
             foreach (var process in processes)
             {
                 // Get instances that have a solution with the same name currently open (The solution name is displayed in the title bar).
-                if (process.MainWindowTitle.ToLowerInvariant().StartsWith(solutionPath.GetFileNameWithoutExtension().ToLowerInvariant(), StringComparison.Ordinal))
+                if (process.MainWindowTitle.StartsWith(solutionPath.GetFileNameWithoutExtension(), StringComparison.OrdinalIgnoreCase))
                 {
                     // If there is a matching instance, get its command line.
                     var query = $"SELECT CommandLine FROM Win32_Process WHERE ProcessId = {process.Id}";
@@ -120,7 +120,7 @@ namespace Stride.Core.Assets.Editor.Services
                     {
                         var managementObject = managementObjectSearcher.Get().Cast<ManagementObject>().First();
                         var commandLine = managementObject["CommandLine"].ToString();
-                        if (commandLine.ToLowerInvariant().Replace("/", "\\").Contains(solutionPath.ToString().ToLowerInvariant().Replace('/', '\\')))
+                        if (commandLine.Replace('/', '\\').Contains(solutionPath.ToString().Replace('/', '\\'), StringComparison.OrdinalIgnoreCase))
                         {
                             return process;
                         }

--- a/sources/editor/Stride.Core.Assets.Editor/Settings/ViewModels/SettingsCategoryViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Settings/ViewModels/SettingsCategoryViewModel.cs
@@ -39,7 +39,7 @@ namespace Stride.Core.Assets.Editor.Settings.ViewModels
             // Get all settings key and sort them by display name
             var settingsKeys = profile.Container.GetAllSettingsKeys();
             var settingsPath = Path;
-            if (!settingsPath.EndsWith("/"))
+            if (!settingsPath.EndsWith('/'))
                 settingsPath += "/";
             int pathLength = settingsPath.Length;
             settingsKeys.Sort(new AnonymousComparer<SettingsKey>((x, y) => x.DisplayName.CompareTo(y.DisplayName)));
@@ -48,7 +48,7 @@ namespace Stride.Core.Assets.Editor.Settings.ViewModels
             foreach (SettingsKey key in settingsKeys)
             {
                 var displayName = key.DisplayName.ToString();
-                if (displayName.StartsWith(settingsPath) && !displayName.Substring(pathLength).Contains("/"))
+                if (displayName.StartsWith(settingsPath, StringComparison.Ordinal) && !displayName[pathLength..].Contains('/'))
                 {
                     var settingsObject = PackageSettingsWrapper.SettingsKeyWrapper.Create(key, profile);
                     settingsList.Add(key.DisplayName.GetFileName(), settingsObject);
@@ -60,7 +60,7 @@ namespace Stride.Core.Assets.Editor.Settings.ViewModels
             foreach (SettingsCommand command in commands)
             {
                 var displayName = command.DisplayName.ToString();
-                if (displayName.StartsWith(settingsPath) && !displayName.Substring(pathLength).Contains("/"))
+                if (displayName.StartsWith(settingsPath, StringComparison.Ordinal) && !displayName[pathLength..].Contains('/'))
                 {
                     settingsList.Add(command.DisplayName.GetFileName(), command);
                 }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -559,7 +559,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
                     var fullPath = Path.GetFullPath(fileDialog.FilePath);
 
-                    bool inResource = directory.Package.Package.ResourceFolders.Any(x => fullPath.StartsWith(Path.GetFullPath(x.FullPath)));
+                    bool inResource = directory.Package.Package.ResourceFolders.Any(x => fullPath.StartsWith(Path.GetFullPath(x.FullPath), StringComparison.Ordinal));
                     if (inResource)
                     {
                         return fullPath;
@@ -580,7 +580,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 for (int i = 0; i < files.Count; i++)
                 {
                     var file = files[i];
-                    bool inResourceFolder = directory.Package.Package.ResourceFolders.Any(x => file.FullPath.StartsWith(x.FullPath));
+                    bool inResourceFolder = directory.Package.Package.ResourceFolders.Any(x => file.FullPath.StartsWith(x.FullPath, StringComparison.Ordinal));
 
                     if (inResourceFolder)
                         continue;
@@ -989,7 +989,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         {
             foreach (var asset in assets)
             {
-                if (asset.AssetItem.Location.HasDirectory && (directory.Parent == null || !asset.Url.StartsWith(directory.Parent.Path)))
+                if (asset.AssetItem.Location.HasDirectory && (directory.Parent == null || !asset.Url.StartsWith(directory.Parent.Path, StringComparison.Ordinal)))
                 {
                     throw new InvalidOperationException("One of the asset does not match the directory hierarchy.");
                 }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/DirectoryViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/DirectoryViewModel.cs
@@ -186,7 +186,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             {
                 var normalized = UPath.Normalize(path);
                 var result = System.IO.Path.GetFullPath(normalized.ToString());
-                if (result.StartsWith("\\\\.\\"))
+                if (result.StartsWith("\\\\.\\", StringComparison.Ordinal))
                 {
                     message = Tr._p("Message", "Path is a device name");  // pipe, CON, NUL, COM1...
                     ok = false;

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -286,7 +286,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             }
 
             var solutionName = !string.IsNullOrWhiteSpace(newSessionParameters.SolutionName) ? newSessionParameters.SolutionName : newSessionParameters.OutputName;
-            solutionName = solutionName.ToLowerInvariant().EndsWith(SolutionExtension) ? solutionName : solutionName + SolutionExtension;
+            solutionName = solutionName.ToLowerInvariant().EndsWith(SolutionExtension, StringComparison.Ordinal) ? solutionName : solutionName + SolutionExtension;
             session.SolutionPath = UPath.Combine<UFile>(solutionDir, solutionName);
             session.VisualStudioVersion = PackageSession.DefaultVisualStudioVersion;
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -286,7 +286,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             }
 
             var solutionName = !string.IsNullOrWhiteSpace(newSessionParameters.SolutionName) ? newSessionParameters.SolutionName : newSessionParameters.OutputName;
-            solutionName = solutionName.ToLowerInvariant().EndsWith(SolutionExtension, StringComparison.Ordinal) ? solutionName : solutionName + SolutionExtension;
+            solutionName = solutionName.EndsWith(SolutionExtension, StringComparison.OrdinalIgnoreCase) ? solutionName : solutionName + SolutionExtension;
             session.SolutionPath = UPath.Combine<UFile>(solutionDir, solutionName);
             session.VisualStudioVersion = PackageSession.DefaultVisualStudioVersion;
 

--- a/sources/editor/Stride.GameStudio/Debugging/AssemblyRecompiler.cs
+++ b/sources/editor/Stride.GameStudio/Debugging/AssemblyRecompiler.cs
@@ -192,27 +192,27 @@ namespace Stride.GameStudio.Debugging
                             foreach (var referencePath in referenceBuildResult.ProjectStateAfterBuild.Items.Where(x => x.ItemType == "ReferencePath"))
                             {
                                 assemblyProcessorApp.References.Add(referencePath.EvaluatedInclude);
-                                if (referencePath.EvaluatedInclude.EndsWith("Stride.SpriteStudio.Runtime.dll")) //todo hard-coded! needs to go when plug in system is in
+                                if (referencePath.EvaluatedInclude.EndsWith("Stride.SpriteStudio.Runtime.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Physics.dll")) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Physics.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Particles.dll")) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Particles.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Native.dll")) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Native.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.UI.dll")) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.UI.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Video.dll")) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Video.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }

--- a/sources/editor/Stride.GameStudio/Debugging/AssemblyRecompiler.cs
+++ b/sources/editor/Stride.GameStudio/Debugging/AssemblyRecompiler.cs
@@ -192,27 +192,27 @@ namespace Stride.GameStudio.Debugging
                             foreach (var referencePath in referenceBuildResult.ProjectStateAfterBuild.Items.Where(x => x.ItemType == "ReferencePath"))
                             {
                                 assemblyProcessorApp.References.Add(referencePath.EvaluatedInclude);
-                                if (referencePath.EvaluatedInclude.EndsWith("Stride.SpriteStudio.Runtime.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
+                                if (referencePath.EvaluatedInclude.EndsWith("Stride.SpriteStudio.Runtime.dll", StringComparison.OrdinalIgnoreCase)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Physics.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Physics.dll", StringComparison.OrdinalIgnoreCase)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Particles.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Particles.dll", StringComparison.OrdinalIgnoreCase)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Native.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Native.dll", StringComparison.OrdinalIgnoreCase)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.UI.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.UI.dll", StringComparison.OrdinalIgnoreCase)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }
-                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Video.dll", StringComparison.Ordinal)) //todo hard-coded! needs to go when plug in system is in
+                                else if (referencePath.EvaluatedInclude.EndsWith("Stride.Video.dll", StringComparison.OrdinalIgnoreCase)) //todo hard-coded! needs to go when plug in system is in
                                 {
                                     assemblyProcessorApp.ReferencesToAdd.Add(referencePath.EvaluatedInclude);
                                 }

--- a/sources/engine/Stride.Assets.Models/ImportModelCommand.Animation.cs
+++ b/sources/engine/Stride.Assets.Models/ImportModelCommand.Animation.cs
@@ -72,14 +72,14 @@ namespace Stride.Assets.Models
 
                             // Root motion
                             var channelName = channel.Key;
-                            if (channelName.StartsWith("Transform."))
+                            if (channelName.StartsWith("Transform.", StringComparison.Ordinal))
                             {
                                 animationClip.AddCurve($"[TransformComponent.Key]." + channelName.Replace("Transform.", string.Empty), curve);
                             }
 
                             // Also apply Camera curves
                             // TODO: Add some other curves?
-                            if (channelName.StartsWith("Camera."))
+                            if (channelName.StartsWith("Camera.", StringComparison.Ordinal))
                             {
                                 animationClip.AddCurve($"[CameraComponent.Key]." + channelName.Replace("Camera.", string.Empty), curve);
                             }
@@ -230,7 +230,7 @@ namespace Stride.Assets.Models
 
                             // TODO: Root motion
                             var channelName = channel.Key;
-                            if (channelName.StartsWith(transformStart))
+                            if (channelName.StartsWith(transformStart, StringComparison.Ordinal))
                             {
                                 if (channelName == transformPosition)
                                 {

--- a/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
+++ b/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -107,12 +108,12 @@ namespace Stride.Assets.Effect
                 var outputDirectory = UPath.Combine(package.RootDirectory, baseUrl);
 
                 var fieldName = compilerParameters.Get(EffectSourceCodeKeys.FieldName);
-                if (fieldName.StartsWith("binary"))
+                if (fieldName.StartsWith("binary", StringComparison.Ordinal))
                 {
                     fieldName = fieldName.Substring("binary".Length);
                     if (char.IsUpper(fieldName[0]))
                     {
-                        fieldName = char.ToLower(fieldName[0]) + fieldName.Substring(1);
+                        fieldName = char.ToLower(fieldName[0]) + fieldName[1..];
                     }
                 }
 

--- a/sources/engine/Stride.Assets/Rendering/GraphicsCompositorAsset.cs
+++ b/sources/engine/Stride.Assets/Rendering/GraphicsCompositorAsset.cs
@@ -134,7 +134,7 @@ namespace Stride.Assets.Rendering
                 YamlNode assetNode = asset.Node;
                 foreach (var node in assetNode.AllNodes)
                 {
-                    if (node.Tag != null && node.Tag.EndsWith(",Stride.Engine")
+                    if (node.Tag != null && node.Tag.EndsWith(",Stride.Engine", StringComparison.Ordinal)
                         // Several types are still in Stride.Engine
                         && node.Tag != "!Stride.Rendering.Compositing.ForwardRenderer,Stride.Engine"
                         && node.Tag != "!Stride.Rendering.Compositing.SceneCameraRenderer,Stride.Engine")

--- a/sources/engine/Stride.Assets/StridePackageUpgrader.NamespaceRenaming.cs
+++ b/sources/engine/Stride.Assets/StridePackageUpgrader.NamespaceRenaming.cs
@@ -33,7 +33,7 @@ namespace Stride.Assets
                     // Search for all source files in project directory
                     foreach (var extension in new[] { new { Extension = ".csproj", Type = XenkoToStrideRenameHelper.StrideContentType.Project }, new { Extension = ".cs", Type = XenkoToStrideRenameHelper.StrideContentType.Code } })
                     {
-                        var files = allFiles.Where(file => file.ToLower().EndsWith(extension.Extension));
+                        var files = allFiles.Where(file => file.ToLower().EndsWith(extension.Extension, StringComparison.Ordinal));
                         foreach (var file in files)
                         {
                             XenkoToStrideRenameHelper.RenameStrideFile(file, extension.Type);

--- a/sources/engine/Stride.Assets/StridePackageUpgrader.NamespaceRenaming.cs
+++ b/sources/engine/Stride.Assets/StridePackageUpgrader.NamespaceRenaming.cs
@@ -33,7 +33,7 @@ namespace Stride.Assets
                     // Search for all source files in project directory
                     foreach (var extension in new[] { new { Extension = ".csproj", Type = XenkoToStrideRenameHelper.StrideContentType.Project }, new { Extension = ".cs", Type = XenkoToStrideRenameHelper.StrideContentType.Code } })
                     {
-                        var files = allFiles.Where(file => file.ToLower().EndsWith(extension.Extension, StringComparison.Ordinal));
+                        var files = allFiles.Where(file => file.EndsWith(extension.Extension, StringComparison.OrdinalIgnoreCase));
                         foreach (var file in files)
                         {
                             XenkoToStrideRenameHelper.RenameStrideFile(file, extension.Type);

--- a/sources/engine/Stride.Assets/StridePackageUpgrader.cs
+++ b/sources/engine/Stride.Assets/StridePackageUpgrader.cs
@@ -164,7 +164,7 @@ namespace Stride.Assets
 
                     foreach (var packageReference in packageReferences)
                     {
-                        if (packageReference.EvaluatedInclude.StartsWith("Stride.") && packageReference.GetMetadataValue("Version") != CurrentVersion)
+                        if (packageReference.EvaluatedInclude.StartsWith("Stride.", StringComparison.Ordinal) && packageReference.GetMetadataValue("Version") != CurrentVersion)
                         {
                             packageReference.SetMetadataValue("Version", CurrentVersion).Xml.ExpressedAsAttribute = true;
                             foreach (var metadata in packageReference.Metadata)
@@ -224,7 +224,7 @@ namespace Stride.Assets
                         {
                             // Library
                             if (tfm.EvaluatedValue == "netstandard2.0"
-                                || (tfm.EvaluatedValue.StartsWith("net4") && solutionProject.Type == ProjectType.Library))
+                                || (tfm.EvaluatedValue.StartsWith("net4", StringComparison.Ordinal) && solutionProject.Type == ProjectType.Library))
                             {
                                 // In case it's a single TargetFramework, add the "s" at the end
                                 tfm.Xml.Name = "TargetFrameworks";
@@ -232,7 +232,7 @@ namespace Stride.Assets
                                 isProjectDirty = true;
                             }
                             // Executable
-                            else if ((tfm.EvaluatedValue.StartsWith("net4") || tfm.EvaluatedValue.StartsWith("net5")) && solutionProject.Type == ProjectType.Executable)
+                            else if ((tfm.EvaluatedValue.StartsWith("net4", StringComparison.Ordinal) || tfm.EvaluatedValue.StartsWith("net5", StringComparison.Ordinal)) && solutionProject.Type == ProjectType.Executable)
                             {
                                 tfm.Xml.Value = solutionProject.Platform == PlatformType.Windows ? "net6.0-windows" : "net6.0";
                                 isProjectDirty = true;

--- a/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
+++ b/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
@@ -196,7 +196,7 @@ namespace Stride.Assets.Templates
             // Special case for sdfx files
             foreach (var file in generatedFiles)
             {
-                if (file.EndsWith(".sdfx", StringComparison.Ordinal))
+                if (file.EndsWith(".sdfx", StringComparison.OrdinalIgnoreCase))
                 {
                     ConvertXkfxToCSharp(file);
                 }

--- a/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
+++ b/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
@@ -72,8 +72,8 @@ namespace Stride.Assets.Templates
 
             // Sample templates still have .Game in their name
             var packageNameWithoutGame = package.Meta.Name;
-            if (packageNameWithoutGame.EndsWith(".Game"))
-                packageNameWithoutGame = packageNameWithoutGame.Substring(0, packageNameWithoutGame.Length - ".Game".Length);
+            if (packageNameWithoutGame.EndsWith(".Game", StringComparison.Ordinal))
+                packageNameWithoutGame = packageNameWithoutGame[..^".Game".Length];
 
             AddOption(parameters, "PackageGameName", packageNameWithoutGame);
             AddOption(parameters, "PackageGameDisplayName", package.Meta.Title ?? packageNameWithoutGame);
@@ -177,8 +177,8 @@ namespace Stride.Assets.Templates
         public static UFile GeneratePlatformProjectLocation(string name, Package package, SolutionPlatform platform)
         {
             // Remove .Game suffix
-            if (name.EndsWith(".Game"))
-                name = name.Substring(0, name.Length - ".Game".Length);
+            if (name.EndsWith(".Game", StringComparison.Ordinal))
+                name = name[..^".Game".Length];
 
             var projectName = Utilities.BuildValidNamespaceName(name) + "." + platform.Name;
             return UPath.Combine(UPath.Combine(package.RootDirectory.GetParent(), (UDirectory)projectName), (UFile)(projectName + ".csproj"));
@@ -196,7 +196,7 @@ namespace Stride.Assets.Templates
             // Special case for sdfx files
             foreach (var file in generatedFiles)
             {
-                if (file.EndsWith(".sdfx"))
+                if (file.EndsWith(".sdfx", StringComparison.Ordinal))
                 {
                     ConvertXkfxToCSharp(file);
                 }

--- a/sources/engine/Stride.Engine/Shaders.Compiler/Internals/NetworkVirtualFileProvider.cs
+++ b/sources/engine/Stride.Engine/Shaders.Compiler/Internals/NetworkVirtualFileProvider.cs
@@ -44,7 +44,7 @@ namespace Stride.Shaders.Compiler.Internals
         {
             this.socketMessageLayer = socketMessageLayer;
             RemoteUrl = remoteUrl;
-            if (!RemoteUrl.EndsWith(VirtualFileSystem.DirectorySeparatorChar.ToString()))
+            if (!RemoteUrl.EndsWith(VirtualFileSystem.DirectorySeparatorChar))
                 RemoteUrl += VirtualFileSystem.DirectorySeparatorChar;
         }
 

--- a/sources/engine/Stride.Shaders.Compiler/OpenGL/ShaderCompiler.cs
+++ b/sources/engine/Stride.Shaders.Compiler/OpenGL/ShaderCompiler.cs
@@ -271,8 +271,8 @@ namespace Stride.Shaders.Compiler.OpenGL
                         || variable.Type.Name.Text.Contains("samplerBuffer"))
                     {
                         // TODO: Make more robust
-                        var textureBindingIndex = reflection.ResourceBindings.IndexOf(x => variable.Name.ToString().StartsWith(x.RawName));
-                        var samplerBindingIndex = reflection.ResourceBindings.IndexOf(x => variable.Name.ToString().EndsWith(x.RawName));
+                        var textureBindingIndex = reflection.ResourceBindings.IndexOf(x => variable.Name.ToString().StartsWith(x.RawName, StringComparison.Ordinal));
+                        var samplerBindingIndex = reflection.ResourceBindings.IndexOf(x => variable.Name.ToString().EndsWith(x.RawName, StringComparison.Ordinal));
 
                         if (textureBindingIndex != -1)
                             MarkResourceBindingAsUsed(reflection, textureBindingIndex, stage);
@@ -329,7 +329,7 @@ namespace Stride.Shaders.Compiler.OpenGL
                     // Add layout(set, bindings) qualifier to all other uniforms
                     foreach (var variable in glslShader.Declarations.OfType<Variable>().Where(x => (x.Qualifiers.Contains(StorageQualifier.Uniform))))
                     {
-                        var layoutBindingIndex = bindings.IndexOf(x => variable.Name.Text.StartsWith(x.Key.RawName));
+                        var layoutBindingIndex = bindings.IndexOf(x => variable.Name.Text.StartsWith(x.Key.RawName, StringComparison.Ordinal));
 
                         if (layoutBindingIndex != -1)
                         {

--- a/sources/engine/Stride.Shaders.Parser/Mixins/ShaderKeyGeneratorBase.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/ShaderKeyGeneratorBase.cs
@@ -169,9 +169,9 @@ namespace Stride.Shaders.Parser.Mixins
                         }
 
                         // Rename float2/3/4 to Vector2/3/4
-                        if (initialValueString.StartsWith("float2")
-                            || initialValueString.StartsWith("float3")
-                            || initialValueString.StartsWith("float4"))
+                        if (initialValueString.StartsWith("float2", StringComparison.Ordinal)
+                            || initialValueString.StartsWith("float3", StringComparison.Ordinal)
+                            || initialValueString.StartsWith("float4", StringComparison.Ordinal))
                             initialValueString = initialValueString.Replace("float", "new Vector");
                         else if (IsArrayStatus)
                         {

--- a/sources/engine/Stride.Shaders.Parser/Mixins/StreamOutputParser.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/StreamOutputParser.cs
@@ -92,7 +92,7 @@ namespace Stride.Shaders.Parser.Mixins
 
             foreach (var maskRef in masks)
             {
-                var index = maskRef.IndexOf(mask);
+                var index = maskRef.IndexOf(mask, StringComparison.Ordinal);
                 if (index != -1)
                 {
                     componentCount = (byte)mask.Length;

--- a/sources/engine/Stride.Shaders.Parser/Mixins/StrideStreamCreator.cs
+++ b/sources/engine/Stride.Shaders.Parser/Mixins/StrideStreamCreator.cs
@@ -444,7 +444,7 @@ namespace Stride.Shaders.Parser.Mixins
                     foreach (var variable in nextStreamUsage.OutStreamList)
                     {
                         var sem = ((Variable)variable).Qualifiers.OfType<Semantic>().FirstOrDefault();
-                        if (sem != null && (sem.Name.Text.StartsWith("SV_Target") || sem.Name.Text == "SV_Depth"))
+                        if (sem != null && (sem.Name.Text.StartsWith("SV_Target", StringComparison.Ordinal) || sem.Name.Text == "SV_Depth"))
                             semVar.Add(variable);
                         else
                             nonSemVar.Add(variable);

--- a/sources/engine/Stride/Rendering/ParameterCollection.cs
+++ b/sources/engine/Stride/Rendering/ParameterCollection.cs
@@ -838,7 +838,7 @@ namespace Stride.Rendering
                 foreach (var parameterKeyInfo in destination.Layout.LayoutParameterKeyInfos)
                 {
                     var sourceKey = parameterKeyInfo.Key;
-                    if (subKey != null && sourceKey.Name.EndsWith(subKey))
+                    if (subKey != null && sourceKey.Name.EndsWith(subKey, StringComparison.Ordinal))
                     {
                         // That's a match
                         var subkeyName = parameterKeyInfo.Key.Name.Substring(0, parameterKeyInfo.Key.Name.Length - subKey.Length);
@@ -927,10 +927,10 @@ namespace Stride.Rendering
                     bool isResource = parameterKeyInfo.BindingSlot != -1;
                     bool isData = parameterKeyInfo.Offset != -1;
 
-                    if (parameterKeyInfo.Key.Name.EndsWith(keyRoot))
+                    if (parameterKeyInfo.Key.Name.EndsWith(keyRoot, StringComparison.Ordinal))
                     {
                         // That's a match
-                        var subkeyName = parameterKeyInfo.Key.Name.Substring(0, parameterKeyInfo.Key.Name.Length - keyRoot.Length);
+                        var subkeyName = parameterKeyInfo.Key.Name[..^keyRoot.Length];
                         var subkey = ParameterKeys.FindByName(subkeyName);
 
                         if (isData)

--- a/sources/presentation/Stride.Core.Presentation.Quantum/ViewModels/NodeViewModelDynamicMetaObject.cs
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/ViewModels/NodeViewModelDynamicMetaObject.cs
@@ -30,21 +30,21 @@ namespace Stride.Core.Presentation.Quantum.ViewModels
             var propertyName = binder.Name;
             var args = new Expression[1];
 
-            if (binder.Name.StartsWith(GraphViewModel.HasChildPrefix))
+            if (binder.Name.StartsWith(GraphViewModel.HasChildPrefix, StringComparison.Ordinal))
             {
                 propertyName = binder.Name.Substring(GraphViewModel.HasChildPrefix.Length);
                 args[0] = Expression.Constant(propertyName);
                 expression = Expression.Call(self, typeof(NodeViewModel).GetMethod(nameof(NodeViewModel.GetChild), BindingFlags.Public | BindingFlags.Instance), args);
                 expression = Expression.Convert(Expression.NotEqual(expression, Expression.Constant(null)), binder.ReturnType);
             }
-            else if (binder.Name.StartsWith(GraphViewModel.HasCommandPrefix))
+            else if (binder.Name.StartsWith(GraphViewModel.HasCommandPrefix, StringComparison.Ordinal))
             {
                 propertyName = binder.Name.Substring(GraphViewModel.HasCommandPrefix.Length);
                 args[0] = Expression.Constant(propertyName);
                 expression = Expression.Call(self, typeof(NodeViewModel).GetMethod(nameof(NodeViewModel.GetCommand), BindingFlags.Public | BindingFlags.Instance), args);
                 expression = Expression.Convert(Expression.NotEqual(expression, Expression.Constant(null)), binder.ReturnType);
             }
-            else if (binder.Name.StartsWith(GraphViewModel.HasAssociatedDataPrefix))
+            else if (binder.Name.StartsWith(GraphViewModel.HasAssociatedDataPrefix, StringComparison.Ordinal))
             {
                 propertyName = binder.Name.Substring(GraphViewModel.HasAssociatedDataPrefix.Length);
                 args[0] = Expression.Constant(propertyName);

--- a/sources/presentation/Stride.Core.Presentation/Diagnostics/TriggerTracing.cs
+++ b/sources/presentation/Stride.Core.Presentation/Diagnostics/TriggerTracing.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 #if DEBUG
-
+using System;
 using System.Windows;
 using System.Windows.Media.Animation;
 using System.Diagnostics;
@@ -166,10 +166,9 @@ namespace Stride.Core.Presentation.Diagnostics
             {
                 base.TraceEvent(eventCache, source, eventType, id, format, args);
 
-                if (format.StartsWith("Storyboard has begun;"))
+                if (format.StartsWith("Storyboard has begun;", StringComparison.Ordinal))
                 {
-                    var storyboard = args[1] as TriggerTraceStoryboard;
-                    if (storyboard != null)
+                    if (args[1] is TriggerTraceStoryboard storyboard)
                     {
                         // add a breakpoint here to see when your trigger has been
                         // entered or exited

--- a/sources/presentation/Stride.Core.Presentation/Windows/WindowManager.cs
+++ b/sources/presentation/Stride.Core.Presentation/Windows/WindowManager.cs
@@ -258,7 +258,7 @@ namespace Stride.Core.Presentation.Windows
                     // Some external processes might attach a window to ours, we want to discard them.
                     foreach (var debugWindowTypeName in DebugWindowTypeNames)
                     {
-                        if (windowInfo.Window?.GetType().FullName.StartsWith(debugWindowTypeName) ?? false)
+                        if (windowInfo.Window?.GetType().FullName.StartsWith(debugWindowTypeName, StringComparison.Ordinal) ?? false)
                         {
                             Logger.Debug($"Discarding debug/diagnostics window '{windowInfo.Window.GetType().FullName}' ({hwnd})");
                             return;

--- a/sources/presentation/Stride.Core.Presentation/XamlMarkdown.cs
+++ b/sources/presentation/Stride.Core.Presentation/XamlMarkdown.cs
@@ -425,7 +425,7 @@ namespace Stride.Core.Presentation
             
             var url = match.Groups[3].Value;
 
-            if (url.StartsWith("<", StringComparison.Ordinal) && url.EndsWith(">", StringComparison.Ordinal))
+            if (url.StartsWith('<') && url.EndsWith('>'))
                 url = url.Substring(1, url.Length - 2);    // Remove <>'s surrounding URL, if present
 
             return ImageTag(url, null, null);
@@ -440,7 +440,7 @@ namespace Stride.Core.Presentation
             var url = match.Groups[3].Value;
             var title = match.Groups[6].Value;
 
-            if (url.StartsWith("<", StringComparison.Ordinal) && url.EndsWith(">", StringComparison.Ordinal))
+            if (url.StartsWith('<') && url.EndsWith('>'))
                 url = url.Substring(1, url.Length - 2);    // Remove <>'s surrounding URL, if present
 
             return ImageTag(url, altText, title);

--- a/sources/presentation/Stride.Core.Presentation/XamlMarkdown.cs
+++ b/sources/presentation/Stride.Core.Presentation/XamlMarkdown.cs
@@ -347,7 +347,7 @@ namespace Stride.Core.Presentation
             var url = match.Groups[3].Value;
             var title = match.Groups[6].Value;
 
-            if (!Uri.IsWellFormedUriString(url, UriKind.Absolute) && (!System.IO.Path.IsPathRooted(url) || !url.StartsWith("/") || !url.StartsWith("\\")))
+            if (!Uri.IsWellFormedUriString(url, UriKind.Absolute) && (!System.IO.Path.IsPathRooted(url) || !url.StartsWith('/') || !url.StartsWith('\\')))
             {
                 // Make relative URL absolute
                 url = (BaseUrl ?? string.Empty) + url;
@@ -425,7 +425,7 @@ namespace Stride.Core.Presentation
             
             var url = match.Groups[3].Value;
 
-            if (url.StartsWith("<") && url.EndsWith(">"))
+            if (url.StartsWith("<", StringComparison.Ordinal) && url.EndsWith(">", StringComparison.Ordinal))
                 url = url.Substring(1, url.Length - 2);    // Remove <>'s surrounding URL, if present
 
             return ImageTag(url, null, null);
@@ -440,7 +440,7 @@ namespace Stride.Core.Presentation
             var url = match.Groups[3].Value;
             var title = match.Groups[6].Value;
 
-            if (url.StartsWith("<") && url.EndsWith(">"))
+            if (url.StartsWith("<", StringComparison.Ordinal) && url.EndsWith(">", StringComparison.Ordinal))
                 url = url.Substring(1, url.Length - 2);    // Remove <>'s surrounding URL, if present
 
             return ImageTag(url, altText, title);
@@ -452,7 +452,7 @@ namespace Stride.Core.Presentation
             var image = new Image();
             try
             {
-                if (!Uri.IsWellFormedUriString(url, UriKind.Absolute) && (!System.IO.Path.IsPathRooted(url) || !url.StartsWith("/") || !url.StartsWith("\\")))
+                if (!Uri.IsWellFormedUriString(url, UriKind.Absolute) && (!System.IO.Path.IsPathRooted(url) || !url.StartsWith('/') || !url.StartsWith('\\')))
                 {
                     // Make relative URL absolute
                     url = (BaseUrl ?? string.Empty) + url;
@@ -539,7 +539,7 @@ namespace Stride.Core.Presentation
             if (match == null) throw new ArgumentNullException(nameof(match));
 
             var header = match.Groups[1].Value;
-            var level = match.Groups[2].Value.StartsWith("=") ? 1 : 2;
+            var level = match.Groups[2].Value.StartsWith('=') ? 1 : 2;
             
             return CreateHeader(level, RunSpanGamut(header.Trim()));
         }

--- a/sources/shaders/Stride.Core.Shaders/Analysis/Hlsl/HlslSemanticAnalysis.cs
+++ b/sources/shaders/Stride.Core.Shaders/Analysis/Hlsl/HlslSemanticAnalysis.cs
@@ -68,11 +68,11 @@ namespace Stride.Core.Shaders.Analysis.Hlsl
 
             swizzles = new List<MatrixType.Indexer>();
 
-            if (components.StartsWith("_"))
+            if (components.StartsWith("_", StringComparison.Ordinal))
             {
                 string[] splitComponents;
                 int indexOffset = 0;
-                if (components.StartsWith("_m"))
+                if (components.StartsWith("_m", StringComparison.Ordinal))
                 {
                     splitComponents = components.Split(new[] { "_m" }, StringSplitOptions.RemoveEmptyEntries);
                 }

--- a/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
@@ -2724,7 +2724,7 @@ namespace Stride.Core.Shaders.Convertor
                         MemberReferenceExpression src;
 
                         var glVariableName = GetGlVariableNameFromSemantic(field.Semantic(), true);
-                        if (glVariableName != null && glVariableName.StartsWith("gl_"))
+                        if (glVariableName != null && glVariableName.StartsWith("gl_", StringComparison.Ordinal))
                         {
                             var newIndexerExpression = new IndexerExpression(new VariableReferenceExpression("gl_in"), new LiteralExpression(i));
                             src = new MemberReferenceExpression(newIndexerExpression, glVariableName);
@@ -2976,10 +2976,10 @@ namespace Stride.Core.Shaders.Convertor
             // http://msdn.microsoft.com/en-us/library/bb219850%28v=vs.85%29.aspx
             foreach (var semanticModifier in SemanticModifiers)
             {
-                if (semantic.ToLowerInvariant().EndsWith(semanticModifier))
+                if (semantic.ToLowerInvariant().EndsWith(semanticModifier, StringComparison.Ordinal))
                 {
                     // Console.WriteLine("Warning, unsupported semantic modifier [{0}] for semantic [{1}]", semanticModifier, semantic);
-                    semantic = semantic.Substring(0, semantic.Length - semanticModifier.Length);
+                    semantic = semantic[..^semanticModifier.Length];
                     break;
                 }
             }
@@ -3003,8 +3003,8 @@ namespace Stride.Core.Shaders.Convertor
                 int registerIndex;
                 var register = registerLocation.Register.Text;
 
-                var allocatedRegister = register.StartsWith("s") ? allocatedRegistersForSamplers : allocatedRegistersForUniforms;
-                string registerIndexStr = register[1] != '[' ? register.Substring(1) : register.Substring(2, register.Length - 3);
+                var allocatedRegister = register.StartsWith('s') ? allocatedRegistersForSamplers : allocatedRegistersForUniforms;
+                string registerIndexStr = register[1] != '[' ? register[1..] : register.Substring(2, register.Length - 3);
 
                 if (!int.TryParse(registerIndexStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out registerIndex))
                 {
@@ -3048,10 +3048,10 @@ namespace Stride.Core.Shaders.Convertor
 
                 var layout = this.GetTagLayout(cBuffer, registerStr);
 
-                if (registerStr.StartsWith("b"))
+                if (registerStr.StartsWith('b'))
                 {
                     int registerIndex;
-                    string registerIndexStr = registerStr.Substring(1);
+                    string registerIndexStr = registerStr[1..];
 
                     if (!int.TryParse(registerIndexStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out registerIndex))
                     {
@@ -3100,7 +3100,7 @@ namespace Stride.Core.Shaders.Convertor
         private void AddGlobalDeclaration<T>(T declaration, bool forceToAdd = false) where T : Node, IDeclaration
         {
             // Don't add glsl variable 
-            if (!declaration.Name.Text.StartsWith("gl_") || forceToAdd)
+            if (!declaration.Name.Text.StartsWith("gl_", StringComparison.Ordinal) || forceToAdd)
             {
                 var index = shader.Declarations.IndexOf(entryPoint);
                 shader.Declarations.Insert(index, declaration);
@@ -3159,7 +3159,7 @@ namespace Stride.Core.Shaders.Convertor
         private Variable BindLocation(Semantic semantic, TypeBase typebase, bool isInput, string defaultName, ref int location, SourceSpan span)
         {
             var variableFromSemantic = GetVariableFromSemantic(semantic, typebase, isInput, defaultName, span);
-            if (!variableFromSemantic.Name.Text.StartsWith("gl_"))
+            if (!variableFromSemantic.Name.Text.StartsWith("gl_", StringComparison.Ordinal))
             {
                 var variableTag = this.GetTagLayout(variableFromSemantic);
 
@@ -3385,7 +3385,7 @@ namespace Stride.Core.Shaders.Convertor
                 var semanticVariable = GetVariableFromSemantic(field.Semantic(), fieldType, false, fieldRef.FieldNamePath, span);
 
                 // If this is a special semantic we need to convert each indices
-                if (fieldArrayType != null && semanticVariable.Name.Text.StartsWith("gl_"))
+                if (fieldArrayType != null && semanticVariable.Name.Text.StartsWith("gl_", StringComparison.Ordinal))
                 {
                     var arrayDimension = fieldArrayType.Dimensions[0] as LiteralExpression;
                     var arrayValue = arrayDimension != null ? Convert.ChangeType(arrayDimension.Literal.Value, typeof(int)) : null;
@@ -3992,7 +3992,7 @@ namespace Stride.Core.Shaders.Convertor
                         var variableRef = node as VariableReferenceExpression;
                         if (declaration != null && declaration.Name != null)
                         {
-                            if (!(declaration is Variable && ((Variable)declaration).Type.Name.Text.StartsWith("layout")))
+                            if (!(declaration is Variable variable && variable.Type.Name.Text.StartsWith("layout", StringComparison.Ordinal)))
                             {
                                 declaration.Name.Text = RenameGlslKeyword(declaration.Name.Text);
                             }
@@ -4026,12 +4026,12 @@ namespace Stride.Core.Shaders.Convertor
             semanticGlBase = semanticGl;
             semanticIndex = semantic.Value;
 
-            if (semanticGl != null && semanticGl.EndsWith("[]"))
+            if (semanticGl != null && semanticGl.EndsWith("[]", StringComparison.Ordinal))
             {
-                semanticGlBase = semanticGl.Substring(0, semanticGl.Length - 2);
+                semanticGlBase = semanticGl[..^2];
 
                 // If there is [] at the end of the string, insert semantic index within []
-                semanticGl = semanticGlBase + "[" + semantic.Value + "]";
+                semanticGl = $"{semanticGlBase}[{semantic.Value}]";
             }
 
             return semantic;
@@ -4200,15 +4200,14 @@ namespace Stride.Core.Shaders.Convertor
         {
             var targetTypeName = targetType.Name.Text;
 
-            if (targetTypeName.StartsWith("Texture"))
-                targetTypeName = "texture" + targetTypeName.Substring("Texture".Length);
-            else if (targetTypeName.StartsWith("Buffer"))
+            if (targetTypeName.StartsWith("Texture", StringComparison.Ordinal))
+                targetTypeName = "texture" + targetTypeName["Texture".Length..];
+            else if (targetTypeName.StartsWith("Buffer", StringComparison.Ordinal))
                 targetTypeName = "textureBuffer";
             else return null;
 
             // TODO: How do we support this on OpenGL ES 2.0? Cast to int/uint on Load()/Sample()?
-            var genericSamplerType = targetType as IGenerics;
-            if (genericSamplerType != null && genericSamplerType.GenericArguments.Count == 1)
+            if (targetType is IGenerics genericSamplerType && genericSamplerType.GenericArguments.Count == 1)
             {
                 var genericArgument = genericSamplerType.GenericArguments[0].ResolveType();
                 if (TypeBase.GetBaseType(genericArgument) == ScalarType.UInt)

--- a/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
@@ -2976,7 +2976,7 @@ namespace Stride.Core.Shaders.Convertor
             // http://msdn.microsoft.com/en-us/library/bb219850%28v=vs.85%29.aspx
             foreach (var semanticModifier in SemanticModifiers)
             {
-                if (semantic.ToLowerInvariant().EndsWith(semanticModifier, StringComparison.Ordinal))
+                if (semantic.EndsWith(semanticModifier, StringComparison.OrdinalIgnoreCase))
                 {
                     // Console.WriteLine("Warning, unsupported semantic modifier [{0}] for semantic [{1}]", semanticModifier, semantic);
                     semantic = semantic[..^semanticModifier.Length];

--- a/sources/shaders/Stride.Core.Shaders/Convertor/HlslTypes.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/HlslTypes.cs
@@ -16,9 +16,9 @@ namespace Stride.Core.Shaders.Convertor
         public static Tuple<TypeBase, int, int> GetType(string type)
         {
             string prefix = null;
-            if (type.StartsWith("matrix"))
+            if (type.StartsWith("matrix", StringComparison.Ordinal))
             {
-                var dimStr = type.Substring("matrix".Length);
+                var dimStr = type["matrix".Length..];
                 if (dimStr.Length == 0)
                 {
                     return new Tuple<TypeBase, int, int>(new MatrixType(), 4, 4);
@@ -29,32 +29,32 @@ namespace Stride.Core.Shaders.Convertor
 
             TypeBase declaration = null;
 
-            if (type.StartsWith("float"))
+            if (type.StartsWith("float", StringComparison.Ordinal))
             {
                 prefix = "float";
                 declaration = ScalarType.Float;
             }
-            else if (type.StartsWith("int"))
+            else if (type.StartsWith("int", StringComparison.Ordinal))
             {
                 prefix = "int";
                 declaration = ScalarType.Int;
             }
-            else if (type.StartsWith("half"))
+            else if (type.StartsWith("half", StringComparison.Ordinal))
             {
                 prefix = "half";
                 declaration = ScalarType.Half;
             }
-            else if (type.StartsWith("uint"))
+            else if (type.StartsWith("uint", StringComparison.Ordinal))
             {
                 prefix = "uint";
                 declaration = ScalarType.UInt;
             }
-            else if (type.StartsWith("bool"))
+            else if (type.StartsWith("bool", StringComparison.Ordinal))
             {
                 prefix = "bool";
                 declaration = ScalarType.Bool;
             }
-            else if (type.StartsWith("double"))
+            else if (type.StartsWith("double", StringComparison.Ordinal))
             {
                 prefix = "double";
                 declaration = ScalarType.Double;

--- a/sources/shaders/Stride.Core.Shaders/Convertor/SamplerMappingVisitor.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/SamplerMappingVisitor.cs
@@ -115,7 +115,7 @@ namespace Stride.Core.Shaders.Convertor
                     var textureType = textureVariable.Type.ResolveType();
 
                     if (textureType is TextureType || (CultureInfo.InvariantCulture.CompareInfo.IsPrefix(textureType.Name.Text, "Texture", CompareOptions.IgnoreCase))
-                        || (textureType.IsBuiltIn && textureType.Name.Text.StartsWith("Buffer")))
+                        || (textureType.IsBuiltIn && textureType.Name.Text.StartsWith("Buffer", StringComparison.Ordinal)))
                     {
                         switch (memberRef.Member)
                         {
@@ -358,9 +358,9 @@ namespace Stride.Core.Shaders.Convertor
                 var samplerType = texture.Type.ResolveType();
                 var samplerTypeName = samplerType.Name.Text;
 
-                if (samplerTypeName.StartsWith("Texture"))
-                    samplerTypeName = "sampler" + samplerTypeName.Substring("Texture".Length);
-                else if (samplerTypeName.StartsWith("Buffer"))
+                if (samplerTypeName.StartsWith("Texture", StringComparison.Ordinal))
+                    samplerTypeName = "sampler" + samplerTypeName["Texture".Length..];
+                else if (samplerTypeName.StartsWith("Buffer", StringComparison.Ordinal))
                     samplerTypeName = "samplerBuffer";
 
                 // TODO: How do we support this on OpenGL ES 2.0? Cast to int/uint on Load()/Sample()?
@@ -394,20 +394,20 @@ namespace Stride.Core.Shaders.Convertor
         /// </returns>
         private static Tuple<int, TexFetchType> ParseTexFetch(string name)
         {
-            if (!name.StartsWith("tex"))
+            if (!name.StartsWith("tex", StringComparison.Ordinal))
                 return null;
 
-            name = name.Substring(3);
+            name = name[3..];
 
             int dimension;
 
-            if (name.StartsWith("1D"))
+            if (name.StartsWith("1D", StringComparison.Ordinal))
                 dimension = 1;
-            else if (name.StartsWith("2D"))
+            else if (name.StartsWith("2D", StringComparison.Ordinal))
                 dimension = 2;
-            else if (name.StartsWith("3D"))
+            else if (name.StartsWith("3D", StringComparison.Ordinal))
                 dimension = 3;
-            else if (name.StartsWith("CUBE"))
+            else if (name.StartsWith("CUBE", StringComparison.Ordinal))
                 dimension = 4;
             else
                 return null;

--- a/sources/shaders/Stride.Core.Shaders/Convertor/ShaderModel.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/ShaderModel.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 using System.Globalization;
 
 namespace Stride.Core.Shaders.Convertor
@@ -86,24 +88,24 @@ namespace Stride.Core.Shaders.Convertor
         {
             profile = CultureInfo.InvariantCulture.TextInfo.ToLower(profile);
 
-            if (profile.StartsWith("vs"))
+            if (profile.StartsWith("vs", StringComparison.Ordinal))
                 stage = PipelineStage.Vertex;
-            else if (profile.StartsWith("ps"))
+            else if (profile.StartsWith("ps", StringComparison.Ordinal))
                 stage = PipelineStage.Pixel;
-            else if (profile.StartsWith("gs"))
+            else if (profile.StartsWith("gs", StringComparison.Ordinal))
                 stage = PipelineStage.Geometry;
-            else if (profile.StartsWith("cs"))
+            else if (profile.StartsWith("cs", StringComparison.Ordinal))
                 stage = PipelineStage.Compute;
-            else if (profile.StartsWith("hs"))
+            else if (profile.StartsWith("hs", StringComparison.Ordinal))
                 stage = PipelineStage.Hull;
-            else if (profile.StartsWith("ds"))
+            else if (profile.StartsWith("ds", StringComparison.Ordinal))
                 stage = PipelineStage.Domain;
             else
             {
                 stage = PipelineStage.None;
             }
 
-            return profile.Length > 4 ? Parse(profile.Substring(3)) : ShaderModel.Model30;
+            return profile.Length > 4 ? Parse(profile[3..]) : ShaderModel.Model30;
         }
     }
 }

--- a/sources/shaders/Stride.Core.Shaders/Grammar/ShaderGrammar.Ast.cs
+++ b/sources/shaders/Stride.Core.Shaders/Grammar/ShaderGrammar.Ast.cs
@@ -1080,10 +1080,10 @@ namespace Stride.Core.Shaders.Grammar
             // Check for Hexa decimal
             if (intStr.StartsWith("0x", StringComparison.CurrentCultureIgnoreCase))
             {
-                intStr = intStr.Substring(2);
+                intStr = intStr[2..];
                 style = NumberStyles.HexNumber;
             }
-            else if (intStr.StartsWith("0") && intStr.Length > 1)
+            else if (intStr.StartsWith('0') && intStr.Length > 1)
             {
                 // Else parse Octal
                 isOctal = true;

--- a/sources/shaders/Stride.Core.Shaders/Writer/ShaderWriter.cs
+++ b/sources/shaders/Stride.Core.Shaders/Writer/ShaderWriter.cs
@@ -561,7 +561,7 @@ namespace Stride.Core.Shaders.Writer
                 return;
             }
 
-            var isStringLiteral = literal.Value is string && !literal.Text.StartsWith("\"");
+            var isStringLiteral = literal.Value is string && !literal.Text.StartsWith('\"');
             if (isStringLiteral)
             {
                 Write("\"");

--- a/sources/shared/ConsoleProgram.cs
+++ b/sources/shared/ConsoleProgram.cs
@@ -169,9 +169,9 @@ namespace Stride
 
         private bool ParseArgument(string arg)
         {
-            if (arg.StartsWith("/") || arg.StartsWith("-"))
+            if (arg.StartsWith('/') || arg.StartsWith('-'))
             {
-                string name = arg.Substring(1);
+                string name = arg[1..];
 
                 string value = null;
 

--- a/sources/shared/LoaderToolLocator/LoaderToolLocator.cs
+++ b/sources/shared/LoaderToolLocator/LoaderToolLocator.cs
@@ -31,7 +31,7 @@ namespace Stride.Core
                 const string LibPath = "\\lib";
 
                 var parentPath = Path.GetDirectoryName(tfmPath);
-                if (parentPath.EndsWith(LibPath))
+                if (parentPath.EndsWith(LibPath, StringComparison.Ordinal))
                 {
                     // Replace lib to tools
                     var tfm = tfmPath.Substring(parentPath.Length + 1);

--- a/sources/shared/Process/AndroidDeviceEnumerator.cs
+++ b/sources/shared/Process/AndroidDeviceEnumerator.cs
@@ -113,10 +113,10 @@ namespace Stride
             {
                 var device = devices[i];
                 //TODO: doing a grep instead will be better
-                var deviceNameOutputs = ShellHelper.RunProcessAndGetOutput(adbPath, string.Format(@"-s {0} shell cat /system/build.prop", device.Serial));
+                var deviceNameOutputs = ShellHelper.RunProcessAndGetOutput(adbPath, $@"-s {device.Serial} shell cat /system/build.prop");
                 foreach (var line in deviceNameOutputs.OutputLines)
                 {
-                    if (line != null && line.StartsWith(@"ro.product.model")) // correct line
+                    if (line != null && line.StartsWith(@"ro.product.model", StringComparison.Ordinal)) // correct line
                     {
                         var parts = line.Split('=');
 

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -140,7 +140,7 @@ namespace Stride.Core.Assets
 #if NETCOREAPP
                             // Add TargetPlatform to net6.0 TFM (i.e. net6.0 to net6.0-windows7.0)
                             var platform = metadataAssembly?.GetCustomAttribute<TargetPlatformAttribute>()?.PlatformName ?? string.Empty;
-                            if (framework.StartsWith(FrameworkConstants.FrameworkIdentifiers.NetCoreApp) && platform != string.Empty)
+                            if (framework.StartsWith(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.Ordinal) && platform != string.Empty)
                             {
                                 var platformParseResult = Regex.Match(platform, @"([a-zA-Z]+)(\d+.*)");
                                 if (platformParseResult.Success && Version.TryParse(platformParseResult.Groups[2].Value, out var platformVersion))
@@ -199,7 +199,7 @@ namespace Stride.Core.Assets
                 if (assemblies != null)
                 {
                     var aname = new AssemblyName(eventArgs.Name);
-                    if (aname.Name.StartsWith("Microsoft.Build") && aname.Name != "Microsoft.Build.Locator")
+                    if (aname.Name.StartsWith("Microsoft.Build", StringComparison.Ordinal) && aname.Name != "Microsoft.Build.Locator")
                         return null;
                     var assemblyPath = assemblies.FirstOrDefault(x => Path.GetFileNameWithoutExtension(x) == aname.Name);
                     if (assemblyPath != null)
@@ -220,7 +220,7 @@ namespace Stride.Core.Assets
                 {
                     var path = packageSource.GetValueAsPath();
 
-                    if (packageSource.Key.StartsWith(prefixName))
+                    if (packageSource.Key.StartsWith(prefixName, StringComparison.Ordinal))
                     {
                         // Remove entry from packageSources
                         settings.Remove("packageSources", packageSource);

--- a/sources/tools/Stride.Core.ProjectTemplating/ProjectTemplate.cs
+++ b/sources/tools/Stride.Core.ProjectTemplating/ProjectTemplate.cs
@@ -299,7 +299,7 @@ namespace Stride.Core.ProjectTemplating
             var projectFile = File.ReadAllText(fullFilePath);
             ProjectTemplate template;
             // If this a project template?
-            if (projectFile.StartsWith("<#@"))
+            if (projectFile.StartsWith("<#@", StringComparison.Ordinal))
             {
                 template = new ProjectTemplate() { IsDynamicTemplate = true };
             }

--- a/sources/tools/Stride.Core.Translation.Extractor/Extractors/CSharpExtractor.cs
+++ b/sources/tools/Stride.Core.Translation.Extractor/Extractors/CSharpExtractor.cs
@@ -97,9 +97,9 @@ namespace Stride.Core.Translation.Extractor
                 // Note: we need to match literal strings to exclude false positives: they might contain comment characters.
                 return Regex.Replace(str, $"{blockPattern}|{linePattern}|{CSharpStringPattern}", m =>
                     {
-                        if (m.Value.StartsWith("/*") || m.Value.StartsWith("//"))
+                        if (m.Value.StartsWith("/*", StringComparison.Ordinal) || m.Value.StartsWith("//", StringComparison.Ordinal))
                         {
-                            if (m.Value.StartsWith("//"))
+                            if (m.Value.StartsWith("//", StringComparison.Ordinal))
                                 return Environment.NewLine;
                             var count = m.Groups[1].Captures.Count + 1;
                             return string.Concat(Enumerable.Repeat(Environment.NewLine, count));
@@ -179,7 +179,7 @@ namespace Stride.Core.Translation.Extractor
 
             string Unescape(string str)
             {
-                return str.StartsWith("@") ? str.Trim(@"@""".ToCharArray()) : Regex.Unescape(str.Trim(@"@""".ToCharArray()));
+                return str.StartsWith("@", StringComparison.Ordinal) ? str.Trim(@"@""".ToCharArray()) : Regex.Unescape(str.Trim(@"@""".ToCharArray()));
             }
         }
 

--- a/sources/tools/Stride.Core.Translation.Extractor/Extractors/CSharpExtractor.cs
+++ b/sources/tools/Stride.Core.Translation.Extractor/Extractors/CSharpExtractor.cs
@@ -179,7 +179,7 @@ namespace Stride.Core.Translation.Extractor
 
             string Unescape(string str)
             {
-                return str.StartsWith("@", StringComparison.Ordinal) ? str.Trim(@"@""".ToCharArray()) : Regex.Unescape(str.Trim(@"@""".ToCharArray()));
+                return str.StartsWith('@') ? str.Trim(@"@""".ToCharArray()) : Regex.Unescape(str.Trim(@"@""".ToCharArray()));
             }
         }
 

--- a/sources/tools/Stride.FixProjectReferences/FixProjectReference.cs
+++ b/sources/tools/Stride.FixProjectReferences/FixProjectReference.cs
@@ -84,7 +84,7 @@ namespace Stride.FixProjectReferences
             foreach (var solutionProject in solution.Projects.ToArray())
             {
                 // Is it really a project?
-                if (!solutionProject.FullPath.EndsWith(".csproj") && !solutionProject.FullPath.EndsWith(".vcxproj"))
+                if (!solutionProject.FullPath.EndsWith(".csproj", StringComparison.Ordinal) && !solutionProject.FullPath.EndsWith(".vcxproj", StringComparison.Ordinal))
                     continue;
 
                 // Load XML project
@@ -92,8 +92,8 @@ namespace Stride.FixProjectReferences
                 var ns = doc.Root.Name.Namespace;
                 var allElements = doc.DescendantNodes().OfType<XElement>().ToList();
 
-                var hasOutputPath = allElements.Any(element => element.Name.LocalName == "OutputPath" || element.Name.LocalName == "StrideOutputPath");
-                var isTest = allElements.Any(element => element.Name.LocalName == "StrideOutputFolder" && element.Value.StartsWith("Tests"));
+                var hasOutputPath = allElements.Any(element => element.Name.LocalName is "OutputPath" or "StrideOutputPath");
+                var isTest = allElements.Any(element => element.Name.LocalName == "StrideOutputFolder" && element.Value.StartsWith("Tests", StringComparison.Ordinal));
                 if (!hasOutputPath && !isTest)
                 {
                     bool projectUpdated = false;
@@ -103,7 +103,7 @@ namespace Stride.FixProjectReferences
                     foreach (var referenceNode in allElements.Where(element => element.Name.LocalName == "ProjectReference"))
                     {
                         var attr = referenceNode.Attribute("Include");
-                        if (attr != null && (attr.Value.EndsWith(".csproj") || attr.Value.EndsWith(".vcxproj")))
+                        if (attr != null && (attr.Value.EndsWith(".csproj", StringComparison.Ordinal) || attr.Value.EndsWith(".vcxproj", StringComparison.Ordinal)))
                         {
                             var isPrivate = referenceNode.DescendantNodes().OfType<XElement>().FirstOrDefault(element => element.Name.LocalName == "Private");
                             bool referenceUpdated = false;

--- a/sources/tools/Stride.FixProjectReferences/FixProjectReference.cs
+++ b/sources/tools/Stride.FixProjectReferences/FixProjectReference.cs
@@ -84,7 +84,7 @@ namespace Stride.FixProjectReferences
             foreach (var solutionProject in solution.Projects.ToArray())
             {
                 // Is it really a project?
-                if (!solutionProject.FullPath.EndsWith(".csproj", StringComparison.Ordinal) && !solutionProject.FullPath.EndsWith(".vcxproj", StringComparison.Ordinal))
+                if (!solutionProject.FullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) && !solutionProject.FullPath.EndsWith(".vcxproj", StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 // Load XML project
@@ -103,7 +103,7 @@ namespace Stride.FixProjectReferences
                     foreach (var referenceNode in allElements.Where(element => element.Name.LocalName == "ProjectReference"))
                     {
                         var attr = referenceNode.Attribute("Include");
-                        if (attr != null && (attr.Value.EndsWith(".csproj", StringComparison.Ordinal) || attr.Value.EndsWith(".vcxproj", StringComparison.Ordinal)))
+                        if (attr != null && (attr.Value.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) || attr.Value.EndsWith(".vcxproj", StringComparison.OrdinalIgnoreCase)))
                         {
                             var isPrivate = referenceNode.DescendantNodes().OfType<XElement>().FirstOrDefault(element => element.Name.LocalName == "Private");
                             bool referenceUpdated = false;

--- a/sources/tools/Stride.Importer.Assimp/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.Assimp/MeshConverter.cs
@@ -418,7 +418,7 @@ namespace Stride.Importer.Assimp
                     itemName = itemName.Substring(0, itemNameSplitPosition);
                 }
 
-                itemNameSplitPosition = itemName.IndexOf("__");
+                itemNameSplitPosition = itemName.IndexOf("__", StringComparison.Ordinal);
                 if (itemNameSplitPosition != -1)
                 {
                     itemName = itemName.Substring(0, itemNameSplitPosition);

--- a/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
+++ b/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
@@ -1218,7 +1218,7 @@ public:
 		// First try to get the texture filename by relative path, if not valid then use absolute path
 		// (According to FBX doc, resolved first by absolute name, and relative name if absolute name is not valid)
 		auto fileNameToUse = Path::Combine(inputPath, relFileName);
-		if(fileNameToUse->StartsWith("\\\\"))
+		if(fileNameToUse->StartsWith("\\\\", StringComparison::Ordinal))
 		{
 			logger->Warning(String::Format("Importer detected a network address in referenced assets. This may temporary block the build if the file does not exist. [Address='{0}']", fileNameToUse), (CallerInfo^)nullptr);
 		}

--- a/sources/tools/Stride.ProjectGenerator/Program.cs
+++ b/sources/tools/Stride.ProjectGenerator/Program.cs
@@ -377,7 +377,7 @@ namespace Stride.ProjectGenerator
             foreach (var solutionProject in solution.Projects.ToArray())
             {
                 // Is it really a project?
-                if (!solutionProject.FullPath.EndsWith(".csproj", StringComparison.Ordinal) && !solutionProject.FullPath.EndsWith(".vcxproj", StringComparison.Ordinal) && !solutionProject.FullPath.EndsWith(".shproj", StringComparison.Ordinal))
+                if (!solutionProject.FullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) && !solutionProject.FullPath.EndsWith(".vcxproj", StringComparison.OrdinalIgnoreCase) && !solutionProject.FullPath.EndsWith(".shproj", StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 // Load XML project

--- a/sources/tools/Stride.ProjectGenerator/Program.cs
+++ b/sources/tools/Stride.ProjectGenerator/Program.cs
@@ -377,7 +377,7 @@ namespace Stride.ProjectGenerator
             foreach (var solutionProject in solution.Projects.ToArray())
             {
                 // Is it really a project?
-                if (!solutionProject.FullPath.EndsWith(".csproj") && !solutionProject.FullPath.EndsWith(".vcxproj") && !solutionProject.FullPath.EndsWith(".shproj"))
+                if (!solutionProject.FullPath.EndsWith(".csproj", StringComparison.Ordinal) && !solutionProject.FullPath.EndsWith(".vcxproj", StringComparison.Ordinal) && !solutionProject.FullPath.EndsWith(".shproj", StringComparison.Ordinal))
                     continue;
 
                 // Load XML project
@@ -400,7 +400,7 @@ namespace Stride.ProjectGenerator
 
                 // Windows-specific project without a platform-specific equivalent are removed.
                 var fullPath = solutionProject.FullPath;
-                if (Path.GetFileNameWithoutExtension(fullPath).EndsWith(".Windows"))
+                if (Path.GetFileNameWithoutExtension(fullPath).EndsWith(".Windows", StringComparison.Ordinal))
                 {
                     // Replace .Windows with current platform
                     fullPath = fullPath.Replace(".Windows", "." + platform);
@@ -487,15 +487,15 @@ namespace Stride.ProjectGenerator
                     {
                         var includeAttribute = projectReference.Attribute(XName.Get("Include"));
                         var referencedContext =
-                            projectProcessorContexts.FirstOrDefault(x => x.Modified && includeAttribute.Value.EndsWith(Path.GetFileName(x.Project.FullPath)));
+                            projectProcessorContexts.FirstOrDefault(x => x.Modified && includeAttribute.Value.EndsWith(Path.GetFileName(x.Project.FullPath), StringComparison.Ordinal));
                         if (referencedContext != null)
                         {
                             // This project has been "modified" (new .csproj), let's update reference to it
                             var projectFileName = Path.GetFileName(referencedContext.Project.FullPath);
                             var generatedProjectFileName = projectFileName.Replace(".Windows", string.Empty);
                             var fileExtPosition = generatedProjectFileName.LastIndexOf('.');
-                            generatedProjectFileName = generatedProjectFileName.Substring(0, fileExtPosition + 1) + projectSuffix +
-                                                           generatedProjectFileName.Substring(fileExtPosition);
+                            generatedProjectFileName = generatedProjectFileName[..(fileExtPosition + 1)] + projectSuffix +
+                                                           generatedProjectFileName[fileExtPosition..];
 
                             includeAttribute.Value = includeAttribute.Value.Replace(projectFileName, generatedProjectFileName);
 
@@ -693,7 +693,7 @@ namespace Stride.ProjectGenerator
                             context.Project.PlatformProperties.Add(new PropertyItem(newName, newValue));
 
                             // Active Deploy in solution configuration
-                            if (needDeploy && !keepProjectPlatform && newName.EndsWith("Build.0"))
+                            if (needDeploy && !keepProjectPlatform && newName.EndsWith("Build.0", StringComparison.Ordinal))
                             {
                                 context.Project.PlatformProperties.Add(new PropertyItem(newName.Replace("Build.0", "Deploy.0"), newValue));
                             }

--- a/sources/tools/Stride.TestRunner/Program.cs
+++ b/sources/tools/Stride.TestRunner/Program.cs
@@ -265,7 +265,7 @@ namespace Stride.TestRunner
 
             foreach (var packageFile in commandArgs)
             {
-                if (!packageFile.EndsWith("-Signed.apk"))
+                if (!packageFile.EndsWith("-Signed.apk", StringComparison.Ordinal))
                     throw new OptionException("APK should end up with \"-Signed.apk\"", "apk");
 
                 // Remove -Signed.apk suffix

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MetadataModel.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MetadataModel.cs
@@ -713,9 +713,9 @@ namespace FreeImageAPI.Metadata
 		{
 			if (string.IsNullOrEmpty(s))
 				return null;
-			if (s.StartsWith("R98"))
+			if (s.StartsWith("R98", StringComparison.Ordinal))
 				return InteroperabilityMode.R98;
-			if (s.StartsWith("THM"))
+			if (s.StartsWith("THM", StringComparison.Ordinal))
 				return InteroperabilityMode.THM;
 			return InteroperabilityMode.Undefined;
 		}

--- a/sources/tools/Stride.TextureConverter/Frontend/Console/Program.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/Console/Program.cs
@@ -220,7 +220,7 @@ namespace Stride.TextureConverter
         private int ParsePixelSize(string pixelSize, out bool isPercentage)
         {
             isPercentage = false;
-            if (pixelSize.EndsWith("p"))
+            if (pixelSize.EndsWith("p", StringComparison.Ordinal))
             {
                 pixelSize = pixelSize.TrimEnd('p');
                 isPercentage = true;


### PR DESCRIPTION
# PR Details
A user had the editor fail to create projects because of this `IndexOf` call:
https://github.com/stride3d/stride/blob/91017546503e82eb18cdb31c97e44e833819c5fc/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs#L75-L83
His culture somehow detected this `,` at index `0` of the string `Stride.Graphics.SpriteFont, Stride.Graphics, Version=4.1.0.1898, Culture=neutral, PublicKeyToken=null` leading to the `AssemblyName` `ctor` throwing.

All string methods that take `char` as input always perform operations through ordinal comparison. 
When they take strings as inputs, the comparison depends on the method, `IndexOf`, `LastIndexOf`, `StartsWith` and `EndsWith` use the current culture.
This PR ensures that every call to those methods uses ordinal wherever it makes sense (which ended up being all of them) to ensure we do not have other related issues hidden in our source.

### There's a lot of files spread out all over the project, we should merge this as soon as possible to avoid merge conflicts in the future

## Related Issue
The issue mentioned was reported on discord, it hasn't been logged as far as I know.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.