### PR TITLE
[AssemblyProcessor] Fixed packing path.

### DIFF
--- a/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
+++ b/sources/core/Stride.Core.AssemblyProcessor/Stride.Core.AssemblyProcessor.csproj
@@ -27,7 +27,7 @@
   
   <!-- Add support for building this project from the Project Directory -->
   <PropertyGroup>
-    <DependencyDir>$(ProjectDir)..\..\..\..\deps</DependencyDir>
+    <DependencyDir>$(ProjectDir)..\..\..\deps</DependencyDir>
   </PropertyGroup>
 
   <!-- ======================================================================================== -->


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Directory specified went a level up too far so nothing gets packed/copied to the deps folder.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue caused by #1894

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
AssemblyProcessor project does not complete its build properly due to incorrect path for dll copying and IL packing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
