### PR TITLE
[Editor] Remove some windows dependencies in editor libraries

### DIFF
--- a/samples/Tests/Stride.Samples.Tests.csproj
+++ b/samples/Tests/Stride.Samples.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\sources\shared\Stride.NuGetResolver\Stride.NuGetResolver.projitems" Label="Shared" />
   <Import Project="..\..\sources\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>

--- a/sources/assets/Stride.Core.Assets.Quantum.Tests/Stride.Core.Assets.Quantum.Tests.csproj
+++ b/sources/assets/Stride.Core.Assets.Quantum.Tests/Stride.Core.Assets.Quantum.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
   </PropertyGroup>

--- a/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
+++ b/sources/assets/Stride.Core.Assets.Quantum/Stride.Core.Assets.Quantum.csproj
@@ -9,8 +9,6 @@
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\build\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />

--- a/sources/assets/Stride.Core.Assets.Tests/Stride.Core.Assets.Tests.csproj
+++ b/sources/assets/Stride.Core.Assets.Tests/Stride.Core.Assets.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>

--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
@@ -5,7 +5,7 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePackAssets>true</StridePackAssets>
     <StrideLocalized>true</StrideLocalized>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization --parameter-key</StrideAssemblyProcessorOptions>

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/Stride.Core.Assets.Editor.Tests.csproj
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/Stride.Core.Assets.Editor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
   </PropertyGroup>

--- a/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
+++ b/sources/editor/Stride.Core.Assets.Editor/Stride.Core.Assets.Editor.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\targets\Stride.Core.props" />
   <PropertyGroup>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StrideLocalized>true</StrideLocalized>

--- a/sources/editor/Stride.Editor/Stride.Editor.csproj
+++ b/sources/editor/Stride.Editor/Stride.Editor.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideLocalized>true</StrideLocalized>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>

--- a/sources/editor/Stride.GameStudio.Tests/Stride.GameStudio.Tests.csproj
+++ b/sources/editor/Stride.GameStudio.Tests/Stride.GameStudio.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
   </PropertyGroup>

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/sources/presentation/Stride.Core.Presentation.Dialogs/Stride.Core.Presentation.Dialogs.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Dialogs/Stride.Core.Presentation.Dialogs.csproj
@@ -4,7 +4,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>
     <UseWPF>true</UseWPF>

--- a/sources/presentation/Stride.Core.Presentation.Graph/Stride.Core.Presentation.Graph.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Graph/Stride.Core.Presentation.Graph.csproj
@@ -4,7 +4,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ParadoxBuildTags>WindowsTools</ParadoxBuildTags>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\build\</SolutionDir>

--- a/sources/presentation/Stride.Core.Presentation.Quantum.Tests/Stride.Core.Presentation.Quantum.Tests.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Quantum.Tests/Stride.Core.Presentation.Quantum.Tests.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <UseWPF>true</UseWPF>

--- a/sources/presentation/Stride.Core.Presentation.Quantum/Stride.Core.Presentation.Quantum.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/Stride.Core.Presentation.Quantum.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <UseWPF>true</UseWPF>
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>

--- a/sources/presentation/Stride.Core.Presentation.Tests/Stride.Core.Presentation.Tests.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Tests/Stride.Core.Presentation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <UseWPF>true</UseWPF>

--- a/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Presentation/Stride.Core.Presentation.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StrideLocalized>true</StrideLocalized>

--- a/sources/presentation/Stride.Core.Quantum.Tests/Stride.Core.Quantum.Tests.csproj
+++ b/sources/presentation/Stride.Core.Quantum.Tests/Stride.Core.Quantum.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\targets\Stride.UnitTests.props" />
   <PropertyGroup>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>

--- a/sources/presentation/Stride.Core.Translation.Presentation/Stride.Core.Translation.Presentation.csproj
+++ b/sources/presentation/Stride.Core.Translation.Presentation/Stride.Core.Translation.Presentation.csproj
@@ -4,7 +4,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>

--- a/sources/targets/Stride.Core.TargetFrameworks.Editor.props
+++ b/sources/targets/Stride.Core.TargetFrameworks.Editor.props
@@ -2,7 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <StrideEditorTargetFramework>net6.0-windows7.0</StrideEditorTargetFramework>
+    <StrideEditorTargetFramework>net6.0</StrideEditorTargetFramework>
+    <StrideEditorAppTargetFramework>net6.0-windows7.0</StrideEditorAppTargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/sources/tools/Stride.ConnectionRouter/Stride.ConnectionRouter.csproj
+++ b/sources/tools/Stride.ConnectionRouter/Stride.ConnectionRouter.csproj
@@ -4,7 +4,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>

--- a/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
+++ b/sources/tools/Stride.Core.Translation.Extractor/Stride.Core.Translation.Extractor.csproj
@@ -5,7 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{164A5B9A-E684-4B3F-9EF4-B7765FC0A8A1}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>

--- a/sources/tools/Stride.EffectCompilerServer/Stride.EffectCompilerServer.csproj
+++ b/sources/tools/Stride.EffectCompilerServer/Stride.EffectCompilerServer.csproj
@@ -5,7 +5,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
   </PropertyGroup>

--- a/sources/tools/Stride.Importer.FBX/Stride.Importer.FBX.vcxproj
+++ b/sources/tools/Stride.Importer.FBX/Stride.Importer.FBX.vcxproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\targets\Stride.props" />
   <PropertyGroup>
     <StrideProjectType>Cpp</StrideProjectType>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessorOptions>
     </StrideAssemblyProcessorOptions>

--- a/sources/tools/Stride.SamplesTestServer/Stride.SamplesTestServer.csproj
+++ b/sources/tools/Stride.SamplesTestServer/Stride.SamplesTestServer.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\targets\Stride.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
   </PropertyGroup>

--- a/sources/tools/Stride.TestRunner/Stride.TestRunner.csproj
+++ b/sources/tools/Stride.TestRunner/Stride.TestRunner.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\targets\Stride.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(StrideEditorTargetFramework)</TargetFramework>
+    <TargetFramework>$(StrideEditorAppTargetFramework)</TargetFramework>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
     <StrideCompilerTargetsEnable Condition="'$(StridePackageBuild)' == 'true'">false</StrideCompilerTargetsEnable>
     <StrideCompilerTargetsEnable Condition="'$(StrideSkipUnitTests)' == 'true'">false</StrideCompilerTargetsEnable>


### PR DESCRIPTION
# PR Details

Target .NET 6 (cross-platform) for editor libraries that don't have any Windows dependencies.

## Description

Introduce `StrideEditorAppTargetFramework` in `sources\targets\Stride.Core.TargetFrameworks.Editor.props` and change existing `StrideEditorTargetFramework` to target `net6.0` only.

## Related Issue

N/A

## Motivation and Context

Some editor libraries should be cross-platform (esp. `Stride.Core.Assets.Quantum`). This will allow to reuse these libraries for other tools that don't necessarily target Windows.

On the other hand, editor libraries with `Presentation` in their name have a strong dependency to either Windows Form or WPF.

## Types of changes

- [x] Build change

## Checklist

- [x] All new and existing tests should pass.