### PR TITLE
[Launcher] Prevent launcher automatically closing when offline

### DIFF
--- a/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/LauncherViewModel.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32;
@@ -184,7 +185,8 @@ namespace Stride.LauncherApp.ViewModels
 ```";
                         await ServiceProvider.Get<IDialogService>().MessageBox(message, MessageBoxButton.OK, MessageBoxImage.Error);
                         // We do not want our users to use the old launcher when a new one is available.
-                        Environment.Exit(1);
+                        if (e is not HttpRequestException) // Prevent launcher closing when the user does not have internet access
+                            Environment.Exit(1);
                     }
                 });
                 // Run news task early so that it can run while we fetch package versions


### PR DESCRIPTION
# PR Details
To be honest, I don't even know it should automatically close when the update process fails, it should just let the user know and still give the user the ability to launch the gamestudio ...

## Related Issue
None reported

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.