### PR TITLE
Fix missing OpenGLES texture formats.

### DIFF
--- a/sources/engine/Stride.Graphics/OpenGL/OpenGLConvertExtensions.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/OpenGLConvertExtensions.cs
@@ -466,6 +466,27 @@ namespace Stride.Graphics
                     pixelSize = 2;
                     type = PixelType.UnsignedByte;
                     break;
+                case PixelFormat.ETC2_RGB:
+                    internalFormat = InternalFormat.CompressedRgb8Etc2Oes;
+                    format = PixelFormatGl.Rgb;
+                    compressed = true;
+                    pixelSize = 2;
+                    type = PixelType.UnsignedByte;
+                    break;
+                case PixelFormat.ETC2_RGB_SRgb:
+                    internalFormat = InternalFormat.CompressedSrgb8Etc2Oes;
+                    format = PixelFormatGl.Rgb;
+                    compressed = true;
+                    pixelSize = 2;
+                    type = PixelType.UnsignedByte;
+                    break;
+                case PixelFormat.ETC2_RGB_A1:
+                    internalFormat = InternalFormat.CompressedRgb8PunchthroughAlpha1Etc2Oes;
+                    format = PixelFormatGl.Rgba;
+                    compressed = true;
+                    pixelSize = 2;
+                    type = PixelType.UnsignedByte;
+                    break;
                 case PixelFormat.ETC2_RGBA:
                     internalFormat = InternalFormat.CompressedRgba8Etc2Eac;
                     format = PixelFormatGl.Rgba;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix loading certain textures on Android.
eg. With TopDownRPG template, the game would crash with
```
Stride.Core.Serialization.Contents.ContentManagerException: Unexpected exception while loading asset [Textures/LensFlare01]. Reason: Unsupported texture format: ETC2_RGB.
```

## Description

<!--- Describe your changes in detail -->
Add the missing ETC2 formats.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.