### PR TITLE
[Math] Relax constraints on arguments passed as ref across math types

### DIFF
--- a/sources/core/Stride.Core.Mathematics/BoundingBox.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingBox.cs
@@ -104,10 +104,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="ray">The ray to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray)
+        public bool Intersects(ref readonly Ray ray)
         {
             float distance;
-            return CollisionHelper.RayIntersectsBox(ref ray, ref this, out distance);
+            return CollisionHelper.RayIntersectsBox(in ray, ref this, out distance);
         }
 
         /// <summary>
@@ -117,9 +117,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out float distance)
+        public bool Intersects(ref readonly Ray ray, out float distance)
         {
-            return CollisionHelper.RayIntersectsBox(ref ray, ref this, out distance);
+            return CollisionHelper.RayIntersectsBox(in ray, ref this, out distance);
         }
 
         /// <summary>
@@ -129,9 +129,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out Vector3 point)
+        public bool Intersects(ref readonly Ray ray, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsBox(ref ray, ref this, out point);
+            return CollisionHelper.RayIntersectsBox(in ray, ref this, out point);
         }
 
         /// <summary>
@@ -139,9 +139,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The plane to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref Plane plane)
+        public PlaneIntersectionType Intersects(ref readonly Plane plane)
         {
-            return CollisionHelper.PlaneIntersectsBox(ref plane, ref this);
+            return CollisionHelper.PlaneIntersectsBox(in plane, ref this);
         }
 
         /* This implentation is wrong
@@ -163,9 +163,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingBox box)
+        public bool Intersects(ref readonly BoundingBox box)
         {
-            return CollisionHelper.BoxIntersectsBox(ref this, ref box);
+            return CollisionHelper.BoxIntersectsBox(ref this, in box);
         }
 
         /// <summary>
@@ -173,9 +173,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingSphere sphere)
+        public bool Intersects(ref readonly BoundingSphere sphere)
         {
-            return CollisionHelper.BoxIntersectsSphere(ref this, ref sphere);
+            return CollisionHelper.BoxIntersectsSphere(ref this, in sphere);
         }
 
         /// <summary>
@@ -183,9 +183,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref Vector3 point)
+        public ContainmentType Contains(ref readonly Vector3 point)
         {
-            return CollisionHelper.BoxContainsPoint(ref this, ref point);
+            return CollisionHelper.BoxContainsPoint(ref this, in point);
         }
 
         /* This implentation is wrong
@@ -207,9 +207,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref BoundingBox box)
+        public ContainmentType Contains(ref readonly BoundingBox box)
         {
-            return CollisionHelper.BoxContainsBox(ref this, ref box);
+            return CollisionHelper.BoxContainsBox(ref this, in box);
         }
 
         /// <summary>
@@ -217,9 +217,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref BoundingSphere sphere)
+        public ContainmentType Contains(ref readonly BoundingSphere sphere)
         {
-            return CollisionHelper.BoxContainsSphere(ref this, ref sphere);
+            return CollisionHelper.BoxContainsSphere(ref this, in sphere);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere that will designate the extents of the box.</param>
         /// <param name="result">When the method completes, contains the newly constructed bounding box.</param>
-        public static void FromSphere(ref BoundingSphere sphere, out BoundingBox result)
+        public static void FromSphere(ref readonly BoundingSphere sphere, out BoundingBox result)
         {
             result.Minimum = new Vector3(sphere.Center.X - sphere.Radius, sphere.Center.Y - sphere.Radius, sphere.Center.Z - sphere.Radius);
             result.Maximum = new Vector3(sphere.Center.X + sphere.Radius, sphere.Center.Y + sphere.Radius, sphere.Center.Z + sphere.Radius);
@@ -298,7 +298,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The original bounding box.</param>
         /// <param name="transform">The transform to apply to the bounding box.</param>
         /// <param name="result">The transformed bounding box.</param>
-        public static void Transform(ref BoundingBox value, ref Matrix transform, out BoundingBox result)
+        public static void Transform(ref readonly BoundingBox value, ref readonly Matrix transform, out BoundingBox result)
         {
             var boundingBox = new BoundingBoxExt(value);
             boundingBox.Transform(transform);
@@ -311,10 +311,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The box to merge.</param>
         /// <param name="value2">The point to merge.</param>
         /// <param name="result">When the method completes, contains the newly constructed bounding box.</param>
-        public static void Merge(ref BoundingBox value1, ref Vector3 value2, out BoundingBox result)
+        public static void Merge(ref readonly BoundingBox value1, ref readonly Vector3 value2, out BoundingBox result)
         {
-            Vector3.Min(ref value1.Minimum, ref value2, out result.Minimum);
-            Vector3.Max(ref value1.Maximum, ref value2, out result.Maximum);
+            Vector3.Min(in value1.Minimum, in value2, out result.Minimum);
+            Vector3.Max(in value1.Maximum, in value2, out result.Maximum);
         }
         
         /// <summary>
@@ -323,10 +323,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The first box to merge.</param>
         /// <param name="value2">The second box to merge.</param>
         /// <param name="result">When the method completes, contains the newly constructed bounding box.</param>
-        public static void Merge(ref BoundingBox value1, ref BoundingBox value2, out BoundingBox result)
+        public static void Merge(ref readonly BoundingBox value1, ref readonly BoundingBox value2, out BoundingBox result)
         {
-            Vector3.Min(ref value1.Minimum, ref value2.Minimum, out result.Minimum);
-            Vector3.Max(ref value1.Maximum, ref value2.Maximum, out result.Maximum);
+            Vector3.Min(in value1.Minimum, in value2.Minimum, out result.Minimum);
+            Vector3.Max(in value1.Maximum, in value2.Maximum, out result.Maximum);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/BoundingBoxExt.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingBoxExt.cs
@@ -109,7 +109,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second box to merge.</param>
         /// <param name="result">When the method completes, contains the newly constructed bounding box.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Merge(ref BoundingBoxExt value1, ref BoundingBoxExt value2, out BoundingBoxExt result)
+        public static void Merge(ref readonly BoundingBoxExt value1, ref readonly BoundingBoxExt value2, out BoundingBoxExt result)
         {
             var maximum = Vector3.Max(value1.Maximum, value2.Maximum);
             var minimum = Vector3.Min(value1.Minimum, value2.Minimum);

--- a/sources/core/Stride.Core.Mathematics/BoundingFrustum.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingFrustum.cs
@@ -44,7 +44,7 @@ namespace Stride.Core.Mathematics
         /// Initializes a new instance of the <see cref="BoundingFrustum"/> struct from a matrix view-projection.
         /// </summary>
         /// <param name="matrix">The matrix view projection.</param>
-        public BoundingFrustum(ref Matrix matrix)
+        public BoundingFrustum(ref readonly Matrix matrix)
         {
             // Left
             Plane.Normalize(
@@ -101,9 +101,9 @@ namespace Stride.Core.Mathematics
         /// <param name="boundingBoxExt">The bounding box.</param>
         /// <returns><c>true</c> if this frustum contains the specified bounding box.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Contains(ref BoundingBoxExt boundingBoxExt)
+        public bool Contains(ref readonly BoundingBoxExt boundingBoxExt)
         {
-            return CollisionHelper.FrustumContainsBox(ref this, ref boundingBoxExt);
+            return CollisionHelper.FrustumContainsBox(ref this, in boundingBoxExt);
         }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
+++ b/sources/core/Stride.Core.Mathematics/BoundingSphere.cs
@@ -71,10 +71,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="ray">The ray to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray)
+        public bool Intersects(ref readonly Ray ray)
         {
             float distance;
-            return CollisionHelper.RayIntersectsSphere(ref ray, ref this, out distance);
+            return CollisionHelper.RayIntersectsSphere(in ray, ref this, out distance);
         }
 
         /// <summary>
@@ -84,9 +84,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out float distance)
+        public bool Intersects(ref readonly Ray ray, out float distance)
         {
-            return CollisionHelper.RayIntersectsSphere(ref ray, ref this, out distance);
+            return CollisionHelper.RayIntersectsSphere(in ray, ref this, out distance);
         }
 
         /// <summary>
@@ -96,9 +96,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out Vector3 point)
+        public bool Intersects(ref readonly Ray ray, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsSphere(ref ray, ref this, out point);
+            return CollisionHelper.RayIntersectsSphere(in ray, ref this, out point);
         }
 
         /// <summary>
@@ -106,9 +106,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The plane to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref Plane plane)
+        public PlaneIntersectionType Intersects(ref readonly Plane plane)
         {
-            return CollisionHelper.PlaneIntersectsSphere(ref plane, ref this);
+            return CollisionHelper.PlaneIntersectsSphere(in plane, ref this);
         }
 
         /// <summary>
@@ -118,9 +118,9 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triagnle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public bool Intersects(ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
-            return CollisionHelper.SphereIntersectsTriangle(ref this, ref vertex1, ref vertex2, ref vertex3);
+            return CollisionHelper.SphereIntersectsTriangle(ref this, in vertex1, in vertex2, in vertex3);
         }
 
         /// <summary>
@@ -128,9 +128,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingBox box)
+        public bool Intersects(ref readonly BoundingBox box)
         {
-            return CollisionHelper.BoxIntersectsSphere(ref box, ref this);
+            return CollisionHelper.BoxIntersectsSphere(in box, ref this);
         }
 
         /// <summary>
@@ -138,9 +138,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingSphere sphere)
+        public bool Intersects(ref readonly BoundingSphere sphere)
         {
-            return CollisionHelper.SphereIntersectsSphere(ref this, ref sphere);
+            return CollisionHelper.SphereIntersectsSphere(ref this, in sphere);
         }
 
         /// <summary>
@@ -148,9 +148,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref Vector3 point)
+        public ContainmentType Contains(ref readonly Vector3 point)
         {
-            return CollisionHelper.SphereContainsPoint(ref this, ref point);
+            return CollisionHelper.SphereContainsPoint(ref this, in point);
         }
 
         /// <summary>
@@ -160,9 +160,9 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triagnle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public ContainmentType Contains(ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
-            return CollisionHelper.SphereContainsTriangle(ref this, ref vertex1, ref vertex2, ref vertex3);
+            return CollisionHelper.SphereContainsTriangle(ref this, in vertex1, in vertex2, in vertex3);
         }
 
         /// <summary>
@@ -170,9 +170,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref BoundingBox box)
+        public ContainmentType Contains(ref readonly BoundingBox box)
         {
-            return CollisionHelper.SphereContainsBox(ref this, ref box);
+            return CollisionHelper.SphereContainsBox(ref this, in box);
         }
 
         /// <summary>
@@ -180,9 +180,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public ContainmentType Contains(ref BoundingSphere sphere)
+        public ContainmentType Contains(ref readonly BoundingSphere sphere)
         {
-            return CollisionHelper.SphereContainsSphere(ref this, ref sphere);
+            return CollisionHelper.SphereContainsSphere(ref this, in sphere);
         }
 
         /// <summary>
@@ -269,9 +269,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box that will designate the extents of the sphere.</param>
         /// <param name="result">When the method completes, the newly constructed bounding sphere.</param>
-        public static void FromBox(ref BoundingBox box, out BoundingSphere result)
+        public static void FromBox(ref readonly BoundingBox box, out BoundingSphere result)
         {
-            Vector3.Lerp(ref box.Minimum, ref box.Maximum, 0.5f, out result.Center);
+            Vector3.Lerp(in box.Minimum, in box.Maximum, 0.5f, out result.Center);
 
             float x = box.Minimum.X - box.Maximum.X;
             float y = box.Minimum.Y - box.Maximum.Y;
@@ -299,9 +299,9 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The original bounding sphere.</param>
         /// <param name="transform">The transform to apply to the bounding sphere.</param>
         /// <param name="result">The transformed bounding sphere.</param>
-        public static void Transform(ref BoundingSphere value, ref Matrix transform, out BoundingSphere result)
+        public static void Transform(ref readonly BoundingSphere value, ref readonly Matrix transform, out BoundingSphere result)
         {
-            Vector3.TransformCoordinate(ref value.Center, ref transform, out result.Center);
+            Vector3.TransformCoordinate(in value.Center, in transform, out result.Center);
 
             var majorAxisLengthSquared = MathF.Max(
                 (transform.M11 * transform.M11) + (transform.M12 * transform.M12) + (transform.M13 * transform.M13), MathF.Max(
@@ -317,7 +317,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The first sphere to merge.</param>
         /// <param name="value2">The second sphere to merge.</param>
         /// <param name="result">When the method completes, contains the newly constructed bounding sphere.</param>
-        public static void Merge(ref BoundingSphere value1, ref BoundingSphere value2, out BoundingSphere result)
+        public static void Merge(ref readonly BoundingSphere value1, ref readonly BoundingSphere value2, out BoundingSphere result)
         {
             // Pre-exit if one of the bounding sphere by assuming that a merge with an empty sphere is equivalent at taking the non-empty sphere
             if (value1 == Empty)

--- a/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
+++ b/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
@@ -68,7 +68,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex to test.</param>
         /// <param name="vertex3">The third vertex to test.</param>
         /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
-        public static void ClosestPointPointTriangle(ref Vector3 point, ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3, out Vector3 result)
+        public static void ClosestPointPointTriangle(ref readonly Vector3 point, ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3, out Vector3 result)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 136
@@ -146,13 +146,13 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The plane to test.</param>
         /// <param name="point">The point to test.</param>
         /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
-        public static void ClosestPointPlanePoint(ref Plane plane, ref Vector3 point, out Vector3 result)
+        public static void ClosestPointPlanePoint(ref readonly Plane plane, ref readonly Vector3 point, out Vector3 result)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 126
 
             float dot;
-            Vector3.Dot(ref plane.Normal, ref point, out dot);
+            Vector3.Dot(in plane.Normal, in point, out dot);
             float t = dot - plane.D;
 
             result = point - (t * plane.Normal);
@@ -164,14 +164,14 @@ namespace Stride.Core.Mathematics
         /// <param name="box">The box to test.</param>
         /// <param name="point">The point to test.</param>
         /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
-        public static void ClosestPointBoxPoint(ref BoundingBox box, ref Vector3 point, out Vector3 result)
+        public static void ClosestPointBoxPoint(ref readonly BoundingBox box, ref readonly Vector3 point, out Vector3 result)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 130
 
             Vector3 temp;
-            Vector3.Max(ref point, ref box.Minimum, out temp);
-            Vector3.Min(ref temp, ref box.Maximum, out result);
+            Vector3.Max(in point, in box.Minimum, out temp);
+            Vector3.Min(ref temp, in box.Maximum, out result);
         }
 
         /// <summary>
@@ -181,13 +181,13 @@ namespace Stride.Core.Mathematics
         /// <param name="point">The point to test.</param>
         /// <param name="result">When the method completes, contains the closest point between the two objects;
         /// or, if the point is directly in the center of the sphere, contains <see cref="Stride.Core.Mathematics.Vector3.Zero"/>.</param>
-        public static void ClosestPointSpherePoint(ref BoundingSphere sphere, ref Vector3 point, out Vector3 result)
+        public static void ClosestPointSpherePoint(ref readonly BoundingSphere sphere, ref readonly Vector3 point, out Vector3 result)
         {
             //Source: Jorgy343
             //Reference: None
 
             //Get the unit direction from the sphere's center to the point.
-            Vector3.Subtract(ref point, ref sphere.Center, out result);
+            Vector3.Subtract(in point, in sphere.Center, out result);
             result.Normalize();
 
             //Multiply the unit direction by the sphere's radius to get a vector
@@ -210,13 +210,13 @@ namespace Stride.Core.Mathematics
         /// is the 'closest' point of intersection. This can also be considered is the deepest point of
         /// intersection.
         /// </remarks>
-        public static void ClosestPointSphereSphere(ref BoundingSphere sphere1, ref BoundingSphere sphere2, out Vector3 result)
+        public static void ClosestPointSphereSphere(ref readonly BoundingSphere sphere1, ref readonly BoundingSphere sphere2, out Vector3 result)
         {
             //Source: Jorgy343
             //Reference: None
 
             //Get the unit direction from the first sphere's center to the second sphere's center.
-            Vector3.Subtract(ref sphere2.Center, ref sphere1.Center, out result);
+            Vector3.Subtract(in sphere2.Center, in sphere1.Center, out result);
             result.Normalize();
 
             //Multiply the unit direction by the first sphere's radius to get a vector
@@ -233,13 +233,13 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The plane to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>The distance between the two objects.</returns>
-        public static float DistancePlanePoint(ref Plane plane, ref Vector3 point)
+        public static float DistancePlanePoint(ref readonly Plane plane, ref readonly Vector3 point)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 127
 
             float dot;
-            Vector3.Dot(ref plane.Normal, ref point, out dot);
+            Vector3.Dot(in plane.Normal, in point, out dot);
             return dot - plane.D;
         }
 
@@ -249,7 +249,7 @@ namespace Stride.Core.Mathematics
         /// <param name="box">The box to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>The distance between the two objects.</returns>
-        public static float DistanceBoxPoint(ref BoundingBox box, ref Vector3 point)
+        public static float DistanceBoxPoint(ref readonly BoundingBox box, ref readonly Vector3 point)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 131
@@ -280,7 +280,7 @@ namespace Stride.Core.Mathematics
         /// <param name="box1">The first box to test.</param>
         /// <param name="box2">The second box to test.</param>
         /// <returns>The distance between the two objects.</returns>
-        public static float DistanceBoxBox(ref BoundingBox box1, ref BoundingBox box2)
+        public static float DistanceBoxBox(ref readonly BoundingBox box1, ref readonly BoundingBox box2)
         {
             //Source:
             //Reference:
@@ -332,13 +332,13 @@ namespace Stride.Core.Mathematics
         /// <param name="sphere">The sphere to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>The distance between the two objects.</returns>
-        public static float DistanceSpherePoint(ref BoundingSphere sphere, ref Vector3 point)
+        public static float DistanceSpherePoint(ref readonly BoundingSphere sphere, ref readonly Vector3 point)
         {
             //Source: Jorgy343
             //Reference: None
 
             float distance;
-            Vector3.Distance(ref sphere.Center, ref point, out distance);
+            Vector3.Distance(in sphere.Center, in point, out distance);
             distance -= sphere.Radius;
 
             return MathF.Max(distance, 0f);
@@ -350,13 +350,13 @@ namespace Stride.Core.Mathematics
         /// <param name="sphere1">The first sphere to test.</param>
         /// <param name="sphere2">The second sphere to test.</param>
         /// <returns>The distance between the two objects.</returns>
-        public static float DistanceSphereSphere(ref BoundingSphere sphere1, ref BoundingSphere sphere2)
+        public static float DistanceSphereSphere(ref readonly BoundingSphere sphere1, ref readonly BoundingSphere sphere2)
         {
             //Source: Jorgy343
             //Reference: None
 
             float distance;
-            Vector3.Distance(ref sphere1.Center, ref sphere2.Center, out distance);
+            Vector3.Distance(in sphere1.Center, in sphere2.Center, out distance);
             distance -= sphere1.Radius + sphere2.Radius;
 
             return MathF.Max(distance, 0f);
@@ -368,13 +368,13 @@ namespace Stride.Core.Mathematics
         /// <param name="ray">The ray to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>Whether the two objects intersect.</returns>
-        public static bool RayIntersectsPoint(ref Ray ray, ref Vector3 point)
+        public static bool RayIntersectsPoint(ref readonly Ray ray, ref readonly Vector3 point)
         {
             //Source: RayIntersectsSphere
             //Reference: None
 
             Vector3 m;
-            Vector3.Subtract(ref ray.Position, ref point, out m);
+            Vector3.Subtract(in ray.Position, in point, out m);
 
             //Same thing as RayIntersectsSphere except that the radius of the sphere (point)
             //is the epsilon for zero.
@@ -410,14 +410,14 @@ namespace Stride.Core.Mathematics
         /// of the second ray, det denotes the determinant of a matrix, x denotes the cross
         /// product, [ ] denotes a matrix, and || || denotes the length or magnitude of a vector.
         /// </remarks>
-        public static bool RayIntersectsRay(ref Ray ray1, ref Ray ray2, out Vector3 point)
+        public static bool RayIntersectsRay(ref readonly Ray ray1, ref readonly Ray ray2, out Vector3 point)
         {
             //Source: Real-Time Rendering, Third Edition
             //Reference: Page 780
 
             Vector3 cross;
 
-            Vector3.Cross(ref ray1.Direction, ref ray2.Direction, out cross);
+            Vector3.Cross(in ray1.Direction, in ray2.Direction, out cross);
             float denominator = cross.Length();
 
             //Lines are parallel.
@@ -498,13 +498,13 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersect.</returns>
-        public static bool RayIntersectsPlane(ref Ray ray, ref Plane plane, out float distance)
+        public static bool RayIntersectsPlane(ref readonly Ray ray, ref readonly Plane plane, out float distance)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 175
 
             float direction;
-            Vector3.Dot(ref plane.Normal, ref ray.Direction, out direction);
+            Vector3.Dot(in plane.Normal, in ray.Direction, out direction);
 
             if (MathF.Abs(direction) < MathUtil.ZeroTolerance)
             {
@@ -513,7 +513,7 @@ namespace Stride.Core.Mathematics
             }
 
             float position;
-            Vector3.Dot(ref plane.Normal, ref ray.Position, out position);
+            Vector3.Dot(in plane.Normal, in ray.Position, out position);
             distance = (-plane.D - position) / direction;
 
             if (distance < 0f)
@@ -538,13 +538,13 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool RayIntersectsPlane(ref Ray ray, ref Plane plane, out Vector3 point)
+        public static bool RayIntersectsPlane(ref readonly Ray ray, ref readonly Plane plane, out Vector3 point)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 175
 
             float distance;
-            if (!RayIntersectsPlane(ref ray, ref plane, out distance))
+            if (!RayIntersectsPlane(in ray, in plane, out distance))
             {
                 point = Vector3.Zero;
                 return false;
@@ -571,7 +571,7 @@ namespace Stride.Core.Mathematics
         /// the ray, no intersection is assumed to have happened. In both cases of assumptions,
         /// this method returns false.
         /// </remarks>
-        public static bool RayIntersectsTriangle(ref Ray ray, ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3, out float distance)
+        public static bool RayIntersectsTriangle(ref readonly Ray ray, ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3, out float distance)
         {
             //Source: Fast Minimum Storage Ray / Triangle Intersection
             //Reference: http://www.cs.virginia.edu/~gfx/Courses/2003/ImageSynthesis/papers/Acceleration/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf
@@ -671,10 +671,10 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool RayIntersectsTriangle(ref Ray ray, ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3, out Vector3 point)
+        public static bool RayIntersectsTriangle(ref readonly Ray ray, ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3, out Vector3 point)
         {
             float distance;
-            if (!RayIntersectsTriangle(ref ray, ref vertex1, ref vertex2, ref vertex3, out distance))
+            if (!RayIntersectsTriangle(in ray, in vertex1, in vertex2, in vertex3, out distance))
             {
                 point = Vector3.Zero;
                 return false;
@@ -693,7 +693,7 @@ namespace Stride.Core.Mathematics
         /// <param name="normalAxis">The index of axis defining the normal of the rectangle in the world. This value should be 0, 1 or 2</param>
         /// <param name="intersectionPoint">The position of the intersection point in the world</param>
         /// <returns><value>true</value> if the ray and rectangle intersects.</returns>
-        public static bool RayIntersectsRectangle(ref Ray ray, ref Matrix rectangleWorldMatrix, ref Vector3 rectangleSize, int normalAxis, out Vector3 intersectionPoint)
+        public static bool RayIntersectsRectangle(ref readonly Ray ray, ref readonly Matrix rectangleWorldMatrix, ref readonly Vector3 rectangleSize, int normalAxis, out Vector3 intersectionPoint)
         {
             bool intersects;
 
@@ -723,7 +723,7 @@ namespace Stride.Core.Mathematics
             var plane = new Plane(rectanglePosition, new Vector3(rectangleWorldMatrix[normalRowStart], rectangleWorldMatrix[normalRowStart + 1], rectangleWorldMatrix[normalRowStart + 2]));
 
             // early exist the planes were parallels 
-            if (!plane.Intersects(ref ray, out intersectionPoint))
+            if (!plane.Intersects(in ray, out intersectionPoint))
                 return false;
 
             // the position of the intersection point with respect to the rectangle center
@@ -790,7 +790,7 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool RayIntersectsBox(ref Ray ray, ref BoundingBox box, out float distance)
+        public static bool RayIntersectsBox(ref readonly Ray ray, ref readonly BoundingBox box, out float distance)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 179
@@ -902,10 +902,10 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool RayIntersectsBox(ref Ray ray, ref BoundingBox box, out Vector3 point)
+        public static bool RayIntersectsBox(ref readonly Ray ray, ref readonly BoundingBox box, out Vector3 point)
         {
             float distance;
-            if (!RayIntersectsBox(ref ray, ref box, out distance))
+            if (!RayIntersectsBox(in ray, in box, out distance))
             {
                 point = Vector3.Zero;
                 return false;
@@ -923,13 +923,13 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool RayIntersectsSphere(ref Ray ray, ref BoundingSphere sphere, out float distance)
+        public static bool RayIntersectsSphere(ref readonly Ray ray, ref readonly BoundingSphere sphere, out float distance)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 177
 
             Vector3 m;
-            Vector3.Subtract(ref ray.Position, ref sphere.Center, out m);
+            Vector3.Subtract(in ray.Position, in sphere.Center, out m);
 
             float b = Vector3.Dot(m, ray.Direction);
             float c = Vector3.Dot(m, m) - (sphere.Radius * sphere.Radius);
@@ -964,10 +964,10 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool RayIntersectsSphere(ref Ray ray, ref BoundingSphere sphere, out Vector3 point)
+        public static bool RayIntersectsSphere(ref readonly Ray ray, ref readonly BoundingSphere sphere, out Vector3 point)
         {
             float distance;
-            if (!RayIntersectsSphere(ref ray, ref sphere, out distance))
+            if (!RayIntersectsSphere(in ray, in sphere, out distance))
             {
                 point = Vector3.Zero;
                 return false;
@@ -983,10 +983,10 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The plane to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static PlaneIntersectionType PlaneIntersectsPoint(ref Plane plane, ref Vector3 point)
+        public static PlaneIntersectionType PlaneIntersectsPoint(ref readonly Plane plane, ref readonly Vector3 point)
         {
             float distance;
-            Vector3.Dot(ref plane.Normal, ref point, out distance);
+            Vector3.Dot(in plane.Normal, in point, out distance);
             distance += plane.D;
 
             if (distance > 0f)
@@ -1004,10 +1004,10 @@ namespace Stride.Core.Mathematics
         /// <param name="plane1">The first plane to test.</param>
         /// <param name="plane2">The second plane to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool PlaneIntersectsPlane(ref Plane plane1, ref Plane plane2)
+        public static bool PlaneIntersectsPlane(ref readonly Plane plane1, ref readonly Plane plane2)
         {
             Vector3 direction;
-            Vector3.Cross(ref plane1.Normal, ref plane2.Normal, out direction);
+            Vector3.Cross(in plane1.Normal, in plane2.Normal, out direction);
 
             //If direction is the zero vector, the planes are parallel and possibly
             //coincident. It is not an intersection. The dot product will tell us.
@@ -1033,13 +1033,13 @@ namespace Stride.Core.Mathematics
         /// a line in three dimensions which has no real origin. The ray is considered valid when
         /// both the positive direction is used and when the negative direction is used.
         /// </remarks>
-        public static bool PlaneIntersectsPlane(ref Plane plane1, ref Plane plane2, out Ray line)
+        public static bool PlaneIntersectsPlane(ref readonly Plane plane1, ref readonly Plane plane2, out Ray line)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 207
 
             Vector3 direction;
-            Vector3.Cross(ref plane1.Normal, ref plane2.Normal, out direction);
+            Vector3.Cross(in plane1.Normal, in plane2.Normal, out direction);
 
             //If direction is the zero vector, the planes are parallel and possibly
             //coincident. It is not an intersection. The dot product will tell us.
@@ -1074,14 +1074,14 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triagnle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static PlaneIntersectionType PlaneIntersectsTriangle(ref Plane plane, ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public static PlaneIntersectionType PlaneIntersectsTriangle(ref readonly Plane plane, ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 207
 
-            PlaneIntersectionType test1 = PlaneIntersectsPoint(ref plane, ref vertex1);
-            PlaneIntersectionType test2 = PlaneIntersectsPoint(ref plane, ref vertex2);
-            PlaneIntersectionType test3 = PlaneIntersectsPoint(ref plane, ref vertex3);
+            PlaneIntersectionType test1 = PlaneIntersectsPoint(in plane, in vertex1);
+            PlaneIntersectionType test2 = PlaneIntersectsPoint(in plane, in vertex2);
+            PlaneIntersectionType test3 = PlaneIntersectsPoint(in plane, in vertex3);
 
             if (test1 == PlaneIntersectionType.Front && test2 == PlaneIntersectionType.Front && test3 == PlaneIntersectionType.Front)
                 return PlaneIntersectionType.Front;
@@ -1098,7 +1098,7 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The plane to test.</param>
         /// <param name="box">The box to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static PlaneIntersectionType PlaneIntersectsBox(ref Plane plane, ref BoundingBox box)
+        public static PlaneIntersectionType PlaneIntersectsBox(ref readonly Plane plane, ref readonly BoundingBox box)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 161
@@ -1114,7 +1114,7 @@ namespace Stride.Core.Mathematics
             min.Z = (plane.Normal.Z >= 0.0f) ? box.Maximum.Z : box.Minimum.Z;
 
             float distance;
-            Vector3.Dot(ref plane.Normal, ref max, out distance);
+            Vector3.Dot(in plane.Normal, ref max, out distance);
 
             if (distance + plane.D > 0.0f)
                 return PlaneIntersectionType.Front;
@@ -1133,13 +1133,13 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The plane to test.</param>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static PlaneIntersectionType PlaneIntersectsSphere(ref Plane plane, ref BoundingSphere sphere)
+        public static PlaneIntersectionType PlaneIntersectsSphere(ref readonly Plane plane, ref readonly BoundingSphere sphere)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 160
 
             float distance;
-            Vector3.Dot(ref plane.Normal, ref sphere.Center, out distance);
+            Vector3.Dot(in plane.Normal, in sphere.Center, out distance);
             distance += plane.D;
 
             if (distance > sphere.Radius)
@@ -1181,7 +1181,7 @@ namespace Stride.Core.Mathematics
         /// <param name="box1">The first box to test.</param>
         /// <param name="box2">The second box to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool BoxIntersectsBox(ref BoundingBox box1, ref BoundingBox box2)
+        public static bool BoxIntersectsBox(ref readonly BoundingBox box1, ref readonly BoundingBox box2)
         {
             if (box1.Minimum.X > box2.Maximum.X || box2.Minimum.X > box1.Maximum.X)
                 return false;
@@ -1201,13 +1201,13 @@ namespace Stride.Core.Mathematics
         /// <param name="box">The box to test.</param>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool BoxIntersectsSphere(ref BoundingBox box, ref BoundingSphere sphere)
+        public static bool BoxIntersectsSphere(ref readonly BoundingBox box, ref readonly BoundingSphere sphere)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 166
 
             Vector3 vector;
-            Vector3.Clamp(ref sphere.Center, ref box.Minimum, ref box.Maximum, out vector);
+            Vector3.Clamp(in sphere.Center, in box.Minimum, in box.Maximum, out vector);
             float distance = Vector3.DistanceSquared(sphere.Center, vector);
 
             return distance <= sphere.Radius * sphere.Radius;
@@ -1221,13 +1221,13 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triagnle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool SphereIntersectsTriangle(ref BoundingSphere sphere, ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public static bool SphereIntersectsTriangle(ref readonly BoundingSphere sphere, ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
             //Source: Real-Time Collision Detection by Christer Ericson
             //Reference: Page 167
 
             Vector3 point;
-            ClosestPointPointTriangle(ref sphere.Center, ref vertex1, ref vertex2, ref vertex3, out point);
+            ClosestPointPointTriangle(in sphere.Center, in vertex1, in vertex2, in vertex3, out point);
             Vector3 v = point - sphere.Center;
 
             float dot;
@@ -1242,7 +1242,7 @@ namespace Stride.Core.Mathematics
         /// <param name="sphere1">First sphere to test.</param>
         /// <param name="sphere2">Second sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public static bool SphereIntersectsSphere(ref BoundingSphere sphere1, ref BoundingSphere sphere2)
+        public static bool SphereIntersectsSphere(ref readonly BoundingSphere sphere1, ref readonly BoundingSphere sphere2)
         {
             float radiisum = sphere1.Radius + sphere2.Radius;
             return Vector3.DistanceSquared(sphere1.Center, sphere2.Center) <= radiisum * radiisum;
@@ -1254,7 +1254,7 @@ namespace Stride.Core.Mathematics
         /// <param name="box">The box to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType BoxContainsPoint(ref BoundingBox box, ref Vector3 point)
+        public static ContainmentType BoxContainsPoint(ref readonly BoundingBox box, ref readonly Vector3 point)
         {
             if (box.Minimum.X <= point.X && box.Maximum.X >= point.X &&
                 box.Minimum.Y <= point.Y && box.Maximum.Y >= point.Y &&
@@ -1297,7 +1297,7 @@ namespace Stride.Core.Mathematics
         /// <param name="box1">The first box to test.</param>
         /// <param name="box2">The second box to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType BoxContainsBox(ref BoundingBox box1, ref BoundingBox box2)
+        public static ContainmentType BoxContainsBox(ref readonly BoundingBox box1, ref readonly BoundingBox box2)
         {
             if (box1.Maximum.X < box2.Minimum.X || box1.Minimum.X > box2.Maximum.X)
                 return ContainmentType.Disjoint;
@@ -1324,10 +1324,10 @@ namespace Stride.Core.Mathematics
         /// <param name="box">The box to test.</param>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType BoxContainsSphere(ref BoundingBox box, ref BoundingSphere sphere)
+        public static ContainmentType BoxContainsSphere(ref readonly BoundingBox box, ref readonly BoundingSphere sphere)
         {
             Vector3 vector;
-            Vector3.Clamp(ref sphere.Center, ref box.Minimum, ref box.Maximum, out vector);
+            Vector3.Clamp(in sphere.Center, in box.Minimum, in box.Maximum, out vector);
             float distance = Vector3.DistanceSquared(sphere.Center, vector);
 
             if (distance > sphere.Radius * sphere.Radius)
@@ -1349,7 +1349,7 @@ namespace Stride.Core.Mathematics
         /// <param name="sphere">The sphere to test.</param>
         /// <param name="point">The point to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType SphereContainsPoint(ref BoundingSphere sphere, ref Vector3 point)
+        public static ContainmentType SphereContainsPoint(ref readonly BoundingSphere sphere, ref readonly Vector3 point)
         {
             if (Vector3.DistanceSquared(point, sphere.Center) <= sphere.Radius * sphere.Radius)
                 return ContainmentType.Contains;
@@ -1365,19 +1365,19 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triagnle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType SphereContainsTriangle(ref BoundingSphere sphere, ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public static ContainmentType SphereContainsTriangle(ref readonly BoundingSphere sphere, ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
             //Source: Jorgy343
             //Reference: None
 
-            ContainmentType test1 = SphereContainsPoint(ref sphere, ref vertex1);
-            ContainmentType test2 = SphereContainsPoint(ref sphere, ref vertex2);
-            ContainmentType test3 = SphereContainsPoint(ref sphere, ref vertex3);
+            ContainmentType test1 = SphereContainsPoint(in sphere, in vertex1);
+            ContainmentType test2 = SphereContainsPoint(in sphere, in vertex2);
+            ContainmentType test3 = SphereContainsPoint(in sphere, in vertex3);
 
             if (test1 == ContainmentType.Contains && test2 == ContainmentType.Contains && test3 == ContainmentType.Contains)
                 return ContainmentType.Contains;
 
-            if (SphereIntersectsTriangle(ref sphere, ref vertex1, ref vertex2, ref vertex3))
+            if (SphereIntersectsTriangle(in sphere, in vertex1, in vertex2, in vertex3))
                 return ContainmentType.Intersects;
 
             return ContainmentType.Disjoint;
@@ -1389,11 +1389,11 @@ namespace Stride.Core.Mathematics
         /// <param name="sphere">The sphere to test.</param>
         /// <param name="box">The box to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType SphereContainsBox(ref BoundingSphere sphere, ref BoundingBox box)
+        public static ContainmentType SphereContainsBox(ref readonly BoundingSphere sphere, ref readonly BoundingBox box)
         {
             Vector3 vector;
 
-            if (!BoxIntersectsSphere(ref box, ref sphere))
+            if (!BoxIntersectsSphere(in box, in sphere))
                 return ContainmentType.Disjoint;
 
             float radiussquared = sphere.Radius * sphere.Radius;
@@ -1462,7 +1462,7 @@ namespace Stride.Core.Mathematics
         /// <param name="sphere1">The first sphere to test.</param>
         /// <param name="sphere2">The second sphere to test.</param>
         /// <returns>The type of containment the two objects have.</returns>
-        public static ContainmentType SphereContainsSphere(ref BoundingSphere sphere1, ref BoundingSphere sphere2)
+        public static ContainmentType SphereContainsSphere(ref readonly BoundingSphere sphere1, ref readonly BoundingSphere sphere2)
         {
             float distance = Vector3.Distance(sphere1.Center, sphere2.Center);
 
@@ -1482,7 +1482,7 @@ namespace Stride.Core.Mathematics
         /// <param name="frustum">The frustum.</param>
         /// <param name="boundingBoxExt">The bounding box ext.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
-        public static bool FrustumContainsBox(ref BoundingFrustum frustum, ref BoundingBoxExt boundingBoxExt)
+        public static bool FrustumContainsBox(ref readonly BoundingFrustum frustum, ref readonly BoundingBoxExt boundingBoxExt)
         {
             unsafe
             {
@@ -1559,7 +1559,7 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">The distance from the start of the ray.</param>
         /// <param name="point">The position of the collision.</param>
         /// <returns>Whether there was a hit.</returns>
-        public static bool GetNearestHit<T>(IEnumerable<T> objects, ref Ray ray, out T hitObject, out float distance, out Vector3 point)
+        public static bool GetNearestHit<T>(IEnumerable<T> objects, ref readonly Ray ray, out T hitObject, out float distance, out Vector3 point)
             where T : IIntersectableWithRay
         {
             bool hit = false;
@@ -1568,7 +1568,7 @@ namespace Stride.Core.Mathematics
 
             foreach (var o in objects)
             {
-                if (o.Intersects(ref ray, out float d) && (d < distance))
+                if (o.Intersects(in ray, out float d) && (d < distance))
                 {
                     distance = d;
                     hitObject = o;
@@ -1577,7 +1577,7 @@ namespace Stride.Core.Mathematics
             }
 
             if (hit)
-                hitObject.Intersects(ref ray, out point);
+                hitObject.Intersects(in ray, out point);
             else
                 point = default;
 

--- a/sources/core/Stride.Core.Mathematics/Color.cs
+++ b/sources/core/Stride.Core.Mathematics/Color.cs
@@ -461,7 +461,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to add.</param>
         /// <param name="right">The second color to add.</param>
         /// <param name="result">When the method completes, completes the sum of the two colors.</param>
-        public static void Add(ref Color left, ref Color right, out Color result)
+        public static void Add(ref readonly Color left, ref readonly Color right, out Color result)
         {
             result.A = (byte)(left.A + right.A);
             result.R = (byte)(left.R + right.R);
@@ -486,7 +486,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to subtract.</param>
         /// <param name="right">The second color to subtract.</param>
         /// <param name="result">WHen the method completes, contains the difference of the two colors.</param>
-        public static void Subtract(ref Color left, ref Color right, out Color result)
+        public static void Subtract(ref readonly Color left, ref readonly Color right, out Color result)
         {
             result.A = (byte)(left.A - right.A);
             result.R = (byte)(left.R - right.R);
@@ -511,7 +511,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to modulate.</param>
         /// <param name="right">The second color to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated color.</param>
-        public static void Modulate(ref Color left, ref Color right, out Color result)
+        public static void Modulate(ref readonly Color left, ref readonly Color right, out Color result)
         {
             result.A = (byte)(left.A * right.A / 255);
             result.R = (byte)(left.R * right.R / 255);
@@ -536,7 +536,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color to scale.</param>
         /// <param name="scale">The amount by which to scale.</param>
         /// <param name="result">When the method completes, contains the scaled color.</param>
-        public static void Scale(ref Color value, float scale, out Color result)
+        public static void Scale(ref readonly Color value, float scale, out Color result)
         {
             result.A = (byte)(value.A * scale);
             result.R = (byte)(value.R * scale);
@@ -560,7 +560,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The color to negate.</param>
         /// <param name="result">When the method completes, contains the negated color.</param>
-        public static void Negate(ref Color value, out Color result)
+        public static void Negate(ref readonly Color value, out Color result)
         {
             result.A = (byte)(255 - value.A);
             result.R = (byte)(255 - value.R);
@@ -585,7 +585,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Color value, ref Color min, ref Color max, out Color result)
+        public static void Clamp(ref readonly Color value, ref readonly Color min, ref readonly Color max, out Color result)
         {
             byte alpha = value.A;
             alpha = (alpha > max.A) ? max.A : alpha;
@@ -690,7 +690,7 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Color start, ref Color end, float amount, out Color result)
+        public static void Lerp(ref readonly Color start, ref readonly Color end, float amount, out Color result)
         {
             result.R = MathUtil.Lerp(start.R, end.R, amount);
             result.G = MathUtil.Lerp(start.G, end.G, amount);
@@ -722,10 +722,10 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End color.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two colors.</param>
-        public static void SmoothStep(ref Color start, ref Color end, float amount, out Color result)
+        public static void SmoothStep(ref readonly Color start, ref readonly Color end, float amount, out Color result)
         {
             amount = MathUtil.SmoothStep(amount);
-            Lerp(ref start, ref end, amount, out result);
+            Lerp(in start, in end, amount, out result);
         }
 
         /// <summary>
@@ -748,7 +748,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the largest components of the source colors.</param>
-        public static void Max(ref Color left, ref Color right, out Color result)
+        public static void Max(ref readonly Color left, ref readonly Color right, out Color result)
         {
             result.A = (left.A > right.A) ? left.A : right.A;
             result.R = (left.R > right.R) ? left.R : right.R;
@@ -775,7 +775,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the smallest components of the source colors.</param>
-        public static void Min(ref Color left, ref Color right, out Color result)
+        public static void Min(ref readonly Color left, ref readonly Color right, out Color result)
         {
             result.A = (left.A < right.A) ? left.A : right.A;
             result.R = (left.R < right.R) ? left.R : right.R;
@@ -802,7 +802,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose contrast is to be adjusted.</param>
         /// <param name="contrast">The amount by which to adjust the contrast.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustContrast(ref Color value, float contrast, out Color result)
+        public static void AdjustContrast(ref readonly Color value, float contrast, out Color result)
         {
             result.A = value.A;
             result.R = ToByte(0.5f + contrast * (value.R / 255.0f - 0.5f));
@@ -831,7 +831,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose saturation is to be adjusted.</param>
         /// <param name="saturation">The amount by which to adjust the saturation.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustSaturation(ref Color value, float saturation, out Color result)
+        public static void AdjustSaturation(ref readonly Color value, float saturation, out Color result)
         {
             float grey = value.R / 255.0f * 0.2125f + value.G / 255.0f * 0.7154f + value.B / 255.0f * 0.0721f;
 

--- a/sources/core/Stride.Core.Mathematics/Color3.cs
+++ b/sources/core/Stride.Core.Mathematics/Color3.cs
@@ -225,7 +225,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to add.</param>
         /// <param name="right">The second color to add.</param>
         /// <param name="result">When the method completes, completes the sum of the two colors.</param>
-        public static void Add(ref Color3 left, ref Color3 right, out Color3 result)
+        public static void Add(ref readonly Color3 left, ref readonly Color3 right, out Color3 result)
         {
             result.R = left.R + right.R;
             result.G = left.G + right.G;
@@ -249,7 +249,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to subtract.</param>
         /// <param name="right">The second color to subtract.</param>
         /// <param name="result">WHen the method completes, contains the difference of the two colors.</param>
-        public static void Subtract(ref Color3 left, ref Color3 right, out Color3 result)
+        public static void Subtract(ref readonly Color3 left, ref readonly Color3 right, out Color3 result)
         {
             result.R = left.R - right.R;
             result.G = left.G - right.G;
@@ -273,7 +273,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to modulate.</param>
         /// <param name="right">The second color to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated color.</param>
-        public static void Modulate(ref Color3 left, ref Color3 right, out Color3 result)
+        public static void Modulate(ref readonly Color3 left, ref readonly Color3 right, out Color3 result)
         {
             result.R = left.R * right.R;
             result.G = left.G * right.G;
@@ -297,7 +297,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color to scale.</param>
         /// <param name="scale">The amount by which to scale.</param>
         /// <param name="result">When the method completes, contains the scaled color.</param>
-        public static void Scale(ref Color3 value, float scale, out Color3 result)
+        public static void Scale(ref readonly Color3 value, float scale, out Color3 result)
         {
             result.R = value.R * scale;
             result.G = value.G * scale;
@@ -320,7 +320,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The color to negate.</param>
         /// <param name="result">When the method completes, contains the negated color.</param>
-        public static void Negate(ref Color3 value, out Color3 result)
+        public static void Negate(ref readonly Color3 value, out Color3 result)
         {
             result.R = 1.0f - value.R;
             result.G = 1.0f - value.G;
@@ -344,7 +344,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Color3 value, ref Color3 min, ref Color3 max, out Color3 result)
+        public static void Clamp(ref readonly Color3 value, ref readonly Color3 min, ref readonly Color3 max, out Color3 result)
         {
             float red = value.R;
             red = (red > max.R) ? max.R : red;
@@ -387,7 +387,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Color3 start, ref Color3 end, float amount, out Color3 result)
+        public static void Lerp(ref readonly Color3 start, ref readonly Color3 end, float amount, out Color3 result)
         {
             result.R = start.R + amount * (end.R - start.R);
             result.G = start.G + amount * (end.G - start.G);
@@ -421,7 +421,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End color.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two colors.</param>
-        public static void SmoothStep(ref Color3 start, ref Color3 end, float amount, out Color3 result)
+        public static void SmoothStep(ref readonly Color3 start, ref readonly Color3 end, float amount, out Color3 result)
         {
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -455,7 +455,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the largest components of the source colorss.</param>
-        public static void Max(ref Color3 left, ref Color3 right, out Color3 result)
+        public static void Max(ref readonly Color3 left, ref readonly Color3 right, out Color3 result)
         {
             result.R = (left.R > right.R) ? left.R : right.R;
             result.G = (left.G > right.G) ? left.G : right.G;
@@ -481,7 +481,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the smallest components of the source colors.</param>
-        public static void Min(ref Color3 left, ref Color3 right, out Color3 result)
+        public static void Min(ref readonly Color3 left, ref readonly Color3 right, out Color3 result)
         {
             result.R = (left.R < right.R) ? left.R : right.R;
             result.G = (left.G < right.G) ? left.G : right.G;
@@ -507,7 +507,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose contrast is to be adjusted.</param>
         /// <param name="contrast">The amount by which to adjust the contrast.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustContrast(ref Color3 value, float contrast, out Color3 result)
+        public static void AdjustContrast(ref readonly Color3 value, float contrast, out Color3 result)
         {
             result.R = 0.5f + contrast * (value.R - 0.5f);
             result.G = 0.5f + contrast * (value.G - 0.5f);
@@ -534,7 +534,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose saturation is to be adjusted.</param>
         /// <param name="saturation">The amount by which to adjust the saturation.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustSaturation(ref Color3 value, float saturation, out Color3 result)
+        public static void AdjustSaturation(ref readonly Color3 value, float saturation, out Color3 result)
         {
             float grey = value.R * 0.2125f + value.G * 0.7154f + value.B * 0.0721f;
 

--- a/sources/core/Stride.Core.Mathematics/Color4.cs
+++ b/sources/core/Stride.Core.Mathematics/Color4.cs
@@ -355,7 +355,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to add.</param>
         /// <param name="right">The second color to add.</param>
         /// <param name="result">When the method completes, completes the sum of the two colors.</param>
-        public static void Add(ref Color4 left, ref Color4 right, out Color4 result)
+        public static void Add(ref readonly Color4 left, ref readonly Color4 right, out Color4 result)
         {
             result.A = left.A + right.A;
             result.R = left.R + right.R;
@@ -380,7 +380,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to subtract.</param>
         /// <param name="right">The second color to subtract.</param>
         /// <param name="result">WHen the method completes, contains the difference of the two colors.</param>
-        public static void Subtract(ref Color4 left, ref Color4 right, out Color4 result)
+        public static void Subtract(ref readonly Color4 left, ref readonly Color4 right, out Color4 result)
         {
             result.A = left.A - right.A;
             result.R = left.R - right.R;
@@ -405,7 +405,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to modulate.</param>
         /// <param name="right">The second color to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated color.</param>
-        public static void Modulate(ref Color4 left, ref Color4 right, out Color4 result)
+        public static void Modulate(ref readonly Color4 left, ref readonly Color4 right, out Color4 result)
         {
             result.A = left.A * right.A;
             result.R = left.R * right.R;
@@ -430,7 +430,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color to scale.</param>
         /// <param name="scale">The amount by which to scale.</param>
         /// <param name="result">When the method completes, contains the scaled color.</param>
-        public static void Scale(ref Color4 value, float scale, out Color4 result)
+        public static void Scale(ref readonly Color4 value, float scale, out Color4 result)
         {
             result.A = value.A * scale;
             result.R = value.R * scale;
@@ -454,7 +454,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The color to negate.</param>
         /// <param name="result">When the method completes, contains the negated color.</param>
-        public static void Negate(ref Color4 value, out Color4 result)
+        public static void Negate(ref readonly Color4 value, out Color4 result)
         {
             result.A = 1.0f - value.A;
             result.R = 1.0f - value.R;
@@ -479,7 +479,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Color4 value, ref Color4 min, ref Color4 max, out Color4 result)
+        public static void Clamp(ref readonly Color4 value, ref readonly Color4 min, ref readonly Color4 max, out Color4 result)
         {
             float alpha = value.A;
             alpha = (alpha > max.A) ? max.A : alpha;
@@ -524,7 +524,7 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Color4 start, ref Color4 end, float amount, out Color4 result)
+        public static void Lerp(ref readonly Color4 start, ref readonly Color4 end, float amount, out Color4 result)
         {
             result.R = MathUtil.Lerp(start.R, end.R, amount);
             result.G = MathUtil.Lerp(start.G, end.G, amount);
@@ -556,10 +556,10 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End color.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two colors.</param>
-        public static void SmoothStep(ref Color4 start, ref Color4 end, float amount, out Color4 result)
+        public static void SmoothStep(ref readonly Color4 start, ref readonly Color4 end, float amount, out Color4 result)
         {
             amount = MathUtil.SmoothStep(amount);
-            Lerp(ref start, ref end, amount, out result);
+            Lerp(in start, in end, amount, out result);
         }
 
         /// <summary>
@@ -582,7 +582,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the largest components of the source colors.</param>
-        public static void Max(ref Color4 left, ref Color4 right, out Color4 result)
+        public static void Max(ref readonly Color4 left, ref readonly Color4 right, out Color4 result)
         {
             result.A = (left.A > right.A) ? left.A : right.A;
             result.R = (left.R > right.R) ? left.R : right.R;
@@ -609,7 +609,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the smallest components of the source colors.</param>
-        public static void Min(ref Color4 left, ref Color4 right, out Color4 result)
+        public static void Min(ref readonly Color4 left, ref readonly Color4 right, out Color4 result)
         {
             result.A = (left.A < right.A) ? left.A : right.A;
             result.R = (left.R < right.R) ? left.R : right.R;
@@ -636,7 +636,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose contrast is to be adjusted.</param>
         /// <param name="contrast">The amount by which to adjust the contrast.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustContrast(ref Color4 value, float contrast, out Color4 result)
+        public static void AdjustContrast(ref readonly Color4 value, float contrast, out Color4 result)
         {
             result.A = value.A;
             result.R = 0.5f + contrast * (value.R - 0.5f);
@@ -665,7 +665,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose saturation is to be adjusted.</param>
         /// <param name="saturation">The amount by which to adjust the saturation.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustSaturation(ref Color4 value, float saturation, out Color4 result)
+        public static void AdjustSaturation(ref readonly Color4 value, float saturation, out Color4 result)
         {
             float grey = value.R * 0.2125f + value.G * 0.7154f + value.B * 0.0721f;
 

--- a/sources/core/Stride.Core.Mathematics/ColorBGRA.cs
+++ b/sources/core/Stride.Core.Mathematics/ColorBGRA.cs
@@ -435,7 +435,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to add.</param>
         /// <param name="right">The second color to add.</param>
         /// <param name="result">When the method completes, completes the sum of the two colors.</param>
-        public static void Add(ref ColorBGRA left, ref ColorBGRA right, out ColorBGRA result)
+        public static void Add(ref readonly ColorBGRA left, ref readonly ColorBGRA right, out ColorBGRA result)
         {
             result.A = (byte)(left.A + right.A);
             result.R = (byte)(left.R + right.R);
@@ -460,7 +460,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to subtract.</param>
         /// <param name="right">The second color to subtract.</param>
         /// <param name="result">WHen the method completes, contains the difference of the two colors.</param>
-        public static void Subtract(ref ColorBGRA left, ref ColorBGRA right, out ColorBGRA result)
+        public static void Subtract(ref readonly ColorBGRA left, ref readonly ColorBGRA right, out ColorBGRA result)
         {
             result.A = (byte)(left.A - right.A);
             result.R = (byte)(left.R - right.R);
@@ -485,7 +485,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first color to modulate.</param>
         /// <param name="right">The second color to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated color.</param>
-        public static void Modulate(ref ColorBGRA left, ref ColorBGRA right, out ColorBGRA result)
+        public static void Modulate(ref readonly ColorBGRA left, ref readonly ColorBGRA right, out ColorBGRA result)
         {
             result.A = (byte)(left.A * right.A / 255);
             result.R = (byte)(left.R * right.R / 255);
@@ -510,7 +510,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color to scale.</param>
         /// <param name="scale">The amount by which to scale.</param>
         /// <param name="result">When the method completes, contains the scaled color.</param>
-        public static void Scale(ref ColorBGRA value, float scale, out ColorBGRA result)
+        public static void Scale(ref readonly ColorBGRA value, float scale, out ColorBGRA result)
         {
             result.A = (byte)(value.A * scale);
             result.R = (byte)(value.R * scale);
@@ -534,7 +534,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The color to negate.</param>
         /// <param name="result">When the method completes, contains the negated color.</param>
-        public static void Negate(ref ColorBGRA value, out ColorBGRA result)
+        public static void Negate(ref readonly ColorBGRA value, out ColorBGRA result)
         {
             result.A = (byte)(255 - value.A);
             result.R = (byte)(255 - value.R);
@@ -559,7 +559,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref ColorBGRA value, ref ColorBGRA min, ref ColorBGRA max, out ColorBGRA result)
+        public static void Clamp(ref readonly ColorBGRA value, ref readonly ColorBGRA min, ref readonly ColorBGRA max, out ColorBGRA result)
         {
             byte alpha = value.A;
             alpha = (alpha > max.A) ? max.A : alpha;
@@ -604,7 +604,7 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref ColorBGRA start, ref ColorBGRA end, float amount, out ColorBGRA result)
+        public static void Lerp(ref readonly ColorBGRA start, ref readonly ColorBGRA end, float amount, out ColorBGRA result)
         {
             result.B = MathUtil.Lerp(start.B, end.B, amount);
             result.G = MathUtil.Lerp(start.G, end.G, amount);
@@ -636,10 +636,10 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End color.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two colors.</param>
-        public static void SmoothStep(ref ColorBGRA start, ref ColorBGRA end, float amount, out ColorBGRA result)
+        public static void SmoothStep(ref readonly ColorBGRA start, ref readonly ColorBGRA end, float amount, out ColorBGRA result)
         {
             amount = MathUtil.SmoothStep(amount);
-            Lerp(ref start, ref end, amount, out result);
+            Lerp(in start, in end, amount, out result);
         }
 
         /// <summary>
@@ -662,7 +662,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the largest components of the source colorss.</param>
-        public static void Max(ref ColorBGRA left, ref ColorBGRA right, out ColorBGRA result)
+        public static void Max(ref readonly ColorBGRA left, ref readonly ColorBGRA right, out ColorBGRA result)
         {
             result.A = (left.A > right.A) ? left.A : right.A;
             result.R = (left.R > right.R) ? left.R : right.R;
@@ -689,7 +689,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
         /// <param name="result">When the method completes, contains an new color composed of the smallest components of the source colors.</param>
-        public static void Min(ref ColorBGRA left, ref ColorBGRA right, out ColorBGRA result)
+        public static void Min(ref readonly ColorBGRA left, ref readonly ColorBGRA right, out ColorBGRA result)
         {
             result.A = (left.A < right.A) ? left.A : right.A;
             result.R = (left.R < right.R) ? left.R : right.R;
@@ -716,7 +716,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose contrast is to be adjusted.</param>
         /// <param name="contrast">The amount by which to adjust the contrast.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustContrast(ref ColorBGRA value, float contrast, out ColorBGRA result)
+        public static void AdjustContrast(ref readonly ColorBGRA value, float contrast, out ColorBGRA result)
         {
             result.A = value.A;
             result.R = ToByte(0.5f + contrast * (value.R / 255.0f - 0.5f));
@@ -745,7 +745,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The color whose saturation is to be adjusted.</param>
         /// <param name="saturation">The amount by which to adjust the saturation.</param>
         /// <param name="result">When the method completes, contains the adjusted color.</param>
-        public static void AdjustSaturation(ref ColorBGRA value, float saturation, out ColorBGRA result)
+        public static void AdjustSaturation(ref readonly ColorBGRA value, float saturation, out ColorBGRA result)
         {
             float grey = value.R / 255.0f * 0.2125f + value.G / 255.0f * 0.7154f + value.B / 255.0f * 0.0721f;
 

--- a/sources/core/Stride.Core.Mathematics/Double2.cs
+++ b/sources/core/Stride.Core.Mathematics/Double2.cs
@@ -431,7 +431,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second vector.</param>
         /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
         /// <remarks>
-        /// <see cref="Stride.Core.Mathematics.Double2.DistanceSquared(ref Double2, ref Double2, out double)"/> may be preferred when only the relative distance is needed
+        /// <see cref="Stride.Core.Mathematics.Double2.DistanceSquared(ref readonly Double2, ref readonly Double2, out double)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
         public static void Distance(ref readonly Double2 value1, ref readonly Double2 value2, out double result)

--- a/sources/core/Stride.Core.Mathematics/Double2.cs
+++ b/sources/core/Stride.Core.Mathematics/Double2.cs
@@ -200,7 +200,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Add(ref Double2 left, ref Double2 right, out Double2 result)
+        public static void Add(ref readonly Double2 left, ref readonly Double2 right, out Double2 result)
         {
             result = new Double2(left.X + right.X, left.Y + right.Y);
         }
@@ -224,7 +224,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Subtract(ref Double2 left, ref Double2 right, out Double2 result)
+        public static void Subtract(ref readonly Double2 left, ref readonly Double2 right, out Double2 result)
         {
             result = new Double2(left.X - right.X, left.Y - right.Y);
         }
@@ -248,7 +248,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Multiply(ref Double2 value, double scale, out Double2 result)
+        public static void Multiply(ref readonly Double2 value, double scale, out Double2 result)
         {
             result = new Double2(value.X * scale, value.Y * scale);
         }
@@ -272,7 +272,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Modulate(ref Double2 left, ref Double2 right, out Double2 result)
+        public static void Modulate(ref readonly Double2 left, ref readonly Double2 right, out Double2 result)
         {
             result = new Double2(left.X * right.X, left.Y * right.Y);
         }
@@ -296,7 +296,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Divide(ref Double2 value, double scale, out Double2 result)
+        public static void Divide(ref readonly Double2 value, double scale, out Double2 result)
         {
             result = new Double2(value.X / scale, value.Y / scale);
         }
@@ -320,7 +320,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to demodulate.</param>
         /// <param name="result">When the method completes, contains the demodulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Demodulate(ref Double2 left, ref Double2 right, out Double2 result)
+        public static void Demodulate(ref readonly Double2 left, ref readonly Double2 right, out Double2 result)
         {
             result = new Double2(left.X / right.X, left.Y / right.Y);
         }
@@ -343,7 +343,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Negate(ref Double2 value, out Double2 result)
+        public static void Negate(ref readonly Double2 value, out Double2 result)
         {
             result = new Double2(-value.X, -value.Y);
         }
@@ -368,7 +368,7 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains the 2D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Double2 value1, ref Double2 value2, ref Double2 value3, double amount1, double amount2, out Double2 result)
+        public static void Barycentric(ref readonly Double2 value1, ref readonly Double2 value2, ref readonly Double2 value3, double amount1, double amount2, out Double2 result)
         {
             result = new Double2((value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
                 (value1.Y + (amount1 * (value2.Y - value1.Y))) + (amount2 * (value3.Y - value1.Y)));
@@ -397,7 +397,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Double2 value, ref Double2 min, ref Double2 max, out Double2 result)
+        public static void Clamp(ref readonly Double2 value, ref readonly Double2 min, ref readonly Double2 max, out Double2 result)
         {
             double x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -434,7 +434,7 @@ namespace Stride.Core.Mathematics
         /// <see cref="Stride.Core.Mathematics.Double2.DistanceSquared(ref Double2, ref Double2, out double)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
-        public static void Distance(ref Double2 value1, ref Double2 value2, out double result)
+        public static void Distance(ref readonly Double2 value1, ref readonly Double2 value2, out double result)
         {
             double x = value1.X - value2.X;
             double y = value1.Y - value2.Y;
@@ -473,7 +473,7 @@ namespace Stride.Core.Mathematics
         /// involves two square roots, which are computationally expensive. However, using distance squared 
         /// provides the same information and avoids calculating two square roots.
         /// </remarks>
-        public static void DistanceSquared(ref Double2 value1, ref Double2 value2, out double result)
+        public static void DistanceSquared(ref readonly Double2 value1, ref readonly Double2 value2, out double result)
         {
             double x = value1.X - value2.X;
             double y = value1.Y - value2.Y;
@@ -509,7 +509,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Dot(ref Double2 left, ref Double2 right, out double result)
+        public static void Dot(ref readonly Double2 left, ref readonly Double2 right, out double result)
         {
             result = (left.X * right.X) + (left.Y * right.Y);
         }
@@ -532,7 +532,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Normalize(ref Double2 value, out Double2 result)
+        public static void Normalize(ref readonly Double2 value, out Double2 result)
         {
             result = value;
             result.Normalize();
@@ -562,7 +562,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Double2 start, ref Double2 end, double amount, out Double2 result)
+        public static void Lerp(ref readonly Double2 start, ref readonly Double2 end, double amount, out Double2 result)
         {
             result.X = start.X + ((end.X - start.X) * amount);
             result.Y = start.Y + ((end.Y - start.Y) * amount);
@@ -594,7 +594,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Double2 start, ref Double2 end, double amount, out Double2 result)
+        public static void SmoothStep(ref readonly Double2 start, ref readonly Double2 end, double amount, out Double2 result)
         {
             amount = (amount > 1.0) ? 1.0 : ((amount < 0.0) ? 0.0 : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -626,7 +626,7 @@ namespace Stride.Core.Mathematics
         /// <param name="tangent2">Second source tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
-        public static void Hermite(ref Double2 value1, ref Double2 tangent1, ref Double2 value2, ref Double2 tangent2, double amount, out Double2 result)
+        public static void Hermite(ref readonly Double2 value1, ref readonly Double2 tangent1, ref readonly Double2 value2, ref readonly Double2 tangent2, double amount, out Double2 result)
         {
             double squared = amount * amount;
             double cubed = amount * squared;
@@ -664,7 +664,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
-        public static void CatmullRom(ref Double2 value1, ref Double2 value2, ref Double2 value3, ref Double2 value4, double amount, out Double2 result)
+        public static void CatmullRom(ref readonly Double2 value1, ref readonly Double2 value2, ref readonly Double2 value3, ref readonly Double2 value4, double amount, out Double2 result)
         {
             double squared = amount * amount;
             double cubed = amount * squared;
@@ -701,7 +701,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Max(ref Double2 left, ref Double2 right, out Double2 result)
+        public static void Max(ref readonly Double2 left, ref readonly Double2 right, out Double2 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -728,7 +728,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Min(ref Double2 left, ref Double2 right, out Double2 result)
+        public static void Min(ref readonly Double2 left, ref readonly Double2 right, out Double2 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;
@@ -756,7 +756,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the reflected vector.</param>
         /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
         /// whether the original vector was close enough to the surface to hit it.</remarks>
-        public static void Reflect(ref Double2 vector, ref Double2 normal, out Double2 result)
+        public static void Reflect(ref readonly Double2 vector, ref readonly Double2 normal, out Double2 result)
         {
             double dot = (vector.X * normal.X) + (vector.Y * normal.Y);
 
@@ -878,7 +878,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The vector to rotate.</param>
         /// <param name="rotation">The <see cref="Stride.Core.Mathematics.Quaternion"/> rotation to apply.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double4"/>.</param>
-        public static void Transform(ref Double2 vector, ref Quaternion rotation, out Double2 result)
+        public static void Transform(ref readonly Double2 vector, ref readonly Quaternion rotation, out Double2 result)
         {
             double x = rotation.X + rotation.X;
             double y = rotation.Y + rotation.Y;
@@ -914,7 +914,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Double2[] source, ref Quaternion rotation, Double2[] destination)
+        public static void Transform(Double2[] source, ref readonly Quaternion rotation, Double2[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -951,7 +951,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double4"/>.</param>
-        public static void Transform(ref Double2 vector, ref Matrix transform, out Double4 result)
+        public static void Transform(ref readonly Double2 vector, ref readonly Matrix transform, out Double4 result)
         {
             result = new Double4(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + transform.M41,
@@ -981,7 +981,7 @@ namespace Stride.Core.Mathematics
         /// <param name="destination">The array for which the transformed vectors are stored.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Double2[] source, ref Matrix transform, Double4[] destination)
+        public static void Transform(Double2[] source, ref readonly Matrix transform, Double4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -992,7 +992,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                Transform(ref source[i], ref transform, out destination[i]);
+                Transform(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1009,7 +1009,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(ref Double2 coordinate, ref Matrix transform, out Double2 result)
+        public static void TransformCoordinate(ref readonly Double2 coordinate, ref readonly Matrix transform, out Double2 result)
         {
             Double4 vector = new Double4();
             vector.X = (coordinate.X * transform.M11) + (coordinate.Y * transform.M21) + transform.M41;
@@ -1056,7 +1056,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(Double2[] source, ref Matrix transform, Double2[] destination)
+        public static void TransformCoordinate(Double2[] source, ref readonly Matrix transform, Double2[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1067,7 +1067,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformCoordinate(ref source[i], ref transform, out destination[i]);
+                TransformCoordinate(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1084,7 +1084,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(ref Double2 normal, ref Matrix transform, out Double2 result)
+        public static void TransformNormal(ref readonly Double2 normal, ref readonly Matrix transform, out Double2 result)
         {
             result = new Double2(
                 (normal.X * transform.M11) + (normal.Y * transform.M21),
@@ -1127,7 +1127,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(Double2[] source, ref Matrix transform, Double2[] destination)
+        public static void TransformNormal(Double2[] source, ref readonly Matrix transform, Double2[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1138,7 +1138,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformNormal(ref source[i], ref transform, out destination[i]);
+                TransformNormal(ref source[i], in transform, out destination[i]);
             }
         }
 

--- a/sources/core/Stride.Core.Mathematics/Double3.cs
+++ b/sources/core/Stride.Core.Mathematics/Double3.cs
@@ -242,7 +242,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Add(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Add(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result = new Double3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
         }
@@ -266,7 +266,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Subtract(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Subtract(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result = new Double3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
         }
@@ -290,7 +290,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Multiply(ref Double3 value, double scale, out Double3 result)
+        public static void Multiply(ref readonly Double3 value, double scale, out Double3 result)
         {
             result = new Double3(value.X * scale, value.Y * scale, value.Z * scale);
         }
@@ -314,7 +314,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Modulate(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Modulate(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result = new Double3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
         }
@@ -338,7 +338,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Divide(ref Double3 value, double scale, out Double3 result)
+        public static void Divide(ref readonly Double3 value, double scale, out Double3 result)
         {
             result = new Double3(value.X / scale, value.Y / scale, value.Z / scale);
         }
@@ -362,7 +362,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to demodulate.</param>
         /// <param name="result">When the method completes, contains the demodulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Demodulate(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Demodulate(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result = new Double3(left.X / right.X, left.Y / right.Y, left.Z / right.Z);
         }
@@ -385,7 +385,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Negate(ref Double3 value, out Double3 result)
+        public static void Negate(ref readonly Double3 value, out Double3 result)
         {
             result = new Double3(-value.X, -value.Y, -value.Z);
         }
@@ -410,7 +410,7 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains the 3D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Double3 value1, ref Double3 value2, ref Double3 value3, double amount1, double amount2, out Double3 result)
+        public static void Barycentric(ref readonly Double3 value1, ref readonly Double3 value2, ref readonly Double3 value3, double amount1, double amount2, out Double3 result)
         {
             result = new Double3((value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
                 (value1.Y + (amount1 * (value2.Y - value1.Y))) + (amount2 * (value3.Y - value1.Y)),
@@ -440,7 +440,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Double3 value, ref Double3 min, ref Double3 max, out Double3 result)
+        public static void Clamp(ref readonly Double3 value, ref readonly Double3 min, ref readonly Double3 max, out Double3 result)
         {
             double x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -477,7 +477,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">First source vector.</param>
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains he cross product of the two vectors.</param>
-        public static void Cross(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Cross(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result = new Double3(
                 (left.Y * right.Z) - (left.Z * right.Y),
@@ -505,10 +505,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second vector.</param>
         /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
         /// <remarks>
-        /// <see cref="Stride.Core.Mathematics.Double3.DistanceSquared(ref Double3, ref Double3, out double)"/> may be preferred when only the relative distance is needed
+        /// <see cref="Stride.Core.Mathematics.Double3.DistanceSquared(ref readonly Double3, ref readonly Double3, out double)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
-        public static void Distance(ref Double3 value1, ref Double3 value2, out double result)
+        public static void Distance(ref readonly Double3 value1, ref readonly Double3 value2, out double result)
         {
             double x = value1.X - value2.X;
             double y = value1.Y - value2.Y;
@@ -549,7 +549,7 @@ namespace Stride.Core.Mathematics
         /// involves two square roots, which are computationally expensive. However, using distance squared 
         /// provides the same information and avoids calculating two square roots.
         /// </remarks>
-        public static void DistanceSquared(ref Double3 value1, ref Double3 value2, out double result)
+        public static void DistanceSquared(ref readonly Double3 value1, ref readonly Double3 value2, out double result)
         {
             double x = value1.X - value2.X;
             double y = value1.Y - value2.Y;
@@ -587,7 +587,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Dot(ref Double3 left, ref Double3 right, out double result)
+        public static void Dot(ref readonly Double3 left, ref readonly Double3 right, out double result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
         }
@@ -610,7 +610,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Normalize(ref Double3 value, out Double3 result)
+        public static void Normalize(ref readonly Double3 value, out Double3 result)
         {
             result = value;
             result.Normalize();
@@ -640,7 +640,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Double3 start, ref Double3 end, double amount, out Double3 result)
+        public static void Lerp(ref readonly Double3 start, ref readonly Double3 end, double amount, out Double3 result)
         {
             result.X = start.X + ((end.X - start.X) * amount);
             result.Y = start.Y + ((end.Y - start.Y) * amount);
@@ -673,7 +673,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Double3 start, ref Double3 end, double amount, out Double3 result)
+        public static void SmoothStep(ref readonly Double3 start, ref readonly Double3 end, double amount, out Double3 result)
         {
             amount = (amount > 1.0) ? 1.0 : ((amount < 0.0) ? 0.0 : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -706,7 +706,7 @@ namespace Stride.Core.Mathematics
         /// <param name="tangent2">Second source tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
-        public static void Hermite(ref Double3 value1, ref Double3 tangent1, ref Double3 value2, ref Double3 tangent2, double amount, out Double3 result)
+        public static void Hermite(ref readonly Double3 value1, ref readonly Double3 tangent1, ref readonly Double3 value2, ref readonly Double3 tangent2, double amount, out Double3 result)
         {
             double squared = amount * amount;
             double cubed = amount * squared;
@@ -745,7 +745,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
-        public static void CatmullRom(ref Double3 value1, ref Double3 value2, ref Double3 value3, ref Double3 value4, double amount, out Double3 result)
+        public static void CatmullRom(ref readonly Double3 value1, ref readonly Double3 value2, ref readonly Double3 value3, ref readonly Double3 value4, double amount, out Double3 result)
         {
             double squared = amount * amount;
             double cubed = amount * squared;
@@ -786,7 +786,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Max(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Max(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -814,7 +814,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Min(ref Double3 left, ref Double3 right, out Double3 result)
+        public static void Min(ref readonly Double3 left, ref readonly Double3 right, out Double3 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;
@@ -847,10 +847,10 @@ namespace Stride.Core.Mathematics
         /// <param name="maxZ">The maximum depth of the viewport.</param>
         /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
         /// <param name="result">When the method completes, contains the vector in screen space.</param>
-        public static void Project(ref Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, ref Matrix worldViewProjection, out Double3 result)
+        public static void Project(ref readonly Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, ref readonly Matrix worldViewProjection, out Double3 result)
         {
             Double3 v;
-            TransformCoordinate(ref vector, ref worldViewProjection, out v);
+            TransformCoordinate(in vector, in worldViewProjection, out v);
 
             result = new Double3(((1.0 + v.X) * 0.5f * width) + x, ((1.0 - v.Y) * 0.5f * height) + y, (v.Z * (maxZ - minZ)) + minZ);
         }
@@ -886,11 +886,11 @@ namespace Stride.Core.Mathematics
         /// <param name="maxZ">The maximum depth of the viewport.</param>
         /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
         /// <param name="result">When the method completes, contains the vector in object space.</param>
-        public static void Unproject(ref Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, ref Matrix worldViewProjection, out Double3 result)
+        public static void Unproject(ref readonly Double3 vector, double x, double y, double width, double height, double minZ, double maxZ, ref readonly Matrix worldViewProjection, out Double3 result)
         {
             Double3 v = new Double3();
             Matrix matrix;
-            Matrix.Invert(ref worldViewProjection, out matrix);
+            Matrix.Invert(in worldViewProjection, out matrix);
 
             v.X = (((vector.X - x) / width) * 2.0f) - 1.0;
             v.Y = -((((vector.Y - y) / height) * 2.0f) - 1.0);
@@ -926,7 +926,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the reflected vector.</param>
         /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
         /// whether the original vector was close enough to the surface to hit it.</remarks>
-        public static void Reflect(ref Double3 vector, ref Double3 normal, out Double3 result)
+        public static void Reflect(ref readonly Double3 vector, ref readonly Double3 normal, out Double3 result)
         {
             double dot = (vector.X * normal.X) + (vector.Y * normal.Y) + (vector.Z * normal.Z);
 
@@ -1049,7 +1049,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The vector to rotate.</param>
         /// <param name="rotation">The <see cref="Stride.Core.Mathematics.Quaternion"/> rotation to apply.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double4"/>.</param>
-        public static void Transform(ref Double3 vector, ref Quaternion rotation, out Double3 result)
+        public static void Transform(ref readonly Double3 vector, ref readonly Quaternion rotation, out Double3 result)
         {
             double x = rotation.X + rotation.X;
             double y = rotation.Y + rotation.Y;
@@ -1092,7 +1092,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Double3[] source, ref Quaternion rotation, Double3[] destination)
+        public static void Transform(Double3[] source, ref readonly Quaternion rotation, Double3[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1139,7 +1139,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double4"/>.</param>
-        public static void Transform(ref Double3 vector, ref Matrix transform, out Double4 result)
+        public static void Transform(ref readonly Double3 vector, ref readonly Matrix transform, out Double4 result)
         {
             result = new Double4(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + transform.M41,
@@ -1154,7 +1154,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double3"/>.</param>
-        public static void Transform(ref Double3 vector, ref Matrix transform, out Double3 result)
+        public static void Transform(ref readonly Double3 vector, ref readonly Matrix transform, out Double3 result)
         {
             result = new Double3(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + transform.M41,
@@ -1183,7 +1183,7 @@ namespace Stride.Core.Mathematics
         /// <param name="destination">The array for which the transformed vectors are stored.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Double3[] source, ref Matrix transform, Double4[] destination)
+        public static void Transform(Double3[] source, ref readonly Matrix transform, Double4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1194,7 +1194,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                Transform(ref source[i], ref transform, out destination[i]);
+                Transform(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1211,7 +1211,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(ref Double3 coordinate, ref Matrix transform, out Double3 result)
+        public static void TransformCoordinate(ref readonly Double3 coordinate, ref readonly Matrix transform, out Double3 result)
         {
             var invW = 1f / ((coordinate.X * transform.M14) + (coordinate.Y * transform.M24) + (coordinate.Z * transform.M34) + transform.M44);
             result = new Double3(
@@ -1256,7 +1256,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(Double3[] source, ref Matrix transform, Double3[] destination)
+        public static void TransformCoordinate(Double3[] source, ref readonly Matrix transform, Double3[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1267,7 +1267,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformCoordinate(ref source[i], ref transform, out destination[i]);
+                TransformCoordinate(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1284,7 +1284,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(ref Double3 normal, ref Matrix transform, out Double3 result)
+        public static void TransformNormal(ref readonly Double3 normal, ref readonly Matrix transform, out Double3 result)
         {
             result = new Double3(
                 (normal.X * transform.M11) + (normal.Y * transform.M21) + (normal.Z * transform.M31),
@@ -1328,7 +1328,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(Double3[] source, ref Matrix transform, Double3[] destination)
+        public static void TransformNormal(Double3[] source, ref readonly Matrix transform, Double3[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1339,7 +1339,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformNormal(ref source[i], ref transform, out destination[i]);
+                TransformNormal(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1360,10 +1360,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="quaternion">The input rotation as quaternion</param>
         /// <param name="yawPitchRoll">The equivation yaw/pitch/roll rotation</param>
-        public static void RotationYawPitchRoll(ref Quaternion quaternion, out Double3 yawPitchRoll)
+        public static void RotationYawPitchRoll(ref readonly Quaternion quaternion, out Double3 yawPitchRoll)
         {
             Vector3 yawPitchRollV;
-            Quaternion.RotationYawPitchRoll(ref quaternion, out yawPitchRollV.X, out yawPitchRollV.Y, out yawPitchRollV.Z);
+            Quaternion.RotationYawPitchRoll(in quaternion, out yawPitchRollV.X, out yawPitchRollV.Y, out yawPitchRollV.Z);
             yawPitchRoll = yawPitchRollV;
         }
 
@@ -1610,7 +1610,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The right vector.</param>
         /// <param name="epsilon">The epsilon.</param>
         /// <returns><c>true</c> if left and right are near another 3D, <c>false</c> otherwise</returns>
-        public static bool NearEqual(ref Double3 left, ref Double3 right, ref Double3 epsilon)
+        public static bool NearEqual(ref readonly Double3 left, ref readonly Double3 right, ref readonly Double3 epsilon)
         {
             return MathUtil.WithinEpsilon((float)left.X, (float)right.X, (float)epsilon.X) &&
                     MathUtil.WithinEpsilon((float)left.Y, (float)right.Y, (float)epsilon.Y) &&

--- a/sources/core/Stride.Core.Mathematics/Double4.cs
+++ b/sources/core/Stride.Core.Mathematics/Double4.cs
@@ -277,7 +277,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Add(ref Double4 left, ref Double4 right, out Double4 result)
+        public static void Add(ref readonly Double4 left, ref readonly Double4 right, out Double4 result)
         {
             result = new Double4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
         }
@@ -301,7 +301,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Subtract(ref Double4 left, ref Double4 right, out Double4 result)
+        public static void Subtract(ref readonly Double4 left, ref readonly Double4 right, out Double4 result)
         {
             result = new Double4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
         }
@@ -325,7 +325,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Multiply(ref Double4 value, double scale, out Double4 result)
+        public static void Multiply(ref readonly Double4 value, double scale, out Double4 result)
         {
             result = new Double4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
         }
@@ -349,7 +349,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Modulate(ref Double4 left, ref Double4 right, out Double4 result)
+        public static void Modulate(ref readonly Double4 left, ref readonly Double4 right, out Double4 result)
         {
             result = new Double4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
         }
@@ -373,7 +373,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Divide(ref Double4 value, double scale, out Double4 result)
+        public static void Divide(ref readonly Double4 value, double scale, out Double4 result)
         {
             result = new Double4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
         }
@@ -397,7 +397,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to demodulate.</param>
         /// <param name="result">When the method completes, contains the demodulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Demodulate(ref Double4 left, ref Double4 right, out Double4 result)
+        public static void Demodulate(ref readonly Double4 left, ref readonly Double4 right, out Double4 result)
         {
             result = new Double4(left.X / right.X, left.Y / right.Y, left.Z / right.Z, left.W / right.W);
         }
@@ -420,7 +420,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Negate(ref Double4 value, out Double4 result)
+        public static void Negate(ref readonly Double4 value, out Double4 result)
         {
             result = new Double4(-value.X, -value.Y, -value.Z, -value.W);
         }
@@ -445,7 +445,7 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains the 4D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Double4 value1, ref Double4 value2, ref Double4 value3, double amount1, double amount2, out Double4 result)
+        public static void Barycentric(ref readonly Double4 value1, ref readonly Double4 value2, ref readonly Double4 value3, double amount1, double amount2, out Double4 result)
         {
             result = new Double4((value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
                 (value1.Y + (amount1 * (value2.Y - value1.Y))) + (amount2 * (value3.Y - value1.Y)),
@@ -476,7 +476,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Double4 value, ref Double4 min, ref Double4 max, out Double4 result)
+        public static void Clamp(ref readonly Double4 value, ref readonly Double4 min, ref readonly Double4 max, out Double4 result)
         {
             double x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -518,10 +518,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second vector.</param>
         /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
         /// <remarks>
-        /// <see cref="Stride.Core.Mathematics.Double4.DistanceSquared(ref Double4, ref Double4, out double)"/> may be preferred when only the relative distance is needed
+        /// <see cref="Stride.Core.Mathematics.Double4.DistanceSquared(ref readonly Double4, ref readonly Double4, out double)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
-        public static void Distance(ref Double4 value1, ref Double4 value2, out double result)
+        public static void Distance(ref readonly Double4 value1, ref readonly Double4 value2, out double result)
         {
             double x = value1.X - value2.X;
             double y = value1.Y - value2.Y;
@@ -564,7 +564,7 @@ namespace Stride.Core.Mathematics
         /// involves two square roots, which are computationally expensive. However, using distance squared 
         /// provides the same information and avoids calculating two square roots.
         /// </remarks>
-        public static void DistanceSquared(ref Double4 value1, ref Double4 value2, out double result)
+        public static void DistanceSquared(ref readonly Double4 value1, ref readonly Double4 value2, out double result)
         {
             double x = value1.X - value2.X;
             double y = value1.Y - value2.Y;
@@ -604,7 +604,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Dot(ref Double4 left, ref Double4 right, out double result)
+        public static void Dot(ref readonly Double4 left, ref readonly Double4 right, out double result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
         }
@@ -627,7 +627,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Normalize(ref Double4 value, out Double4 result)
+        public static void Normalize(ref readonly Double4 value, out Double4 result)
         {
             Double4 temp = value;
             result = temp;
@@ -658,7 +658,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Double4 start, ref Double4 end, double amount, out Double4 result)
+        public static void Lerp(ref readonly Double4 start, ref readonly Double4 end, double amount, out Double4 result)
         {
             result.X = start.X + ((end.X - start.X) * amount);
             result.Y = start.Y + ((end.Y - start.Y) * amount);
@@ -692,7 +692,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Double4 start, ref Double4 end, double amount, out Double4 result)
+        public static void SmoothStep(ref readonly Double4 start, ref readonly Double4 end, double amount, out Double4 result)
         {
             amount = (amount > 1.0) ? 1.0 : ((amount < 0.0) ? 0.0 : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -726,7 +726,7 @@ namespace Stride.Core.Mathematics
         /// <param name="tangent2">Second source tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
-        public static void Hermite(ref Double4 value1, ref Double4 tangent1, ref Double4 value2, ref Double4 tangent2, double amount, out Double4 result)
+        public static void Hermite(ref readonly Double4 value1, ref readonly Double4 tangent1, ref readonly Double4 value2, ref readonly Double4 tangent2, double amount, out Double4 result)
         {
             double squared = amount * amount;
             double cubed = amount * squared;
@@ -766,7 +766,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
-        public static void CatmullRom(ref Double4 value1, ref Double4 value2, ref Double4 value3, ref Double4 value4, double amount, out Double4 result)
+        public static void CatmullRom(ref readonly Double4 value1, ref readonly Double4 value2, ref readonly Double4 value3, ref readonly Double4 value4, double amount, out Double4 result)
         {
             double squared = amount * amount;
             double cubed = amount * squared;
@@ -800,7 +800,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Max(ref Double4 left, ref Double4 right, out Double4 result)
+        public static void Max(ref readonly Double4 left, ref readonly Double4 right, out Double4 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -829,7 +829,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Min(ref Double4 left, ref Double4 right, out Double4 result)
+        public static void Min(ref readonly Double4 left, ref readonly Double4 right, out Double4 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;
@@ -950,7 +950,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The vector to rotate.</param>
         /// <param name="rotation">The <see cref="Stride.Core.Mathematics.Quaternion"/> rotation to apply.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double4"/>.</param>
-        public static void Transform(ref Double4 vector, ref Quaternion rotation, out Double4 result)
+        public static void Transform(ref readonly Double4 vector, ref readonly Quaternion rotation, out Double4 result)
         {
             double x = rotation.X + rotation.X;
             double y = rotation.Y + rotation.Y;
@@ -994,7 +994,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Double4[] source, ref Quaternion rotation, Double4[] destination)
+        public static void Transform(Double4[] source, ref readonly Quaternion rotation, Double4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1042,7 +1042,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Double4"/>.</param>
-        public static void Transform(ref Double4 vector, ref Matrix transform, out Double4 result)
+        public static void Transform(ref readonly Double4 vector, ref readonly Matrix transform, out Double4 result)
         {
             result = new Double4(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + (vector.W * transform.M41),
@@ -1073,7 +1073,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Double4[] source, ref Matrix transform, Double4[] destination)
+        public static void Transform(Double4[] source, ref readonly Matrix transform, Double4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1084,7 +1084,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                Transform(ref source[i], ref transform, out destination[i]);
+                Transform(ref source[i], in transform, out destination[i]);
             }
         }
 

--- a/sources/core/Stride.Core.Mathematics/Half.cs
+++ b/sources/core/Stride.Core.Mathematics/Half.cs
@@ -219,7 +219,7 @@ namespace Stride.Core.Mathematics
         /// <returns>
         ///   <c>true</c> if <paramref name = "value1" /> is the same instance as <paramref name = "value2" /> or 
         ///   if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
-        public static bool Equals(ref Half value1, ref Half value2)
+        public static bool Equals(ref readonly Half value1, ref readonly Half value2)
         {
             return value1.value == value2.value;
         }

--- a/sources/core/Stride.Core.Mathematics/Half2.cs
+++ b/sources/core/Stride.Core.Mathematics/Half2.cs
@@ -175,7 +175,7 @@ namespace Stride.Core.Mathematics
         /// <returns>
         /// <c>true</c> if <paramref name="value1" /> is the same instance as <paramref name="value2" /> or 
         /// if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
-        public static bool Equals(ref Half2 value1, ref Half2 value2)
+        public static bool Equals(ref readonly Half2 value1, ref readonly Half2 value2)
         {
             return ((value1.X == value2.X) && (value1.Y == value2.Y));
         }

--- a/sources/core/Stride.Core.Mathematics/Half3.cs
+++ b/sources/core/Stride.Core.Mathematics/Half3.cs
@@ -193,7 +193,7 @@ namespace Stride.Core.Mathematics
         /// <returns>
         /// <c>true</c> if <paramref name="value1" /> is the same instance as <paramref name="value2" /> or 
         /// if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
-        public static bool Equals(ref Half3 value1, ref Half3 value2)
+        public static bool Equals(ref readonly Half3 value1, ref readonly Half3 value2)
         {
             return (((value1.X == value2.X) && (value1.Y == value2.Y)) && (value1.Z == value2.Z));
         }

--- a/sources/core/Stride.Core.Mathematics/Half4.cs
+++ b/sources/core/Stride.Core.Mathematics/Half4.cs
@@ -211,7 +211,7 @@ namespace Stride.Core.Mathematics
         /// <returns>
         /// <c>true</c> if <paramref name="value1" /> is the same instance as <paramref name="value2" /> or 
         /// if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
-        public static bool Equals(ref Half4 value1, ref Half4 value2)
+        public static bool Equals(ref readonly Half4 value1, ref readonly Half4 value2)
         {
             return (((value1.X == value2.X) && (value1.Y == value2.Y)) && ((value1.Z == value2.Z) && (value1.W == value2.W)));
         }

--- a/sources/core/Stride.Core.Mathematics/IIntersectableWithPlane.cs
+++ b/sources/core/Stride.Core.Mathematics/IIntersectableWithPlane.cs
@@ -10,6 +10,6 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The plane to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref Plane plane);
+        public PlaneIntersectionType Intersects(ref readonly Plane plane);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/IIntersectableWithRay.cs
+++ b/sources/core/Stride.Core.Mathematics/IIntersectableWithRay.cs
@@ -10,7 +10,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="ray">The ray to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray);
+        public bool Intersects(ref readonly Ray ray);
 
         /// <summary>
         /// Determines if there is an intersection between the current object and a <see cref="Stride.Core.Mathematics.Ray"/>.
@@ -19,7 +19,7 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out float distance);
+        public bool Intersects(ref readonly Ray ray, out float distance);
 
         /// <summary>
         /// Determines if there is an intersection between the current object and a <see cref="Stride.Core.Mathematics.Ray"/>.
@@ -28,6 +28,6 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out Vector3 point);
+        public bool Intersects(ref readonly Ray ray, out Vector3 point);
     }
 }

--- a/sources/core/Stride.Core.Mathematics/Int2.cs
+++ b/sources/core/Stride.Core.Mathematics/Int2.cs
@@ -208,7 +208,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first vector to add.</param>
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
-        public static void Add(ref Int2 left, ref Int2 right, out Int2 result)
+        public static void Add(ref readonly Int2 left, ref readonly Int2 right, out Int2 result)
         {
             result = new Int2(left.X + right.X, left.Y + right.Y);
         }
@@ -230,7 +230,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first vector to subtract.</param>
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
-        public static void Subtract(ref Int2 left, ref Int2 right, out Int2 result)
+        public static void Subtract(ref readonly Int2 left, ref readonly Int2 right, out Int2 result)
         {
             result = new Int2(left.X - right.X, left.Y - right.Y);
         }
@@ -252,7 +252,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to scale.</param>
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
-        public static void Multiply(ref Int2 value, int scale, out Int2 result)
+        public static void Multiply(ref readonly Int2 value, int scale, out Int2 result)
         {
             result = new Int2(value.X * scale, value.Y * scale);
         }
@@ -274,7 +274,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first vector to modulate.</param>
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
-        public static void Modulate(ref Int2 left, ref Int2 right, out Int2 result)
+        public static void Modulate(ref readonly Int2 left, ref readonly Int2 right, out Int2 result)
         {
             result = new Int2(left.X * right.X, left.Y * right.Y);
         }
@@ -296,7 +296,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to scale.</param>
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
-        public static void Divide(ref Int2 value, int scale, out Int2 result)
+        public static void Divide(ref readonly Int2 value, int scale, out Int2 result)
         {
             result = new Int2(value.X / scale, value.Y / scale);
         }
@@ -317,7 +317,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
-        public static void Negate(ref Int2 value, out Int2 result)
+        public static void Negate(ref readonly Int2 value, out Int2 result)
         {
             result = new Int2(-value.X, -value.Y);
         }
@@ -339,7 +339,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Int2 value, ref Int2 min, ref Int2 max, out Int2 result)
+        public static void Clamp(ref readonly Int2 value, ref readonly Int2 min, ref readonly Int2 max, out Int2 result)
         {
             int x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -372,7 +372,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">First source vector.</param>
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
-        public static void Dot(ref Int2 left, ref Int2 right, out int result)
+        public static void Dot(ref readonly Int2 left, ref readonly Int2 right, out int result)
         {
             result = (left.X * right.X) + (left.Y * right.Y);
         }
@@ -400,7 +400,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Int2 start, ref Int2 end, float amount, out Int2 result)
+        public static void Lerp(ref readonly Int2 start, ref readonly Int2 end, float amount, out Int2 result)
         {
             result.X = (int)(start.X + ((end.X - start.X) * amount));
             result.Y = (int)(start.Y + ((end.Y - start.Y) * amount));
@@ -432,7 +432,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Int2 start, ref Int2 end, float amount, out Int2 result)
+        public static void SmoothStep(ref readonly Int2 start, ref readonly Int2 end, float amount, out Int2 result)
         {
             amount = (amount > 1) ? 1 : ((amount < 0) ? 0 : amount);
             amount = amount * amount * (3 - (2 * amount));
@@ -461,7 +461,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source vector.</param>
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
-        public static void Max(ref Int2 left, ref Int2 right, out Int2 result)
+        public static void Max(ref readonly Int2 left, ref readonly Int2 right, out Int2 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -486,7 +486,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source vector.</param>
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
-        public static void Min(ref Int2 left, ref Int2 right, out Int2 result)
+        public static void Min(ref readonly Int2 left, ref readonly Int2 right, out Int2 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;

--- a/sources/core/Stride.Core.Mathematics/Int3.cs
+++ b/sources/core/Stride.Core.Mathematics/Int3.cs
@@ -237,7 +237,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first vector to add.</param>
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
-        public static void Add(ref Int3 left, ref Int3 right, out Int3 result)
+        public static void Add(ref readonly Int3 left, ref readonly Int3 right, out Int3 result)
         {
             result = new Int3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
         }
@@ -259,7 +259,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first vector to subtract.</param>
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
-        public static void Subtract(ref Int3 left, ref Int3 right, out Int3 result)
+        public static void Subtract(ref readonly Int3 left, ref readonly Int3 right, out Int3 result)
         {
             result = new Int3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
         }
@@ -281,7 +281,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to scale.</param>
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
-        public static void Multiply(ref Int3 value, int scale, out Int3 result)
+        public static void Multiply(ref readonly Int3 value, int scale, out Int3 result)
         {
             result = new Int3(value.X * scale, value.Y * scale, value.Z * scale);
         }
@@ -303,7 +303,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first vector to modulate.</param>
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
-        public static void Modulate(ref Int3 left, ref Int3 right, out Int3 result)
+        public static void Modulate(ref readonly Int3 left, ref readonly Int3 right, out Int3 result)
         {
             result = new Int3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
         }
@@ -325,7 +325,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to scale.</param>
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
-        public static void Divide(ref Int3 value, int scale, out Int3 result)
+        public static void Divide(ref readonly Int3 value, int scale, out Int3 result)
         {
             result = new Int3(value.X / scale, value.Y / scale, value.Z / scale);
         }
@@ -346,7 +346,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
-        public static void Negate(ref Int3 value, out Int3 result)
+        public static void Negate(ref readonly Int3 value, out Int3 result)
         {
             result = new Int3(-value.X, -value.Y, -value.Z);
         }
@@ -368,7 +368,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Int3 value, ref Int3 min, ref Int3 max, out Int3 result)
+        public static void Clamp(ref readonly Int3 value, ref readonly Int3 min, ref readonly Int3 max, out Int3 result)
         {
             int x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -405,7 +405,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">First source vector.</param>
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
-        public static void Dot(ref Int3 left, ref Int3 right, out int result)
+        public static void Dot(ref readonly Int3 left, ref readonly Int3 right, out int result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
         }
@@ -433,7 +433,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Int3 start, ref Int3 end, float amount, out Int3 result)
+        public static void Lerp(ref readonly Int3 start, ref readonly Int3 end, float amount, out Int3 result)
         {
             result.X = (int)(start.X + ((end.X - start.X) * amount));
             result.Y = (int)(start.Y + ((end.Y - start.Y) * amount));
@@ -466,7 +466,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Int3 start, ref Int3 end, float amount, out Int3 result)
+        public static void SmoothStep(ref readonly Int3 start, ref readonly Int3 end, float amount, out Int3 result)
         {
             amount = (amount > 1) ? 1 : ((amount < 0) ? 0 : amount);
             amount = (amount * amount) * (3 - (2 * amount));
@@ -496,7 +496,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source vector.</param>
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
-        public static void Max(ref Int3 left, ref Int3 right, out Int3 result)
+        public static void Max(ref readonly Int3 left, ref readonly Int3 right, out Int3 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -522,7 +522,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first source vector.</param>
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
-        public static void Min(ref Int3 left, ref Int3 right, out Int3 result)
+        public static void Min(ref readonly Int3 left, ref readonly Int3 right, out Int3 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;

--- a/sources/core/Stride.Core.Mathematics/Int4.cs
+++ b/sources/core/Stride.Core.Mathematics/Int4.cs
@@ -221,7 +221,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first vector to add.</param>
         /// <param name = "right">The second vector to add.</param>
         /// <param name = "result">When the method completes, contains the sum of the two vectors.</param>
-        public static void Add(ref Int4 left, ref Int4 right, out Int4 result)
+        public static void Add(ref readonly Int4 left, ref readonly Int4 right, out Int4 result)
         {
             result = new Int4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
         }
@@ -243,7 +243,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first vector to subtract.</param>
         /// <param name = "right">The second vector to subtract.</param>
         /// <param name = "result">When the method completes, contains the difference of the two vectors.</param>
-        public static void Subtract(ref Int4 left, ref Int4 right, out Int4 result)
+        public static void Subtract(ref readonly Int4 left, ref readonly Int4 right, out Int4 result)
         {
             result = new Int4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
         }
@@ -265,7 +265,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "value">The vector to scale.</param>
         /// <param name = "scale">The amount by which to scale the vector.</param>
         /// <param name = "result">When the method completes, contains the scaled vector.</param>
-        public static void Multiply(ref Int4 value, int scale, out Int4 result)
+        public static void Multiply(ref readonly Int4 value, int scale, out Int4 result)
         {
             result = new Int4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
         }
@@ -287,7 +287,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first vector to modulate.</param>
         /// <param name = "right">The second vector to modulate.</param>
         /// <param name = "result">When the method completes, contains the modulated vector.</param>
-        public static void Modulate(ref Int4 left, ref Int4 right, out Int4 result)
+        public static void Modulate(ref readonly Int4 left, ref readonly Int4 right, out Int4 result)
         {
             result = new Int4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
         }
@@ -309,7 +309,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "value">The vector to scale.</param>
         /// <param name = "scale">The amount by which to scale the vector.</param>
         /// <param name = "result">When the method completes, contains the scaled vector.</param>
-        public static void Divide(ref Int4 value, int scale, out Int4 result)
+        public static void Divide(ref readonly Int4 value, int scale, out Int4 result)
         {
             result = new Int4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
         }
@@ -330,7 +330,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name = "value">The vector to negate.</param>
         /// <param name = "result">When the method completes, contains a vector facing in the opposite direction.</param>
-        public static void Negate(ref Int4 value, out Int4 result)
+        public static void Negate(ref readonly Int4 value, out Int4 result)
         {
             result = new Int4(-value.X, -value.Y, -value.Z, -value.W);
         }
@@ -352,7 +352,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "min">The minimum value.</param>
         /// <param name = "max">The maximum value.</param>
         /// <param name = "result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Int4 value, ref Int4 min, ref Int4 max, out Int4 result)
+        public static void Clamp(ref readonly Int4 value, ref readonly Int4 min, ref readonly Int4 max, out Int4 result)
         {
             int x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -393,7 +393,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first source vector.</param>
         /// <param name = "right">The second source vector.</param>
         /// <param name = "result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
-        public static void Max(ref Int4 left, ref Int4 right, out Int4 result)
+        public static void Max(ref readonly Int4 left, ref readonly Int4 right, out Int4 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -420,7 +420,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first source vector.</param>
         /// <param name = "right">The second source vector.</param>
         /// <param name = "result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
-        public static void Min(ref Int4 left, ref Int4 right, out Int4 result)
+        public static void Min(ref readonly Int4 left, ref readonly Int4 right, out Int4 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;

--- a/sources/core/Stride.Core.Mathematics/Matrix.cs
+++ b/sources/core/Stride.Core.Mathematics/Matrix.cs
@@ -896,7 +896,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to add.</param>
         /// <param name="right">The second matrix to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two matrices.</param>
-        public static void Add(ref Matrix left, ref Matrix right, out Matrix result)
+        public static void Add(ref readonly Matrix left, ref readonly Matrix right, out Matrix result)
         {
             result.M11 = left.M11 + right.M11;
             result.M21 = left.M21 + right.M21;
@@ -935,7 +935,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to subtract.</param>
         /// <param name="right">The second matrix to subtract.</param>
         /// <param name="result">When the method completes, contains the difference between the two matrices.</param>
-        public static void Subtract(ref Matrix left, ref Matrix right, out Matrix result)
+        public static void Subtract(ref readonly Matrix left, ref readonly Matrix right, out Matrix result)
         {
             result.M11 = left.M11 - right.M11;
             result.M21 = left.M21 - right.M21;
@@ -974,7 +974,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The matrix to scale.</param>
         /// <param name="right">The amount by which to scale.</param>
         /// <param name="result">When the method completes, contains the scaled matrix.</param>
-        public static void Multiply(ref Matrix left, float right, out Matrix result)
+        public static void Multiply(ref readonly Matrix left, float right, out Matrix result)
         {
             result.M11 = left.M11 * right;
             result.M21 = left.M21 * right;
@@ -1015,12 +1015,12 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to multiply.</param>
         /// <param name="right">The second matrix to multiply.</param>
         /// <param name="result">The product of the two matrices.</param>
-        public static void Multiply(ref Matrix left, ref Matrix right, out Matrix result)
+        public static void Multiply(ref readonly Matrix left, ref readonly Matrix right, out Matrix result)
         {
-            ref MatrixDotnet l = ref UnsafeRefAsDotNet(in left);
-            ref MatrixDotnet r = ref UnsafeRefAsDotNet(in right);
+            ref readonly MatrixDotnet l = ref UnsafeReadonlyRefAsDotNet(in left);
+            ref readonly MatrixDotnet r = ref UnsafeReadonlyRefAsDotNet(in right);
             Unsafe.SkipInit(out result);
-            UnsafeRefAsDotNet(in result) = LayoutIsRowMajor ? l * r : r * l;
+            UnsafeRefAsDotNet(ref result) = LayoutIsRowMajor ? l * r : r * l;
         }
 
         /// <summary>
@@ -1033,10 +1033,10 @@ namespace Stride.Core.Mathematics
         /// <param name="result">The product of the two matrices.</param>
         public static void MultiplyIn(in Matrix left, in Matrix right, out Matrix result)
         {
-            ref MatrixDotnet l = ref UnsafeRefAsDotNet(in left);
-            ref MatrixDotnet r = ref UnsafeRefAsDotNet(in right);
+            ref readonly MatrixDotnet l = ref UnsafeReadonlyRefAsDotNet(in left);
+            ref readonly MatrixDotnet r = ref UnsafeReadonlyRefAsDotNet(in right);
             Unsafe.SkipInit(out result);
-            UnsafeRefAsDotNet(in result) = LayoutIsRowMajor ? l * r : r * l;
+            UnsafeRefAsDotNet(ref result) = LayoutIsRowMajor ? l * r : r * l;
         }
 
         /// <summary>
@@ -1053,7 +1053,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The matrix to scale.</param>
         /// <param name="right">The amount by which to scale.</param>
         /// <param name="result">When the method completes, contains the scaled matrix.</param>
-        public static void Divide(ref Matrix left, float right, out Matrix result)
+        public static void Divide(ref readonly Matrix left, float right, out Matrix result)
         {
             float inv = 1.0f / right;
 
@@ -1094,7 +1094,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to divide.</param>
         /// <param name="right">The second matrix to divide.</param>
         /// <param name="result">When the method completes, contains the quotient of the two matrices.</param>
-        public static void Divide(ref Matrix left, ref Matrix right, out Matrix result)
+        public static void Divide(ref readonly Matrix left, ref readonly Matrix right, out Matrix result)
         {
             result.M11 = left.M11 / right.M11;
             result.M21 = left.M21 / right.M21;
@@ -1134,7 +1134,7 @@ namespace Stride.Core.Mathematics
         /// <param name="exponent">The exponent to raise the matrix to.</param>
         /// <param name="result">When the method completes, contains the exponential matrix.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="exponent"/> is negative.</exception>
-        public static void Exponent(ref Matrix value, int exponent, out Matrix result)
+        public static void Exponent(ref readonly Matrix value, int exponent, out Matrix result)
         {
             //Source: http://rosettacode.org
             //Refrence: http://rosettacode.org/wiki/Matrix-exponentiation_operator
@@ -1192,7 +1192,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The matrix to be negated.</param>
         /// <param name="result">When the method completes, contains the negated matrix.</param>
-        public static void Negate(ref Matrix value, out Matrix result)
+        public static void Negate(ref readonly Matrix value, out Matrix result)
         {
             result.M11 = -value.M11;
             result.M21 = -value.M21;
@@ -1236,7 +1236,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned.
         /// </remarks>
-        public static void Lerp(ref Matrix start, ref Matrix end, float amount, out Matrix result)
+        public static void Lerp(ref readonly Matrix start, ref readonly Matrix end, float amount, out Matrix result)
         {
             result.M11 = start.M11 + ((end.M11 - start.M11) * amount);
             result.M21 = start.M21 + ((end.M21 - start.M21) * amount);
@@ -1282,7 +1282,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End matrix.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two matrices.</param>
-        public static void SmoothStep(ref Matrix start, ref Matrix end, float amount, out Matrix result)
+        public static void SmoothStep(ref readonly Matrix start, ref readonly Matrix end, float amount, out Matrix result)
         {
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -1324,7 +1324,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The matrix whose transpose is to be calculated.</param>
         /// <param name="result">When the method completes, contains the transpose of the specified matrix.</param>
-        public static void Transpose(ref Matrix value, out Matrix result)
+        public static void Transpose(ref readonly Matrix value, out Matrix result)
         {
             result = new Matrix(
                 value.M11,
@@ -1350,7 +1350,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The matrix whose transpose is to be calculated.</param>
         /// <returns>The transpose of the specified matrix.</returns>
-        public static Matrix Transpose(Matrix value)
+        public static Matrix Transpose(in Matrix value)
         {
             value.Transpose();
             return value;
@@ -1362,11 +1362,11 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The matrix whose inverse is to be calculated.</param>
         /// <param name="result">When the method completes, contains the inverse of the specified matrix.</param>
-        public static void Invert(ref Matrix value, out Matrix result)
+        public static void Invert(ref readonly Matrix value, out Matrix result)
         {
             // Invert works the same in row and column major, no need to transpose
             Unsafe.SkipInit(out result);
-            if (!MatrixDotnet.Invert(UnsafeRefAsDotNet(value), out UnsafeRefAsDotNet(result)))
+            if (!MatrixDotnet.Invert(UnsafeReadonlyRefAsDotNet(value), out UnsafeRefAsDotNet(ref result)))
             {
                 result = Zero;
             }
@@ -1400,7 +1400,7 @@ namespace Stride.Core.Mathematics
         /// If you wish for this operation to be performed on the columns, first transpose the
         /// input and than transpose the output.</para>
         /// </remarks>
-        public static void Orthogonalize(ref Matrix value, out Matrix result)
+        public static void Orthogonalize(ref readonly Matrix value, out Matrix result)
         {
             //Uses the modified Gram-Schmidt process.
             //q1 = m1
@@ -1471,7 +1471,7 @@ namespace Stride.Core.Mathematics
         /// If you wish for this operation to be performed on the columns, first transpose the
         /// input and than transpose the output.</para>
         /// </remarks>
-        public static void Orthonormalize(ref Matrix value, out Matrix result)
+        public static void Orthonormalize(ref readonly Matrix value, out Matrix result)
         {
             //Uses the modified Gram-Schmidt process.
             //Because we are making unit vectors, we can optimize the math for orthogonalization
@@ -1544,7 +1544,7 @@ namespace Stride.Core.Mathematics
         /// of linear equations, than this often means that either no solution exists or an infinite
         /// number of solutions exist.
         /// </remarks>
-        public static void UpperTriangularForm(ref Matrix value, out Matrix result)
+        public static void UpperTriangularForm(ref readonly Matrix value, out Matrix result)
         {
             //Adapted from the row echelon code.
             result = value;
@@ -1624,11 +1624,11 @@ namespace Stride.Core.Mathematics
         /// of linear equations, than this often means that either no solution exists or an infinite
         /// number of solutions exist.
         /// </remarks>
-        public static void LowerTriangularForm(ref Matrix value, out Matrix result)
+        public static void LowerTriangularForm(ref readonly Matrix value, out Matrix result)
         {
             //Adapted from the row echelon code.
             Matrix temp = value;
-            Matrix.Transpose(ref temp, out result);
+            Transpose(ref temp, out result);
 
             int lead = 0;
             int rowcount = 4;
@@ -1676,7 +1676,7 @@ namespace Stride.Core.Mathematics
                 lead++;
             }
 
-            Matrix.Transpose(ref result, out result);
+            Transpose(ref result, out result);
         }
 
         /// <summary>
@@ -1702,7 +1702,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The matrix to put into row echelon form.</param>
         /// <param name="result">When the method completes, contains the row echelon form of the matrix.</param>
-        public static void RowEchelonForm(ref Matrix value, out Matrix result)
+        public static void RowEchelonForm(ref readonly Matrix value, out Matrix result)
         {
             //Source: Wikipedia psuedo code
             //Reference: http://en.wikipedia.org/wiki/Row_echelon_form#Pseudocode
@@ -1788,7 +1788,7 @@ namespace Stride.Core.Mathematics
         /// the <paramref name="augmentResult"/> will contain the solution for the system. It is up to the user
         /// to analyze both the input and the result to determine if a solution really exists.</para>
         /// </remarks>
-        public static void ReducedRowEchelonForm(ref Matrix value, ref Vector4 augment, out Matrix result, out Vector4 augmentResult)
+        public static void ReducedRowEchelonForm(ref readonly Matrix value, ref readonly Vector4 augment, out Matrix result, out Vector4 augmentResult)
         {
             //Source: http://rosettacode.org
             //Reference: http://rosettacode.org/wiki/Reduced_row_echelon_form
@@ -1904,7 +1904,7 @@ namespace Stride.Core.Mathematics
         /// <param name="cameraUpVector">The up vector of the camera.</param>
         /// <param name="cameraForwardVector">The forward vector of the camera.</param>
         /// <param name="result">When the method completes, contains the created billboard matrix.</param>
-        public static void Billboard(ref Vector3 objectPosition, ref Vector3 cameraPosition, ref Vector3 cameraUpVector, ref Vector3 cameraForwardVector, out Matrix result)
+        public static void Billboard(ref readonly Vector3 objectPosition, ref readonly Vector3 cameraPosition, ref readonly Vector3 cameraUpVector, ref readonly Vector3 cameraForwardVector, out Matrix result)
         {
             Vector3 crossed;
             Vector3 final;
@@ -1916,7 +1916,7 @@ namespace Stride.Core.Mathematics
             else
                 difference *= 1.0f / MathF.Sqrt(lengthSq);
 
-            Vector3.Cross(ref cameraUpVector, ref difference, out crossed);
+            Vector3.Cross(in cameraUpVector, ref difference, out crossed);
             crossed.Normalize();
             Vector3.Cross(ref difference, ref crossed, out final);
 
@@ -1960,11 +1960,11 @@ namespace Stride.Core.Mathematics
         /// <param name="target">The camera look-at target.</param>
         /// <param name="up">The camera's up vector.</param>
         /// <param name="result">When the method completes, contains the created look-at matrix.</param>
-        public static void LookAtLH(ref Vector3 eye, ref Vector3 target, ref Vector3 up, out Matrix result)
+        public static void LookAtLH(ref readonly Vector3 eye, ref readonly Vector3 target, ref readonly Vector3 up, out Matrix result)
         {
             Vector3 xaxis, yaxis, zaxis;
-            Vector3.Subtract(ref target, ref eye, out zaxis); zaxis.Normalize();
-            Vector3.Cross(ref up, ref zaxis, out xaxis); xaxis.Normalize();
+            Vector3.Subtract(in target, in eye, out zaxis); zaxis.Normalize();
+            Vector3.Cross(in up, ref zaxis, out xaxis); xaxis.Normalize();
             Vector3.Cross(ref zaxis, ref xaxis, out yaxis);
 
             result = Matrix.Identity;
@@ -1972,9 +1972,9 @@ namespace Stride.Core.Mathematics
             result.M12 = yaxis.X; result.M22 = yaxis.Y; result.M32 = yaxis.Z;
             result.M13 = zaxis.X; result.M23 = zaxis.Y; result.M33 = zaxis.Z;
 
-            Vector3.Dot(ref xaxis, ref eye, out result.M41);
-            Vector3.Dot(ref yaxis, ref eye, out result.M42);
-            Vector3.Dot(ref zaxis, ref eye, out result.M43);
+            Vector3.Dot(ref xaxis, in eye, out result.M41);
+            Vector3.Dot(ref yaxis, in eye, out result.M42);
+            Vector3.Dot(ref zaxis, in eye, out result.M43);
 
             result.M41 = -result.M41;
             result.M42 = -result.M42;
@@ -2002,11 +2002,11 @@ namespace Stride.Core.Mathematics
         /// <param name="target">The camera look-at target.</param>
         /// <param name="up">The camera's up vector.</param>
         /// <param name="result">When the method completes, contains the created look-at matrix.</param>
-        public static void LookAtRH(ref Vector3 eye, ref Vector3 target, ref Vector3 up, out Matrix result)
+        public static void LookAtRH(ref readonly Vector3 eye, ref readonly Vector3 target, ref readonly Vector3 up, out Matrix result)
         {
             Vector3 xaxis, yaxis, zaxis;
-            Vector3.Subtract(ref eye, ref target, out zaxis); zaxis.Normalize();
-            Vector3.Cross(ref up, ref zaxis, out xaxis); xaxis.Normalize();
+            Vector3.Subtract(in eye, in target, out zaxis); zaxis.Normalize();
+            Vector3.Cross(in up, ref zaxis, out xaxis); xaxis.Normalize();
             Vector3.Cross(ref zaxis, ref xaxis, out yaxis);
 
             result = Matrix.Identity;
@@ -2014,9 +2014,9 @@ namespace Stride.Core.Mathematics
             result.M12 = yaxis.X; result.M22 = yaxis.Y; result.M32 = yaxis.Z;
             result.M13 = zaxis.X; result.M23 = zaxis.Y; result.M33 = zaxis.Z;
 
-            Vector3.Dot(ref xaxis, ref eye, out result.M41);
-            Vector3.Dot(ref yaxis, ref eye, out result.M42);
-            Vector3.Dot(ref zaxis, ref eye, out result.M43);
+            Vector3.Dot(ref xaxis, in eye, out result.M41);
+            Vector3.Dot(ref yaxis, in eye, out result.M42);
+            Vector3.Dot(ref zaxis, in eye, out result.M43);
 
             result.M41 = -result.M41;
             result.M42 = -result.M42;
@@ -2384,7 +2384,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The plane for which the reflection occurs. This parameter is assumed to be normalized.</param>
         /// <param name="result">When the method completes, contains the reflection matrix.</param>
-        public static void Reflection(ref Plane plane, out Matrix result)
+        public static void Reflection(ref readonly Plane plane, out Matrix result)
         {
             float x = plane.Normal.X;
             float y = plane.Normal.Y;
@@ -2430,7 +2430,7 @@ namespace Stride.Core.Mathematics
         /// W component is 1, the light is a point light.</param>
         /// <param name="plane">The plane onto which to project the geometry as a shadow. This parameter is assumed to be normalized.</param>
         /// <param name="result">When the method completes, contains the shadow matrix.</param>
-        public static void Shadow(ref Vector4 light, ref Plane plane, out Matrix result)
+        public static void Shadow(ref readonly Vector4 light, ref readonly Plane plane, out Matrix result)
         {
             float dot = (plane.Normal.X * light.X) + (plane.Normal.Y * light.Y) + (plane.Normal.Z * light.Z) + (plane.D * light.W);
             float x = -plane.Normal.X;
@@ -2475,7 +2475,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="scale">Scaling factor for all three axes.</param>
         /// <param name="result">When the method completes, contains the created scaling matrix.</param>
-        public static void Scaling(ref Vector3 scale, out Matrix result)
+        public static void Scaling(ref readonly Vector3 scale, out Matrix result)
         {
             Scaling(scale.X, scale.Y, scale.Z, out result);
         }
@@ -2637,7 +2637,7 @@ namespace Stride.Core.Mathematics
         /// <param name="axis">The axis around which to rotate. This parameter is assumed to be normalized.</param>
         /// <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis toward the origin.</param>
         /// <param name="result">When the method completes, contains the created rotation matrix.</param>
-        public static void RotationAxis(ref Vector3 axis, float angle, out Matrix result)
+        public static void RotationAxis(ref readonly Vector3 axis, float angle, out Matrix result)
         {
             float x = axis.X;
             float y = axis.Y;
@@ -2681,7 +2681,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="rotation">The quaternion to use to build the matrix.</param>
         /// <param name="result">The created rotation matrix.</param>
-        public static void RotationQuaternion(ref Quaternion rotation, out Matrix result)
+        public static void RotationQuaternion(ref readonly Quaternion rotation, out Matrix result)
         {
             float xx = rotation.X * rotation.X;
             float yy = rotation.Y * rotation.Y;
@@ -2712,7 +2712,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis toward the origin.</param>
         /// <param name="translation">The translation.</param>
         /// <param name="result">When the method completes, contains the created rotation matrix.</param>
-        public static void Transformation(ref Vector3 scaling, ref Quaternion rotation, ref Vector3 translation, out Matrix result)
+        public static void Transformation(ref readonly Vector3 scaling, ref readonly Quaternion rotation, ref readonly Vector3 translation, out Matrix result)
         {
             // Equivalent to:
             //result =
@@ -2818,7 +2818,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The offset for all three coordinate planes.</param>
         /// <param name="result">When the method completes, contains the created translation matrix.</param>
-        public static void Translation(ref Vector3 value, out Matrix result)
+        public static void Translation(ref readonly Vector3 value, out Matrix result)
         {
             Translation(value.X, value.Y, value.Z, out result);
         }
@@ -2871,7 +2871,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The rotation of the transformation.</param>
         /// <param name="translation">The translation factor of the transformation.</param>
         /// <param name="result">When the method completes, contains the created affine transformation matrix.</param>
-        public static void AffineTransformation(float scaling, ref Quaternion rotation, ref Vector3 translation, out Matrix result)
+        public static void AffineTransformation(float scaling, ref readonly Quaternion rotation, ref readonly Vector3 translation, out Matrix result)
         {
             result = Scaling(scaling) * RotationQuaternion(rotation) * Translation(translation);
         }
@@ -2898,7 +2898,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The rotation of the transformation.</param>
         /// <param name="translation">The translation factor of the transformation.</param>
         /// <param name="result">When the method completes, contains the created affine transformation matrix.</param>
-        public static void AffineTransformation(float scaling, ref Vector3 rotationCenter, ref Quaternion rotation, ref Vector3 translation, out Matrix result)
+        public static void AffineTransformation(float scaling, ref readonly Vector3 rotationCenter, ref readonly Quaternion rotation, ref readonly Vector3 translation, out Matrix result)
         {
             result = Scaling(scaling) * Translation(-rotationCenter) * RotationQuaternion(rotation) *
                 Translation(rotationCenter) * Translation(translation);
@@ -2926,7 +2926,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The rotation of the transformation.</param>
         /// <param name="translation">The translation factor of the transformation.</param>
         /// <param name="result">When the method completes, contains the created affine transformation matrix.</param>
-        public static void AffineTransformation2D(float scaling, float rotation, ref Vector2 translation, out Matrix result)
+        public static void AffineTransformation2D(float scaling, float rotation, ref readonly Vector2 translation, out Matrix result)
         {
             result = Scaling(scaling, scaling, 1.0f) * RotationZ(rotation) * Translation((Vector3)translation);
         }
@@ -2953,7 +2953,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The rotation of the transformation.</param>
         /// <param name="translation">The translation factor of the transformation.</param>
         /// <param name="result">When the method completes, contains the created affine transformation matrix.</param>
-        public static void AffineTransformation2D(float scaling, ref Vector2 rotationCenter, float rotation, ref Vector2 translation, out Matrix result)
+        public static void AffineTransformation2D(float scaling, ref readonly Vector2 rotationCenter, float rotation, ref readonly Vector2 translation, out Matrix result)
         {
             result = Scaling(scaling, scaling, 1.0f) * Translation((Vector3)(-rotationCenter)) * RotationZ(rotation) *
                 Translation((Vector3)rotationCenter) * Translation((Vector3)translation);
@@ -2984,7 +2984,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The rotation of the transformation.</param>
         /// <param name="translation">The translation factor of the transformation.</param>
         /// <param name="result">When the method completes, contains the created transformation matrix.</param>
-        public static void Transformation(ref Vector3 scalingCenter, ref Quaternion scalingRotation, ref Vector3 scaling, ref Vector3 rotationCenter, ref Quaternion rotation, ref Vector3 translation, out Matrix result)
+        public static void Transformation(ref readonly Vector3 scalingCenter, ref readonly Quaternion scalingRotation, ref readonly Vector3 scaling, ref readonly Vector3 rotationCenter, ref readonly Quaternion rotation, ref readonly Vector3 translation, out Matrix result)
         {
             Matrix sr = RotationQuaternion(scalingRotation);
 
@@ -3019,7 +3019,7 @@ namespace Stride.Core.Mathematics
         /// <param name="rotation">The rotation of the transformation.</param>
         /// <param name="translation">The translation factor of the transformation.</param>
         /// <param name="result">When the method completes, contains the created transformation matrix.</param>
-        public static void Transformation2D(ref Vector2 scalingCenter, float scalingRotation, ref Vector2 scaling, ref Vector2 rotationCenter, float rotation, ref Vector2 translation, out Matrix result)
+        public static void Transformation2D(ref readonly Vector2 scalingCenter, float scalingRotation, ref readonly Vector2 scaling, ref readonly Vector2 rotationCenter, float rotation, ref readonly Vector2 translation, out Matrix result)
         {
             result = Translation((Vector3)(-scalingCenter)) * RotationZ(-scalingRotation) * Scaling((Vector3)scaling) * RotationZ(scalingRotation) * Translation((Vector3)scalingCenter) *
                 Translation((Vector3)(-rotationCenter)) * RotationZ(rotation) * Translation((Vector3)rotationCenter) * Translation((Vector3)translation);
@@ -3092,8 +3092,10 @@ namespace Stride.Core.Mathematics
             }
         }
 
-        static ref MatrixDotnet UnsafeRefAsDotNet(in Matrix m) => ref Unsafe.As<Matrix, MatrixDotnet>(ref Unsafe.AsRef(in m));
-        static ref Matrix UnsafeRefFromDotNet(in MatrixDotnet m) => ref Unsafe.As<MatrixDotnet, Matrix>(ref Unsafe.AsRef(in m));
+        static ref readonly MatrixDotnet UnsafeReadonlyRefAsDotNet(in Matrix m) => ref Unsafe.As<Matrix, MatrixDotnet>(ref Unsafe.AsRef(in m));
+        static ref readonly Matrix UnsafeReadonlyRefFromDotNet(in MatrixDotnet m) => ref Unsafe.As<MatrixDotnet, Matrix>(ref Unsafe.AsRef(in m));
+        static ref MatrixDotnet UnsafeRefAsDotNet(ref Matrix m) => ref Unsafe.As<Matrix, MatrixDotnet>(ref Unsafe.AsRef(in m));
+        static ref Matrix UnsafeRefFromDotNet(ref MatrixDotnet m) => ref Unsafe.As<MatrixDotnet, Matrix>(ref Unsafe.AsRef(in m));
 
         /// <summary>
         /// Adds two matrices.
@@ -3101,10 +3103,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to add.</param>
         /// <param name="right">The second matrix to add.</param>
         /// <returns>The sum of the two matrices.</returns>
-        public static Matrix operator +(Matrix left, Matrix right)
+        public static Matrix operator +(in Matrix left, in Matrix right)
         {
             Matrix result;
-            Add(ref left, ref right, out result);
+            Add(in left, in right, out result);
             return result;
         }
 
@@ -3124,10 +3126,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to subtract.</param>
         /// <param name="right">The second matrix to subtract.</param>
         /// <returns>The difference between the two matrices.</returns>
-        public static Matrix operator -(Matrix left, Matrix right)
+        public static Matrix operator -(in Matrix left, in Matrix right)
         {
             Matrix result;
-            Subtract(ref left, ref right, out result);
+            Subtract(in left, in right, out result);
             return result;
         }
 
@@ -3136,10 +3138,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The matrix to negate.</param>
         /// <returns>The negated matrix.</returns>
-        public static Matrix operator -(Matrix value)
+        public static Matrix operator -(in Matrix value)
         {
             Matrix result;
-            Negate(ref value, out result);
+            Negate(in value, out result);
             return result;
         }
 
@@ -3149,10 +3151,10 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The matrix to scale.</param>
         /// <param name="left">The amount by which to scale.</param>
         /// <returns>The scaled matrix.</returns>
-        public static Matrix operator *(float left, Matrix right)
+        public static Matrix operator *(float left, in Matrix right)
         {
             Matrix result;
-            Multiply(ref right, left, out result);
+            Multiply(in right, left, out result);
             return result;
         }
 
@@ -3162,10 +3164,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The matrix to scale.</param>
         /// <param name="right">The amount by which to scale.</param>
         /// <returns>The scaled matrix.</returns>
-        public static Matrix operator *(Matrix left, float right)
+        public static Matrix operator *(in Matrix left, float right)
         {
             Matrix result;
-            Multiply(ref left, right, out result);
+            Multiply(in left, right, out result);
             return result;
         }
 
@@ -3177,9 +3179,9 @@ namespace Stride.Core.Mathematics
         /// <returns>The product of the two matrices.</returns>
         public static Matrix operator *(in Matrix left, in Matrix right)
         {
-            ref MatrixDotnet l = ref UnsafeRefAsDotNet(in left);
-            ref MatrixDotnet r = ref UnsafeRefAsDotNet(in right);
-            return UnsafeRefFromDotNet(LayoutIsRowMajor ? l * r : r * l);
+            ref readonly MatrixDotnet l = ref UnsafeReadonlyRefAsDotNet(in left);
+            ref readonly MatrixDotnet r = ref UnsafeReadonlyRefAsDotNet(in right);
+            return UnsafeReadonlyRefFromDotNet(LayoutIsRowMajor ? l * r : r * l);
         }
 
         /// <summary>
@@ -3188,10 +3190,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The matrix to scale.</param>
         /// <param name="right">The amount by which to scale.</param>
         /// <returns>The scaled matrix.</returns>
-        public static Matrix operator /(Matrix left, float right)
+        public static Matrix operator /(in Matrix left, in float right)
         {
             Matrix result;
-            Divide(ref left, right, out result);
+            Divide(in left, right, out result);
             return result;
         }
 
@@ -3201,10 +3203,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first matrix to divide.</param>
         /// <param name="right">The second matrix to divide.</param>
         /// <returns>The quotient of the two matrices.</returns>
-        public static Matrix operator /(Matrix left, Matrix right)
+        public static Matrix operator /(in Matrix left, in Matrix right)
         {
             Matrix result;
-            Divide(ref left, ref right, out result);
+            Divide(in left, in right, out result);
             return result;
         }
 
@@ -3214,7 +3216,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(Matrix left, Matrix right)
+        public static bool operator ==(in Matrix left, in Matrix right)
         {
             return left.Equals(right);
         }
@@ -3225,7 +3227,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(Matrix left, Matrix right)
+        public static bool operator !=(in Matrix left, in Matrix right)
         {
             return !left.Equals(right);
         }
@@ -3318,7 +3320,7 @@ namespace Stride.Core.Mathematics
         /// <returns>
         /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Matrix"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public bool Equals(Matrix other)
+        public readonly bool Equals(Matrix other)
         {
             return (MathF.Abs(other.M11 - M11) < MathUtil.ZeroTolerance &&
                 MathF.Abs(other.M12 - M12) < MathUtil.ZeroTolerance &&
@@ -3350,13 +3352,7 @@ namespace Stride.Core.Mathematics
         /// </returns>
         public override bool Equals(object value)
         {
-            if (value == null)
-                return false;
-
-            if (value.GetType() != GetType())
-                return false;
-
-            return Equals((Matrix)value);
+            return value is Matrix mat ? Equals(mat) : false;
         }
 
 #if SlimDX1xInterop

--- a/sources/core/Stride.Core.Mathematics/Plane.cs
+++ b/sources/core/Stride.Core.Mathematics/Plane.cs
@@ -212,9 +212,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref Vector3 point)
+        public PlaneIntersectionType Intersects(ref readonly Vector3 point)
         {
-            return CollisionHelper.PlaneIntersectsPoint(ref this, ref point);
+            return CollisionHelper.PlaneIntersectsPoint(ref this, in point);
         }
 
         /// <summary>
@@ -222,10 +222,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="ray">The ray to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray)
+        public bool Intersects(ref readonly Ray ray)
         {
             float distance;
-            return CollisionHelper.RayIntersectsPlane(ref ray, ref this, out distance);
+            return CollisionHelper.RayIntersectsPlane(in ray, ref this, out distance);
         }
 
         /// <summary>
@@ -235,9 +235,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out float distance)
+        public bool Intersects(ref readonly Ray ray, out float distance)
         {
-            return CollisionHelper.RayIntersectsPlane(ref ray, ref this, out distance);
+            return CollisionHelper.RayIntersectsPlane(in ray, ref this, out distance);
         }
 
         /// <summary>
@@ -247,9 +247,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out Vector3 point)
+        public bool Intersects(ref readonly Ray ray, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsPlane(ref ray, ref this, out point);
+            return CollisionHelper.RayIntersectsPlane(in ray, ref this, out point);
         }
 
         /// <summary>
@@ -257,9 +257,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The plane to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Plane plane)
+        public bool Intersects(ref readonly Plane plane)
         {
-            return CollisionHelper.PlaneIntersectsPlane(ref this, ref plane);
+            return CollisionHelper.PlaneIntersectsPlane(ref this, in plane);
         }
 
         /// <summary>
@@ -269,9 +269,9 @@ namespace Stride.Core.Mathematics
         /// <param name="line">When the method completes, contains the line of intersection
         /// as a <see cref="Stride.Core.Mathematics.Ray"/>, or a zero ray if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Plane plane, out Ray line)
+        public bool Intersects(ref readonly Plane plane, out Ray line)
         {
-            return CollisionHelper.PlaneIntersectsPlane(ref this, ref plane, out line);
+            return CollisionHelper.PlaneIntersectsPlane(ref this, in plane, out line);
         }
 
         /// <summary>
@@ -281,9 +281,9 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triagnle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public PlaneIntersectionType Intersects(ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
-            return CollisionHelper.PlaneIntersectsTriangle(ref this, ref vertex1, ref vertex2, ref vertex3);
+            return CollisionHelper.PlaneIntersectsTriangle(ref this, in vertex1, in vertex2, in vertex3);
         }
 
         /// <summary>
@@ -291,9 +291,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref BoundingBox box)
+        public PlaneIntersectionType Intersects(ref readonly BoundingBox box)
         {
-            return CollisionHelper.PlaneIntersectsBox(ref this, ref box);
+            return CollisionHelper.PlaneIntersectsBox(ref this, in box);
         }
 
         /// <summary>
@@ -301,9 +301,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public PlaneIntersectionType Intersects(ref BoundingSphere sphere)
+        public PlaneIntersectionType Intersects(ref readonly BoundingSphere sphere)
         {
-            return CollisionHelper.PlaneIntersectsSphere(ref this, ref sphere);
+            return CollisionHelper.PlaneIntersectsSphere(ref this, in sphere);
         }
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The plane to scale.</param>
         /// <param name="scale">The amount by which to scale the plane.</param>
         /// <param name="result">When the method completes, contains the scaled plane.</param>
-        public static void Multiply(ref Plane value, float scale, out Plane result)
+        public static void Multiply(ref readonly Plane value, float scale, out Plane result)
         {
             result.Normal.X = value.Normal.X * scale;
             result.Normal.Y = value.Normal.Y * scale;
@@ -337,7 +337,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The source plane.</param>
         /// <param name="right">The source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the specified plane and vector.</param>
-        public static void Dot(ref Plane left, ref Vector4 right, out float result)
+        public static void Dot(ref readonly Plane left, ref readonly Vector4 right, out float result)
         {
             result = (left.Normal.X * right.X) + (left.Normal.Y * right.Y) + (left.Normal.Z * right.Z) + (left.D * right.W);
         }
@@ -359,7 +359,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The source plane.</param>
         /// <param name="right">The source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of a specified vector and the normal of the Plane plus the distance value of the plane.</param>
-        public static void DotCoordinate(ref Plane left, ref Vector3 right, out float result)
+        public static void DotCoordinate(ref readonly Plane left, ref readonly Vector3 right, out float result)
         {
             result = (left.Normal.X * right.X) + (left.Normal.Y * right.Y) + (left.Normal.Z * right.Z) + left.D;
         }
@@ -381,7 +381,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The source plane.</param>
         /// <param name="right">The source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the specified vector and the normal of the plane.</param>
-        public static void DotNormal(ref Plane left, ref Vector3 right, out float result)
+        public static void DotNormal(ref readonly Plane left, ref readonly Vector3 right, out float result)
         {
             result = (left.Normal.X * right.X) + (left.Normal.Y * right.Y) + (left.Normal.Z * right.Z);
         }
@@ -403,14 +403,14 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The plane to project the point to.</param>
         /// <param name="point">The point to project.</param>
         /// <param name="result">The projected point.</param>
-        public static void Project(ref Plane plane, ref Vector3 point, out Vector3 result)
+        public static void Project(ref readonly Plane plane, ref readonly Vector3 point, out Vector3 result)
         {
             float distance;
-            DotCoordinate(ref plane, ref point, out distance);
+            DotCoordinate(in plane, in point, out distance);
 
             // compute: point - distance * plane.Normal
-            Vector3.Multiply(ref plane.Normal, distance, out result);
-            Vector3.Subtract(ref point, ref result, out result);
+            Vector3.Multiply(in plane.Normal, distance, out result);
+            Vector3.Subtract(in point, ref result, out result);
         }
 
         /// <summary>
@@ -449,7 +449,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The source plane.</param>
         /// <param name="result">When the method completes, contains the normalized plane.</param>
-        public static void Normalize(ref Plane plane, out Plane result)
+        public static void Normalize(ref readonly Plane plane, out Plane result)
         {
             float magnitude = 1.0f / MathF.Sqrt((plane.Normal.X * plane.Normal.X) + (plane.Normal.Y * plane.Normal.Y) + (plane.Normal.Z * plane.Normal.Z));
 
@@ -475,7 +475,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The source plane.</param>
         /// <param name="result">When the method completes, contains the flipped plane.</param>
-        public static void Negate(ref Plane plane, out Plane result)
+        public static void Negate(ref readonly Plane plane, out Plane result)
         {
             result.Normal.X = -plane.Normal.X;
             result.Normal.Y = -plane.Normal.Y;
@@ -500,7 +500,7 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The normalized source plane.</param>
         /// <param name="rotation">The quaternion rotation.</param>
         /// <param name="result">When the method completes, contains the transformed plane.</param>
-        public static void Transform(ref Plane plane, ref Quaternion rotation, out Plane result)
+        public static void Transform(ref readonly Plane plane, ref readonly Quaternion rotation, out Plane result)
         {
             float x2 = rotation.X + rotation.X;
             float y2 = rotation.Y + rotation.Y;
@@ -565,7 +565,7 @@ namespace Stride.Core.Mathematics
         /// <param name="planes">The array of normalized planes to transform.</param>
         /// <param name="rotation">The quaternion rotation.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="planes"/> is <c>null</c>.</exception>
-        public static void Transform(Plane[] planes, ref Quaternion rotation)
+        public static void Transform(Plane[] planes, ref readonly Quaternion rotation)
         {
             if (planes == null)
                 throw new ArgumentNullException("planes");
@@ -605,7 +605,7 @@ namespace Stride.Core.Mathematics
         /// <param name="plane">The normalized source plane.</param>
         /// <param name="transformation">The transformation matrix.</param>
         /// <param name="result">When the method completes, contains the transformed plane.</param>
-        public static void Transform(ref Plane plane, ref Matrix transformation, out Plane result)
+        public static void Transform(ref readonly Plane plane, ref readonly Matrix transformation, out Plane result)
         {
             float x = plane.Normal.X;
             float y = plane.Normal.Y;
@@ -613,7 +613,7 @@ namespace Stride.Core.Mathematics
             float d = plane.D;
 
             Matrix inverse;
-            Matrix.Invert(ref transformation, out inverse);
+            Matrix.Invert(in transformation, out inverse);
 
             result.Normal.X = (((x * inverse.M11) + (y * inverse.M12)) + (z * inverse.M13)) + (d * inverse.M14);
             result.Normal.Y = (((x * inverse.M21) + (y * inverse.M22)) + (z * inverse.M23)) + (d * inverse.M24);
@@ -650,17 +650,17 @@ namespace Stride.Core.Mathematics
         /// <param name="planes">The array of normalized planes to transform.</param>
         /// <param name="transformation">The transformation matrix.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="planes"/> is <c>null</c>.</exception>
-        public static void Transform(Plane[] planes, ref Matrix transformation)
+        public static void Transform(Plane[] planes, ref readonly Matrix transformation)
         {
             if (planes == null)
                 throw new ArgumentNullException("planes");
 
             Matrix inverse;
-            Matrix.Invert(ref transformation, out inverse);
+            Matrix.Invert(in transformation, out inverse);
 
             for (int i = 0; i < planes.Length; ++i)
             {
-                Transform(ref planes[i], ref transformation, out planes[i]);
+                Transform(ref planes[i], in transformation, out planes[i]);
             }
         }
 

--- a/sources/core/Stride.Core.Mathematics/Quaternion.cs
+++ b/sources/core/Stride.Core.Mathematics/Quaternion.cs
@@ -28,6 +28,7 @@
 */
 using System;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static System.MathF;
