### PR TITLE
[Physics] Change simulation substeping behavior

### DIFF
--- a/sources/engine/Stride.Physics/PhysicsSettings.cs
+++ b/sources/engine/Stride.Physics/PhysicsSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using Stride.Core;
 using Stride.Data;
 
@@ -14,9 +15,10 @@ namespace Stride.Physics
         public PhysicsEngineFlags Flags;
 
         /// <userdoc>
-        /// The maximum number of simulations the the physics engine can run in a frame to compensate for slowdown
+        /// The maximum number of simulations the physics engine can run in a frame to compensate for slowdown
         /// </userdoc>
-        [DataMember(20)]
+        [DataMember(20, DataMemberMode.Never)]
+        [Obsolete($"Value is ignored, use {nameof(MaxTickDuration)} instead")]
         public int MaxSubSteps = 1;
 
         /// <userdoc>
@@ -24,5 +26,14 @@ namespace Stride.Physics
         /// </userdoc>
         [DataMember(30)]
         public float FixedTimeStep = 1.0f / 60.0f;
+
+        /// <userdoc>
+        /// Amount of time in seconds allotted to update the physics simulation when the update rate is lower than <see cref="FixedTimeStep"/>.
+        /// When the whole game takes longer than <see cref="FixedTimeStep"/> to display one frame, the simulation has to tick multiple times to catch up.
+        /// Those additional ticks may themselves make the current frame take longer, leading to a negative feedback loop for your game's performances.
+        /// This variable will 'slow down' the simulation instead.
+        /// </userdoc>
+        [DataMember(40)]
+        public float MaxTickDuration = 1f / 120f;
     }
 }


### PR DESCRIPTION
# PR Details
Right now VSync and other update rate control may affect the simulation speed when under 30 fps;
Physics updates at 60hz, by default there is one additional substep, so if the game runs between 60fps (one tick per update) and 30fps (two ticks per update) the substep will continue to make the simulation run at the expected speed, but under that point the simulation will do the additional substep and ignore the rest of the delta time, which will make it look like the simulation 'slows down'.

To fix this we could naively increase the amount of substeps that the simulation can do, to a point where it could cover from 60 to 5fps let's say. This has the side-effect of creating a negative feedback loop where the reason we have such low FPS is because of the simulation, and the added substeps are making things worse.

To palliate that we would have to detect whether it is an artificial throttling, and enable additional substeps in those case. So checking VSync and the game's frame cap when running in the background. Which is both very awkward to setup since we're in the Physics solution, but also hard/impossible to detect since the user might have created their own throttling mechanism.

This fix instead sidesteps the issue by deprecating `MaxSubSteps` in favor of a `MaxTickDuration`, the system will process as many substeps as it needs as long as physics doesn't take longer than that value. If the game runs slow, but physics is actually pretty fast, it'll process all the ticks required and the simulation will continue to update in real time while the rest struggles.

## Related Issue
#1845

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.