### PR TITLE
[Build] Fix native library loading picking up invalid files

### DIFF
--- a/sources/shared/Stride.NuGetResolver/RestoreHelper.cs
+++ b/sources/shared/Stride.NuGetResolver/RestoreHelper.cs
@@ -93,6 +93,10 @@ namespace Stride.Core.Assets
                 {
                     foreach (var n in lib.NativeLibraries)
                     {
+                        if (!IsValidNativeLibraryFile(n.Path))
+                        {
+                            continue;
+                        }
                         var assemblyFile = Path.Combine(libPath, n.Path.Replace('/', Path.DirectorySeparatorChar));
                         libs.Add(assemblyFile);
                     }
@@ -100,6 +104,18 @@ namespace Stride.Core.Assets
             }
 
             return libs;
+
+            static bool IsValidNativeLibraryFile(string path)
+            {
+                if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                    || path.EndsWith(".so", StringComparison.OrdinalIgnoreCase)
+                    || path.Contains(".so.", StringComparison.OrdinalIgnoreCase)    // Linux allows for files like 'libnativedep.so.6'
+                    || path.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                return false;
+            }
         }
 
         private static Dictionary<(string, NuGetVersion), string> GetLibPaths(LockFile lockFile)


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title above -->


## Description

<!--- Describe your changes in detail -->
NuGet importer allows 'non-native' files in `LockFileTargetLibrary.NativeLibraries`, however as per research https://github.com/stride3d/stride/issues/1750#issuecomment-1783774705 this leads to a subtle incorrect dll loading if multiple files with the same file name exists (eg. `freetype.dll` & `freetype.pdb`).
Wasn't sure whether a blacklist, whitelist or some priority sort would be preferred to ensure the correct file get loaded. ~I've settled on a small blacklist set but I'm open to change it to a different way.~
EDIT: Changed to allowlist logic.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1750

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
