### PR TITLE
Let the user pick which animation stack to import in an fbx

### DIFF
--- a/sources/engine/Stride.Assets.Models/AnimationAsset.cs
+++ b/sources/engine/Stride.Assets.Models/AnimationAsset.cs
@@ -60,10 +60,10 @@ namespace Stride.Assets.Models
         public override UFile MainSource => Source;
 
         /// <summary>
-        /// Index for FbxAnimStack.
+        /// Index of imported animation in the source file.
         /// </summary>
         /// <userdoc>
-        /// Index of animation to import if multiple are present in the FBX file
+        /// Index of animation to import if multiple are present in the source file.
         /// </userdoc>
         [DataMember(-10)]
         [Display("Animation Index")]

--- a/sources/engine/Stride.Assets.Models/AnimationAsset.cs
+++ b/sources/engine/Stride.Assets.Models/AnimationAsset.cs
@@ -60,6 +60,16 @@ namespace Stride.Assets.Models
         public override UFile MainSource => Source;
 
         /// <summary>
+        /// Index for FbxAnimStack.
+        /// </summary>
+        /// <userdoc>
+        /// Index of animation to import if multiple are present in the FBX file
+        /// </userdoc>
+        [DataMember(-10)]
+        [Display("Animation Index")]
+        public int AnimationStack { get; set; }
+
+        /// <summary>
         /// Enable clipping of the animation duration
         /// </summary>
         /// <userdoc>

--- a/sources/engine/Stride.Assets.Models/AnimationAssetCompiler.cs
+++ b/sources/engine/Stride.Assets.Models/AnimationAssetCompiler.cs
@@ -53,6 +53,7 @@ namespace Stride.Assets.Models
             sourceBuildCommand.Mode = ImportModelCommand.ExportMode.Animation;
             sourceBuildCommand.SourcePath = assetSource;
             sourceBuildCommand.Location = targetUrlInStorage;
+            sourceBuildCommand.AnimationStack = asset.AnimationStack;
             sourceBuildCommand.AnimationRepeatMode = asset.RepeatMode;
             sourceBuildCommand.AnimationRootMotion = asset.RootMotion;
             sourceBuildCommand.ImportCustomAttributes = asset.ImportCustomAttributes;
@@ -109,6 +110,7 @@ namespace Stride.Assets.Models
                 baseBuildCommand.Location = baseUrlInStorage;
                 baseBuildCommand.AnimationRepeatMode = asset.RepeatMode;
                 baseBuildCommand.AnimationRootMotion = asset.RootMotion;
