### PR TITLE
Replaced 'xcopy' Exec task with the more universal Copy task to suppo…

### DIFF
--- a/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
+++ b/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
@@ -76,33 +76,44 @@
 
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
   </ItemGroup>
-  <!-- Generate hash file for assembly -->
+  
+  <!-- Define a custom task for writing text to a file -->
   <UsingTask
-  TaskName="WriteAllText"
-  TaskFactory="RoslynCodeTaskFactory"
-  AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    TaskName="WriteAllText"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
-      <Path ParameterType="System.String" />
-      <Contents ParameterType="System.String" />
+      <Path ParameterType="System.String"/>
+      <Contents ParameterType="System.String"/>
     </ParameterGroup>
     <Task>
       <Using Namespace="System"/>
       <Using Namespace="System.IO"/>
       <Code Type="Fragment" Language="cs">
         <![CDATA[
-File.WriteAllText(Path, Contents);
-]]>
+          File.WriteAllText(Path, Contents);
+        ]]>
       </Code>
     </Task>
   </UsingTask>
-  <!--<UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-  <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>-->
 
+  <ItemGroup>
+    <BuiltItems Include="$(TargetDir)*" />
+  </ItemGroup>
 
-  <Target Name="GenerateHash" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y $(TargetDir)*.* $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\
-cd $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\
-$(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
+  <!-- Copy the built items to the deps folder -->
+  <Target Name="CopyFiles" AfterTargets="PostBuildEvent">
+    <Copy
+      SourceFiles="@(BuiltItems)"
+      DestinationFolder="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)"
+    />
+  </Target>
+  
+  <Target Name="GenerateHash" AfterTargets="CopyFiles">
+    <!-- Repack the assemblies into a single file -->
+    <Exec Command="cd $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)
+    $(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.* Mono.Options.* /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
+    <!-- Generate the hash and then write it to disk with the .hash extension -->
     <GetFileHash Files="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\Stride.Core.AssemblyProcessor.Packed$(TargetExt)">
       <Output
           TaskParameter="Hash"


### PR DESCRIPTION
…rt OS's which do not have xcopy.

# PR Details

Replaced 'xcopy' Exec task with the more universal Copy task to support OS's which do not have xcopy.

## Description

Added a new ItemGroup called BuiltItems that includes the entire set of output in the TargetDir. Then I created a new Target called CopyFiles, which, after the PostBuildEvent, copies the set of files in BuiltItems to the appropriate deps folder.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

xcopy is a Windows-specific tool which does not exist on Linux. To move towards a Linux build pipeline we'll need to gradually remove any such Windows-only dependencies.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.