### PR TITLE
Added a new PropertyGroup to Stride.Core.targets...

### DIFF
--- a/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
+++ b/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
@@ -24,6 +24,25 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  
+  <!-- Add support for building this project from the Project Directory -->
+  <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(ProjectDir)..\..\..\build\</SolutionDir>
+  </PropertyGroup>
+
+  <!-- ======================================================================================== -->
+  <!-- Item Groups                                                                              -->
+  <!-- ======================================================================================== -->
+
+  <!-- Referenced Packages -->
+  <ItemGroup>
+    <PackageReference Include="ILRepack" Version="2.0.18" PrivateAssets="All" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
+  </ItemGroup>
+  
+  <!-- Compiled Items -->
   <ItemGroup>
     <Compile Include="..\Stride.Core\DataMemberMode.cs">
       <Link>Core\DataMemberMode.cs</Link>
@@ -63,19 +82,25 @@
       <DesignTime>True</DesignTime>
     </Compile>
   </ItemGroup>
+  
+  <!-- Items that have no role in the build process -->
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
+  
+  <!-- Indicates this Project is included in Unit Test Projects -->
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  
+  <!-- Define the full set of built items for later use -->
   <ItemGroup>
-    <PackageReference Include="ILRepack" Version="2.0.18" PrivateAssets="All" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
+    <BuiltItems Include="$(TargetDir)*" />
   </ItemGroup>
+
+  <!-- ======================================================================================== -->
+  <!-- Tasks & Targets                                                                          -->
+  <!-- ======================================================================================== -->
   
   <!-- Define a custom task for writing text to a file -->
   <UsingTask
@@ -97,11 +122,7 @@
     </Task>
   </UsingTask>
 
-  <ItemGroup>
-    <BuiltItems Include="$(TargetDir)*" />
-  </ItemGroup>
-
-  <!-- Copy the built items to the deps folder -->
+  <!-- Copies the built items to the deps folder -->
   <Target Name="CopyFiles" AfterTargets="PostBuildEvent">
     <Copy
       SourceFiles="@(BuiltItems)"
@@ -109,10 +130,11 @@
     />
   </Target>
   
+  <!-- Packs the BuildItems into a single .Packed DLL and generates a .hash file from it -->
   <Target Name="GenerateHash" AfterTargets="CopyFiles">
     <!-- Repack the assemblies into a single file -->
     <Exec Command="cd $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)
-    $(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.* Mono.Options.* /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
+    $(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
     <!-- Generate the hash and then write it to disk with the .hash extension -->
     <GetFileHash Files="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\Stride.Core.AssemblyProcessor.Packed$(TargetExt)">
       <Output

--- a/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
+++ b/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
@@ -76,33 +76,44 @@
 
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
   </ItemGroup>
-  <!-- Generate hash file for assembly -->
+  
+  <!-- Define a custom task for writing text to a file -->
   <UsingTask
-  TaskName="WriteAllText"
-  TaskFactory="RoslynCodeTaskFactory"
-  AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    TaskName="WriteAllText"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
-      <Path ParameterType="System.String" />
-      <Contents ParameterType="System.String" />
+      <Path ParameterType="System.String"/>
+      <Contents ParameterType="System.String"/>
     </ParameterGroup>
     <Task>
       <Using Namespace="System"/>
       <Using Namespace="System.IO"/>
       <Code Type="Fragment" Language="cs">
         <![CDATA[
-File.WriteAllText(Path, Contents);
-]]>
+          File.WriteAllText(Path, Contents);
+        ]]>
       </Code>
     </Task>
   </UsingTask>
-  <!--<UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-  <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>-->
 
+  <ItemGroup>
+    <BuiltItems Include="$(TargetDir)*" />
+  </ItemGroup>
 