@@ -351,7 +352,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first quaternion to add.</param>
         /// <param name="right">The second quaternion to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two quaternions.</param>
-        public static void Add(ref Quaternion left, ref Quaternion right, out Quaternion result)
+        public static void Add(ref readonly Quaternion left, ref readonly Quaternion right, out Quaternion result)
         {
             result.X = left.X + right.X;
             result.Y = left.Y + right.Y;
@@ -378,7 +379,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first quaternion to subtract.</param>
         /// <param name="right">The second quaternion to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two quaternions.</param>
-        public static void Subtract(ref Quaternion left, ref Quaternion right, out Quaternion result)
+        public static void Subtract(ref readonly Quaternion left, ref readonly Quaternion right, out Quaternion result)
         {
             result.X = left.X - right.X;
             result.Y = left.Y - right.Y;
@@ -405,7 +406,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The quaternion to scale.</param>
         /// <param name="scale">The amount by which to scale the quaternion.</param>
         /// <param name="result">When the method completes, contains the scaled quaternion.</param>
-        public static void Multiply(ref Quaternion value, float scale, out Quaternion result)
+        public static void Multiply(ref readonly Quaternion value, float scale, out Quaternion result)
         {
             result.X = value.X * scale;
             result.Y = value.Y * scale;
@@ -432,7 +433,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first quaternion to modulate.</param>
         /// <param name="right">The second quaternion to modulate.</param>
         /// <param name="result">When the moethod completes, contains the modulated quaternion.</param>
-        public static void Multiply(ref Quaternion left, ref Quaternion right, out Quaternion result)
+        public static void Multiply(ref readonly Quaternion left, ref readonly Quaternion right, out Quaternion result)
         {
             float lx = left.X;
             float ly = left.Y;
@@ -478,7 +479,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion to negate.</param>
         /// <param name="result">When the method completes, contains a quaternion facing in the opposite direction.</param>
-        public static void Negate(ref Quaternion value, out Quaternion result)
+        public static void Negate(ref readonly Quaternion value, out Quaternion result)
         {
             result.X = -value.X;
             result.Y = -value.Y;
@@ -507,11 +508,11 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains a new <see cref="Stride.Core.Mathematics.Quaternion"/> containing the 4D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Quaternion value1, ref Quaternion value2, ref Quaternion value3, float amount1, float amount2, out Quaternion result)
+        public static void Barycentric(ref readonly Quaternion value1, ref readonly Quaternion value2, ref readonly Quaternion value3, float amount1, float amount2, out Quaternion result)
         {
             Quaternion start, end;
-            Slerp(ref value1, ref value2, amount1 + amount2, out start);
-            Slerp(ref value1, ref value3, amount1 + amount2, out end);
+            Slerp(in value1, in value2, amount1 + amount2, out start);
+            Slerp(in value1, in value3, amount1 + amount2, out end);
             Slerp(ref start, ref end, amount2 / (amount1 + amount2), out result);
         }
 
@@ -536,7 +537,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion to conjugate.</param>
         /// <param name="result">When the method completes, contains the conjugated quaternion.</param>
-        public static void Conjugate(ref Quaternion value, out Quaternion result)
+        public static void Conjugate(ref readonly Quaternion value, out Quaternion result)
         {
             result.X = -value.X;
             result.Y = -value.Y;
@@ -560,7 +561,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">First source quaternion.</param>
         /// <param name="right">Second source quaternion.</param>
         /// <param name="result">When the method completes, contains the dot product of the two quaternions.</param>
-        public static void Dot(ref Quaternion left, ref Quaternion right, out float result)
+        public static void Dot(ref readonly Quaternion left, ref readonly Quaternion right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
         }
@@ -589,7 +590,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion to exponentiate.</param>
         /// <param name="result">When the method completes, contains the exponentiated quaternion.</param>
-        public static void Exponential(ref Quaternion value, out Quaternion result)
+        public static void Exponential(ref readonly Quaternion value, out Quaternion result)
         {
             float angle = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
             float sin = MathF.Sin(angle);
@@ -626,7 +627,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion to conjugate and renormalize.</param>
         /// <param name="result">When the method completes, contains the conjugated and renormalized quaternion.</param>
-        public static void Invert(ref Quaternion value, out Quaternion result)
+        public static void Invert(ref readonly Quaternion value, out Quaternion result)
         {
             result = value;
             result.Invert();
@@ -656,7 +657,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned.
         /// </remarks>
-        public static void Lerp(ref Quaternion start, ref Quaternion end, float amount, out Quaternion result)
+        public static void Lerp(ref readonly Quaternion start, ref readonly Quaternion end, float amount, out Quaternion result)
         {
             float inverse = 1.0f - amount;
 
@@ -720,7 +721,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion whose logarithm will be calculated.</param>
         /// <param name="result">When the method completes, contains the natural logarithm of the quaternion.</param>
-        public static void Logarithm(ref Quaternion value, out Quaternion result)
+        public static void Logarithm(ref readonly Quaternion value, out Quaternion result)
         {
             if (MathF.Abs(value.W) < 1.0f)
             {
@@ -764,7 +765,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized quaternion.</param>
-        public static void Normalize(ref Quaternion value, out Quaternion result)
+        public static void Normalize(ref readonly Quaternion value, out Quaternion result)
         {
             Quaternion temp = value;
             result = temp;
@@ -802,10 +803,10 @@ namespace Stride.Core.Mathematics
         /// <param name="axis">The axis of rotation.</param>
         /// <param name="angle">The angle of rotation.</param>
         /// <param name="result">When the method completes, contains the newly created quaternion.</param>
-        public static void RotationAxis(ref Vector3 axis, float angle, out Quaternion result)
+        public static void RotationAxis(ref readonly Vector3 axis, float angle, out Quaternion result)
         {
             Vector3 normalized;
-            Vector3.Normalize(ref axis, out normalized);
+            Vector3.Normalize(in axis, out normalized);
 
             float half = angle * 0.5f;
             float sin = MathF.Sin(half);
@@ -835,7 +836,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="matrix">The rotation matrix.</param>
         /// <param name="result">When the method completes, contains the newly created quaternion.</param>
-        public static void RotationMatrix(ref Matrix matrix, out Quaternion result)
+        public static void RotationMatrix(ref readonly Matrix matrix, out Quaternion result)
         {
             float sqrt;
             float half;
@@ -971,7 +972,7 @@ namespace Stride.Core.Mathematics
         /// <param name="yaw">The yaw component in radians.</param>
         /// <param name="pitch">The pitch component in radians.</param>
         /// <param name="roll">The roll component in radians.</param>
-        public static void RotationYawPitchRoll(ref Quaternion rotation, out float yaw, out float pitch, out float roll)
+        public static void RotationYawPitchRoll(ref readonly Quaternion rotation, out float yaw, out float pitch, out float roll)
         {
             // Equivalent to:
             //  Matrix rotationMatrix;
@@ -1087,7 +1088,7 @@ namespace Stride.Core.Mathematics
         /// <param name="source">The source vector of the transformation.</param>
         /// <param name="target">The target vector of the transformation.</param>
         /// <param name="result">The resulting quaternion corresponding to the transformation of the source vector to the target vector.</param>
-        public static void BetweenDirections(ref Vector3 source, ref Vector3 target, out Quaternion result)
+        public static void BetweenDirections(ref readonly Vector3 source, ref readonly Vector3 target, out Quaternion result)
         {
             var norms = MathF.Sqrt(source.LengthSquared() * target.LengthSquared());
             var real = norms + Vector3.Dot(source, target);
@@ -1115,7 +1116,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End quaternion.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the spherical linear interpolation of the two quaternions.</param>
-        public static void Slerp(ref Quaternion start, ref Quaternion end, float amount, out Quaternion result)
+        public static void Slerp(ref readonly Quaternion start, ref readonly Quaternion end, float amount, out Quaternion result)
         {
             float opposite;
             float inverse;
@@ -1198,11 +1199,11 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">Fourth source quaternion.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of interpolation.</param>
         /// <param name="result">When the method completes, contains the spherical quadrangle interpolation of the quaternions.</param>
-        public static void Squad(ref Quaternion value1, ref Quaternion value2, ref Quaternion value3, ref Quaternion value4, float amount, out Quaternion result)
+        public static void Squad(ref readonly Quaternion value1, ref readonly Quaternion value2, ref readonly Quaternion value3, ref readonly Quaternion value4, float amount, out Quaternion result)
         {
             Quaternion start, end;
-            Slerp(ref value1, ref value4, amount, out start);
-            Slerp(ref value2, ref value3, amount, out end);
+            Slerp(in value1, in value4, amount, out start);
+            Slerp(in value2, in value3, amount, out end);
             Slerp(ref start, ref end, 2.0f * amount * (1.0f - amount), out result);
         }
 
@@ -1255,10 +1256,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first quaternion to add.</param>
         /// <param name="right">The second quaternion to add.</param>
         /// <returns>The sum of the two quaternions.</returns>
-        public static Quaternion operator +(Quaternion left, Quaternion right)
+        public static Quaternion operator +(in Quaternion left, in Quaternion right)
         {
             Quaternion result;
-            Add(ref left, ref right, out result);
+            Add(in left, in right, out result);
             return result;
         }
 
@@ -1268,10 +1269,10 @@ namespace Stride.Core.Mathematics
         /// <param name="left">The first quaternion to subtract.</param>
         /// <param name="right">The second quaternion to subtract.</param>
         /// <returns>The difference of the two quaternions.</returns>
-        public static Quaternion operator -(Quaternion left, Quaternion right)
+        public static Quaternion operator -(in Quaternion left, in Quaternion right)
         {
             Quaternion result;
-            Subtract(ref left, ref right, out result);
+            Subtract(in left, in right, out result);
             return result;
         }
 
@@ -1280,10 +1281,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The quaternion to negate.</param>
         /// <returns>A quaternion facing in the opposite direction.</returns>
-        public static Quaternion operator -(Quaternion value)
+        public static Quaternion operator -(in Quaternion value)
         {
             Quaternion result;
-            Negate(ref value, out result);
+            Negate(in value, out result);
             return result;
         }
 
@@ -1293,10 +1294,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The quaternion to scale.</param>
         /// <param name="scale">The amount by which to scale the quaternion.</param>
         /// <returns>The scaled quaternion.</returns>
-        public static Quaternion operator *(float scale, Quaternion value)
+        public static Quaternion operator *(float scale, in Quaternion value)
         {
             Quaternion result;
-            Multiply(ref value, scale, out result);
+            Multiply(in value, scale, out result);
             return result;
         }
 
@@ -1306,10 +1307,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The quaternion to scale.</param>
         /// <param name="scale">The amount by which to scale the quaternion.</param>
         /// <returns>The scaled quaternion.</returns>
-        public static Quaternion operator *(Quaternion value, float scale)
+        public static Quaternion operator *(in Quaternion value, float scale)
         {
             Quaternion result;
-            Multiply(ref value, scale, out result);
+            Multiply(in value, scale, out result);
             return result;
         }
 
@@ -1321,7 +1322,9 @@ namespace Stride.Core.Mathematics
         /// <returns>The multiplied quaternion.</returns>
         public static Quaternion operator *(in Quaternion left, in Quaternion right)
         {
-            return Multiply(left, right);
+            Quaternion result;
+            Multiply(in left, in right, out result);
+            return result;
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Ray.cs
+++ b/sources/core/Stride.Core.Mathematics/Ray.cs
@@ -65,9 +65,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Vector3 point)
+        public bool Intersects(ref readonly Vector3 point)
         {
-            return CollisionHelper.RayIntersectsPoint(ref this, ref point);
+            return CollisionHelper.RayIntersectsPoint(ref this, in point);
         }
 
         /// <summary>
@@ -75,10 +75,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="ray">The ray to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray)
+        public bool Intersects(ref readonly Ray ray)
         {
             Vector3 point;
-            return CollisionHelper.RayIntersectsRay(ref this, ref ray, out point);
+            return CollisionHelper.RayIntersectsRay(ref this, in ray, out point);
         }
 
         /// <summary>
@@ -88,9 +88,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Ray ray, out Vector3 point)
+        public bool Intersects(ref readonly Ray ray, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsRay(ref this, ref ray, out point);
+            return CollisionHelper.RayIntersectsRay(ref this, in ray, out point);
         }
 
         /// <summary>
@@ -98,10 +98,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="plane">The plane to test</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Plane plane)
+        public bool Intersects(ref readonly Plane plane)
         {
             float distance;
-            return CollisionHelper.RayIntersectsPlane(ref this, ref plane, out distance);
+            return CollisionHelper.RayIntersectsPlane(ref this, in plane, out distance);
         }
 
         /// <summary>
@@ -111,9 +111,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Plane plane, out float distance)
+        public bool Intersects(ref readonly Plane plane, out float distance)
         {
-            return CollisionHelper.RayIntersectsPlane(ref this, ref plane, out distance);
+            return CollisionHelper.RayIntersectsPlane(ref this, in plane, out distance);
         }
 
         /// <summary>
@@ -123,9 +123,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Plane plane, out Vector3 point)
+        public bool Intersects(ref readonly Plane plane, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsPlane(ref this, ref plane, out point);
+            return CollisionHelper.RayIntersectsPlane(ref this, in plane, out point);
         }
 
         /// <summary>
@@ -135,10 +135,10 @@ namespace Stride.Core.Mathematics
         /// <param name="vertex2">The second vertex of the triangle to test.</param>
         /// <param name="vertex3">The third vertex of the triangle to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3)
+        public bool Intersects(ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3)
         {
             float distance;
-            return CollisionHelper.RayIntersectsTriangle(ref this, ref vertex1, ref vertex2, ref vertex3, out distance);
+            return CollisionHelper.RayIntersectsTriangle(ref this, in vertex1, in vertex2, in vertex3, out distance);
         }
 
         /// <summary>
@@ -150,9 +150,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3, out float distance)
+        public bool Intersects(ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3, out float distance)
         {
-            return CollisionHelper.RayIntersectsTriangle(ref this, ref vertex1, ref vertex2, ref vertex3, out distance);
+            return CollisionHelper.RayIntersectsTriangle(ref this, in vertex1, in vertex2, in vertex3, out distance);
         }
 
         /// <summary>
@@ -164,9 +164,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref Vector3 vertex1, ref Vector3 vertex2, ref Vector3 vertex3, out Vector3 point)
+        public bool Intersects(ref readonly Vector3 vertex1, ref readonly Vector3 vertex2, ref readonly Vector3 vertex3, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsTriangle(ref this, ref vertex1, ref vertex2, ref vertex3, out point);
+            return CollisionHelper.RayIntersectsTriangle(ref this, in vertex1, in vertex2, in vertex3, out point);
         }
 
         /// <summary>
@@ -174,10 +174,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="box">The box to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingBox box)
+        public bool Intersects(ref readonly BoundingBox box)
         {
             float distance;
-            return CollisionHelper.RayIntersectsBox(ref this, ref box, out distance);
+            return CollisionHelper.RayIntersectsBox(ref this, in box, out distance);
         }
 
         /// <summary>
@@ -187,9 +187,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingBox box, out float distance)
+        public bool Intersects(ref readonly BoundingBox box, out float distance)
         {
-            return CollisionHelper.RayIntersectsBox(ref this, ref box, out distance);
+            return CollisionHelper.RayIntersectsBox(ref this, in box, out distance);
         }
 
         /// <summary>
@@ -199,9 +199,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingBox box, out Vector3 point)
+        public bool Intersects(ref readonly BoundingBox box, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsBox(ref this, ref box, out point);
+            return CollisionHelper.RayIntersectsBox(ref this, in box, out point);
         }
 
         /// <summary>
@@ -209,10 +209,10 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="sphere">The sphere to test.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingSphere sphere)
+        public bool Intersects(ref readonly BoundingSphere sphere)
         {
             float distance;
-            return CollisionHelper.RayIntersectsSphere(ref this, ref sphere, out distance);
+            return CollisionHelper.RayIntersectsSphere(ref this, in sphere, out distance);
         }
 
         /// <summary>
@@ -222,9 +222,9 @@ namespace Stride.Core.Mathematics
         /// <param name="distance">When the method completes, contains the distance of the intersection,
         /// or 0 if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingSphere sphere, out float distance)
+        public bool Intersects(ref readonly BoundingSphere sphere, out float distance)
         {
-            return CollisionHelper.RayIntersectsSphere(ref this, ref sphere, out distance);
+            return CollisionHelper.RayIntersectsSphere(ref this, in sphere, out distance);
         }
 
         /// <summary>
@@ -234,9 +234,9 @@ namespace Stride.Core.Mathematics
         /// <param name="point">When the method completes, contains the point of intersection,
         /// or <see cref="Stride.Core.Mathematics.Vector3.Zero"/> if there was no intersection.</param>
         /// <returns>Whether the two objects intersected.</returns>
-        public bool Intersects(ref BoundingSphere sphere, out Vector3 point)
+        public bool Intersects(ref readonly BoundingSphere sphere, out Vector3 point)
         {
-            return CollisionHelper.RayIntersectsSphere(ref this, ref sphere, out point);
+            return CollisionHelper.RayIntersectsSphere(ref this, in sphere, out point);
         }
 
         /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Rectangle.cs
+++ b/sources/core/Stride.Core.Mathematics/Rectangle.cs
@@ -268,7 +268,7 @@ namespace Stride.Core.Mathematics
         /// <summary>Determines whether this rectangle contains a specified Point.</summary>
         /// <param name="value">The Point to evaluate.</param>
         /// <param name="result">[OutAttribute] true if the specified Point is contained within this rectangle; false otherwise.</param>
-        public void Contains(ref Point value, out bool result)
+        public void Contains(ref readonly Point value, out bool result)
         {
             result = (X <= value.X) && (value.X < Right) && (Y <= value.Y) && (value.Y < Bottom);
         }
@@ -285,7 +285,7 @@ namespace Stride.Core.Mathematics
         /// <summary>Determines whether this rectangle entirely contains a specified rectangle.</summary>
         /// <param name="value">The rectangle to evaluate.</param>
         /// <param name="result">[OutAttribute] On exit, is true if this rectangle entirely contains the specified rectangle, or false if not.</param>
-        public void Contains(ref Rectangle value, out bool result)
+        public void Contains(ref readonly Rectangle value, out bool result)
         {
             result = (X <= value.X) && (value.Right <= Right) && (Y <= value.Y) && (value.Bottom <= Bottom);
         }
@@ -335,7 +335,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The rectangle to evaluate</param>
         /// <param name="result">[OutAttribute] true if the specified rectangle intersects with this one; false otherwise.</param>
-        public void Intersects(ref Rectangle value, out bool result)
+        public void Intersects(ref readonly Rectangle value, out bool result)
         {
             result = (value.X < Right) && (X < value.Right) && (value.Y < Bottom) && (Y < value.Bottom);
         }
@@ -357,7 +357,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The first rectangle to compare.</param>
         /// <param name="value2">The second rectangle to compare.</param>
         /// <param name="result">[OutAttribute] The area where the two first parameters overlap.</param>
-        public static void Intersect(ref Rectangle value1, ref Rectangle value2, out Rectangle result)
+        public static void Intersect(ref readonly Rectangle value1, ref readonly Rectangle value2, out Rectangle result)
         {
             int newLeft = (value1.X > value2.X) ? value1.X : value2.X;
             int newTop = (value1.Y > value2.Y) ? value1.Y : value2.Y;
@@ -406,7 +406,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The first rectangle to contain.</param>
         /// <param name="value2">The second rectangle to contain.</param>
         /// <param name="result">[OutAttribute] The rectangle that must be the union of the first two rectangles.</param>
-        public static void Union(ref Rectangle value1, ref Rectangle value2, out Rectangle result)
+        public static void Union(ref readonly Rectangle value1, ref readonly Rectangle value2, out Rectangle result)
         {
             var left = Math.Min(value1.Left, value2.Left);
             var right = Math.Max(value1.Right, value2.Right);

--- a/sources/core/Stride.Core.Mathematics/RectangleF.cs
+++ b/sources/core/Stride.Core.Mathematics/RectangleF.cs
@@ -267,7 +267,7 @@ namespace Stride.Core.Mathematics
         /// <summary>Determines whether this rectangle contains a specified Point.</summary>
         /// <param name="value">The Point to evaluate.</param>
         /// <param name="result">[OutAttribute] true if the specified Point is contained within this rectangle; false otherwise.</param>
-        public void Contains(ref Vector2 value, out bool result)
+        public void Contains(ref readonly Vector2 value, out bool result)
         {
             result = value.X >= this.X && value.X <= Right && value.Y >= this.Y && value.Y <= Bottom;
         }
@@ -282,7 +282,7 @@ namespace Stride.Core.Mathematics
         /// <summary>Determines whether this rectangle entirely contains a specified rectangle.</summary>
         /// <param name="value">The rectangle to evaluate.</param>
         /// <param name="result">[OutAttribute] On exit, is true if this rectangle entirely contains the specified rectangle, or false if not.</param>
-        public void Contains(ref RectangleF value, out bool result)
+        public void Contains(ref readonly RectangleF value, out bool result)
         {
             result = (X <= value.X) && (value.Right <= Right) && (Y <= value.Y) && (value.Bottom <= Bottom);
         }
@@ -342,7 +342,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The rectangle to evaluate</param>
         /// <param name="result">[OutAttribute] true if the specified rectangle intersects with this one; false otherwise.</param>
-        public void Intersects(ref RectangleF value, out bool result)
+        public void Intersects(ref readonly RectangleF value, out bool result)
         {
             result = (value.X < Right) && (X < value.Right) && (value.Y < Bottom) && (Y < value.Bottom);
         }
@@ -364,7 +364,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The first rectangle to compare.</param>
         /// <param name="value2">The second rectangle to compare.</param>
         /// <param name="result">[OutAttribute] The area where the two first parameters overlap.</param>
-        public static void Intersect(ref RectangleF value1, ref RectangleF value2, out RectangleF result)
+        public static void Intersect(ref readonly RectangleF value1, ref readonly RectangleF value2, out RectangleF result)
         {
             float newLeft = (value1.X > value2.X) ? value1.X : value2.X;
             float newTop = (value1.Y > value2.Y) ? value1.Y : value2.Y;
@@ -399,7 +399,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value1">The first rectangle to contain.</param>
         /// <param name="value2">The second rectangle to contain.</param>
         /// <param name="result">[OutAttribute] The rectangle that must be the union of the first two rectangles.</param>
-        public static void Union(ref RectangleF value1, ref RectangleF value2, out RectangleF result)
+        public static void Union(ref readonly RectangleF value1, ref readonly RectangleF value2, out RectangleF result)
         {
             var left = Math.Min(value1.Left, value2.Left);
             var right = Math.Max(value1.Right, value2.Right);

--- a/sources/core/Stride.Core.Mathematics/UInt4.cs
+++ b/sources/core/Stride.Core.Mathematics/UInt4.cs
@@ -199,7 +199,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first vector to add.</param>
         /// <param name = "right">The second vector to add.</param>
         /// <param name = "result">When the method completes, contains the sum of the two vectors.</param>
-        public static void Add(ref UInt4 left, ref UInt4 right, out UInt4 result)
+        public static void Add(ref readonly UInt4 left, ref readonly UInt4 right, out UInt4 result)
         {
             result = new UInt4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
         }
@@ -221,7 +221,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first vector to subtract.</param>
         /// <param name = "right">The second vector to subtract.</param>
         /// <param name = "result">When the method completes, contains the difference of the two vectors.</param>
-        public static void Subtract(ref UInt4 left, ref UInt4 right, out UInt4 result)
+        public static void Subtract(ref readonly UInt4 left, ref readonly UInt4 right, out UInt4 result)
         {
             result = new UInt4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
         }
@@ -243,7 +243,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "value">The vector to scale.</param>
         /// <param name = "scale">The amount by which to scale the vector.</param>
         /// <param name = "result">When the method completes, contains the scaled vector.</param>
-        public static void Multiply(ref UInt4 value, uint scale, out UInt4 result)
+        public static void Multiply(ref readonly UInt4 value, uint scale, out UInt4 result)
         {
             result = new UInt4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
         }
@@ -265,7 +265,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first vector to modulate.</param>
         /// <param name = "right">The second vector to modulate.</param>
         /// <param name = "result">When the method completes, contains the modulated vector.</param>
-        public static void Modulate(ref UInt4 left, ref UInt4 right, out UInt4 result)
+        public static void Modulate(ref readonly UInt4 left, ref readonly UInt4 right, out UInt4 result)
         {
             result = new UInt4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
         }
@@ -287,7 +287,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "value">The vector to scale.</param>
         /// <param name = "scale">The amount by which to scale the vector.</param>
         /// <param name = "result">When the method completes, contains the scaled vector.</param>
-        public static void Divide(ref UInt4 value, uint scale, out UInt4 result)
+        public static void Divide(ref readonly UInt4 value, uint scale, out UInt4 result)
         {
             result = new UInt4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
         }
@@ -310,7 +310,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "min">The minimum value.</param>
         /// <param name = "max">The maximum value.</param>
         /// <param name = "result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref UInt4 value, ref UInt4 min, ref UInt4 max, out UInt4 result)
+        public static void Clamp(ref readonly UInt4 value, ref readonly UInt4 min, ref readonly UInt4 max, out UInt4 result)
         {
             uint x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -351,7 +351,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first source vector.</param>
         /// <param name = "right">The second source vector.</param>
         /// <param name = "result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
-        public static void Max(ref UInt4 left, ref UInt4 right, out UInt4 result)
+        public static void Max(ref readonly UInt4 left, ref readonly UInt4 right, out UInt4 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -378,7 +378,7 @@ namespace Stride.Core.Mathematics
         /// <param name = "left">The first source vector.</param>
         /// <param name = "right">The second source vector.</param>
         /// <param name = "result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
-        public static void Min(ref UInt4 left, ref UInt4 right, out UInt4 result)
+        public static void Min(ref readonly UInt4 left, ref readonly UInt4 right, out UInt4 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -232,7 +232,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Add(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void Add(ref readonly Vector2 left, ref readonly Vector2 right, out Vector2 result)
         {
             result = new Vector2(left.X + right.X, left.Y + right.Y);
         }
@@ -256,7 +256,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Subtract(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void Subtract(ref readonly Vector2 left, ref readonly Vector2 right, out Vector2 result)
         {
             result = new Vector2(left.X - right.X, left.Y - right.Y);
         }
@@ -280,7 +280,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Multiply(ref Vector2 value, float scale, out Vector2 result)
+        public static void Multiply(ref readonly Vector2 value, float scale, out Vector2 result)
         {
             result = new Vector2(value.X * scale, value.Y * scale);
         }
@@ -304,7 +304,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Modulate(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void Modulate(ref readonly Vector2 left, ref readonly Vector2 right, out Vector2 result)
         {
             result = new Vector2(left.X * right.X, left.Y * right.Y);
         }
@@ -328,7 +328,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Divide(ref Vector2 value, float scale, out Vector2 result)
+        public static void Divide(ref readonly Vector2 value, float scale, out Vector2 result)
         {
             result = new Vector2(value.X / scale, value.Y / scale);
         }
@@ -352,7 +352,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to demodulate.</param>
         /// <param name="result">When the method completes, contains the demodulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Demodulate(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void Demodulate(ref readonly Vector2 left, ref readonly Vector2 right, out Vector2 result)
         {
             result = new Vector2(left.X / right.X, left.Y / right.Y);
         }
@@ -375,7 +375,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Negate(ref Vector2 value, out Vector2 result)
+        public static void Negate(ref readonly Vector2 value, out Vector2 result)
         {
             result = new Vector2(-value.X, -value.Y);
         }
@@ -400,7 +400,7 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains the 2D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Vector2 value1, ref Vector2 value2, ref Vector2 value3, float amount1, float amount2, out Vector2 result)
+        public static void Barycentric(ref readonly Vector2 value1, ref readonly Vector2 value2, ref readonly Vector2 value3, float amount1, float amount2, out Vector2 result)
         {
             result = new Vector2(
                 (value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
@@ -430,7 +430,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Vector2 value, ref Vector2 min, ref Vector2 max, out Vector2 result)
+        public static void Clamp(ref readonly Vector2 value, ref readonly Vector2 min, ref readonly Vector2 max, out Vector2 result)
         {
             float x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -464,10 +464,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second vector.</param>
         /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
         /// <remarks>
-        /// <see cref="Stride.Core.Mathematics.Vector2.DistanceSquared(ref Vector2, ref Vector2, out float)"/> may be preferred when only the relative distance is needed
+        /// <see cref="Stride.Core.Mathematics.Vector2.DistanceSquared(ref readonly Vector2, ref readonly Vector2, out float)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
-        public static void Distance(ref Vector2 value1, ref Vector2 value2, out float result)
+        public static void Distance(ref readonly Vector2 value1, ref readonly Vector2 value2, out float result)
         {
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
@@ -506,7 +506,7 @@ namespace Stride.Core.Mathematics
         /// involves two square roots, which are computationally expensive. However, using distance squared 
         /// provides the same information and avoids calculating two square roots.
         /// </remarks>
-        public static void DistanceSquared(ref Vector2 value1, ref Vector2 value2, out float result)
+        public static void DistanceSquared(ref readonly Vector2 value1, ref readonly Vector2 value2, out float result)
         {
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
@@ -542,7 +542,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Dot(ref Vector2 left, ref Vector2 right, out float result)
+        public static void Dot(ref readonly Vector2 left, ref readonly Vector2 right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y);
         }
@@ -565,7 +565,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Normalize(ref Vector2 value, out Vector2 result)
+        public static void Normalize(ref readonly Vector2 value, out Vector2 result)
         {
             result = value;
             result.Normalize();
@@ -595,7 +595,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Vector2 start, ref Vector2 end, float amount, out Vector2 result)
+        public static void Lerp(ref readonly Vector2 start, ref readonly Vector2 end, float amount, out Vector2 result)
         {
             result.X = start.X + ((end.X - start.X) * amount);
             result.Y = start.Y + ((end.Y - start.Y) * amount);
@@ -627,7 +627,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Vector2 start, ref Vector2 end, float amount, out Vector2 result)
+        public static void SmoothStep(ref readonly Vector2 start, ref readonly Vector2 end, float amount, out Vector2 result)
         {
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -659,7 +659,7 @@ namespace Stride.Core.Mathematics
         /// <param name="tangent2">Second source tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
-        public static void Hermite(ref Vector2 value1, ref Vector2 tangent1, ref Vector2 value2, ref Vector2 tangent2, float amount, out Vector2 result)
+        public static void Hermite(ref readonly Vector2 value1, ref readonly Vector2 tangent1, ref readonly Vector2 value2, ref readonly Vector2 tangent2, float amount, out Vector2 result)
         {
             float squared = amount * amount;
             float cubed = amount * squared;
@@ -697,7 +697,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
-        public static void CatmullRom(ref Vector2 value1, ref Vector2 value2, ref Vector2 value3, ref Vector2 value4, float amount, out Vector2 result)
+        public static void CatmullRom(ref readonly Vector2 value1, ref readonly Vector2 value2, ref readonly Vector2 value3, ref readonly Vector2 value4, float amount, out Vector2 result)
         {
             float squared = amount * amount;
             float cubed = amount * squared;
@@ -734,7 +734,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Max(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void Max(ref readonly Vector2 left, ref readonly Vector2 right, out Vector2 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -761,7 +761,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Min(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void Min(ref readonly Vector2 left, ref readonly Vector2 right, out Vector2 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;
@@ -789,7 +789,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the reflected vector.</param>
         /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
         /// whether the original vector was close enough to the surface to hit it.</remarks>
-        public static void Reflect(ref Vector2 vector, ref Vector2 normal, out Vector2 result)
+        public static void Reflect(ref readonly Vector2 vector, ref readonly Vector2 normal, out Vector2 result)
         {
             float dot = (vector.X * normal.X) + (vector.Y * normal.Y);
 
@@ -911,7 +911,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The vector to rotate.</param>
         /// <param name="rotation">The <see cref="Stride.Core.Mathematics.Quaternion"/> rotation to apply.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector4"/>.</param>
-        public static void Transform(ref Vector2 vector, ref Quaternion rotation, out Vector2 result)
+        public static void Transform(ref readonly Vector2 vector, ref readonly Quaternion rotation, out Vector2 result)
         {
             float x = rotation.X + rotation.X;
             float y = rotation.Y + rotation.Y;
@@ -947,7 +947,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Vector2[] source, ref Quaternion rotation, Vector2[] destination)
+        public static void Transform(Vector2[] source, ref readonly Quaternion rotation, Vector2[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -984,7 +984,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector4"/>.</param>
-        public static void Transform(ref Vector2 vector, ref Matrix transform, out Vector4 result)
+        public static void Transform(ref readonly Vector2 vector, ref readonly Matrix transform, out Vector4 result)
         {
             result = new Vector4(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + transform.M41,
@@ -1014,7 +1014,7 @@ namespace Stride.Core.Mathematics
         /// <param name="destination">The array for which the transformed vectors are stored.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Vector2[] source, ref Matrix transform, Vector4[] destination)
+        public static void Transform(Vector2[] source, ref readonly Matrix transform, Vector4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1025,7 +1025,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                Transform(ref source[i], ref transform, out destination[i]);
+                Transform(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1042,7 +1042,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(ref Vector2 coordinate, ref Matrix transform, out Vector2 result)
+        public static void TransformCoordinate(ref readonly Vector2 coordinate, ref readonly Matrix transform, out Vector2 result)
         {
             Vector4 vector = new Vector4();
             vector.X = (coordinate.X * transform.M11) + (coordinate.Y * transform.M21) + transform.M41;
@@ -1089,7 +1089,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(Vector2[] source, ref Matrix transform, Vector2[] destination)
+        public static void TransformCoordinate(Vector2[] source, ref readonly Matrix transform, Vector2[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1100,7 +1100,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformCoordinate(ref source[i], ref transform, out destination[i]);
+                TransformCoordinate(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1117,7 +1117,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(ref Vector2 normal, ref Matrix transform, out Vector2 result)
+        public static void TransformNormal(ref readonly Vector2 normal, ref readonly Matrix transform, out Vector2 result)
         {
             result = new Vector2(
                 (normal.X * transform.M11) + (normal.Y * transform.M21),
@@ -1160,7 +1160,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(Vector2[] source, ref Matrix transform, Vector2[] destination)
+        public static void TransformNormal(Vector2[] source, ref readonly Matrix transform, Vector2[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1171,7 +1171,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformNormal(ref source[i], ref transform, out destination[i]);
+                TransformNormal(ref source[i], in transform, out destination[i]);
             }
         }
 

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -273,7 +273,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Add(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Add(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result = new Vector3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
         }
@@ -297,7 +297,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Subtract(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Subtract(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result = new Vector3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
         }
@@ -321,7 +321,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Multiply(ref Vector3 value, float scale, out Vector3 result)
+        public static void Multiply(ref readonly Vector3 value, float scale, out Vector3 result)
         {
             result = new Vector3(value.X * scale, value.Y * scale, value.Z * scale);
         }
@@ -345,7 +345,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Modulate(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Modulate(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result = new Vector3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
         }
@@ -369,7 +369,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Divide(ref Vector3 value, float scale, out Vector3 result)
+        public static void Divide(ref readonly Vector3 value, float scale, out Vector3 result)
         {
             result = new Vector3(value.X / scale, value.Y / scale, value.Z / scale);
         }
@@ -393,7 +393,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to demodulate.</param>
         /// <param name="result">When the method completes, contains the demodulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Demodulate(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Demodulate(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result = new Vector3(left.X / right.X, left.Y / right.Y, left.Z / right.Z);
         }
@@ -416,7 +416,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Negate(ref Vector3 value, out Vector3 result)
+        public static void Negate(ref readonly Vector3 value, out Vector3 result)
         {
             result = new Vector3(-value.X, -value.Y, -value.Z);
         }
@@ -441,7 +441,7 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains the 3D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Vector3 value1, ref Vector3 value2, ref Vector3 value3, float amount1, float amount2, out Vector3 result)
+        public static void Barycentric(ref readonly Vector3 value1, ref readonly Vector3 value2, ref readonly Vector3 value3, float amount1, float amount2, out Vector3 result)
         {
             result = new Vector3(
                 (value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
@@ -472,7 +472,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Vector3 value, ref Vector3 min, ref Vector3 max, out Vector3 result)
+        public static void Clamp(ref readonly Vector3 value, ref readonly Vector3 min, ref readonly Vector3 max, out Vector3 result)
         {
             float x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -509,7 +509,7 @@ namespace Stride.Core.Mathematics
         /// <param name="left">First source vector.</param>
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains he cross product of the two vectors.</param>
-        public static void Cross(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Cross(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result = new Vector3(
                 (left.Y * right.Z) - (left.Z * right.Y),
@@ -538,10 +538,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second vector.</param>
         /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
         /// <remarks>
-        /// <see cref="Stride.Core.Mathematics.Vector3.DistanceSquared(ref Vector3, ref Vector3, out float)"/> may be preferred when only the relative distance is needed
+        /// <see cref="Stride.Core.Mathematics.Vector3.DistanceSquared(ref readonly Vector3, ref readonly Vector3, out float)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
-        public static void Distance(ref Vector3 value1, ref Vector3 value2, out float result)
+        public static void Distance(ref readonly Vector3 value1, ref readonly Vector3 value2, out float result)
         {
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
@@ -582,7 +582,7 @@ namespace Stride.Core.Mathematics
         /// involves two square roots, which are computationally expensive. However, using distance squared 
         /// provides the same information and avoids calculating two square roots.
         /// </remarks>
-        public static void DistanceSquared(ref Vector3 value1, ref Vector3 value2, out float result)
+        public static void DistanceSquared(ref readonly Vector3 value1, ref readonly Vector3 value2, out float result)
         {
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
@@ -620,7 +620,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Dot(ref Vector3 left, ref Vector3 right, out float result)
+        public static void Dot(ref readonly Vector3 left, ref readonly Vector3 right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
         }
@@ -643,7 +643,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Normalize(ref Vector3 value, out Vector3 result)
+        public static void Normalize(ref readonly Vector3 value, out Vector3 result)
         {
             result = value;
             result.Normalize();
@@ -673,7 +673,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Vector3 start, ref Vector3 end, float amount, out Vector3 result)
+        public static void Lerp(ref readonly Vector3 start, ref readonly Vector3 end, float amount, out Vector3 result)
         {
             result.X = start.X + ((end.X - start.X) * amount);
             result.Y = start.Y + ((end.Y - start.Y) * amount);
@@ -706,7 +706,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Vector3 start, ref Vector3 end, float amount, out Vector3 result)
+        public static void SmoothStep(ref readonly Vector3 start, ref readonly Vector3 end, float amount, out Vector3 result)
         {
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -739,7 +739,7 @@ namespace Stride.Core.Mathematics
         /// <param name="tangent2">Second source tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
-        public static void Hermite(ref Vector3 value1, ref Vector3 tangent1, ref Vector3 value2, ref Vector3 tangent2, float amount, out Vector3 result)
+        public static void Hermite(ref readonly Vector3 value1, ref readonly Vector3 tangent1, ref readonly Vector3 value2, ref readonly Vector3 tangent2, float amount, out Vector3 result)
         {
             float squared = amount * amount;
             float cubed = amount * squared;
@@ -778,7 +778,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
-        public static void CatmullRom(ref Vector3 value1, ref Vector3 value2, ref Vector3 value3, ref Vector3 value4, float amount, out Vector3 result)
+        public static void CatmullRom(ref readonly Vector3 value1, ref readonly Vector3 value2, ref readonly Vector3 value3, ref readonly Vector3 value4, float amount, out Vector3 result)
         {
             float squared = amount * amount;
             float cubed = amount * squared;
@@ -819,7 +819,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of each component's modulo.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Mod(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Mod(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result.X = MathUtil.Mod(left.X, right.X);
             result.Y = MathUtil.Mod(left.Y, right.Y);
@@ -847,7 +847,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Max(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Max(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -875,7 +875,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Min(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Min(ref readonly Vector3 left, ref readonly Vector3 right, out Vector3 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;
@@ -908,10 +908,10 @@ namespace Stride.Core.Mathematics
         /// <param name="maxZ">The maximum depth of the viewport.</param>
         /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
         /// <param name="result">When the method completes, contains the vector in screen space.</param>
-        public static void Project(ref Vector3 vector, float x, float y, float width, float height, float minZ, float maxZ, ref Matrix worldViewProjection, out Vector3 result)
+        public static void Project(ref readonly Vector3 vector, float x, float y, float width, float height, float minZ, float maxZ, ref readonly Matrix worldViewProjection, out Vector3 result)
         {
             Vector3 v;
-            TransformCoordinate(ref vector, ref worldViewProjection, out v);
+            TransformCoordinate(in vector, in worldViewProjection, out v);
 
             result = new Vector3(((1.0f + v.X) * 0.5f * width) + x, ((1.0f - v.Y) * 0.5f * height) + y, (v.Z * (maxZ - minZ)) + minZ);
         }
@@ -947,11 +947,11 @@ namespace Stride.Core.Mathematics
         /// <param name="maxZ">The maximum depth of the viewport.</param>
         /// <param name="worldViewProjection">The combined world-view-projection matrix.</param>
         /// <param name="result">When the method completes, contains the vector in object space.</param>
-        public static void Unproject(ref Vector3 vector, float x, float y, float width, float height, float minZ, float maxZ, ref Matrix worldViewProjection, out Vector3 result)
+        public static void Unproject(ref readonly Vector3 vector, float x, float y, float width, float height, float minZ, float maxZ, ref readonly Matrix worldViewProjection, out Vector3 result)
         {
             Vector3 v = new Vector3();
             Matrix matrix;
-            Matrix.Invert(ref worldViewProjection, out matrix);
+            Matrix.Invert(in worldViewProjection, out matrix);
 
             v.X = (((vector.X - x) / width) * 2.0f) - 1.0f;
             v.Y = -((((vector.Y - y) / height) * 2.0f) - 1.0f);
@@ -987,7 +987,7 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the reflected vector.</param>
         /// <remarks>Reflect only gives the direction of a reflection off a surface, it does not determine 
         /// whether the original vector was close enough to the surface to hit it.</remarks>
-        public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
+        public static void Reflect(ref readonly Vector3 vector, ref readonly Vector3 normal, out Vector3 result)
         {
             float dot = (vector.X * normal.X) + (vector.Y * normal.Y) + (vector.Z * normal.Z);
 
@@ -1110,7 +1110,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The vector to rotate.</param>
         /// <param name="rotation">The <see cref="Stride.Core.Mathematics.Quaternion"/> rotation to apply.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector4"/>.</param>
-        public static void Transform(ref Vector3 vector, ref Quaternion rotation, out Vector3 result)
+        public static void Transform(ref readonly Vector3 vector, ref readonly Quaternion rotation, out Vector3 result)
         {
             float x = rotation.X + rotation.X;
             float y = rotation.Y + rotation.Y;
@@ -1153,7 +1153,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Vector3[] source, ref Quaternion rotation, Vector3[] destination)
+        public static void Transform(Vector3[] source, ref readonly Quaternion rotation, Vector3[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1200,7 +1200,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector4"/>.</param>
-        public static void Transform(ref Vector3 vector, ref Matrix transform, out Vector4 result)
+        public static void Transform(ref readonly Vector3 vector, ref readonly Matrix transform, out Vector4 result)
         {
             result = new Vector4(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + transform.M41,
@@ -1215,7 +1215,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector3"/>.</param>
-        public static void Transform(ref Vector3 vector, ref Matrix transform, out Vector3 result)
+        public static void Transform(ref readonly Vector3 vector, ref readonly Matrix transform, out Vector3 result)
         {
             result = new Vector3(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + transform.M41,
@@ -1244,7 +1244,7 @@ namespace Stride.Core.Mathematics
         /// <param name="destination">The array for which the transformed vectors are stored.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Vector3[] source, ref Matrix transform, Vector4[] destination)
+        public static void Transform(Vector3[] source, ref readonly Matrix transform, Vector4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1255,7 +1255,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                Transform(ref source[i], ref transform, out destination[i]);
+                Transform(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1272,7 +1272,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(ref Vector3 coordinate, ref Matrix transform, out Vector3 result)
+        public static void TransformCoordinate(ref readonly Vector3 coordinate, ref readonly Matrix transform, out Vector3 result)
         {
             var invW = 1f / ((coordinate.X * transform.M14) + (coordinate.Y * transform.M24) + (coordinate.Z * transform.M34) + transform.M44);
             result = new Vector3(
@@ -1317,7 +1317,7 @@ namespace Stride.Core.Mathematics
         /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
-        public static void TransformCoordinate(Vector3[] source, ref Matrix transform, Vector3[] destination)
+        public static void TransformCoordinate(Vector3[] source, ref readonly Matrix transform, Vector3[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1328,7 +1328,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformCoordinate(ref source[i], ref transform, out destination[i]);
+                TransformCoordinate(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1345,7 +1345,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(ref Vector3 normal, ref Matrix transform, out Vector3 result)
+        public static void TransformNormal(ref readonly Vector3 normal, ref readonly Matrix transform, out Vector3 result)
         {
             result = new Vector3(
                 (normal.X * transform.M11) + (normal.Y * transform.M21) + (normal.Z * transform.M31),
@@ -1389,7 +1389,7 @@ namespace Stride.Core.Mathematics
         /// apply. This is often prefered for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
-        public static void TransformNormal(Vector3[] source, ref Matrix transform, Vector3[] destination)
+        public static void TransformNormal(Vector3[] source, ref readonly Matrix transform, Vector3[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1400,7 +1400,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                TransformNormal(ref source[i], ref transform, out destination[i]);
+                TransformNormal(ref source[i], in transform, out destination[i]);
             }
         }
 
@@ -1421,9 +1421,9 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="quaternion">The input rotation as quaternion</param>
         /// <param name="yawPitchRoll">The equivation yaw/pitch/roll rotation</param>
-        public static void RotationYawPitchRoll(ref Quaternion quaternion, out Vector3 yawPitchRoll)
+        public static void RotationYawPitchRoll(ref readonly Quaternion quaternion, out Vector3 yawPitchRoll)
         {
-            Quaternion.RotationYawPitchRoll(ref quaternion, out yawPitchRoll.X, out yawPitchRoll.Y, out yawPitchRoll.Z);
+            Quaternion.RotationYawPitchRoll(in quaternion, out yawPitchRoll.X, out yawPitchRoll.Y, out yawPitchRoll.Z);
         }
 
 
@@ -1450,7 +1450,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <returns>The sum of the two vectors.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator +(Vector3 left, Vector3 right)
+        public static Vector3 operator +(in Vector3 left, in Vector3 right)
         {
             return new Vector3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
         }
@@ -1461,7 +1461,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to assert (unchange).</param>
         /// <returns>The asserted (unchanged) vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator +(Vector3 value)
+        public static Vector3 operator +(in Vector3 value)
         {
             return value;
         }
@@ -1473,7 +1473,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <returns>The difference of the two vectors.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator -(Vector3 left, Vector3 right)
+        public static Vector3 operator -(in Vector3 left, in Vector3 right)
         {
             return new Vector3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
         }
@@ -1484,7 +1484,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <returns>A vector facing in the opposite direction.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator -(Vector3 value)
+        public static Vector3 operator -(in Vector3 value)
         {
             return new Vector3(-value.X, -value.Y, -value.Z);
         }
@@ -1496,7 +1496,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <returns>The scaled vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator *(float scale, Vector3 value)
+        public static Vector3 operator *(float scale, in Vector3 value)
         {
             return new Vector3(value.X * scale, value.Y * scale, value.Z * scale);
         }
@@ -1508,7 +1508,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <returns>The scaled vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator *(Vector3 value, float scale)
+        public static Vector3 operator *(in Vector3 value, float scale)
         {
             return new Vector3(value.X * scale, value.Y * scale, value.Z * scale);
         }
@@ -1520,7 +1520,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to multiply.</param>
         /// <returns>The multiplication of the two vectors.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator *(Vector3 left, Vector3 right)
+        public static Vector3 operator *(in Vector3 left, in Vector3 right)
         {
             return new Vector3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
         }
@@ -1532,7 +1532,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <returns>The vector offset.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator +(Vector3 value, float scale)
+        public static Vector3 operator +(in Vector3 value, float scale)
         {
             return new Vector3(value.X + scale, value.Y + scale, value.Z + scale);
         }
@@ -1544,7 +1544,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <returns>The vector offset.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator -(Vector3 value, float scale)
+        public static Vector3 operator -(in Vector3 value, float scale)
         {
             return new Vector3(value.X - scale, value.Y - scale, value.Z - scale);
         }
@@ -1556,7 +1556,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The value.</param>
         /// <returns>The scaled vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator /(float numerator, Vector3 value)
+        public static Vector3 operator /(float numerator, in Vector3 value)
         {
             return new Vector3(numerator / value.X, numerator / value.Y, numerator / value.Z);
         }
@@ -1568,7 +1568,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <returns>The scaled vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator /(Vector3 value, float scale)
+        public static Vector3 operator /(in Vector3 value, float scale)
         {
             return new Vector3(value.X / scale, value.Y / scale, value.Z / scale);
         }
@@ -1580,7 +1580,7 @@ namespace Stride.Core.Mathematics
         /// <param name="by">The by.</param>
         /// <returns>The scaled vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 operator /(Vector3 value, Vector3 by)
+        public static Vector3 operator /(in Vector3 value, in Vector3 by)
         {
             return new Vector3(value.X / by.X, value.Y / by.Y, value.Z / by.Z);
         }
@@ -1612,7 +1612,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static explicit operator Vector2(Vector3 value)
+        public static explicit operator Vector2(in Vector3 value)
         {
             return new Vector2(value.X, value.Y);
         }
@@ -1622,7 +1622,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static explicit operator Vector4(Vector3 value)
+        public static explicit operator Vector4(in Vector3 value)
         {
             return new Vector4(value, 0.0f);
         }
@@ -1632,7 +1632,7 @@ namespace Stride.Core.Mathematics
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static explicit operator Int3(Vector3 value)
+        public static explicit operator Int3(in Vector3 value)
         {
             return new Int3((int)value.X, (int)value.Y, (int)value.Z);
         }
@@ -1644,19 +1644,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The right vector.</param>
         /// <param name="epsilon">The epsilon.</param>
         /// <returns><c>true</c> if left and right are near another 3D, <c>false</c> otherwise</returns>
-        public static bool NearEqual(Vector3 left, Vector3 right, Vector3 epsilon)
-        {
-            return NearEqual(ref left, ref right, ref epsilon);
-        }
-
-        /// <summary>
-        /// Tests whether one 3D vector is near another 3D vector.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <param name="epsilon">The epsilon.</param>
-        /// <returns><c>true</c> if left and right are near another 3D, <c>false</c> otherwise</returns>
-        public static bool NearEqual(ref Vector3 left, ref Vector3 right, ref Vector3 epsilon)
+        public static bool NearEqual(ref readonly Vector3 left, ref readonly Vector3 right, ref readonly Vector3 epsilon)
         {
             return MathUtil.WithinEpsilon(left.X, right.X, epsilon.X) &&
                     MathUtil.WithinEpsilon(left.Y, right.Y, epsilon.Y) &&

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -312,7 +312,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to add.</param>
         /// <param name="result">When the method completes, contains the sum of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Add(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void Add(ref readonly Vector4 left, ref readonly Vector4 right, out Vector4 result)
         {
             result = new Vector4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
         }
@@ -336,7 +336,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to subtract.</param>
         /// <param name="result">When the method completes, contains the difference of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Subtract(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void Subtract(ref readonly Vector4 left, ref readonly Vector4 right, out Vector4 result)
         {
             result = new Vector4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
         }
@@ -360,7 +360,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Multiply(ref Vector4 value, float scale, out Vector4 result)
+        public static void Multiply(ref readonly Vector4 value, float scale, out Vector4 result)
         {
             result = new Vector4(value.X * scale, value.Y * scale, value.Z * scale, value.W * scale);
         }
@@ -384,7 +384,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to modulate.</param>
         /// <param name="result">When the method completes, contains the modulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Modulate(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void Modulate(ref readonly Vector4 left, ref readonly Vector4 right, out Vector4 result)
         {
             result = new Vector4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
         }
@@ -408,7 +408,7 @@ namespace Stride.Core.Mathematics
         /// <param name="scale">The amount by which to scale the vector.</param>
         /// <param name="result">When the method completes, contains the scaled vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Divide(ref Vector4 value, float scale, out Vector4 result)
+        public static void Divide(ref readonly Vector4 value, float scale, out Vector4 result)
         {
             result = new Vector4(value.X / scale, value.Y / scale, value.Z / scale, value.W / scale);
         }
@@ -432,7 +432,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second vector to demodulate.</param>
         /// <param name="result">When the method completes, contains the demodulated vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Demodulate(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void Demodulate(ref readonly Vector4 left, ref readonly Vector4 right, out Vector4 result)
         {
             result = new Vector4(left.X / right.X, left.Y / right.Y, left.Z / right.Z, left.W / right.W);
         }
@@ -455,7 +455,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to negate.</param>
         /// <param name="result">When the method completes, contains a vector facing in the opposite direction.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Negate(ref Vector4 value, out Vector4 result)
+        public static void Negate(ref readonly Vector4 value, out Vector4 result)
         {
             result = new Vector4(-value.X, -value.Y, -value.Z, -value.W);
         }
@@ -480,7 +480,7 @@ namespace Stride.Core.Mathematics
         /// <param name="amount1">Barycentric coordinate b2, which expresses the weighting factor toward vertex 2 (specified in <paramref name="value2"/>).</param>
         /// <param name="amount2">Barycentric coordinate b3, which expresses the weighting factor toward vertex 3 (specified in <paramref name="value3"/>).</param>
         /// <param name="result">When the method completes, contains the 4D Cartesian coordinates of the specified point.</param>
-        public static void Barycentric(ref Vector4 value1, ref Vector4 value2, ref Vector4 value3, float amount1, float amount2, out Vector4 result)
+        public static void Barycentric(ref readonly Vector4 value1, ref readonly Vector4 value2, ref readonly Vector4 value3, float amount1, float amount2, out Vector4 result)
         {
             result = new Vector4(
                 (value1.X + (amount1 * (value2.X - value1.X))) + (amount2 * (value3.X - value1.X)),
@@ -512,7 +512,7 @@ namespace Stride.Core.Mathematics
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="result">When the method completes, contains the clamped value.</param>
-        public static void Clamp(ref Vector4 value, ref Vector4 min, ref Vector4 max, out Vector4 result)
+        public static void Clamp(ref readonly Vector4 value, ref readonly Vector4 min, ref readonly Vector4 max, out Vector4 result)
         {
             float x = value.X;
             x = (x > max.X) ? max.X : x;
@@ -554,10 +554,10 @@ namespace Stride.Core.Mathematics
         /// <param name="value2">The second vector.</param>
         /// <param name="result">When the method completes, contains the distance between the two vectors.</param>
         /// <remarks>
-        /// <see cref="Stride.Core.Mathematics.Vector4.DistanceSquared(ref Vector4, ref Vector4, out float)"/> may be preferred when only the relative distance is needed
+        /// <see cref="Stride.Core.Mathematics.Vector4.DistanceSquared(ref readonly Vector4, ref readonly Vector4, out float)"/> may be preferred when only the relative distance is needed
         /// and speed is of the essence.
         /// </remarks>
-        public static void Distance(ref Vector4 value1, ref Vector4 value2, out float result)
+        public static void Distance(ref readonly Vector4 value1, ref readonly Vector4 value2, out float result)
         {
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
@@ -600,7 +600,7 @@ namespace Stride.Core.Mathematics
         /// involves two square roots, which are computationally expensive. However, using distance squared 
         /// provides the same information and avoids calculating two square roots.
         /// </remarks>
-        public static void DistanceSquared(ref Vector4 value1, ref Vector4 value2, out float result)
+        public static void DistanceSquared(ref readonly Vector4 value1, ref readonly Vector4 value2, out float result)
         {
             float x = value1.X - value2.X;
             float y = value1.Y - value2.Y;
@@ -640,7 +640,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">Second source vector.</param>
         /// <param name="result">When the method completes, contains the dot product of the two vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Dot(ref Vector4 left, ref Vector4 right, out float result)
+        public static void Dot(ref readonly Vector4 left, ref readonly Vector4 right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
         }
@@ -663,7 +663,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value">The vector to normalize.</param>
         /// <param name="result">When the method completes, contains the normalized vector.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Normalize(ref Vector4 value, out Vector4 result)
+        public static void Normalize(ref readonly Vector4 value, out Vector4 result)
         {
             Vector4 temp = value;
             result = temp;
@@ -694,7 +694,7 @@ namespace Stride.Core.Mathematics
         /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
-        public static void Lerp(ref Vector4 start, ref Vector4 end, float amount, out Vector4 result)
+        public static void Lerp(ref readonly Vector4 start, ref readonly Vector4 end, float amount, out Vector4 result)
         {
             result.X = start.X + ((end.X - start.X) * amount);
             result.Y = start.Y + ((end.Y - start.Y) * amount);
@@ -728,7 +728,7 @@ namespace Stride.Core.Mathematics
         /// <param name="end">End vector.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the cubic interpolation of the two vectors.</param>
-        public static void SmoothStep(ref Vector4 start, ref Vector4 end, float amount, out Vector4 result)
+        public static void SmoothStep(ref readonly Vector4 start, ref readonly Vector4 end, float amount, out Vector4 result)
         {
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
@@ -762,7 +762,7 @@ namespace Stride.Core.Mathematics
         /// <param name="tangent2">Second source tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Hermite spline interpolation.</param>
-        public static void Hermite(ref Vector4 value1, ref Vector4 tangent1, ref Vector4 value2, ref Vector4 tangent2, float amount, out Vector4 result)
+        public static void Hermite(ref readonly Vector4 value1, ref readonly Vector4 tangent1, ref readonly Vector4 value2, ref readonly Vector4 tangent2, float amount, out Vector4 result)
         {
             float squared = amount * amount;
             float cubed = amount * squared;
@@ -803,7 +803,7 @@ namespace Stride.Core.Mathematics
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <param name="result">When the method completes, contains the result of the Catmull-Rom interpolation.</param>
-        public static void CatmullRom(ref Vector4 value1, ref Vector4 value2, ref Vector4 value3, ref Vector4 value4, float amount, out Vector4 result)
+        public static void CatmullRom(ref readonly Vector4 value1, ref readonly Vector4 value2, ref readonly Vector4 value3, ref readonly Vector4 value4, float amount, out Vector4 result)
         {
             float squared = amount * amount;
             float cubed = amount * squared;
@@ -837,7 +837,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the largest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Max(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void Max(ref readonly Vector4 left, ref readonly Vector4 right, out Vector4 result)
         {
             result.X = (left.X > right.X) ? left.X : right.X;
             result.Y = (left.Y > right.Y) ? left.Y : right.Y;
@@ -866,7 +866,7 @@ namespace Stride.Core.Mathematics
         /// <param name="right">The second source vector.</param>
         /// <param name="result">When the method completes, contains an new vector composed of the smallest components of the source vectors.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Min(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void Min(ref readonly Vector4 left, ref readonly Vector4 right, out Vector4 result)
         {
             result.X = (left.X < right.X) ? left.X : right.X;
             result.Y = (left.Y < right.Y) ? left.Y : right.Y;
@@ -987,7 +987,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The vector to rotate.</param>
         /// <param name="rotation">The <see cref="Stride.Core.Mathematics.Quaternion"/> rotation to apply.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector4"/>.</param>
-        public static void Transform(ref Vector4 vector, ref Quaternion rotation, out Vector4 result)
+        public static void Transform(ref readonly Vector4 vector, ref readonly Quaternion rotation, out Vector4 result)
         {
             float x = rotation.X + rotation.X;
             float y = rotation.Y + rotation.Y;
@@ -1031,7 +1031,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Vector4[] source, ref Quaternion rotation, Vector4[] destination)
+        public static void Transform(Vector4[] source, ref readonly Quaternion rotation, Vector4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1079,7 +1079,7 @@ namespace Stride.Core.Mathematics
         /// <param name="vector">The source vector.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="result">When the method completes, contains the transformed <see cref="Stride.Core.Mathematics.Vector4"/>.</param>
-        public static void Transform(ref Vector4 vector, ref Matrix transform, out Vector4 result)
+        public static void Transform(ref readonly Vector4 vector, ref readonly Matrix transform, out Vector4 result)
         {
             result = new Vector4(
                 (vector.X * transform.M11) + (vector.Y * transform.M21) + (vector.Z * transform.M31) + (vector.W * transform.M41),
@@ -1110,7 +1110,7 @@ namespace Stride.Core.Mathematics
         /// This array may be the same array as <paramref name="source"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="destination"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
-        public static void Transform(Vector4[] source, ref Matrix transform, Vector4[] destination)
+        public static void Transform(Vector4[] source, ref readonly Matrix transform, Vector4[] destination)
         {
             if (source == null)
                 throw new ArgumentNullException("source");
@@ -1121,7 +1121,7 @@ namespace Stride.Core.Mathematics
 
             for (int i = 0; i < source.Length; ++i)
             {
-                Transform(ref source[i], ref transform, out destination[i]);
+                Transform(ref source[i], in transform, out destination[i]);
             }
         }
 


### PR DESCRIPTION
# PR Details
See title, this enables arguments passed as `in` to be passed into those functions without copying.
Has a side effect of allowing users to pass their variables without specifying `in` or `ref` modifier, dotnet will produce a warning instead of syntax error.
Example:
```cs
void F0(ref readonly int i){}

F0(124); // warning: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
int i = 124;
F0(in i); // OK
F0(ref i); // OK

void F1(in int i) => F0(in i); // OK
void F2(ref int i) => F0(in i); // OK
void F3(ref readonly int i) => F2(ref i); // Error, F2 is not readonly
void F3(in int i) => F2(ref i); // Error, F2 is not readonly
```

See `ref readonly` feature specification https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/ref-readonly-parameters

## Related Issue
None

## Motivation and Context
Prevents a forced copy for passing structs that are received as `in`

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
