### PR TITLE
Add support for multiple viewports and scissors

### DIFF
--- a/sources/engine/Stride.Graphics/CommandList.cs
+++ b/sources/engine/Stride.Graphics/CommandList.cs
@@ -12,7 +12,7 @@ namespace Stride.Graphics
     public partial class CommandList : GraphicsResourceBase
     {
         private const int MaxRenderTargetCount = 8;
-        private const int MaxViewportAndScissorRectangleCount = 16;
+        internal const int MaxViewportAndScissorRectangleCount = 16;
         private bool viewportDirty = false;
 
         private int boundViewportCount;

--- a/sources/engine/Stride.Rendering/Rendering/Images/ImageEffectShader.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/ImageEffectShader.cs
@@ -20,6 +20,7 @@ namespace Stride.Rendering.Images
         private bool pipelineStateDirty = true;
         private BlendStateDescription blendState = BlendStateDescription.Default;
         private DepthStencilStateDescription depthStencilState = DepthStencilStateDescription.Default;
+        private RasterizerStateDescription rasterizerState = RasterizerStateDescription.Default;
         private EffectBytecode previousBytecode;
         private bool delaySetRenderTargets;
 
@@ -35,6 +36,13 @@ namespace Stride.Rendering.Images
         {
             get { return depthStencilState; }
             set { depthStencilState = value; pipelineStateDirty = true; }
+        }
+
+        [DataMemberIgnore]
+        public RasterizerStateDescription RasterizerState
+        {
+            get { return rasterizerState; }
+            set { rasterizerState = value; pipelineStateDirty = true; }
         }
 
         /// <summary>
@@ -145,6 +153,7 @@ namespace Stride.Rendering.Images
                 pipelineState.State.EffectBytecode = EffectInstance.Effect.Bytecode;
                 pipelineState.State.BlendState = blendState;
                 pipelineState.State.DepthStencilState = depthStencilState;
+                pipelineState.State.RasterizerState = rasterizerState;
 
                 var renderTargetCount = OutputCount;
                 if (renderTargetCount > 0)


### PR DESCRIPTION
# PR Details

Adding support for multiple viewports as well as scissors for image effects

## Description

Adding support for multiple viewports as well as scissors for image effects

## Related Issue

#1971 

## Motivation and Context
I want to apply image effects only to specific regions in a render texture as far as I understand this should be possible with scissor rectangles. However the image effect base class resets the current pipeline so setting it before the image effect is applied has no effect.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Unfortunately I can not run the tests locally at least a lot of them fail during the build but doesn't seem to be related to my changes so probably sth is missing in my setup?

- [x] My change requires a change to the documentation. (Might make sense to add this to the docs?)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
