### PR TITLE
Update SSH.NET to 2023.0.0

### DIFF
--- a/sources/engine/Stride.Assets/Stride.Assets.csproj
+++ b/sources/engine/Stride.Assets/Stride.Assets.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />


### PR DESCRIPTION
Update SSH.NET to the latest version https://www.nuget.org/packages/SSH.NET/2023.0.0

## New features:
* Support for .NET 6, 7, and .NET Standard 2.0/2.1
* Support for RSA-SHA256/512 signature algorithms
* Support for parsing OpenSSH keys with ECDSA 256/384/521 and RSA
* Support for SHA256 and MD5 fingerprints for host key validation
* Added async support to SftpClient and SftpFileStream
* Added ISftpFile interface to SftpFile
* Removed support for old target frameworks
* Improved performance and stability
* Added the ability to set the last write and access time for Sftp files