### PR TITLE
Fix failing to load data/db/index file on non-Win desktop platforms

### DIFF
--- a/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
@@ -37,8 +37,8 @@ namespace Stride.Core.Storage
             ContentIndexMap = new ObjectDatabaseContentIndexMap();
 
             // Try to open file backends
-            bool isReadOnly = Platform.Type != PlatformType.Windows;
-            var backend = new FileOdbBackend(vfsMainUrl, indexName, isReadOnly);
+            bool isDesktop = Platform.Type is PlatformType.Windows or PlatformType.Linux or PlatformType.macOS;
+            var backend = new FileOdbBackend(vfsMainUrl, indexName, !isDesktop);
 
             ContentIndexMap.Merge(backend.ContentIndexMap);
             if (backend.IsReadOnly)


### PR DESCRIPTION
# PR Details

## Description

On Linux, on creating simple empty window app by simply calling `Game.Run()`, Stride will throw `FileNotFoundException: Could not find file myproj/net6.0/data/db/index`. This bug should also appear on macOS in the same way.

I have now extended setting `isReadOnly` variable to `false` for all desktop platforms, so that the index file doesn't have to be created manually. Tested on Fedora 38, Windows 10.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run app on Linux and Windows**