-  <Target Name="GenerateHash" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y $(TargetDir)*.* $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\
-cd $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\
-$(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
+  <!-- Copy the built items to the deps folder -->
+  <Target Name="CopyFiles" AfterTargets="PostBuildEvent">
+    <Copy
+      SourceFiles="@(BuiltItems)"
+      DestinationFolder="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)"
+    />
+  </Target>
+  
+  <Target Name="GenerateHash" AfterTargets="CopyFiles">
+    <!-- Repack the assemblies into a single file -->
+    <Exec Command="cd $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)
+    $(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.* Mono.Options.* /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
+    <!-- Generate the hash and then write it to disk with the .hash extension -->
     <GetFileHash Files="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\Stride.Core.AssemblyProcessor.Packed$(TargetExt)">
       <Output
           TaskParameter="Hash"

--- a/sources/core/Stride.Core/build/Stride.Core.targets
+++ b/sources/core/Stride.Core/build/Stride.Core.targets
@@ -39,6 +39,12 @@
   Assembly Processor
   *****************************************************************************************************************************
   -->
+
+  <!-- Multi-OS Compatibility Properties -->
+  <PropertyGroup>
+    <TEMP>$([System.IO.Path]::GetTempPath())</TEMP>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <!--By default, turn on assembly processor-->
     <StrideAssemblyProcessor Condition="'$(StrideAssemblyProcessor)' == ''">true</StrideAssemblyProcessor>
@@ -48,13 +54,9 @@
     <StrideAssemblyProcessorBasePath Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\..\deps\AssemblyProcessor\$(StrideAssemblyProcessorFramework)\Stride.Core.AssemblyProcessor.Packed$(StrideAssemblyProcessorExt)')">$(MSBuildThisFileDirectory)..\..\..\..\deps\AssemblyProcessor\$(StrideAssemblyProcessorFramework)\</StrideAssemblyProcessorBasePath>
     <StrideAssemblyProcessorPath>$(StrideAssemblyProcessorBasePath)Stride.Core.AssemblyProcessor.Packed$(StrideAssemblyProcessorExt)</StrideAssemblyProcessorPath>
     <StrideAssemblyProcessorSerializationHashFile>$(IntermediateOutputPath)$(TargetName).sdserializationhash</StrideAssemblyProcessorSerializationHashFile>
-
-    <TempFolder>$(TEMP)</TempFolder>
-    <TempFolder Condition="'$(TempFolder)' == ''">$(TMPDIR)</TempFolder>
-    <TempFolder Condition="'$(TempFolder)' == ''">/tmp</TempFolder>
     
     <StrideAssemblyProcessorHash>$([System.IO.File]::ReadAllText('$(StrideAssemblyProcessorPath).hash'))</StrideAssemblyProcessorHash>
-    <StrideAssemblyProcessorTempBasePath>$(TempFolder)\Stride\AssemblyProcessor\$(StrideAssemblyProcessorFramework)\$(StrideAssemblyProcessorHash)\</StrideAssemblyProcessorTempBasePath>
+    <StrideAssemblyProcessorTempBasePath>$(TEMP)\Stride\AssemblyProcessor\$(StrideAssemblyProcessorFramework)\$(StrideAssemblyProcessorHash)\</StrideAssemblyProcessorTempBasePath>
     <StrideAssemblyProcessorTempPath>$(StrideAssemblyProcessorTempBasePath)Stride.Core.AssemblyProcessor.Packed$(StrideAssemblyProcessorExt)</StrideAssemblyProcessorTempPath>
   </PropertyGroup>
   <UsingTask TaskName="AssemblyProcessorTask" AssemblyFile="$(StrideAssemblyProcessorTempPath)" Condition=" '$(StrideAssemblyProcessorTempPath)' != '' And '$(StrideAssemblyProcessorDev)' != 'true' "/>

--- a/sources/targets/Stride.Core.targets
+++ b/sources/targets/Stride.Core.targets
@@ -23,6 +23,11 @@
     </ItemGroup>
   </Target>
 
+  <!-- Linux Compatibility Properties -->
+  <PropertyGroup>
+    <TEMP>$([System.IO.Path]::GetTempPath())</TEMP>
+  </PropertyGroup>
+
   <!-- Code Analysis -->
   <PropertyGroup Condition="'$(StrideCodeAnalysis)' == 'true'">
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Stride.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
# PR Details

...to support setting environment variables which are native to Windows but which might not exist in other OS's.

The first property being added is $(TEMP) which normally comes from %TEMP% environment variable in Windows.

See https://learn.microsoft.com/en-us/dotnet/api/system.io.path.gettemppath?view=net-6.0&tabs=windows for more information.

## Description

Modified the Stride.Core.targets file by adding a new PropertyGroup and a new TEMP element that overrides the environment variable %TEMP% on Windows and provides a value for other OS's that do not support the %TEMP% environment variable.

The value is pulled from the System.IO.Path.GetTempPath() method which points to the following locations:

On Windows: C:\Users\{UserName}\AppData\Local\Temp\
On Linux: /tmp/

## Motivation and Context

The Stride.Core.targets currently leverages the fact that MSBuild is capable of pulling in and utilizing environment variables directly. However, not all OS's support the same environment variables natively. To prevent additional build steps, such as the manual or automated creation of environment variables, this change seeks to unify the environment where possible.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.