### PR TITLE
Fix: Exception material names contains "/". 

### DIFF
--- a/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
+++ b/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
@@ -1634,6 +1634,7 @@ private:
 
 			// remove all bad characters
 			ReplaceCharacter(materialName, ':', '_');
+			ReplaceCharacter(materialName, '/', '_');
 			RemoveCharacter(materialName, ' ');
 			tempNames[lMaterial] = materialName;
 			


### PR DESCRIPTION
# PR Details
Fix: Exception material names contains "/". #1989
## Description

Replaced "/" with "_" in GenerateMaterialNames.

## Related Issue
https://github.com/stride3d/stride/issues/1989

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
