### PR TITLE
fix(theme): Improve editor tooltip legibility in Light Steel Blue theme

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ScriptEditor/Resources/ThemeScriptEditor.xaml
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ScriptEditor/Resources/ThemeScriptEditor.xaml
@@ -193,8 +193,8 @@
   </Style>
 
   <Style TargetType="{x:Type ListBoxItem}" x:Key="CompletionListBoxItem">
-    <Setter Property="Background" Value="#FF1E1E1E"/>
-    <Setter Property="BorderBrush" Value="#FF1E1E1E"/>
+    <Setter Property="Background" Value="{DynamicResource Background}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">


### PR DESCRIPTION
# PR Details

 Improve editor tooltip legibility in Light Steel Blue theme
    - Updated the `Background` property to use a dynamic resource for the background color.
    - Updated the `BorderBrush` property to use a dynamic resource for the border color.
## Description

The Light Steel Blue theme had issues with legibility in editor tooltip, where it used black font on an almost-black background. This change addresses this problem by updating the theme style.

## Related Issue

Fixes: #1191

## Motivation and Context

Improve Editor UI UX
![image](https://github.com/stride3d/stride/assets/6575712/e93ed056-3d54-4b2b-8d95-21bbef14e159)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.