### PR TITLE
added option to add a parent reference for SDL window

### DIFF
--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -37,7 +37,14 @@ namespace Stride.Graphics.SDL
         /// Initializes a new instance of the <see cref="Window"/> class with <paramref name="title"/> as the title of the Window.
         /// </summary>
         /// <param name="title">Title of the window, see Text property.</param>
-        public unsafe Window(string title)
+        public Window(string title) : this(title, IntPtr.Zero) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Window"/> class with <paramref name="title"/> as the title of the Window.
+        /// </summary>
+        /// <param name="title">Title of the window, see Text property.</param>
+        /// <param name="parent">Parent window handle</param>
+        public Window(string title, IntPtr parent)
         {
             WindowFlags flags = WindowFlags.AllowHighdpi;
 #if STRIDE_GRAPHICS_API_OPENGL
@@ -50,8 +57,34 @@ namespace Stride.Graphics.SDL
 #else
             flags |= WindowFlags.Hidden | WindowFlags.Resizable;
 #endif
-            // Create the SDL window and then extract the native handle.
-            sdlHandle = SDL.CreateWindow(title, Sdl.WindowposUndefined, Sdl.WindowposUndefined, 640, 480, (uint)flags);
+
+            // If there is a parent hwnd
+            if (parent != IntPtr.Zero)
+            {
+                void* parentPtr = parent.ToPointer();
+
+                if (flags.HasFlag(WindowFlags.WindowOpengl))
+                {
+                    // SDL doesn't create OpenGL context when using SDL_CreateWindowFrom.
+                    // See https://wiki.libsdl.org/SDL_CreateWindowFrom
+                    // and https://gamedev.stackexchange.com/a/119903.
+                    var dummy = SDL.CreateWindow($"{title} - OpenGL Dummy", 0, 0, 1, 1, (uint)flags);
+                    var addrStr = new IntPtr(dummy).ToString("X");
+                    SDL.SetHint(Sdl.HintVideoWindowSharePixelFormat, addrStr);
+                    sdlHandle = SDL.CreateWindowFrom(parentPtr);
+                    SDL.SetHint(Sdl.HintVideoWindowSharePixelFormat, string.Empty);
+                    SDL.DestroyWindow(dummy);
+                }
+                else
+                {
+                    sdlHandle = SDL.CreateWindowFrom(parentPtr);
+                }
+            }
+            else // no parent window
+            {
+                // Create the SDL window and then extract the native handle.
+                sdlHandle = SDL.CreateWindow(title, Sdl.WindowposUndefined, Sdl.WindowposUndefined, 640, 480, (uint)flags);
+            }
 
 #if STRIDE_PLATFORM_ANDROID || STRIDE_PLATFORM_IOS
             GraphicsAdapter.DefaultWindow = sdlHandle;


### PR DESCRIPTION
# PR Details

I wanted an easy way to embed Stride into other UI frameworks so I decided to make a simple breakdown of https://github.com/stride3d/stride/pull/1474 without the built in demos.

## Description

This PR allows for SDL to take in a parent handle and use that for rendering.

WinForms example:
![image](https://github.com/stride3d/stride/assets/73259914/9e28903b-c7be-47bc-9932-a93f6ef59682)

In the future I would like to use this for experimenting with Avalonia as the parent host using the NativeControlHost.

## Related Issue

https://github.com/stride3d/stride/pull/1474

## Motivation and Context

Some people have asked for an easy way to embed Stride into UI frameworks in the Discord this will allow an easy constructor to pass in a parent handle.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
