### PR TITLE
[Editor] Fix NuGet.Frameworks' failing to load causing RoslynPad to break

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,11 +49,11 @@
     <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
     <PackageVersion Include="Mono.Options" Version="5.3.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="NuGet.Commands" Version="6.7.0" />
-    <PackageVersion Include="NuGet.Configuration" Version="6.7.0" />
-    <PackageVersion Include="NuGet.PackageManagement" Version="6.7.0" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.7.0" />
-    <PackageVersion Include="NuGet.Resolver" Version="6.7.0" />
+    <PackageVersion Include="NuGet.Commands" Version="6.8.0" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.8.0" />
+    <PackageVersion Include="NuGet.PackageManagement" Version="6.8.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
+    <PackageVersion Include="NuGet.Resolver" Version="6.8.0" />
     <PackageVersion Include="Silk.NET.Assimp" Version="2.17.1" />
     <PackageVersion Include="Stride.GNU.Getopt" Version="2.0.0" />
     <PackageVersion Include="Stride.GNU.Gettext" Version="2.0.0" />


### PR DESCRIPTION
# PR Details
This exception was logged silently to the output:
```
ProjectWatcher: Msbuild failed when processing the file 'D:\Documents\Stride Projects\MyGame45\MyGame45\MyGame45.csproj' with message: C:\Program Files\dotnet\sdk\8.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets: (90, 5): The "ProcessFrameworkReferences" task failed unexpectedly.
System.IO.FileLoadException: Could not load file or assembly 'NuGet.Frameworks, Version=6.8.0.122, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. Could not find or load a specific file. (0x80131621)
File name: 'NuGet.Frameworks, Version=6.8.0.122, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 ---> System.IO.FileLoadException: Could not load file or assembly 'NuGet.Frameworks, Version=6.8.0.122, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String assemblyPath)
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingLoad(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
   at Microsoft.NET.Build.Tasks.ProcessFrameworkReferences.<>c.<AddPacksForFrameworkReferences>b__217_0(ITaskItem item)
   at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToList()
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Microsoft.NET.Build.Tasks.ProcessFrameworkReferences.AddPacksForFrameworkReferences(List`1 packagesToDownload, List`1 runtimeFrameworks, List`1 targetingPacks, List`1 runtimePacks, List`1 unavailableRuntimePacks, List`1& knownRuntimePacksForTargetFramework)
   at Microsoft.NET.Build.Tasks.ProcessFrameworkReferences.ExecuteCore()
   at Microsoft.NET.Build.Tasks.TaskBase.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```
Updating those packages resolved it.

I could not update roslynpad quite yet as we share dependencies and updating those break the build.

## Related Issue
Fixes #2043

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
