### PR TITLE
[Shaders] Fix negative values in shader parser to be treated as literals.

### DIFF
--- a/sources/shaders/Stride.Core.Shaders/Grammar/ShaderGrammar.Ast.cs
+++ b/sources/shaders/Stride.Core.Shaders/Grammar/ShaderGrammar.Ast.cs
@@ -1056,6 +1056,21 @@ namespace Stride.Core.Shaders.Grammar
             }
         }
 
+        protected void CreateNegativeFloatLiteral(ParsingContext context, ParseTreeNode node)
+        {
+            var literalFloat = Ast<Literal>(node);
+            //// negative_float_literal.Rule =
+            ////    [0]       [1]
+            ////    "-" + float_literal;
+            var postiveValueNode = node.ChildNodes[1];
+            var positiveValueLiteral = (Literal)postiveValueNode.AstNode;
+            if (positiveValueLiteral.Value is float floatValue)
+            {
+                literalFloat.Value = -floatValue;
+            }
+            literalFloat.Text = "-" + postiveValueNode.Token.Text;
+        }
+
         /// <summary>
         /// The create integer literal.
         /// </summary>
@@ -1109,6 +1124,21 @@ namespace Stride.Core.Shaders.Grammar
 
             literalInt.Value = value;
             literalInt.Text = node.Token.Text;
+        }
+
+        protected void CreateNegativeIntegerLiteral(ParsingContext context, ParseTreeNode node)
+        {
+            var literalFloat = Ast<Literal>(node);
+            //// negative_integer_literal.Rule =
+            ////    [0]        [1]
+            ////    "-" + integer_literal;
+            var postiveValueNode = node.ChildNodes[1];
+            var positiveValueLiteral = (Literal)postiveValueNode.AstNode;
+            if (positiveValueLiteral.Value is int intValue)
+            {
+                literalFloat.Value = -intValue;
+            }
+            literalFloat.Text = "-" + postiveValueNode.Token.Text;
         }
 
         /// <summary>

--- a/sources/shaders/Stride.Core.Shaders/Grammar/ShaderGrammar.cs
+++ b/sources/shaders/Stride.Core.Shaders/Grammar/ShaderGrammar.cs
@@ -32,6 +32,8 @@ namespace Stride.Core.Shaders.Grammar
         // ------------------------------------------------------------------------------------
         public readonly Terminal float_literal = new Terminal("float_literal") { AstNodeConfig = new TokenInfo(TokenCategory.Number) };
         public readonly Terminal integer_literal = new Terminal("integer_literal") { AstNodeConfig = new TokenInfo(TokenCategory.Number) };
+        public readonly NonTerminal negative_float_literal = new NonTerminal("negative_float_literal") { AstNodeConfig = new TokenInfo(TokenCategory.Number) };
+        public readonly NonTerminal negative_integer_literal = new NonTerminal("negative_integer_literal") { AstNodeConfig = new TokenInfo(TokenCategory.Number) };
         public readonly NonTerminal number = TT("number");
         public readonly Terminal identifier_raw = new Terminal("identifier") { AstNodeConfig = new TokenInfo(TokenCategory.Identifier) };
         public readonly NonTerminal identifier = TT("identifier");
@@ -283,10 +285,16 @@ namespace Stride.Core.Shaders.Grammar
             // Types
             // ------------------------------------------------------------------------------------
 
-            // Numnber rule
-            number.Rule = integer_literal | float_literal;
+            // Number rule
+            number.Rule = integer_literal | negative_integer_literal
+                            | float_literal | negative_float_literal;
             integer_literal.AstNodeCreator = CreateIntegerLiteral;
             float_literal.AstNodeCreator = CreateFloatLiteral;
+
+            negative_integer_literal.Rule = "-" + integer_literal;
+            negative_integer_literal.AstNodeCreator = CreateNegativeIntegerLiteral;
+            negative_float_literal.Rule =  "-" + float_literal;
+            negative_float_literal.AstNodeCreator = CreateNegativeFloatLiteral;
 
             // Boolean rule
             boolean.Rule = Keyword("true") | Keyword("false");


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixes shaders with negative default values by adding parser rule to handle negative values.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Bug introduced in #765
Fixes #1963

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
SpaceEscape sample project's `TransformationBendWorld.sdsl` shader was broken due to #765 adding overriding default values.
However that change caused a problem from this line
https://github.com/stride3d/stride/blob/51f60ac529593379d3954999faf86ef8abf00cec/sources/engine/Stride.Shaders.Parser/ShaderLinker.cs#L699
leading to this method:
https://github.com/stride3d/stride/blob/51f60ac529593379d3954999faf86ef8abf00cec/sources/engine/Stride.Shaders.Parser/ShaderLinker.cs#L984-L990
The default value would only accept `LiteralExpression` otherwise it would return default (which is 0).
For some reason, a negative value would be a `UnaryExpression`, so this pull changes things to force the negative value into a `LiteralExpression`.


Unfortunately, this does mean there's another problem (not fixed in this pull), where a default value being something like:
`stage float DeformFactorX = 1 + 2;`
will still cause an issue because the default value (1+2) is not a literal.
Not really sure what the solution is here. Either do a evaluation on the expression or maybe change the `ToScalar` method calls to return null so it does not override the default value?


Also, while I tested this directly against the SpaceEscape project and tried running against the existing unit tests (which seems to have passed), I am unsure about the larger implication of where this parser operates. Also don't really understand how the parser grammar actually works, so if anyone actually knows how this works, feel free to make the proper fix.
## Will need more eyes on this change to ensure nothing big is broken.


### Other notes
Probably a future thing, but it seems Irony is still alive, and has a `NumberLiteral`
https://github.com/IronyProject/Irony
Not sure if that would be the proper long term fix.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.