### PR TITLE
Always show directional light arrow

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightDirectionalGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/LightDirectionalGizmo.cs
@@ -49,6 +49,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             bodyEntity.Transform.Rotation = Quaternion.RotationX(-MathUtil.PiOverTwo);
             lightRay.AddChild(bodyEntity);
 
+            root.AddChild(lightRay);
+
             return root;
         }
 
@@ -58,23 +60,6 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
             // update the color of the ray
             GizmoEmissiveColorMaterial.UpdateColor(GraphicsDevice, rayMaterial, (Color)new Color4(GetLightColor(GraphicsDevice), 1f));
-        }
-
-        public override bool IsSelected
-        {
-            set
-            {
-                bool hasChanged = IsSelected != value;
-                base.IsSelected = value;
-
-                if (hasChanged)
-                {
-                    if (IsSelected)
-                        GizmoRootEntity.AddChild(lightRay);
-                    else
-                        GizmoRootEntity.RemoveChild(lightRay);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
# PR Details

The logic for hiding/showing the directional light arrow based on whether it has been selected was removed. The arrow is now always visible in the editor. This current implementation is identical to JackPilley's, but that branch was quietly closed before it was merged into the main branch. As was mentioned in the related issue, this is the simplest approach to solving the issue, but we can also look at alternative methods if they're preferred.

I've marked this PR as a work-in-progress in case we want to explore alternative solutions.

This is how the directional light looks with the change, regardless of whether it's been selected:
![image](https://github.com/stride3d/stride/assets/7075456/baacc2c0-ea46-4893-a29d-3bd0a59da235)

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This is in follow-up to the issue requesting the arrow for directional lights always be visible:
https://github.com/stride3d/stride/issues/909

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is helpful for seeing the direction of the light source at a glance without needing to select it.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.