### PR TITLE
create unique IDs for from prefab instantiated entities and components

### DIFF
--- a/sources/engine/Stride.Engine.NoAssets.Tests/PrefabTest.cs
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/PrefabTest.cs
@@ -1,0 +1,43 @@
+using Stride.Graphics.Regression;
+using Xunit;
+
+namespace Stride.Engine.Tests;
+
+public class PrefabTest : GameTestBase
+{
+    [Fact]
+    public void InstantiationWithUniqueIdsTest()
+    {
+        PerformTest(game =>
+        {
+            var prefab = new Prefab();
+            var entity = new Entity();
+            prefab.Entities.Add(entity);
+
+            var entities = prefab.Instantiate();
+
+            Assert.NotEqual(entity.Id, entities[0].Id);
+            Assert.NotEqual(entity.Transform.Id, entities[0].Transform.Id);
+        });
+    }
+
+    [Fact]
+    public void InstantiationOfEntityHierarchyWithUniqueIdsTest()
+    {
+        PerformTest(game =>
+        {
+            var prefab = new Prefab();
+            var entity = new Entity();
+            var child = new Entity();
+            entity.AddChild(child);
+            prefab.Entities.Add(entity);
+
+            var entities = prefab.Instantiate();
+
+            Assert.NotEqual(entity.Id, entities[0].Id);
+            Assert.NotEqual(entity.Transform.Id, entities[0].Transform.Id);
+            Assert.NotEqual(child.Id, entities[0].GetChild(0).Id);
+            Assert.NotEqual(child.Transform.Id, entities[0].GetChild(0).Transform.Id);
+        });
+    }
+}

--- a/sources/engine/Stride.Engine/Engine/Prefab.cs
+++ b/sources/engine/Stride.Engine/Engine/Prefab.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Stride.Core;
 using Stride.Core.Collections;
@@ -30,7 +31,33 @@ namespace Stride.Engine
         public List<Entity> Instantiate()
         {
             var newPrefab = EntityCloner.Clone(this);
+            CreateNewIds(newPrefab.Entities);
             return newPrefab.Entities;
+        }
+
+        /// <summary>
+        /// Creates new IDs for the specified entities and their components.
+        /// </summary>
+        /// <param name="entities">The entities to create new IDs for</param>
+        private static void CreateNewIds(IEnumerable<Entity> entities)
+        {
+            var objects = new HashSet<object>();
+            foreach (var entity in entities)
+            {
+                EntityCloner.CollectEntityTreeHelper(entity, objects);
+            }
+
+            foreach (var item in objects)
+            {
+                if (item is Entity entity)
+                {
+                    entity.Id = Guid.NewGuid();
+                }
+                else if (item is EntityComponent component)
+                {
+                    component.Id = Guid.NewGuid();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# PR Details

After instantiation of a prefab, all entities and components get a new ID.

Closes: #2067 

## Description

Fixes the crash of the Game Studio described in #2067 caused by ambiguous IDs. This could also fix some other consequential errors happening through the ambiguous IDs.

## Related Issue

#2067

## Motivation and Context

The Game Studio crashed each time I changed the hierarchy in my scene.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
