### PR TITLE
Fixed Exception Caused By Privacy Policy URL in Crash Reporter

### DIFF
--- a/sources/editor/Stride.Editor.CrashReport/CrashReportForm.cs
+++ b/sources/editor/Stride.Editor.CrashReport/CrashReportForm.cs
@@ -107,7 +107,11 @@ namespace Stride.Editor.CrashReport
         {
             try
             {
-                Process.Start(PrivacyPolicyUrl);
+                //Open URL in user's default browser when clicked
+                Process process = new Process();
+                process.StartInfo.FileName = PrivacyPolicyUrl;
+                process.StartInfo.UseShellExecute = true;
+                process.Start();
             }
             // FIXME: catch only specific exceptions?
             catch (Exception)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

Clicking the Privacy Policy link in the Crash Reporter will generate an exception.

## Description

<!--- Describe your changes in detail -->
The Process requires shell execute to be enabled, this was the default setting in .NET Framework but is no longer the case with .NET Core.

This PR can be tested by adding the following to Main() in Stride.GameStudio/Program.cs,

```
            try
            {
                throw new Exception("Test");
            }
            catch (Exception ex)
            {
                HandleException(ex, 0);
            }
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.