### PR TITLE
fix: Excludes Stride.CommunityToolkit from packages upgrade

### DIFF
--- a/sources/engine/Stride.Assets/StridePackageUpgrader.cs
+++ b/sources/engine/Stride.Assets/StridePackageUpgrader.cs
@@ -164,7 +164,7 @@ namespace Stride.Assets
 
                     foreach (var packageReference in packageReferences)
                     {
-                        if (packageReference.EvaluatedInclude.StartsWith("Stride.", StringComparison.Ordinal) && packageReference.GetMetadataValue("Version") != CurrentVersion)
+                        if (packageReference.EvaluatedInclude.StartsWith("Stride.", StringComparison.Ordinal) && !packageReference.EvaluatedInclude.StartsWith("Stride.CommunityToolkit", StringComparison.Ordinal) && packageReference.GetMetadataValue("Version") != CurrentVersion)
                         {
                             packageReference.SetMetadataValue("Version", CurrentVersion).Xml.ExpressedAsAttribute = true;
                             foreach (var metadata in packageReference.Metadata)


### PR DESCRIPTION
# PR Details

This update excludes any packages starting with the name `Stride.CommunityToolkit` from the package upgrade.

## Description

The current problem is that the package

 `<PackageReference Include="Stride.CommunityToolkit" Version="1.0.0-preview.11" />`

is being updated to 

`<PackageReference Include="Stride.CommunityToolkit" Version="4.1.0.1898" />`

which is not desired. 

## Motivation and Context

The intention behind `Stride.CommunityToolkit` is to utilize the same namespace structure as the Stride engine, where possible, with the addition of the term `CommunityToolkit` to differentiate it from the main repository. The overarching goal is that once certain functionality is integrated into Stride, the `CommunityToolkit` prefix could be dropped, provided the remaining namespace remains accurate.

## Types of changes

Just additional condition was added.

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.