### PR TITLE
fix(fbx import): Prevent zero-length tangents/normals (partial fix for #325)

### DIFF
--- a/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
+++ b/sources/tools/Stride.Importer.FBX/MeshConverter.cpp
@@ -544,7 +544,7 @@ public:
 						auto src_normal = normalElement->GetDirectArray().GetAt(normalIndex);
 						auto normalPointer = ((Vector3*)(vbPointer + normalOffset));
 						normal = sceneMapping->ConvertNormalFromFbx(src_normal);
-						if (isnan(normal.X) || isnan(normal.Y) || isnan(normal.Z))
+						if (isnan(normal.X) || isnan(normal.Y) || isnan(normal.Z) || normal.Length() < FLT_EPSILON)
 							normal = Vector3(1, 0, 0);
 						normal = Vector3::Normalize(normal);
 						*normalPointer = normal;
@@ -568,7 +568,7 @@ public:
 						auto src_tangent = tangentElement->GetDirectArray().GetAt(tangentIndex);
 						auto tangentPointer = ((Vector4*)(vbPointer + tangentOffset));
 						Vector3 tangent = sceneMapping->ConvertNormalFromFbx(src_tangent);
-						if (isnan(tangent.X) || isnan(tangent.Y) || isnan(tangent.Z))
+						if (isnan(tangent.X) || isnan(tangent.Y) || isnan(tangent.Z) || tangent.Length() < FLT_EPSILON)
 						{
 							*tangentPointer = Vector4(1, 0, 0, 1);
 						}
@@ -578,9 +578,16 @@ public:
 
 							int binormalIndex = GetGroupIndexForLayerElementTemplate(binormalElement, controlPointIndex, vertexIndex, edgeIndex, i, meshName, layerIndexFirstTimeError);
 							auto src_binormal = binormalElement->GetDirectArray().GetAt(binormalIndex);
-							Vector3 binormal = sceneMapping->ConvertNormalFromFbx(src_tangent);
-							// See GenerateTangentBinormal()
-							*tangentPointer = Vector4(tangent.X, tangent.Y, tangent.Z, Vector3::Dot(Vector3::Cross(normal, tangent), binormal) < 0.0f ? -1.0f : 1.0f);
+							Vector3 binormal = sceneMapping->ConvertNormalFromFbx(src_binormal);
+							if (isnan(binormal.X) || isnan(binormal.Y) || isnan(binormal.Z) || binormal.Length() < FLT_EPSILON)
+							{
+								*tangentPointer = Vector4(tangent.X, tangent.Y, tangent.Z, 1.0f);
+							}
+							else
+							{
+								// See GenerateTangentBinormal()
+								*tangentPointer = Vector4(tangent.X, tangent.Y, tangent.Z, Vector3::Dot(Vector3::Cross(normal, tangent), binormal) < 0.0f ? -1.0f : 1.0f);
+							}
 						}
 					}
 


### PR DESCRIPTION
# PR Details

## Description

This fixes the NaN issue in Starbreach, caused by zero-length tangents in the input model. 
Also makes sure the same issue can't happen with normals and tangent handedness.

## Related Issue

#325 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
