### PR TITLE
feat(extension): Rename launcher buttons for clarity

### DIFF
--- a/sources/launcher/Stride.Launcher/Resources/Strings.Designer.cs
+++ b/sources/launcher/Stride.Launcher/Resources/Strings.Designer.cs
@@ -744,6 +744,15 @@ namespace Stride.LauncherApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An installed Visual Studio is required, which can be found here.
+        /// </summary>
+        public static string VisualStudioDownloadPage {
+            get {
+                return ResourceManager.GetString("VisualStudioDownloadPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Visual Studio extension.
         /// </summary>
         public static string VisualStudioExtension {

--- a/sources/launcher/Stride.Launcher/Resources/Strings.resx
+++ b/sources/launcher/Stride.Launcher/Resources/Strings.resx
@@ -321,6 +321,10 @@
     <value>Visual Studio extension</value>
     <comment>Title of this category</comment>
   </data>
+  <data name="VisualStudioDownloadPage" xml:space="preserve">
+    <value>An installed Visual Studio is required, which can be found here</value>
+    <comment>Subtitle of VisualStudioExtension category</comment>
+  </data>
   <data name="VSIXInstallSucessful" xml:space="preserve">
     <value>Visual Studio plugin has been successfully installed. Please restart running instances of Visual Studio.</value>
     <comment>Messagebox text indicating that the installation of the VSIX is successful</comment>

--- a/sources/launcher/Stride.Launcher/Resources/Urls.Designer.cs
+++ b/sources/launcher/Stride.Launcher/Resources/Urls.Designer.cs
@@ -176,5 +176,14 @@ namespace Stride.LauncherApp.Resources {
                 return ResourceManager.GetString("Twitter", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://visualstudio.microsoft.com/downloads.
+        /// </summary>
+        public static string VisualStudio {
+            get {
+                return ResourceManager.GetString("VisualStudio", resourceCulture);
+            }
+        }
     }
 }

--- a/sources/launcher/Stride.Launcher/Resources/Urls.resx
+++ b/sources/launcher/Stride.Launcher/Resources/Urls.resx
@@ -158,4 +158,7 @@
   <data name="Twitter" xml:space="preserve">
     <value>https://twitter.com/stridedotnet</value>
   </data>
+  <data name="VisualStudio" xml:space="preserve">
+    <value>https://visualstudio.microsoft.com/downloads</value>
+  </data>
 </root>

--- a/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
@@ -81,14 +81,14 @@ namespace Stride.LauncherApp.ViewModels
 
         private string FormatStatus(string status)
         {
-            string vsixTarget = "Visual Studio ";
+            string vsixTarget = "Visual Studio {0} Extension";
             switch (vsixSupportedVsVersion)
             {
                 case NugetStore.VsixSupportedVsVersion.VS2019:
-                    vsixTarget += "2019";
+                    vsixTarget = string.Format(vsixTarget,"2019");
                     break;
                 case NugetStore.VsixSupportedVsVersion.VS2022:
-                    vsixTarget += "2022";
+                    vsixTarget = string.Format(vsixTarget, "2022"); ;
                     break;
             }
             return $"{vsixTarget}: {status}";

--- a/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
@@ -81,7 +81,7 @@ namespace Stride.LauncherApp.ViewModels
 
         private string FormatStatus(string status)
         {
-            string vsixTarget = "Visual Studio {0} Extension";
+            string vsixTarget = "Visual Studio {0} extension";
             switch (vsixSupportedVsVersion)
             {
                 case NugetStore.VsixSupportedVsVersion.VS2019:

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -522,7 +522,7 @@
                                                      DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
                     </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
-                      <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.VisualStudioDownloadPage}" FontSize="12" TextAlignment="Left" VerticalAlignment="Center"/>
+                      <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.VisualStudioDownloadPage}" FontSize="12" TextAlignment="Left" VerticalAlignment="Center" Loaded="TextBlockVisualStudioDownloadPage_Loaded"/>
                     </StackPanel>
                   </Button>
                 </DockPanel>

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml
@@ -43,7 +43,7 @@
       <BitmapImage x:Key="ImageBackground" UriSource="pack://application:,,,/Stride.Launcher;component/Resources/Robot.jpg"/>
 
       <s:Double x:Key="ReleaseNotesMargin">20</s:Double>
-      <Thickness x:Key="TileBorderThickness">15</Thickness>
+      <Thickness x:Key="TileBorderThickness">12</Thickness>
       <Thickness x:Key="TileListBorderThickness">0,0,0,20</Thickness>
       <!-- 15 + 16 vertically -->
       <Thickness x:Key="TabHeaderMargin">0,15,0,31</Thickness>
@@ -499,19 +499,36 @@
                 </StackPanel>
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Top">
-                <DockPanel Height="32" Margin="10,0">
+                <DockPanel Height="32" Margin="5,0">
                   <Image Source="{StaticResource ImageSwitchVersion}" Width="26" Height="26" RenderOptions.BitmapScalingMode="HighQuality" VerticalAlignment="Center"/>
                   <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.SwitchOrUpdateVersion}" FontSize="24" TextAlignment="Left" VerticalAlignment="Center"/>
                 </DockPanel>
               </Border>
               <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Bottom">
-                <UniformGrid Columns="2">
-                  <ContentControl Grid.Column="0" Margin="0,0,2,0" Content="{Binding VsixPackage2019}"/>
-                  <ContentControl Grid.Column="1" Margin="2,0,0,0" Content="{Binding VsixPackage2022}"/>
-                </UniformGrid>
+                <StackPanel >
+                  <ContentControl Grid.Column="0" Margin="2" Content="{Binding VsixPackage2019}"/>
+                  <ContentControl Grid.Column="1" Margin="2" Content="{Binding VsixPackage2022}"/>
+                </StackPanel>
               </Border>
-              <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="{StaticResource TileBorderThickness}" DockPanel.Dock="Bottom">
-                <DockPanel Height="32" Margin="10,0">
+              <Border BorderBrush="{StaticResource TileBorderBrush}" DockPanel.Dock="Bottom">
+                <DockPanel Height="20" Margin="5,0">
+                  <Button Style="{StaticResource TransparentButtonStyle}" HorizontalAlignment="Left"
+                        Command="{Binding OpenUrlCommand}"
+                        CommandParameter="{x:Static r:Urls.VisualStudio}"
+                        ToolTipService.IsEnabled="False"
+                        ToolTip="{Binding CommandParameter, RelativeSource={RelativeSource Self}, Converter={sskk:FormatString}, ConverterParameter={x:Static r:Strings.ToolTipOpenLink}}">
+                    <i:Interaction.Behaviors>
+                      <sskk:BindCurrentToolTipStringBehavior ToolTipTarget="{Binding CurrentToolTip}"
+                                                     DefaultValue="{x:Static r:Strings.ToolTipDefault}"/>
+                    </i:Interaction.Behaviors>
+                    <StackPanel Orientation="Horizontal" SnapsToDevicePixels="True">
+                      <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.VisualStudioDownloadPage}" FontSize="12" TextAlignment="Left" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </Button>
+                </DockPanel>
+              </Border>
+              <Border BorderBrush="{StaticResource TileBorderBrush}" BorderThickness="15,0,0,0" DockPanel.Dock="Bottom">
+                <DockPanel Height="32" Margin="5,0">
                   <Image Source="{StaticResource ImageVisualStudio}" Width="26" Height="26" RenderOptions.BitmapScalingMode="HighQuality" VerticalAlignment="Center"/>
                   <TextBlock Margin="10,0,0,0" Text="{x:Static r:Strings.VisualStudioExtension}" FontSize="24" TextAlignment="Left" VerticalAlignment="Center"/>
                 </DockPanel>

--- a/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml.cs
+++ b/sources/launcher/Stride.Launcher/Views/LauncherWindow.xaml.cs
@@ -7,11 +7,13 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Interop;
+using System.Xml.Linq;
 using Stride.Core.Packages;
 using Stride.Core.Presentation.Dialogs;
 using Stride.Core.Presentation.Extensions;
 using Stride.Core.Presentation.View;
 using Stride.Core.Presentation.ViewModel;
+using Stride.Core.VisualStudio;
 using Stride.LauncherApp.Services;
 using Stride.LauncherApp.ViewModels;
 
@@ -79,6 +81,17 @@ namespace Stride.LauncherApp.Views
             LauncherSettings.Save();
             if (ExitOnUserClose)
                 Environment.Exit(1);
+        }
+
+        private void TextBlockVisualStudioDownloadPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            bool hasCompatibleVersion = VisualStudioVersions.AvailableVisualStudioInstances
+                .Any(ide => ide.InstallationVersion.Major == 16 || ide.InstallationVersion.Major == 17);
+
+            if (sender is TextBlock textBlockVisualStudioDownloadPage && hasCompatibleVersion)
+            {
+                textBlockVisualStudioDownloadPage.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void SelectedTabChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
# PR Details

   - Update launcher extension button labels
   - New labels: "Visual Studio Shader {0} Extensions"
   - Add link under `VisualStudioExtension` label: "An installed Visual Studio is required, which can be found here"

## Description

This commit addresses the issue of misleading launcher extension button labels, making it clearer that users are installing an extension, not the IDE itself. The new labels and added clarification help redirect users to the Visual Studio download page to avoid confusion.

## Related Issue

Resolves: #1773

## Motivation and Context

Improves Launcher UX

No Visual Studio 2019 or 2022 found (hovering over the link shows the tooltip in the bottom part of the screen with the Visual Studio download page URL):

![image](https://github.com/stride3d/stride/assets/6575712/88ee8b78-7bf7-49bb-b7b0-93e25435305c)


When one or another is found:

![image](https://github.com/stride3d/stride/assets/6575712/6e67e46a-4fd2-4152-b41f-3c761ebda8d1)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.