### PR TITLE
[Dispatcher] improve api, reduce overhead, improve performances for items > 1k

### DIFF
--- a/sources/core/Stride.Core/Threading/ThreadPool.SemaphoreW.cs
+++ b/sources/core/Stride.Core/Threading/ThreadPool.SemaphoreW.cs
@@ -15,7 +15,7 @@ namespace Stride.Core.Threading
         /// <summary>
         /// Mostly lifted from dotnet's LowLevelLifoSemaphore
         /// </summary>
-        private class SemaphoreW
+        private class SemaphoreW : ISemaphore
         {
             private const int SpinSleep0Threshold = 10;
             
@@ -61,6 +61,8 @@ namespace Stride.Core.Threading
             public void Wait(int timeout = -1) => internals.Wait(spinCount, lifoSemaphore, timeout);
 
             public void Release(int releaseCount) => internals.Release(releaseCount, lifoSemaphore);
+
+            public void Dispose() => lifoSemaphore?.Dispose();
 
             [StructLayout(LayoutKind.Explicit)]
             private struct Counts

--- a/sources/core/Stride.Core/Threading/ThreadPool.SemaphoreW.cs
+++ b/sources/core/Stride.Core/Threading/ThreadPool.SemaphoreW.cs
@@ -60,7 +60,7 @@ namespace Stride.Core.Threading
 
             public void Wait(int timeout = -1) => internals.Wait(spinCount, lifoSemaphore, timeout);
 
-            public void Release(int releaseCount) => internals.Release(releaseCount, lifoSemaphore);
+            public void Release(int count) => internals.Release(count, lifoSemaphore);
 
             public void Dispose() => lifoSemaphore?.Dispose();
 

--- a/sources/engine/Stride.Rendering/Rendering/TransformRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/TransformRenderFeature.cs
@@ -160,51 +160,55 @@ namespace Stride.Rendering
             // Update PerDraw (World, WorldViewProj, etc...)
             // Copy Entity.World to PerDraw cbuffer
             // TODO: Have a PerObject cbuffer?
-            Dispatcher.ForEach(((RootEffectRenderFeature)RootRenderFeature).RenderNodes, (ref RenderNode renderNode) =>
+            Dispatcher.ForBatched(RootRenderFeature.RenderNodes.Count, (from, toExclusive) =>
             {
-                var perDrawLayout = renderNode.RenderEffect.Reflection?.PerDrawLayout;
-                if (perDrawLayout == null)
-                    return;
-
-                var worldOffset = perDrawLayout.GetConstantBufferOffset(this.world);
-                var worldInverseOffset = perDrawLayout.GetConstantBufferOffset(this.worldInverse);
-
-                if (worldOffset == -1 && worldInverseOffset == -1)
-                    return;
-
-                ref var renderModelObjectInfo = ref renderModelObjectInfoData[renderNode.RenderObject.ObjectNode];
-                ref var renderModelViewInfo = ref renderModelViewInfoData[renderNode.ViewObjectNode];
-
-                var mappedCB = renderNode.Resources.ConstantBuffer.Data;
-                if (worldOffset != -1)
+                for (int i = from; i < toExclusive; i++)
                 {
-                    var world = (Matrix*)((byte*)mappedCB + worldOffset);
-                    *world = renderModelObjectInfo.World;
-                }
+                    var renderNode = RootRenderFeature.RenderNodes[i];
+                    var perDrawLayout = renderNode.RenderEffect.Reflection?.PerDrawLayout;
+                    if (perDrawLayout == null)
+                        continue;
 
-                if (worldInverseOffset != -1)
-                {
-                    var perDraw = (PerDrawExtra*)((byte*)mappedCB + worldInverseOffset);
+                    var worldOffset = perDrawLayout.GetConstantBufferOffset(this.world);
+                    var worldInverseOffset = perDrawLayout.GetConstantBufferOffset(this.worldInverse);
 
-                    // Fill PerDraw
-                    var perDrawData = new PerDrawExtra
+                    if (worldOffset == -1 && worldInverseOffset == -1)
+                        continue;
+
+                    ref var renderModelObjectInfo = ref renderModelObjectInfoData[renderNode.RenderObject.ObjectNode];
+                    ref var renderModelViewInfo = ref renderModelViewInfoData[renderNode.ViewObjectNode];
+
+                    var mappedCB = renderNode.Resources.ConstantBuffer.Data;
+                    if (worldOffset != -1)
                     {
-                        WorldView = renderModelViewInfo.WorldView,
-                        WorldViewProjection = renderModelViewInfo.WorldViewProjection,
-                    };
+                        var world = (Matrix*)((byte*)mappedCB + worldOffset);
+                        *world = renderModelObjectInfo.World;
+                    }
 
-                    Matrix.Invert(ref renderModelObjectInfo.World, out perDrawData.WorldInverse);
-                    Matrix.Transpose(ref perDrawData.WorldInverse, out perDrawData.WorldInverseTranspose);
-                    Matrix.Invert(ref renderModelViewInfo.WorldView, out perDrawData.WorldViewInverse);
+                    if (worldInverseOffset != -1)
+                    {
+                        var perDraw = (PerDrawExtra*)((byte*)mappedCB + worldInverseOffset);
 
-                    perDrawData.WorldScale = new Vector3(
-                        ((Vector3)renderModelObjectInfo.World.Row1).Length(),
-                        ((Vector3)renderModelObjectInfo.World.Row2).Length(),
-                        ((Vector3)renderModelObjectInfo.World.Row3).Length());
+                        // Fill PerDraw
+                        var perDrawData = new PerDrawExtra
+                        {
+                            WorldView = renderModelViewInfo.WorldView,
+                            WorldViewProjection = renderModelViewInfo.WorldViewProjection,
+                        };
 
-                    perDrawData.EyeMS = new Vector4(perDrawData.WorldInverse.M41, perDrawData.WorldInverse.M42, perDrawData.WorldInverse.M43, 1.0f);
+                        Matrix.Invert(ref renderModelObjectInfo.World, out perDrawData.WorldInverse);
+                        Matrix.Transpose(ref perDrawData.WorldInverse, out perDrawData.WorldInverseTranspose);
+                        Matrix.Invert(ref renderModelViewInfo.WorldView, out perDrawData.WorldViewInverse);
 
-                    *perDraw = perDrawData;
+                        perDrawData.WorldScale = new Vector3(
+                            ((Vector3)renderModelObjectInfo.World.Row1).Length(),
+                            ((Vector3)renderModelObjectInfo.World.Row2).Length(),
+                            ((Vector3)renderModelObjectInfo.World.Row3).Length());
+
+                        perDrawData.EyeMS = new Vector4(perDrawData.WorldInverse.M41, perDrawData.WorldInverse.M42, perDrawData.WorldInverse.M43, 1.0f);
+
+                        *perDraw = perDrawData;
+                    }
                 }
             });
         }


### PR DESCRIPTION
# PR Details
Threadpool now accepts generic work items, allowing the dispatcher and other callers to compose work items out of structures, in turn enabling the JIT to inline the composed call tree into just one function call from the thread's scope up to the actual work the caller dispatched.

Arguments can now be passed by ref to the dispatcher, which is also passed by ref to threads resolving a lot of issues that would require painful workarounds and allocations, like allowing jobs to read and write to a shared structure, interlocked operations per dispatch, and outputting from a job.

Added an interface for processing items in batches, allowing for improved throughput for jobs that have thousands of items to process.

I only changed a couple of engine calls to be batched, others may benefit in more demanding games.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**