### PR TITLE
Fix Typos in XML docs

### DIFF
--- a/sources/core/Stride.Core.Serialization/Storage/IOdbBackend.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/IOdbBackend.cs
@@ -59,7 +59,7 @@ namespace Stride.Core.Storage
         OdbStreamWriter CreateStream();
 
         /// <summary>
-        /// Determines weither the object with the specified <see cref="ObjectId"/> exists.
+        /// Determines if the object with the specified <see cref="ObjectId"/> exists.
         /// </summary>
         /// <param name="objectId">The <see cref="ObjectId"/> to check existence for.</param>
         /// <returns><c>true</c> if an object with the specified <see cref="ObjectId"/> exists; otherwise, <c>false</c>.</returns>

--- a/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
@@ -146,7 +146,7 @@ namespace Stride.Core.Storage
         }
 
         /// <summary>
-        /// Loads the specified bundle.
+        /// Unloads the specified bundle.
         /// </summary>
         /// <param name="bundleName">Name of the bundle.</param>
         public void UnloadBundle(string bundleName)

--- a/sources/core/Stride.Core/Collections/PoolListStruct.cs
+++ b/sources/core/Stride.Core/Collections/PoolListStruct.cs
@@ -9,7 +9,7 @@ using Stride.Core.Annotations;
 namespace Stride.Core.Collections
 {
     /// <summary>
-    /// A pool of objects allocated and can be cleared without loosing previously allocated instance.
+    /// A pool of objects allocated and can be cleared without losing previously allocated instance.
     /// </summary>
     /// <typeparam name="T">Type of the pooled object</typeparam>
     public struct PoolListStruct<T> : IEnumerable<T> where T : class

--- a/sources/core/Stride.Core/Threading/ConcurrentCollector.cs
+++ b/sources/core/Stride.Core/Threading/ConcurrentCollector.cs
@@ -59,7 +59,7 @@ namespace Stride.Core.Threading
     }
 
     /// <summary>
-    /// A collector that allows for concurrent adding of items, as well as non-thread-safe clearing and accessing of the underlying colletion.
+    /// A collector that allows for concurrent adding of items, as well as non-thread-safe clearing and accessing of the underlying collection.
     /// </summary>
     /// <typeparam name="T">The element type in the collection.</typeparam>
     public class ConcurrentCollector<T> : IReadOnlyList<T>

--- a/sources/core/Stride.Core/Threading/ConcurrentCollector.cs
+++ b/sources/core/Stride.Core/Threading/ConcurrentCollector.cs
@@ -84,6 +84,9 @@ namespace Stride.Core.Threading
             tail = head = new Segment { Items = new T[capacity] };
         }
 
+        /// <summary>
+        /// Gets the underlying array. It is an error to access Items after adding elements, but before closing.
+        /// </summary>
         public T[] Items
         {
             get
@@ -200,6 +203,10 @@ namespace Stride.Core.Threading
             }
         }
 
+        /// <summary>
+        /// Clears the collection. If <paramref name="fastClear"/> is true, the underlying array is not cleared.
+        /// </summary>
+        /// <param name="fastClear"></param>
         public void Clear(bool fastClear)
         {
             Close();

--- a/sources/core/Stride.Core/Threading/PooledAttribute.cs
+++ b/sources/core/Stride.Core/Threading/PooledAttribute.cs
@@ -6,7 +6,7 @@ namespace Stride.Core.Threading
 {
     /// <summary>
     /// Allows delegates passed as parameters to be allocated from a pool and recycled after the method call.
-    /// To prevent recycling, use <see cref="PooledDelegateHelper.AddReference"/> and <see cref="PooledDelegateHelper.Release"/> to hoold onto references to the delegate.
+    /// To prevent recycling, use <see cref="PooledDelegateHelper.AddReference"/> and <see cref="PooledDelegateHelper.Release"/> to hold onto references to the delegate.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class PooledAttribute : Attribute


### PR DESCRIPTION
# PR Details

I was looking through the collections and threading documentation and noticed some typos, this should fix the ones I found.

## Motivation and Context

Documentation clarity is useful.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
