### PR TITLE
Fixes the issue where projects were disappearing from the launcher

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/EditorViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/EditorViewModel.cs
@@ -183,7 +183,6 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 return sessionResult.OperationCancelled ? (bool?)null : false;
             }
 
-            RemoveRecentFile(filePath);
             MRU.AddFile(filePath, EditorVersionMajor);
             Session = loadedSession;
 


### PR DESCRIPTION
# PR Details

Fixes the issue where projects were disappearing from the launcher after exiting without saving an already saved project. Now, projects will persist in the launcher.

## Description

This commit addresses the bug reported where projects were not persisting correctly in the launcher after unsaved exits of saved projects.

    - The EditorViewModel's RemoveRecentFile method calls the RemoveFile method in the MRUDictionary.
    - This triggers the execution of mostRecentlyUsedFiles.RemoveWhere(x => string.Equals(x.FilePath, filePath, StringComparison.OrdinalIgnoreCase)).
    - Similarly, when the AddFile method is used in the MRUDictionary, it also executes the same RemoveWhere operation.

## Related Issue

Refs: #1184

## Motivation and Context

Address the problem of recent projects disappearing from the list.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.