### PR TITLE
[Editor] Re-introduce workaround for missing input while navigating

### DIFF
--- a/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
@@ -48,7 +48,6 @@ namespace Stride.Input
             input = inputManager;
 
             uiControl.LostFocus += UIControlOnLostFocus;
-            MissingInputHack();
 
             // Hook window proc
             defaultWndProc = Win32Native.GetWindowLong(uiControl.Handle, Win32Native.WindowLongType.WndProc);
@@ -63,40 +62,6 @@ namespace Stride.Input
 
             mouse = new MouseWinforms(this, uiControl);
             RegisterDevice(mouse);
-        }
-
-        /// <summary>
-        /// This function houses a hack to fix the window missing some input events,
-        /// see Stride pull #181 for more information (https://github.com/stride3d/stride/pull/181).
-        /// TODO: Find a proper solution to replace this workaround.
-        /// </summary>
-        private void MissingInputHack()
-        {
-#if STRIDE_INPUT_RAWINPUT
-            Device.RegisterDevice(SharpDX.Multimedia.UsagePage.Generic, SharpDX.Multimedia.UsageId.GenericKeyboard, DeviceFlags.None);
-            Device.KeyboardInput += (sender, args) =>
-            {
-                switch (args.State)
-                {
-                    case KeyState.SystemKeyDown:
-                    case KeyState.ImeKeyDown:
-                    case KeyState.KeyDown:
-                    {
-                        keyboard?.HandleKeyUp(args.Key);
-                        heldKeys.Add(args.Key);
-                        break;
-                    }
-                    case KeyState.SystemKeyUp:
-                    case KeyState.ImeKeyUp:
-                    case KeyState.KeyUp:
-                    {
-                        heldKeys.Remove(args.Key);
-                        keyboard?.HandleKeyDown(args.Key);
-                        break;
-                    }
-                }
-            };
-#endif
         }
 
         public override void Dispose()

--- a/sources/presentation/Stride.Core.Presentation/Controls/GameEngineHost.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/GameEngineHost.cs
@@ -148,7 +148,6 @@ namespace Stride.Core.Presentation.Controls
 
             // Hide window, clear parent
             NativeHelper.ShowWindow(Handle, NativeHelper.SW_HIDE);
-            NativeHelper.SetParent(Handle, IntPtr.Zero);
 
             // Unregister keyboard sink
             var site = ((IKeyboardInputSink)this).KeyboardInputSite;

--- a/sources/presentation/Stride.Core.Presentation/Controls/GameEngineHost.cs
+++ b/sources/presentation/Stride.Core.Presentation/Controls/GameEngineHost.cs
@@ -223,6 +223,13 @@ namespace Stride.Core.Presentation.Controls
             switch (msg)
             {
                 case NativeHelper.WM_RBUTTONDOWN:
+                    // Workaround for #94 - Missing input in editor when the window is a child of the gamestudio
+                    // We're disabling the `WS_CHILD` flag when the user is navigating around the scene (holding right click+wasd)
+                    // TODO: Find a proper solution to replace this workaround. Good luck.
+                    int style = NativeHelper.GetWindowLong(Handle, NativeHelper.GWL_STYLE);
+                    style &= ~NativeHelper.WS_CHILD;
+                    NativeHelper.SetWindowLong(Handle, NativeHelper.GWL_STYLE, style);
+
                     mouseMoveCount = 0;
                     task = Dispatcher.InvokeAsync(() =>
                     {
@@ -232,6 +239,12 @@ namespace Stride.Core.Presentation.Controls
                     task.Wait(TimeSpan.FromSeconds(1.0f));
                     break;
                 case NativeHelper.WM_RBUTTONUP:
+                    // Workaround for #94 - Missing input in editor when the window is a child of the gamestudio
+                    // We're re-enabling the `WS_CHILD` flag when the user finished navigating around the scene (released right click)
+                    int style2 = NativeHelper.GetWindowLong(Handle, NativeHelper.GWL_STYLE);
+                    style2 |= NativeHelper.WS_CHILD;
+                    NativeHelper.SetWindowLong(Handle, NativeHelper.GWL_STYLE, style2);
+
                     task = Dispatcher.InvokeAsync(() =>
                     {
                         RaiseMouseButtonEvent(Mouse.PreviewMouseUpEvent, MouseButton.Right);


### PR DESCRIPTION
# PR Details
Looked into this issue for the past two weeks, and still no clue as to what the heck is going on here.
Right now the workaround is only active while right click is being held in the scene view, keeping drag and drop working as intended.

Microsoft Spy++ does show all key message as being received by the window, but the different `WndProc` and `PeekMessage` do not receive some of the key up and key down.

Also included a very small change to improve how fast the view is brought back when swapping between tabs. Detach occurs every time tabs are changed, there's no need to unparent the window at that time.

## Related Issue
#94 

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.