### PR TITLE
[Serialization] More useful throw when missing parameterless ctor

### DIFF
--- a/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
@@ -822,6 +822,7 @@ Mother:
             try
             {
                 SerializeThenDeserialize(new ClassWithNonEmptyCtor(default));
+                Assert.Fail("An exception should have been thrown given that the class cannot be instanced because of the missing empty constructor ");
             }
             catch (Exception ex)
             {

--- a/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
@@ -816,6 +816,24 @@ Mother:
             Assert.Equal(22, family.Mother.Age);
         }
 
+        [Fact]
+        public void ThrowWithoutEmptyCtor()
+        {
+            try
+            {
+                SerializeThenDeserialize(new ClassWithNonEmptyCtor(default));
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex.InnerException is DefaultObjectFactory.InstanceCreationException);
+            }
+        }
+
+        class ClassWithNonEmptyCtor 
+        {
+            public ClassWithNonEmptyCtor(bool parameter) { }
+        }
+
 
         [Fact]
         public void DeserializeEmptyDocument()

--- a/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
@@ -826,7 +826,7 @@ Mother:
             }
             catch (Exception ex)
             {
-                Assert.True(ex.InnerException is DefaultObjectFactory.InstanceCreationException);
+                Assert.IsType<DefaultObjectFactory.InstanceCreationException>(ex.InnerException);
             }
         }
 

--- a/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/Serialization/SerializationTests.cs
@@ -822,7 +822,7 @@ Mother:
             try
             {
                 SerializeThenDeserialize(new ClassWithNonEmptyCtor(default));
-                Assert.Fail("An exception should have been thrown given that the class cannot be instanced because of the missing empty constructor ");
+                Assert.Fail("An exception should have been thrown by this method before hitting this line, the class provided does not have an empty constructor");
             }
             catch (Exception ex)
             {

--- a/sources/core/Stride.Core.Yaml/Serialization/DefaultObjectFactory.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/DefaultObjectFactory.cs
@@ -99,13 +99,14 @@ namespace Stride.Core.Yaml.Serialization
             return type;
         }
 
+        /// <inheritdoc/>
         public object Create(Type type)
         {
             type = GetDefaultImplementation(type);
 
-            // We can't instantiate primitive or arrays
+            // We can't instantiate primitives or arrays
             if (PrimitiveDescriptor.IsPrimitive(type) || type.IsArray)
-                return null;
+                throw new InstanceCreationException($"Failed to create instance of type '{type}', wrong factory.");
 
             if (type.GetConstructor(EmptyTypes) != null || type.IsValueType)
             {
@@ -119,11 +120,12 @@ namespace Stride.Core.Yaml.Serialization
                 }
             }
 
-            return null;
+            throw new InstanceCreationException($"Failed to create instance of type '{type}', type does not implement a parameterless constructor.");
         }
 
         public class InstanceCreationException : Exception
         {
+            public InstanceCreationException(string message) : base(message) { }
             public InstanceCreationException(string message, Exception innerException) : base(message, innerException) { }
         }
     }

--- a/sources/core/Stride.Core.Yaml/Serialization/DefaultObjectFactory.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/DefaultObjectFactory.cs
@@ -120,7 +120,7 @@ namespace Stride.Core.Yaml.Serialization
                 }
             }
 
-            throw new InstanceCreationException($"Failed to create instance of type '{type}', type does not implement a parameterless constructor.");
+            throw new InstanceCreationException($"Failed to create instance of type '{type}', type does not have a parameterless constructor.");
         }
 
         public class InstanceCreationException : Exception

--- a/sources/core/Stride.Core.Yaml/Serialization/IObjectFactory.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/IObjectFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SharpYaml - Alexandre Mutel
+// Copyright (c) 2015 SharpYaml - Alexandre Mutel
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,7 @@ namespace Stride.Core.Yaml.Serialization
     public interface IObjectFactory
     {
         /// <summary>
-        /// Creates an instance of the specified type. Returns null if instance cannot be created.
+        /// Creates an instance of the specified type. Throws with an appropriate exception if the type cannot be created.
         /// </summary>
         object Create(Type type);
     }


### PR DESCRIPTION
# PR Details
Serialization throws with a random null ref exception when the type being deserialized does not have a parameterless constructor defined, this PR throws with a more specific exception. Users should be able to figure it out from there until @IXLLEGACYIXL work gets integrated.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
   ^ It would seem like this would be a breaking change, but all calling logic to that method actually expected it to never return null.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
