### PR TITLE
Handle importing meshes with duplicate material names

### DIFF
--- a/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
+++ b/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
@@ -1901,7 +1901,10 @@ private:
 		ret->Materials = gcnew Dictionary<String^, MaterialAsset^>();
 		for (int i = 0; i < materialInstantiations->Count; ++i)
 		{
-			ret->Materials->Add(materialInstantiations[i]->MaterialName, materialInstantiations[i]->Material);
+			if (!ret->Materials->ContainsKey(materialInstantiations[i]->MaterialName))
+			{
+				ret->Materials->Add(materialInstantiations[i]->MaterialName, materialInstantiations[i]->Material);
+			}
 		}
         
 		return ret;


### PR DESCRIPTION
# PR Details

Use the first material with a given name instead of failing the import with an exception.
Fixes an error I ran into importing a FBX that was created with 3ds Max 2023.  

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.