+                baseBuildCommand.AnimationStack = asset.AnimationStack;
 
                 if (diffAnimationAsset.ClipDuration.Enabled)
                 {

--- a/sources/engine/Stride.Assets.Models/AssimpAssetImporter.cs
+++ b/sources/engine/Stride.Assets.Models/AssimpAssetImporter.cs
@@ -41,7 +41,7 @@ namespace Stride.Assets.Models
         public override void GetAnimationDuration(UFile localPath, Logger logger, AssetImporterParameters importParameters, out TimeSpan startTime, out TimeSpan endTime)
         {
             var meshConverter = new Importer.Assimp.MeshConverter(logger);
-            var sceneData = meshConverter.ConvertAnimation(localPath.FullPath, "");
+            var sceneData = meshConverter.ConvertAnimation(localPath.FullPath, "", 0);
 
             startTime = CompressedTimeSpan.MaxValue; // This will go down, so we start from positive infinity
             endTime = CompressedTimeSpan.MinValue;   // This will go up, so we start from negative infinity

--- a/sources/engine/Stride.Assets.Models/FbxAssetImporter.cs
+++ b/sources/engine/Stride.Assets.Models/FbxAssetImporter.cs
@@ -40,7 +40,8 @@ namespace Stride.Assets.Models
         public override void GetAnimationDuration(UFile localPath, Logger logger, AssetImporterParameters importParameters, out TimeSpan startTime, out TimeSpan endTime)
         {
             var meshConverter = new Importer.FBX.MeshConverter(logger);
-            var durationInSeconds = meshConverter.GetAnimationDuration(localPath.FullPath);
+            // Use the first animation stack by default
+            var durationInSeconds = meshConverter.GetAnimationDuration(localPath.FullPath, 0);
 
             startTime = TimeSpan.Zero;
             endTime = TimeSpan.FromSeconds(durationInSeconds);

--- a/sources/engine/Stride.Assets.Models/ImportAssimpCommand.cs
+++ b/sources/engine/Stride.Assets.Models/ImportAssimpCommand.cs
@@ -54,7 +54,7 @@ namespace Stride.Assets.Models
         protected override Dictionary<string, AnimationClip> LoadAnimation(ICommandContext commandContext, ContentManager contentManager, out TimeSpan duration)
         {
             var meshConverter = this.CreateMeshConverter(commandContext);
-            var sceneData = meshConverter.ConvertAnimation(SourcePath, Location);
+            var sceneData = meshConverter.ConvertAnimation(SourcePath, Location, AnimationStack);
 
             duration = sceneData.Duration;
             return sceneData.AnimationClips;

--- a/sources/engine/Stride.Assets.Models/ImportFbxCommand.cs
+++ b/sources/engine/Stride.Assets.Models/ImportFbxCommand.cs
@@ -34,7 +34,7 @@ namespace Stride.Assets.Models
         protected override Dictionary<string, AnimationClip> LoadAnimation(ICommandContext commandContext, ContentManager contentManager, out TimeSpan duration)
         {
             var meshConverter = CreateMeshConverter(commandContext);
-            var sceneData = meshConverter.ConvertAnimation(SourcePath, Location, ImportCustomAttributes);
+            var sceneData = meshConverter.ConvertAnimation(SourcePath, Location, ImportCustomAttributes, AnimationStack);
             duration = sceneData.Duration;
             return sceneData.AnimationClips;
         }

--- a/sources/engine/Stride.Assets.Models/ImportModelCommand.Animation.cs
+++ b/sources/engine/Stride.Assets.Models/ImportModelCommand.Animation.cs
@@ -24,6 +24,8 @@ namespace Stride.Assets.Models
 
         public bool ImportCustomAttributes { get; set; }
 
+        public int AnimationStack { get; set; }
+
         private unsafe object ExportAnimation(ICommandContext commandContext, ContentManager contentManager, bool failOnEmptyAnimation)
         {
             // Read from model file

--- a/sources/tools/Stride.Importer.Assimp/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.Assimp/MeshConverter.cs
@@ -267,12 +267,13 @@ namespace Stride.Importer.Assimp
                 if (animationIndex < 0)
                 {
                     animationIndex = 0;
+                    Logger.Warning("Specified animation index less than zero, using the first animation.");
                 }
 
                 if (animationIndex >= scene->MNumAnimations)
                 {
                     animationIndex = (int)scene->MNumAnimations - 1;
-                    Logger.Warning($"There less animations in the file than the animation index, using the last animation.");
+                    Logger.Warning("There less animations in the file than the animation index, using the last animation.");
                 }
 
                 var aiAnim = scene->MAnimations[animationIndex];

--- a/sources/tools/Stride.Importer.FBX/AnimationConverter.h
+++ b/sources/tools/Stride.Importer.FBX/AnimationConverter.h
@@ -64,22 +64,25 @@ namespace Stride {
 					return false;
 				}
 
-				AnimationInfo^ ProcessAnimation(String^ inputFilename, String^ vfsOutputFilename, bool importCustomAttributeAnimations)
+				AnimationInfo^ ProcessAnimation(String^ inputFilename, String^ vfsOutputFilename, bool importCustomAttributeAnimations, int animationStack)
 				{
 					auto animationData = gcnew AnimationInfo();
 
 					int animStackCount = scene->GetMemberCount<FbxAnimStack>();
 					if (animStackCount == 0)
 						return animationData;
+
+					if (animationStack == 0)
+						animationStack = 0;
 						
-					// We support only anim stack count == 1
-					if (animStackCount > 1)
+					if (animationStack >= animStackCount)
 					{
-						logger->Warning(String::Format("Multiple FBX animation stacks detected in '{0}', exporting only the first one to '{1}",
+						animationStack = animStackCount - 1;
+						logger->Warning(String::Format("Animation stack count in '{0}' greater than specified stack index, exporting last available stack to '{1}",
 							gcnew String(inputFilename), gcnew String(vfsOutputFilename)), (CallerInfo^)nullptr);
 					}
 
-					FbxAnimStack* animStack = scene->GetMember<FbxAnimStack>(0);
+					FbxAnimStack* animStack = scene->GetMember<FbxAnimStack>(animationStack);
 					int animLayerCount = animStack->GetMemberCount<FbxAnimLayer>();
 
 					// We support only anim layer count == 1

--- a/sources/tools/Stride.Importer.FBX/AnimationConverter.h
+++ b/sources/tools/Stride.Importer.FBX/AnimationConverter.h
@@ -72,8 +72,12 @@ namespace Stride {
 					if (animStackCount == 0)
 						return animationData;
 
-					if (animationStack == 0)
+					if (animationStack < 0)
+					{
 						animationStack = 0;
+						logger->Warning(String::Format("Animation stack specified in '{0}' less than zero, exporting first stack to '{1}",
+							gcnew String(inputFilename), gcnew String(vfsOutputFilename)), (CallerInfo^)nullptr);
+					}
 						
 					if (animationStack >= animStackCount)
 					{

--- a/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
+++ b/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
@@ -2011,14 +2011,14 @@ public:
 		return nullptr;
 	}
 
-	double GetAnimationDuration(String^ inputFileName)
+	double GetAnimationDuration(String^ inputFileName, int animationStack)
 	{
 		try
 		{
 			Initialize(inputFileName, nullptr, ImportConfiguration::ImportEntityConfig());
 
 			auto animationConverter = gcnew AnimationConverter(logger, sceneMapping);
-			auto animationData = animationConverter->ProcessAnimation(inputFilename, "", true);
+			auto animationData = animationConverter->ProcessAnimation(inputFilename, "", true, animationStack);
 
 			return animationData->Duration.TotalSeconds;
 		}
@@ -2085,14 +2085,14 @@ public:
 		return nullptr;
 	}
 
-	AnimationInfo^ ConvertAnimation(String^ inputFilename, String^ vfsOutputFilename, bool importCustomAttributeAnimations)
+	AnimationInfo^ ConvertAnimation(String^ inputFilename, String^ vfsOutputFilename, bool importCustomAttributeAnimations, int animationStack)
 	{
 		try
 		{
 			Initialize(inputFilename, vfsOutputFilename, ImportConfiguration::ImportAnimationsOnly());
 
 			auto animationConverter = gcnew AnimationConverter(logger, sceneMapping);
-			return animationConverter->ProcessAnimation(inputFilename, vfsOutputFilename, importCustomAttributeAnimations);
+			return animationConverter->ProcessAnimation(inputFilename, vfsOutputFilename, importCustomAttributeAnimations, animationStack);
 		}
 		finally
 		{


### PR DESCRIPTION
# PR Details

If multiple animation stacks are present in an fbx, let the user choose the index to import.

## Description

This only allows it to be set after the asset is initially created and imported. Also, the index is clamped so it doesn't break if you set something out of bounds.

Tested with a mixamo animation, since they set everything in the 2nd stack and a t-pose in the first.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
