### PR TITLE
[Build] Fixed an errors in the build pipeline associated with having a space in the user name

### DIFF
--- a/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
+++ b/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
@@ -132,12 +132,9 @@
   
   <!-- Packs the BuildItems into a single .Packed DLL and generates a .hash file from it -->
   <Target Name="GenerateHash" AfterTargets="CopyFiles">
-    
     <!-- Repack the assemblies into a single file -->
     <Exec Command="cd &quot;$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)&quot;
-      &quot;$(ILRepack)&quot; Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)
-    "/>
-    
+    &quot;$(ILRepack)&quot; Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
     <!-- Generate the hash and then write it to disk with the .hash extension -->
     <GetFileHash Files="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\Stride.Core.AssemblyProcessor.Packed$(TargetExt)">
       <Output

--- a/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
+++ b/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProductVersion>16.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -132,9 +132,12 @@
   
   <!-- Packs the BuildItems into a single .Packed DLL and generates a .hash file from it -->
   <Target Name="GenerateHash" AfterTargets="CopyFiles">
+    
     <!-- Repack the assemblies into a single file -->
-    <Exec Command="cd $(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)
-    $(ILRepack) Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)"/>
+    <Exec Command="cd &quot;$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)&quot;
+      &quot;$(ILRepack)&quot; Stride.Core.AssemblyProcessor$(TargetExt) Mono.Cecil.dll Mono.Cecil.Mdb.dll Mono.Cecil.Pdb.dll Mono.Cecil.Rocks.dll Mono.Options.dll /out:Stride.Core.AssemblyProcessor.Packed$(TargetExt)
+    "/>
+    
     <!-- Generate the hash and then write it to disk with the .hash extension -->
     <GetFileHash Files="$(SolutionDir)..\deps\AssemblyProcessor\$(TargetFramework)\Stride.Core.AssemblyProcessor.Packed$(TargetExt)">
       <Output

--- a/sources/targets/Stride.Core.targets
+++ b/sources/targets/Stride.Core.targets
@@ -198,8 +198,8 @@
     <Message Importance="High" Text="Generating translation for %(_StrideTranslations.Identity) %(_StrideTranslations.SourceFolder)"/>
 
     <Exec Condition="Exists('$(SolutionDir)..\sources\localization\%(_StrideTranslations.Source)\$(TargetName).%(_StrideTranslations.Source).po')"
-          Command="$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe -r $(TargetName) -d $(TargetDir) -l %(_StrideTranslations.Identity) -L $(SolutionDir)..\deps\Gettext.Net\ $(MSBuildThisFileDirectory)..\localization\%(_StrideTranslations.Source)\$(TargetName).%(_StrideTranslations.Source).po" />
-
+          Command="&quot;$(SolutionDir)..\deps\Gettext.Net\GNU.Gettext.Msgfmt.exe&quot; -r $(TargetName) -d &quot;$(TargetDir)\&quot; -l %(_StrideTranslations.Identity) -L &quot;$(SolutionDir)..\deps\Gettext.Net&quot; &quot;$(MSBuildThisFileDirectory)..\localization\%(_StrideTranslations.Source)\$(TargetName).%(_StrideTranslations.Source).po&quot;" />
+    
     <ItemGroup>
       <SatelliteDllsProjectOutputGroupOutputIntermediate Include="$(OutDir)%(_StrideTranslations.Identity)\$(TargetName).Messages.resources.dll" Condition="Exists('$(OutDir)%(_StrideTranslations.Identity)\$(TargetName).Messages.resources.dll')">
         <TargetPath>%(_StrideTranslations.Identity)\$(TargetName).Messages.resources.dll</TargetPath>


### PR DESCRIPTION
# PR Details

A fix of #1939, fixing all issues I encountered when building `Stride.Core.AssemblyProcessor` and the errors in `Stride.sln` when generating satellite assemblies (the localization assemblies).

## Description

Adding `&quot;` to the `.csproj` file commands that are failing due to spaces in the user name.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #1939 

## Motivation and Context

I am unable to contribute to the project since it can't build on my machine, which happens to have a space in the user name until issue #1939 is fixed, so I'm working through fixing it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.