### PR TITLE
Update NuGet libraries to 6.4.2

### DIFF
--- a/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
+++ b/sources/assets/Stride.Core.Packages/Stride.Core.Packages.csproj
@@ -7,10 +7,10 @@
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="6.4.0" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
-    <PackageReference Include="NuGet.Resolver" Version="6.4.0" />
-    <PackageReference Include="NuGet.Commands" Version="6.4.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.4.2" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.4.2" />
+    <PackageReference Include="NuGet.Resolver" Version="6.4.2" />
+    <PackageReference Include="NuGet.Commands" Version="6.4.2" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.4.0" />
+    <PackageReference Include="NuGet.Configuration" Version="6.4.2" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>

--- a/sources/shared/Stride.NuGetResolver/RestoreHelper.cs
+++ b/sources/shared/Stride.NuGetResolver/RestoreHelper.cs
@@ -109,7 +109,7 @@ namespace Stride.Core.Assets
             {
                 if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
                     || path.EndsWith(".so", StringComparison.OrdinalIgnoreCase)
-                    || path.Contains(".so.", StringComparison.OrdinalIgnoreCase)    // Linux allows for files like 'libnativedep.so.6'
+                    || path.IndexOf(".so.", StringComparison.OrdinalIgnoreCase) >= 0    // Linux allows for files like 'libnativedep.so.6'
                     || path.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
                 {
                     return true;

--- a/sources/tools/Stride.NuGetLoader/Stride.NuGetLoader.csproj
+++ b/sources/tools/Stride.NuGetLoader/Stride.NuGetLoader.csproj
@@ -17,10 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
-    <PackageReference Include="NuGet.Resolver" Version="6.4.0" />
-		<PackageReference Include="NuGet.Commands" Version="6.4.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.4.2" />
+    <PackageReference Include="NuGet.Resolver" Version="6.4.2" />
+    <PackageReference Include="NuGet.Commands" Version="6.4.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -33,7 +33,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.Commands" Version="6.4.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.4.2" />
 
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating NuGet libraries from 6.4.0 to 6.4.2 as advised by dependabot due RCE vulnerability.

## Related Issue

Closes #2016
Closes #2013
Closes #2012
Closes #2011
Closes #2010
Closes #2009

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

@Basewq I had to change your recent code as `net472` didn't have `string.Contains` which took in comparison hint.