### PR TITLE
fix(graphics): Stop FastTextRenderer VB clobbering

### DIFF
--- a/sources/engine/Stride.Graphics/FastTextRenderer.cs
+++ b/sources/engine/Stride.Graphics/FastTextRenderer.cs
@@ -217,13 +217,14 @@ namespace Stride.Graphics
 
                 //Draw the strings
                 var constantInfos = new RectangleF(GlyphWidth, GlyphHeight, DebugSpriteWidth, DebugSpriteHeight);
+                Span<VertexPositionNormalTexture> vertexPositionSpan = new(mappedVertexBufferPointer.ToPointer(), VertexBufferLength);
                 foreach (var textInfo in stringsToDraw)
                 {
-                    Span<VertexPositionNormalTexture> vertexPositionSpan = new((void*)mappedVertexBufferPointer, VertexBufferLength);
                     var textLength = textInfo.Text.Length;
                     GraphicsFastTextRendererGenerateVertices(constantInfos, textInfo.RenderingInfo, textInfo.Text, ref textLength,  vertexPositionSpan);
 
                     charsToRenderCount += textLength;
+                    vertexPositionSpan = vertexPositionSpan.Slice(textLength*4);
                 }
             }
 


### PR DESCRIPTION
# PR Details

`FastTextRenderer` was overwriting the start of the vertex buffer for every string. This change advances the start of the span to prevent that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.