### PR TITLE
[Breaking] Scoping generic extension methods

### DIFF
--- a/sources/core/Stride.Core/ComponentBaseExtensions.cs
+++ b/sources/core/Stride.Core/ComponentBaseExtensions.cs
@@ -18,6 +18,7 @@ namespace Stride.Core
         /// <param name="container">The container that will keep a reference to the component.</param>
         /// <returns>The same component instance</returns>
         public static T DisposeBy<T>(this T thisArg, ICollectorHolder container)
+            where T : IDisposable
         {
             if (ReferenceEquals(thisArg, null))
                 return default(T);
@@ -31,6 +32,7 @@ namespace Stride.Core
         /// <param name="thisArg">The component to remove.</param>
         /// <param name="container">The container that kept a reference to the component.</param>
         public static void RemoveDisposeBy<T>(this T thisArg, ICollectorHolder container)
+            where T : IDisposable
         {
             if (ReferenceEquals(thisArg, null))
                 return;
@@ -44,7 +46,8 @@ namespace Stride.Core
         /// <param name="thisArg">The component to add a reference to.</param>
         /// <returns>This component.</returns>
         /// <remarks>This method is equivalent to call <see cref="IReferencable.AddReference"/> and return this instance.</remarks>
-        public static T KeepReference<T>(this T thisArg) where T : IReferencable
+        public static T KeepReference<T>(this T thisArg)
+            where T : IReferencable
         {
             if (ReferenceEquals(thisArg, null))
                 return default(T);

--- a/sources/core/Stride.Core/ComponentBaseExtensions.cs
+++ b/sources/core/Stride.Core/ComponentBaseExtensions.cs
@@ -11,7 +11,7 @@ namespace Stride.Core
     public static class ComponentBaseExtensions
     {
         /// <summary>
-        /// Keeps a component alive by adding it to a container.
+        /// Keeps a disposable object alive by adding it to a container.
         /// </summary>
         /// <typeparam name="T">A component</typeparam>
         /// <param name="thisArg">The component to keep alive.</param>
@@ -21,18 +21,47 @@ namespace Stride.Core
             where T : IDisposable
         {
             if (ReferenceEquals(thisArg, null))
-                return default(T);
+                return default;
             return container.Collector.Add(thisArg);
         }
 
         /// <summary>
-        /// Removes a component that ws being kept alive from a container.
+        /// Removes a disposable object that was being kept alive from a container.
         /// </summary>
         /// <typeparam name="T">A component</typeparam>
         /// <param name="thisArg">The component to remove.</param>
         /// <param name="container">The container that kept a reference to the component.</param>
         public static void RemoveDisposeBy<T>(this T thisArg, ICollectorHolder container)
             where T : IDisposable
+        {
+            if (ReferenceEquals(thisArg, null))
+                return;
+            container.Collector.Remove(thisArg);
+        }
+
+        /// <summary>
+        /// Keeps a referencable object alive by adding it to a container.
+        /// </summary>
+        /// <typeparam name="T">A component</typeparam>
+        /// <param name="thisArg">The component to keep alive.</param>
+        /// <param name="container">The container that will keep a reference to the component.</param>
+        /// <returns>The same component instance</returns>
+        public static T ReleaseBy<T>(this T thisArg, ICollectorHolder container)
+            where T : IReferencable
+        {
+            if (ReferenceEquals(thisArg, null))
+                return default;
+            return container.Collector.Add(thisArg);
+        }
+
+        /// <summary>
+        /// Removes a referencable object that was being kept alive from a container.
+        /// </summary>
+        /// <typeparam name="T">A component</typeparam>
+        /// <param name="thisArg">The component to remove.</param>
+        /// <param name="container">The container that kept a reference to the component.</param>
+        public static void RemoveReleaseBy<T>(this T thisArg, ICollectorHolder container)
+            where T : IReferencable
         {
             if (ReferenceEquals(thisArg, null))
                 return;

--- a/sources/core/Stride.Core/Utilities.cs
+++ b/sources/core/Stride.Core/Utilities.cs
@@ -90,7 +90,7 @@ namespace Stride.Core
             : throw new ArgumentException("Alignment is not a power of 2.", nameof(align));
 
         /// <summary>
-        /// Allocate an aligned memory buffer.
+        /// Free an aligned memory buffer.
         /// </summary>
         /// <remarks>
         /// The buffer must have been allocated with <see cref="AllocateMemory"/>


### PR DESCRIPTION
> _"3rd PR and I'm already suggesting breaking changes; I hope this isn't too intrusive, but I considered this quite high priority."_

Adding a generic scope to unscoped generic extension methods.

# PR Details

## Description

This means that these extension methods no longer work with `IntPtr` and `IReferencable` types, however this feature was unused internally and the engine continues to compile like normal.

Should we be interested in using a similar extension method, separate extension methods for `IReferencable` types could be created, potentially without "Dispose" in the name, and instead use the "Release" naming associated with `IReferencable` types.

## Related Issue

- None

## Motivation and Context

This was causing every object to have additional methods appearing in the IDE and on the documentation, which can be very confusing for new developers and irritating for experienced ones.

Everywhere in the documentation are notes about this extension method being usable, despite it being meaningless in the majority of use cases.

![image](https://github.com/stride3d/stride/assets/19309165/cb1aa8b3-250e-444b-8377-aee02faa1588)

And it is also appears on every object, regardless of type.

![image](https://github.com/stride3d/stride/assets/19309165/2b1305d8-c371-431d-8929-80974180e28c)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.