### PR TITLE
Let the user set the default Bullet gravity vector in PhysicsSettings

### DIFF
--- a/sources/engine/Stride.Physics/PhysicsSettings.cs
+++ b/sources/engine/Stride.Physics/PhysicsSettings.cs
@@ -1,4 +1,3 @@
-﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
@@ -42,6 +41,6 @@ namespace Stride.Physics
         /// Default gravity vector for physics simulation.
         /// </userdoc>
         [DataMember(50)]
-        public Vector3 Gravity = new Vector3(0, -9.81f, 0);
+        public Vector3 Gravity = new Vector3(0, -10, 0);
     }
 }

--- a/sources/engine/Stride.Physics/PhysicsSettings.cs
+++ b/sources/engine/Stride.Physics/PhysicsSettings.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using Stride.Core;
+using Stride.Core.Mathematics;
 using Stride.Data;
 
 namespace Stride.Physics
@@ -35,5 +37,11 @@ namespace Stride.Physics
         /// </userdoc>
         [DataMember(40)]
         public float MaxTickDuration = 1f / 120f;
+
+        /// <userdoc>
+        /// Default gravity vector for physics simulation.
+        /// </userdoc>
+        [DataMember(50)]
+        public Vector3 Gravity = new Vector3(0, -9.81f, 0);
     }
 }

--- a/sources/engine/Stride.Physics/Simulation.cs
+++ b/sources/engine/Stride.Physics/Simulation.cs
@@ -132,6 +132,7 @@ namespace Stride.Physics
             else
             {
                 discreteDynamicsWorld = new BulletSharp.DiscreteDynamicsWorld(dispatcher, broadphase, solver, collisionConfiguration);
+                discreteDynamicsWorld.Gravity = configuration.Gravity;
                 collisionWorld = discreteDynamicsWorld;
             }
 


### PR DESCRIPTION
# PR Details

This is propagated to rigidbodies if their gravity override isn't set individually. (0, -10, 0) is Bullet's default, so this should cause no change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.