### PR TITLE
[Samples] Fix ResourceFolders reference in package file

### DIFF
--- a/samples/Audio/SimpleAudio/SimpleAudio.Game/SimpleAudio.Game.sdpkg
+++ b/samples/Audio/SimpleAudio/SimpleAudio.Game/SimpleAudio.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Games/JumpyJet/JumpyJet.Game/JumpyJet.Game.sdpkg
+++ b/samples/Games/JumpyJet/JumpyJet.Game/JumpyJet.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/SpaceEscape.Game.sdpkg
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/SpaceEscape.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Graphics/AnimatedModel/AnimatedModel.Game/AnimatedModel.Game.sdpkg
+++ b/samples/Graphics/AnimatedModel/AnimatedModel.Game/AnimatedModel.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Graphics/CustomEffect/CustomEffect.Game/CustomEffect.Game.sdpkg
+++ b/samples/Graphics/CustomEffect/CustomEffect.Game/CustomEffect.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Graphics/MaterialShader/MaterialShader.Game/MaterialShader.Game.sdpkg
+++ b/samples/Graphics/MaterialShader/MaterialShader.Game/MaterialShader.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Graphics/SpriteFonts/SpriteFonts.Game/SpriteFonts.Game.sdpkg
+++ b/samples/Graphics/SpriteFonts/SpriteFonts.Game/SpriteFonts.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Graphics/SpriteStudioDemo/SpriteStudioDemo.Game/SpriteStudioDemo.Game.sdpkg
+++ b/samples/Graphics/SpriteStudioDemo/SpriteStudioDemo.Game/SpriteStudioDemo.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Input/GravitySensor/GravitySensor.Game/GravitySensor.Game.sdpkg
+++ b/samples/Input/GravitySensor/GravitySensor.Game/GravitySensor.Game.sdpkg
@@ -8,7 +8,8 @@ Meta:
     Dependencies: null
 AssetFolders:
     -   Path: !dir ../Assets/Shared
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Input/TouchInputs/TouchInputs.Game/TouchInputs.Game.sdpkg
+++ b/samples/Input/TouchInputs/TouchInputs.Game/TouchInputs.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Particles/ParticlesSample/ParticlesSample.Game/ParticlesSample.Game.sdpkg
+++ b/samples/Particles/ParticlesSample/ParticlesSample.Game/ParticlesSample.Game.sdpkg
@@ -10,7 +10,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Physics/PhysicsSample/PhysicsSample.Game/PhysicsSample.Game.sdpkg
+++ b/samples/Physics/PhysicsSample/PhysicsSample.Game/PhysicsSample.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/FirstPersonShooter.Game.sdpkg
+++ b/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/FirstPersonShooter.Game.sdpkg
@@ -10,7 +10,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/Packs/MaterialPackage/MaterialPackage.sdpkg
+++ b/samples/Templates/Packs/MaterialPackage/MaterialPackage.sdpkg
@@ -8,7 +8,8 @@ Meta:
     Dependencies: null
 AssetFolders:
     -   Path: !dir Assets
-ResourceFolders: []
+ResourceFolders:
+    - !dir Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/Packs/PrototypingBlocks/PrototypingBlocks.sdpkg
+++ b/samples/Templates/Packs/PrototypingBlocks/PrototypingBlocks.sdpkg
@@ -8,7 +8,8 @@ Meta:
     Dependencies: null
 AssetFolders:
     -   Path: !dir Assets
-ResourceFolders: []
+ResourceFolders:
+    - !dir Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/Packs/SamplesAssetPackage/SamplesAssetPackage.sdpkg
+++ b/samples/Templates/Packs/SamplesAssetPackage/SamplesAssetPackage.sdpkg
@@ -8,7 +8,8 @@ Meta:
     Dependencies: null
 AssetFolders:
     -   Path: !dir Assets
-ResourceFolders: []
+ResourceFolders:
+    - !dir Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/Packs/VFXPackage/VFXPackage.sdpkg
+++ b/samples/Templates/Packs/VFXPackage/VFXPackage.sdpkg
@@ -8,7 +8,8 @@ Meta:
     Dependencies: null
 AssetFolders:
     -   Path: !dir Assets
-ResourceFolders: []
+ResourceFolders:
+    - !dir Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/Packs/mannequinModel/mannequinModel.sdpkg
+++ b/samples/Templates/Packs/mannequinModel/mannequinModel.sdpkg
@@ -8,7 +8,8 @@ Meta:
     Dependencies: null
 AssetFolders:
     -   Path: !dir Assets
-ResourceFolders: []
+ResourceFolders:
+    - !dir Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/ThirdPersonPlatformer.Game.sdpkg
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/ThirdPersonPlatformer.Game.sdpkg
@@ -10,7 +10,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/TopDownRPG.Game.sdpkg
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/TopDownRPG.Game.sdpkg
@@ -10,7 +10,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/Templates/VRSandbox/VRSandbox/VRSandbox.Game/VRSandbox.Game.sdpkg
+++ b/samples/Templates/VRSandbox/VRSandbox/VRSandbox.Game/VRSandbox.Game.sdpkg
@@ -10,7 +10,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/UI/GameMenu/GameMenu.Game/GameMenu.Game.sdpkg
+++ b/samples/UI/GameMenu/GameMenu.Game/GameMenu.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/UI/UIElementLink/UIElementLink.Game/UIElementLink.Game.sdpkg
+++ b/samples/UI/UIElementLink/UIElementLink.Game/UIElementLink.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []

--- a/samples/UI/UIParticles/UIParticles.Game/UIParticles.Game.sdpkg
+++ b/samples/UI/UIParticles/UIParticles.Game/UIParticles.Game.sdpkg
@@ -9,7 +9,8 @@ Meta:
 AssetFolders:
     -   Path: !dir ../Assets/Shared
     -   Path: !dir Effects
-ResourceFolders: []
+ResourceFolders:
+    - !dir ../Resources
 OutputGroupDirectories: {}
 ExplicitFolders: []
 Bundles: []


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Samples don't have the resource folder configured for the Game package. This results in failure when importing an asset from file.

## Steps to reproduce

1. Create a new game from a sample (e.g. `FirstPersonShooter`).
2. In the asset viewer, select add an asset from file.
  ![image](https://github.com/stride3d/stride/assets/3006525/f80f6ab2-b6f2-44e2-82ff-bf90ba57c43c)
4. Select a file from a folder on the machine that is **not** relative to the current project (e.g. in user Documents).
5. When ask to copy the file to the default location, click "Yes"
6. Crash
    ```
    Exception: ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Stride.Core.Assets.Editor.ViewModel.AssetCollectionViewModel.GetAssetCopyDirectory
    ```

## Motivation and Context

Bug fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
