### PR TITLE
Fix readonly serializing on structs/string

### DIFF
--- a/sources/core/Stride.Core.Reflection/MemberDescriptors/FieldDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/MemberDescriptors/FieldDescriptor.cs
@@ -30,7 +30,7 @@ namespace Stride.Core.Reflection
 
         public override bool IsPublic => FieldInfo.IsPublic;
 
-        public override bool HasSet => true;
+        public override bool HasSet => !FieldInfo.IsInitOnly;
 
         public override object Get(object thisObject)
         {

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
@@ -265,14 +265,12 @@ namespace Stride.Core.Reflection
             if (memberAttribute != null)
             {
                 ((IMemberDescriptor)member).Mask = memberAttribute.Mask;
+                member.Mode = memberAttribute.Mode;
                 if (!member.HasSet)
                 {
-                    if (memberAttribute.Mode == DataMemberMode.Assign ||
-                        (memberType.IsValueType && member.Mode == DataMemberMode.Content))
-                        throw new ArgumentException($"{memberType.FullName} {member.OriginalName} is not writeable by {memberAttribute.Mode.ToString()}.");
+                    if (memberAttribute.Mode == DataMemberMode.Assign || memberType.IsValueType || memberType == typeof(string))
+                        member.Mode = DataMemberMode.Never;
                 }
-
-                member.Mode = memberAttribute.Mode;
                 member.Order = memberAttribute.Order;
             }
 


### PR DESCRIPTION
# PR Details
Fixes Serialization of readonly members

## Description

1. readonly structs/strings dont get serialized anymore
2. get only properties of structs/strings dont get serialized anymore
3. HasSet fix in fielddescriptor

## Related Issue

https://discord.com/channels/500285081265635328/1156630820430303373
First part of fixing the serialization on get only members.
Fixing non backing fields is unaffected by this PR


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. ( The Image tests and rasterized fonts test fail i was never able to get them working, but they fail without the changes too )