### PR TITLE
[OpenXR] Fixes crashes when no device is present

### DIFF
--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRException.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRException.cs
@@ -1,0 +1,19 @@
+using System;
+using Silk.NET.OpenXR;
+
+namespace Stride.VirtualReality
+{
+    internal sealed class OpenXRException : Exception
+    {
+        public OpenXRException(Result result, string methodName)
+            : base($"{methodName} returned {result}")
+        {
+            Result = result;
+            MethodName = methodName;
+        }
+
+        public Result Result { get; }
+
+        public string MethodName { get; }
+    }
+}

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Stride.Core.Mathematics;
@@ -14,35 +16,50 @@ namespace Stride.VirtualReality
 {
     public class OpenXRHmd : VRDevice
     {
+        // Public static variable to add extensions to the initialization of the openXR session
+        public static List<string> extensions = new List<string>();
+
+        public static OpenXRHmd? New()
+        {
+            // Create our API object for OpenXR.
+            var xr = XR.GetApi();
+            if (xr is null)
+            {
+                Logger.Debug("Failed to load OpenXR API");
+                return null;
+            }
+
+            // Takes ownership on API object
+            return new OpenXRHmd(xr);
+        }
+
         // API Objects for accessing OpenXR
-        public XR Xr;
+        public readonly XR Xr;
+
+        // OpenXR handles
+        public readonly Instance Instance;
+        public readonly ulong SystemId;
+
         public Session globalSession;
         public Swapchain globalSwapchain;
         public Space globalPlaySpace;
         public FrameState globalFrameState;
         public ReferenceSpaceType play_space_type = ReferenceSpaceType.Local; //XR_REFERENCE_SPACE_TYPE_LOCAL;
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-        public SwapchainImageD3D11KHR[] images;
-        public SharpDX.Direct3D11.RenderTargetView[] render_targets;
+        public SwapchainImageD3D11KHR[]? images;
+        public SharpDX.Direct3D11.RenderTargetView[]? render_targets;
 #endif
-        // Public static variable to add extensions to the initialization of the openXR session
-        public static List<string> extensions = new List<string>();
         public ActionSet globalActionSet;
         public InteractionProfileState handProfileState;
-        internal ulong leftHandPath;
-
-        // OpenXR handles
-        public Instance Instance;
-        public ulong system_id = 0;
+        private ulong leftHandPath;
 
         // Misc
-        private bool _unmanagedResourcesFreed;
         private static Stride.Core.Diagnostics.Logger Logger = Stride.Core.Diagnostics.GlobalLogger.GetLogger("OpenXRHmd");
         private bool runFramecycle = false;
         private bool sessionRunning = false;
         private SessionState state = SessionState.Unknown;
 
-        private GraphicsDevice baseDevice;
+        private GraphicsDevice? baseDevice;
 
         private Size2 renderSize;
 
@@ -51,36 +68,23 @@ namespace Stride.VirtualReality
         private unsafe delegate Result pfnGetD3D11GraphicsRequirementsKHR(Instance instance, ulong sys_id, GraphicsRequirementsD3D11KHR* req);
 #endif
 
-        private unsafe delegate Result pfnCreateDebugUtilsMessengerEXT(Instance instance, DebugUtilsMessengerCreateInfoEXT* createInfo, DebugUtilsMessengerEXT* messenger);
-        private unsafe delegate Result pfnDestroyDebugUtilsMessengerEXT(DebugUtilsMessengerEXT messenger);
 
-
-        internal bool begunFrame, swapImageCollected;
-        internal uint swapchainPointer;
+        private bool begunFrame, swapImageCollected;
+        private uint swapchainPointer;
 
         // array of view_count containers for submitting swapchains with rendered VR frames
-        CompositionLayerProjectionView[] projection_views;
-        View[] views;
+        private CompositionLayerProjectionView[]? projection_views;
+        private View[]? views;
 
         public override Size2 ActualRenderFrameSize
         {
             get => renderSize;
-            protected set
-            {
-                renderSize = value;
-            }
+            protected set => renderSize = value;
         }
 
         public override float RenderFrameScaling { get; set; } = 1f;
 
-        public override DeviceState State
-        {
-            get
-            {
-                if (Xr == null) return DeviceState.Invalid;
-                return DeviceState.Valid;
-            }
-        }
+        public override DeviceState State => CanInitialize ? DeviceState.Valid : DeviceState.Invalid;
 
         private Vector3 headPos;
         public override Vector3 HeadPosition => headPos;
@@ -88,206 +92,66 @@ namespace Stride.VirtualReality
         private Quaternion headRot;
         public override Quaternion HeadRotation => headRot;
 
-        private Vector3 headLinVel;
-        public override Vector3 HeadLinearVelocity => headLinVel;
+        public override Vector3 HeadLinearVelocity => default;
 
-        private Vector3 headAngVel;
-        public override Vector3 HeadAngularVelocity => headAngVel;
+        public override Vector3 HeadAngularVelocity => default;
 
-        private OpenXrTouchController leftHand;
-        public override TouchController LeftHand => leftHand;
+        private OpenXrTouchController? leftHand;
+        public override TouchController? LeftHand => leftHand;
 
-        private OpenXrTouchController rightHand;
-        public override TouchController RightHand => rightHand;
+        private OpenXrTouchController? rightHand;
+        public override TouchController? RightHand => rightHand;
 
-        public override bool CanInitialize => true;
+        public override bool CanInitialize
+        {
+            get
+            {
+#if STRIDE_GRAPHICS_API_DIRECT3D11
+                return SystemId != 0;
+#else
+                return false;
+#endif
+            }
+        }
 
         public override bool CanMirrorTexture => false;
 
         public override Size2 OptimalRenderFrameSize => renderSize;
 
         // TODO (not implemented)
-        private Texture mirrorTexture;
-        public override Texture MirrorTexture { get => mirrorTexture; protected set => mirrorTexture = value; }
+        private Texture? mirrorTexture;
+        public override Texture? MirrorTexture { get => mirrorTexture; protected set => mirrorTexture = value; }
 
-        public override TrackedItem[] TrackedItems => null;
+        public override TrackedItem[]? TrackedItems => null;
 
-        public OpenXRHmd(GraphicsDevice gd)
+        private OpenXRHmd(XR xr)
         {
-            //baseDevice = gd;
+            Xr = xr;
             VRApi = VRApi.OpenXR;
+            Instance = OpenXRUtils.CreateRuntime(xr, extensions, Logger);
+            SystemId = Instance.Handle != 0 ? OpenXRUtils.GetSystem(xr, Instance, Logger) : default;
         }
-
-        /// <summary>
-        /// A simple function which throws an exception if the given OpenXR result indicates an error has been raised.
-        /// </summary>
-        /// <param name="result">The OpenXR result in question.</param>
-        /// <returns>
-        /// The same result passed in, just in case it's meaningful and we just want to use this to filter out errors.
-        /// </returns>
-        /// <exception cref="Exception">An exception for the given result if it indicates an error.</exception>
-        [DebuggerHidden]
-        [DebuggerStepThrough]
-        protected internal static Result CheckResult(Result result, string forFunction)
-        {
-            if ((int)result < 0)
-                throw new InvalidOperationException($"OpenXR error! Make sure a OpenXR runtime is set & running (like SteamVR)\n\nCode: {result} ({result:X}) in " + forFunction + "\n\nStack Trace: " + (new StackTrace()).ToString());
-
-            return result;
-        }
-
-
 
         public override unsafe void Enable(GraphicsDevice device, GraphicsDeviceManager graphicsDeviceManager, bool requireMirror, int mirrorWidth, int mirrorHeight)
         {
-            // Changing the form_factor may require changing the view_type too.
-            ViewConfigurationType view_type = ViewConfigurationType.PrimaryStereo;
+            if (!CanInitialize)
+                throw new InvalidOperationException();
 
             baseDevice = device;
-            // Create our API object for OpenXR.
-            Xr = XR.GetApi();
-
-            PrintApiLayers();
-
-            Logger.Debug("Installing extensions");
-
-            var openXrExtensions = new List<String>();
-#if STRIDE_GRAPHICS_API_DIRECT3D11
-            openXrExtensions.Add("XR_KHR_D3D11_enable");
-#endif
-#if DEBUG_OPENXR
-            openXrExtensions.Add("XR_EXT_debug_utils");
-#endif
-            openXrExtensions.AddRange(extensions);
-
-            uint propCount = 0;
-            Xr.EnumerateInstanceExtensionProperties((byte*)null, 0, &propCount, null);
-
-            ExtensionProperties[] props = new ExtensionProperties[propCount];
-            for (int i = 0; i < props.Length; i++)
-            {
-                props[i].Type = StructureType.TypeExtensionProperties;
-                props[i].Next = null;
-            }
-            Xr.EnumerateInstanceExtensionProperties((byte*)null, propCount, &propCount, props);
-
-            Logger.Debug("Supported extensions (" + propCount + "):");
-            List<string> AvailableExtensions = new List<string>();
-            for (int i = 0; i < props.Length; i++)
-            {
-                fixed (void* nptr = props[i].ExtensionName)
-                {
-                    var extension_name = Marshal.PtrToStringAnsi(new System.IntPtr(nptr));
-                    Logger.Debug(extension_name);
-                    AvailableExtensions.Add(extension_name);
-                }
-            }
-
-            for (int i = 0; i < openXrExtensions.Count; i++)
-            {
-                if (!AvailableExtensions.Contains(openXrExtensions[i]))
-                {
-                    openXrExtensions.RemoveAt(i);
-                    i--;
-                }
-            }
-
-            Logger.Debug("Available extensions of those enabled");
-            for (int i = 0; i < openXrExtensions.Count; i++)
-            {
-                Logger.Debug(openXrExtensions[i]);
-            }
-
-#if STRIDE_GRAPHICS_API_DIRECT3D11
-            if (!AvailableExtensions.Contains("XR_KHR_D3D11_enable"))
-            {
-                throw new InvalidOperationException($"OpenXR error! Current implementation doesn't support Direct3D 11");
-            }
-#endif
-
-            var appInfo = new ApplicationInfo()
-            {
-                ApiVersion = new Version64(1, 0, 10)
-            };
-
-            // We've got to marshal our strings and put them into global, immovable memory. To do that, we use
-            // SilkMarshal.
-            Span<byte> appName = new Span<byte>(appInfo.ApplicationName, 128);
-            Span<byte> engName = new Span<byte>(appInfo.EngineName, 128);
-            SilkMarshal.StringIntoSpan(System.AppDomain.CurrentDomain.FriendlyName, appName);
-            SilkMarshal.StringIntoSpan("Stride", engName);
-
-            var requestedExtensions = SilkMarshal.StringArrayToPtr(openXrExtensions);
-            InstanceCreateInfo instanceCreateInfo = new InstanceCreateInfo
-            (
-                applicationInfo: appInfo,
-                enabledExtensionCount: (uint)openXrExtensions.Count,
-                enabledExtensionNames: (byte**)requestedExtensions,
-                createFlags: 0,
-                enabledApiLayerCount: 0,
-                enabledApiLayerNames: null
-            );
-
-            // Now we're ready to make our instance!
-            CheckResult(Xr.CreateInstance(in instanceCreateInfo, ref Instance), "CreateInstance");
-
-#if DEBUG_OPENXR
-            Silk.NET.Core.PfnVoidFunction xrCreateDebugUtilsMessengerEXT = new Silk.NET.Core.PfnVoidFunction();
-            CheckResult(Xr.GetInstanceProcAddr(Instance, "xrCreateDebugUtilsMessengerEXT", ref xrCreateDebugUtilsMessengerEXT), "GetInstanceProcAddr::xrCreateDebugUtilsMessengerEXT");
-            Delegate create_debug_utils_messenger = Marshal.GetDelegateForFunctionPointer((IntPtr)xrCreateDebugUtilsMessengerEXT.Handle, typeof(pfnCreateDebugUtilsMessengerEXT));
-
-            // https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#debug-message-categorization
-            DebugUtilsMessengerCreateInfoEXT debug_info = new DebugUtilsMessengerCreateInfoEXT()
-            {
-                Type = StructureType.TypeDebugUtilsMessengerCreateInfoExt,
-                MessageTypes = DebugUtilsMessageTypeFlagsEXT.DebugUtilsMessageTypeGeneralBitExt
-                    | DebugUtilsMessageTypeFlagsEXT.DebugUtilsMessageTypeValidationBitExt
-                    | DebugUtilsMessageTypeFlagsEXT.DebugUtilsMessageTypePerformanceBitExt
-                    | DebugUtilsMessageTypeFlagsEXT.DebugUtilsMessageTypeConformanceBitExt,
-                MessageSeverities = DebugUtilsMessageSeverityFlagsEXT.DebugUtilsMessageSeverityVerboseBitExt
-                    | DebugUtilsMessageSeverityFlagsEXT.DebugUtilsMessageSeverityInfoBitExt
-                    | DebugUtilsMessageSeverityFlagsEXT.DebugUtilsMessageSeverityWarningBitExt
-                    | DebugUtilsMessageSeverityFlagsEXT.DebugUtilsMessageSeverityErrorBitExt,
-                UserCallback = (DebugUtilsMessengerCallbackFunctionEXT)DebugCallback,
-            };
-
-            DebugUtilsMessengerEXT xr_debug;
-            var result = create_debug_utils_messenger.DynamicInvoke(Instance, new System.IntPtr(&debug_info), new System.IntPtr(&xr_debug));
-#endif
-
-            // This crashes on oculus
-            // For our benefit, let's log some information about the instance we've just created.
-            InstanceProperties properties = new InstanceProperties()
-            {
-                Type = StructureType.TypeInstanceProperties,
-                Next = null,
-            };
-            CheckResult(Xr.GetInstanceProperties(Instance, ref properties), "GetInstanceProperties");
-
-            var runtimeName = Marshal.PtrToStringAnsi(new System.IntPtr(properties.RuntimeName));
-            var runtimeVersion = ((Version)(Version64)properties.RuntimeVersion).ToString(3);
-
-            Logger.Info($"Using OpenXR Runtime \"{runtimeName}\" v{runtimeVersion}");
-
-            // We're creating a head-mounted-display (HMD, i.e. a VR headset) example, so we ask for a runtime which
-            // supports that form factor. The response we get is a ulong that is the System ID.
-            var getInfo = new SystemGetInfo(formFactor: FormFactor.HeadMountedDisplay) { Type = StructureType.TypeSystemGetInfo };
-            CheckResult(Xr.GetSystem(Instance, in getInfo, ref system_id), "GetSystem");
-            Logger.Debug("Successfully got XrSystem with id " + system_id + " for HMD form factor");
 
             SystemProperties system_props = new SystemProperties()
             {
-                Type = StructureType.TypeSystemProperties,
+                Type = StructureType.SystemProperties,
                 Next = null,
             };
 
-            // CheckResult(Xr.GetSystemProperties(Instance, system_id, &system_props), "GetSystemProperties");
-
+            // Changing the form_factor may require changing the view_type too.
+            ViewConfigurationType view_type = ViewConfigurationType.PrimaryStereo;
             uint view_config_count = 0;
-            CheckResult(Xr.EnumerateViewConfiguration(Instance, system_id, 0, ref view_config_count, null), "EnumerateViewConfiguration");
+            Xr.EnumerateViewConfiguration(Instance, SystemId, 0, ref view_config_count, null).CheckResult();
             var viewconfigs = new ViewConfigurationType[view_config_count];
             fixed (ViewConfigurationType* viewconfigspnt = &viewconfigs[0])
-                CheckResult(Xr.EnumerateViewConfiguration(Instance, system_id, view_config_count, ref view_config_count, viewconfigspnt), "EnumerateViewConfiguration");
+                Xr.EnumerateViewConfiguration(Instance, SystemId, view_config_count, ref view_config_count, viewconfigspnt).CheckResult();
             Logger.Debug("Available config types: ");
             var viewtype_found = false;
             for (int i = 0; i < view_config_count; i++)
@@ -297,19 +161,19 @@ namespace Stride.VirtualReality
             }
             if (!viewtype_found)
             {
-                throw new Exception("The current device doesn´t support primary stereo");
+                throw new Exception("The current device doesn't support primary stereo");
             }
 
             uint view_count = 0;
-            CheckResult(Xr.EnumerateViewConfigurationView(Instance, system_id, view_type, 0, ref view_count, null), "EnumerateViewConfigurationView");
+            Xr.EnumerateViewConfigurationView(Instance, SystemId, view_type, 0, ref view_count, null).CheckResult();
             var viewconfig_views = new ViewConfigurationView[view_count];
             for (int i = 0; i < view_count; i++)
             {
-                viewconfig_views[i].Type = StructureType.TypeViewConfigurationView;
+                viewconfig_views[i].Type = StructureType.ViewConfigurationView;
                 viewconfig_views[i].Next = null;
             }
             fixed (ViewConfigurationView* viewspnt = &viewconfig_views[0])
-                CheckResult(Xr.EnumerateViewConfigurationView(Instance, system_id, view_type, (uint)viewconfig_views.Length, ref view_count, viewspnt), "EnumerateViewConfigurationView");
+                Xr.EnumerateViewConfigurationView(Instance, SystemId, view_type, (uint)viewconfig_views.Length, ref view_count, viewspnt).CheckResult();
 
             // get size
             renderSize.Width = (int)Math.Round(viewconfig_views[0].RecommendedImageRectWidth * RenderFrameScaling) * 2; // 2 views in one frame
@@ -322,14 +186,14 @@ namespace Stride.VirtualReality
             );
             GraphicsRequirementsD3D11KHR dx11 = new GraphicsRequirementsD3D11KHR()
             {
-                Type = StructureType.TypeGraphicsRequirementsD3D11Khr
+                Type = StructureType.GraphicsRequirementsD3D11Khr
             };
 
             Silk.NET.Core.PfnVoidFunction xrGetD3D11GraphicsRequirementsKHR = new Silk.NET.Core.PfnVoidFunction();
-            CheckResult(Xr.GetInstanceProcAddr(Instance, "xrGetD3D11GraphicsRequirementsKHR", ref xrGetD3D11GraphicsRequirementsKHR), "GetInstanceProcAddr::xrGetD3D11GraphicsRequirementsKHR");
+            Xr.GetInstanceProcAddr(Instance, "xrGetD3D11GraphicsRequirementsKHR", ref xrGetD3D11GraphicsRequirementsKHR).CheckResult();
             // this function pointer was loaded with xrGetInstanceProcAddr
             Delegate dx11_req = Marshal.GetDelegateForFunctionPointer((IntPtr)xrGetD3D11GraphicsRequirementsKHR.Handle, typeof(pfnGetD3D11GraphicsRequirementsKHR));
-            dx11_req.DynamicInvoke(Instance, system_id, new System.IntPtr(&dx11));
+            dx11_req.DynamicInvoke(Instance, SystemId, new System.IntPtr(&dx11));
             Logger.Debug("Initializing dx11 graphics device");
             Logger.Debug(
                 "DX11 device luid: " + dx11.AdapterLuid
@@ -338,33 +202,33 @@ namespace Stride.VirtualReality
 
             var graphics_binding_dx11 = new GraphicsBindingD3D11KHR()
             {
-                Type = StructureType.TypeGraphicsBindingD3D11Khr,
+                Type = StructureType.GraphicsBindingD3D11Khr,
                 Device = baseDevice.NativeDevice.NativePointer.ToPointer(),
                 Next = null,
             };
             session_create_info = new SessionCreateInfo()
             {
-                Type = StructureType.TypeSessionCreateInfo,
+                Type = StructureType.SessionCreateInfo,
                 Next = &graphics_binding_dx11,
-                SystemId = system_id
+                SystemId = SystemId
             };
 #else
             throw new Exception("OpenXR is only compatible with DirectX11");
 #endif
 
             Session session;
-            CheckResult(Xr.CreateSession(Instance, &session_create_info, &session), "CreateSession");
+            Xr.CreateSession(Instance, &session_create_info, &session).CheckResult();
             globalSession = session;
 
             // --- Create swapchain for main VR rendering
             Swapchain swapchain = new Swapchain();
             SwapchainCreateInfo swapchain_create_info = new SwapchainCreateInfo()
             {
-                Type = StructureType.TypeSwapchainCreateInfo,
+                Type = StructureType.SwapchainCreateInfo,
                 Next = null,
-                UsageFlags = SwapchainUsageFlags.SwapchainUsageTransferDstBit |
-                                SwapchainUsageFlags.SwapchainUsageSampledBit |
-                                SwapchainUsageFlags.SwapchainUsageColorAttachmentBit,
+                UsageFlags = SwapchainUsageFlags.TransferDstBit |
+                                SwapchainUsageFlags.SampledBit |
+                                SwapchainUsageFlags.ColorAttachmentBit,
                 CreateFlags = 0,
 #if STRIDE_GRAPHICS_API_DIRECT3D11
                 Format = (long)PixelFormat.R8G8B8A8_UNorm_SRgb,
@@ -377,22 +241,22 @@ namespace Stride.VirtualReality
                 MipCount = 1,
             };
 
-            CheckResult(Xr.CreateSwapchain(session, &swapchain_create_info, &swapchain), "CreateSwapchain");
+            Xr.CreateSwapchain(session, &swapchain_create_info, &swapchain).CheckResult();
             globalSwapchain = swapchain;
 
             uint img_count = 0;
-            CheckResult(Xr.EnumerateSwapchainImages(swapchain, 0, ref img_count, null), "EnumerateSwapchainImages");
+            Xr.EnumerateSwapchainImages(swapchain, 0, ref img_count, null).CheckResult();
 #if STRIDE_GRAPHICS_API_DIRECT3D11
             images = new SwapchainImageD3D11KHR[img_count];
             for (int i = 0; i < img_count; i++)
             {
-                images[i].Type = StructureType.TypeSwapchainImageD3D11Khr;
+                images[i].Type = StructureType.SwapchainImageD3D11Khr;
                 images[i].Next = null;
             }
 
             fixed (void* sibhp = &images[0])
             {
-                CheckResult(Xr.EnumerateSwapchainImages(swapchain, img_count, ref img_count, (SwapchainImageBaseHeader*)sibhp), "EnumerateSwapchainImages");
+                Xr.EnumerateSwapchainImages(swapchain, img_count, ref img_count, (SwapchainImageBaseHeader*)sibhp).CheckResult();
             }
 
             render_targets = new SharpDX.Direct3D11.RenderTargetView[img_count];
@@ -416,14 +280,14 @@ namespace Stride.VirtualReality
             views = new View[view_count]; //(XrView*)malloc(sizeof(XrView) * view_count);
             for (int i = 0; i < view_count; i++)
             {
-                views[i].Type = StructureType.TypeView;
+                views[i].Type = StructureType.View;
                 views[i].Next = null;
             }
 
             projection_views = new CompositionLayerProjectionView[view_count]; //(XrCompositionLayerProjectionView*)malloc(sizeof(XrCompositionLayerProjectionView) * view_count);
             for (int i = 0; i < view_count; i++)
             {
-                projection_views[i].Type = StructureType.TypeCompositionLayerProjectionView; //XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
+                projection_views[i].Type = StructureType.CompositionLayerProjectionView; //XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
                 projection_views[i].Next = null;
                 projection_views[i].SubImage.Swapchain = swapchain;
                 projection_views[i].SubImage.ImageArrayIndex = 0;
@@ -436,18 +300,18 @@ namespace Stride.VirtualReality
 
             ReferenceSpaceCreateInfo play_space_create_info = new ReferenceSpaceCreateInfo()
             {
-                Type = StructureType.TypeReferenceSpaceCreateInfo,
+                Type = StructureType.ReferenceSpaceCreateInfo,
                 Next = null,
                 ReferenceSpaceType = play_space_type,
                 PoseInReferenceSpace = new Posef(new Quaternionf(0f, 0f, 0f, 1f), new Vector3f(0f, 0f, 0f)),
             };
             var play_space = new Space();
-            CheckResult(Xr.CreateReferenceSpace(session, &play_space_create_info, &play_space), "CreateReferenceSpace");
+            Xr.CreateReferenceSpace(session, &play_space_create_info, &play_space).CheckResult();
             globalPlaySpace = play_space;
 
             ActionSetCreateInfo gameplay_actionset_info = new ActionSetCreateInfo()
             {
-                Type = StructureType.TypeActionSetCreateInfo,
+                Type = StructureType.ActionSetCreateInfo,
                 Next = null,
             };
 
@@ -457,28 +321,28 @@ namespace Stride.VirtualReality
             SilkMarshal.StringIntoSpan("ActionSet\0", lsname);
 
             ActionSet gameplay_actionset;
-            CheckResult(Xr.CreateActionSet(Instance, &gameplay_actionset_info, &gameplay_actionset), "CreateActionSet");
+            Xr.CreateActionSet(Instance, &gameplay_actionset_info, &gameplay_actionset).CheckResult();
             globalActionSet = gameplay_actionset;
 
-            OpenXRInput.Initialize(this);
+            var input = new OpenXRInput(this);
 
-            leftHand = new OpenXrTouchController(this, TouchControllerHand.Left);
-            rightHand = new OpenXrTouchController(this, TouchControllerHand.Right);
+            leftHand = new OpenXrTouchController(this, input, TouchControllerHand.Left);
+            rightHand = new OpenXrTouchController(this, input, TouchControllerHand.Right);
 
             SessionActionSetsAttachInfo actionset_attach_info = new SessionActionSetsAttachInfo()
             {
-                Type = StructureType.TypeSessionActionSetsAttachInfo,
+                Type = StructureType.SessionActionSetsAttachInfo,
                 Next = null,
                 CountActionSets = 1,
                 ActionSets = &gameplay_actionset
             };
 
-            CheckResult(Xr.AttachSessionActionSets(session, &actionset_attach_info), "AttachSessionActionSets");
+            Xr.AttachSessionActionSets(session, &actionset_attach_info).CheckResult();
 
             // figure out what interaction profile we are using, and determine if it has a touchpad/thumbstick or both
             handProfileState = new InteractionProfileState()
             {
-                Type = StructureType.TypeInteractionProfileState,
+                Type = StructureType.InteractionProfileState,
                 Next = null,
             };
             Xr.StringToPath(Instance, "/user/hand/left", ref leftHandPath);
@@ -488,14 +352,14 @@ namespace Stride.VirtualReality
         {
             FrameEndInfo frame_end_info = new FrameEndInfo()
             {
-                Type = StructureType.TypeFrameEndInfo,
+                Type = StructureType.FrameEndInfo,
                 DisplayTime = globalFrameState.PredictedDisplayTime,
                 EnvironmentBlendMode = EnvironmentBlendMode.Opaque,
                 LayerCount = 0,
                 Layers = null,
                 Next = null,
             };
-            CheckResult(Xr.EndFrame(globalSession, frame_end_info), "BeginFrame");
+            Xr.EndFrame(globalSession, frame_end_info).CheckResult();
         }
 
         public override unsafe void Draw(GameTime gameTime)
@@ -510,25 +374,25 @@ namespace Stride.VirtualReality
             // --- Wait for our turn to do head-pose dependent computation and render a frame
             FrameWaitInfo frame_wait_info = new FrameWaitInfo()
             {
-                Type = StructureType.TypeFrameWaitInfo,
+                Type = StructureType.FrameWaitInfo,
             };
 
             //Logger.Warning("WaitFrame");
             globalFrameState = new FrameState()
             {
-                Type = StructureType.TypeFrameState,
+                Type = StructureType.FrameState,
                 Next = null,
             };
-            CheckResult(Xr.WaitFrame(globalSession, in frame_wait_info, ref globalFrameState), "WaitFrame");
+            Xr.WaitFrame(globalSession, in frame_wait_info, ref globalFrameState).CheckResult();
 
             FrameBeginInfo frame_begin_info = new FrameBeginInfo()
             {
-                Type = StructureType.TypeFrameBeginInfo,
+                Type = StructureType.FrameBeginInfo,
                 Next = null,
             };
 
             //Logger.Warning("BeginFrame");
-            CheckResult(Xr.BeginFrame(globalSession, frame_begin_info), "BeginFrame");
+            Xr.BeginFrame(globalSession, frame_begin_info).CheckResult();
 
             if ((Bool32)globalFrameState.ShouldRender)
             {
@@ -545,10 +409,13 @@ namespace Stride.VirtualReality
 
         public void UpdateViews()
         {
+            if (views is null)
+                return;
+
             // --- Create projection matrices and view matrices for each eye
             ViewLocateInfo view_locate_info = new ViewLocateInfo()
             {
-                Type = StructureType.TypeViewLocateInfo,
+                Type = StructureType.ViewLocateInfo,
                 ViewConfigurationType = ViewConfigurationType.PrimaryStereo,
                 DisplayTime = globalFrameState.PredictedDisplayTime,
                 Space = globalPlaySpace,
@@ -557,7 +424,7 @@ namespace Stride.VirtualReality
 
             ViewState view_state = new ViewState()
             {
-                Type = StructureType.TypeViewState,
+                Type = StructureType.ViewState,
                 Next = null,
             };
 
@@ -565,7 +432,7 @@ namespace Stride.VirtualReality
             {
                 uint view_count = 2;
                 // Logger.Warning("LocateView");
-                CheckResult(Xr.LocateView(globalSession, &view_locate_info, &view_state, 2, &view_count, views), "XrLocateView");
+                Xr.LocateView(globalSession, &view_locate_info, &view_state, 2, &view_count, views).CheckResult();
             }
 
             // get head rotation
@@ -587,14 +454,14 @@ namespace Stride.VirtualReality
             // Get the swapchain image
             var swapchainIndex = 0u;
             var acquireInfo = new SwapchainImageAcquireInfo() { 
-                Type = StructureType.TypeSwapchainImageAcquireInfo,
+                Type = StructureType.SwapchainImageAcquireInfo,
                 Next = null,
             };
-            CheckResult(Xr.AcquireSwapchainImage(globalSwapchain, in acquireInfo, ref swapchainIndex), "AcquireSwapchainImage");
+            Xr.AcquireSwapchainImage(globalSwapchain, in acquireInfo, ref swapchainIndex).CheckResult();
 
             // Logger.Warning("WaitSwapchainImage");
             var waitInfo = new SwapchainImageWaitInfo(timeout: long.MaxValue) { 
-                Type = StructureType.TypeSwapchainImageWaitInfo,
+                Type = StructureType.SwapchainImageWaitInfo,
                 Next = null,
             };
             swapImageCollected = (Xr.WaitSwapchainImage(globalSwapchain, in waitInfo) == Result.Success);
@@ -602,10 +469,10 @@ namespace Stride.VirtualReality
             {
                 // Logger.Warning("WaitSwapchainImage failed");
                 var releaseInfo = new SwapchainImageReleaseInfo() { 
-                    Type = StructureType.TypeSwapchainImageReleaseInfo,
+                    Type = StructureType.SwapchainImageReleaseInfo,
                     Next = null,
                 };
-                CheckResult(Xr.ReleaseSwapchainImage(globalSwapchain, in releaseInfo), "ReleaseSwapchainImage");
+                Xr.ReleaseSwapchainImage(globalSwapchain, in releaseInfo).CheckResult();
             }
 
             return swapchainIndex;
@@ -619,6 +486,9 @@ namespace Stride.VirtualReality
 
         public override void Commit(CommandList commandList, Texture renderFrame)
         {
+            if (baseDevice is null || render_targets is null || projection_views is null || views is null)
+                return;
+
             // if we didn't wait a frame, don't commit
             if (begunFrame == false)
                 return;
@@ -636,10 +506,10 @@ namespace Stride.VirtualReality
             // Release the swapchain image
             // Logger.Warning("ReleaseSwapchainImage");
             var releaseInfo = new SwapchainImageReleaseInfo() { 
-                Type = StructureType.TypeSwapchainImageReleaseInfo,
+                Type = StructureType.SwapchainImageReleaseInfo,
                 Next = null,
             };
-            CheckResult(Xr.ReleaseSwapchainImage(globalSwapchain, in releaseInfo), "ReleaseSwapchainImage");
+            Xr.ReleaseSwapchainImage(globalSwapchain, in releaseInfo).CheckResult();
 
                 for (var eye = 0; eye < 2; eye++)
                 {
@@ -661,7 +531,7 @@ namespace Stride.VirtualReality
                     var layerPointer = (CompositionLayerBaseHeader*)&projectionLayer;
                     var frameEndInfo = new FrameEndInfo()
                     {
-                        Type = StructureType.TypeFrameEndInfo,
+                        Type = StructureType.FrameEndInfo,
                         DisplayTime = globalFrameState.PredictedDisplayTime,
                         EnvironmentBlendMode = EnvironmentBlendMode.Opaque,
                         LayerCount = 1,
@@ -670,7 +540,7 @@ namespace Stride.VirtualReality
                     };
 
                     //Logger.Warning("EndFrame");
-                    CheckResult(Xr.EndFrame(globalSession, in frameEndInfo), "EndFrame");
+                    Xr.EndFrame(globalSession, in frameEndInfo).CheckResult();
                     }
                 }
             }
@@ -699,20 +569,20 @@ namespace Stride.VirtualReality
 
             if (!globalPlaySpace.Equals(null))
             {
-                CheckResult(Xr.DestroySpace(globalPlaySpace), "DestroySpace");
+                Xr.DestroySpace(globalPlaySpace).CheckResult();
             }
 
             var play_space = new Space();
             ReferenceSpaceCreateInfo play_space_create_info = new ReferenceSpaceCreateInfo()
             {
-                Type = StructureType.TypeReferenceSpaceCreateInfo,
+                Type = StructureType.ReferenceSpaceCreateInfo,
                 Next = null,
                 ReferenceSpaceType = play_space_type,
                 PoseInReferenceSpace = new Posef(new Quaternionf(0f, 0f, 0f, 1f), new Vector3f(0f, 0f, 0f)),
             };
             unsafe
             {
-                CheckResult(Xr.CreateReferenceSpace(globalSession, &play_space_create_info, &play_space), "CreateReferenceSpace");
+                Xr.CreateReferenceSpace(globalSession, &play_space_create_info, &play_space).CheckResult();
             }
             globalPlaySpace = play_space;
         }
@@ -726,115 +596,7 @@ namespace Stride.VirtualReality
             // if the specific API can do a renceter or the engine needs to take care of that
         }
 
-#if DEBUG_OPENXR
-        private static unsafe uint DebugCallback(DebugUtilsMessageSeverityFlagsEXT severity, DebugUtilsMessageTypeFlagsEXT types, DebugUtilsMessengerCallbackDataEXT* msg, void* user_data)
-        {
-            // Print the debug message we got! There's a bunch more info we could
-            // add here too, but this is a pretty good start, and you can always
-            // add a breakpoint this line!
-            var function_name = Marshal.PtrToStringAnsi(new System.IntPtr(msg->FunctionName));
-            var message = Marshal.PtrToStringAnsi(new System.IntPtr(msg->Message));
-            Logger.Warning(function_name + " " + message);
-
-            // Returning XR_TRUE here will force the calling function to fail
-            return 0;
-        }
-#endif
-
-        private unsafe void PrintApiLayers()
-        {
-            uint count = 0;
-            CheckResult(Xr.EnumerateApiLayerProperties(0, &count, null), "EnumerateApiLayerProperties");
-
-            if (count == 0)
-            {
-
-                Logger.Debug("No API Layers");
-                return;
-            }
-
-            var props = new ApiLayerProperties[count];
-            for (uint i = 0; i < count; i++)
-            {
-                props[i].Type = StructureType.TypeApiLayerProperties;
-                props[i].Next = null;
-            }
-
-            CheckResult(Xr.EnumerateApiLayerProperties(count, &count, props), "EnumerateApiLayerProperties");
-
-            Logger.Debug("API Layers:");
-            for (uint i = 0; i < count; i++)
-            {
-                fixed (void* nptr = props[i].LayerName)
-                fixed (void* dptr = props[i].Description)
-                    Logger.Debug(
-                        Marshal.PtrToStringAnsi(new System.IntPtr(nptr))
-                        + " "
-                        + props[i].LayerVersion
-                        + " "
-                        + Marshal.PtrToStringAnsi(new System.IntPtr(dptr))
-                    );
-            }
-        }
-
-        private unsafe void PrintSystemProperties(SystemProperties system_properties)
-        {
-            Logger.Debug(
-                "System properties: "
-                + Marshal.PtrToStringAnsi(new System.IntPtr(system_properties.SystemName))
-                + ", vendor: "
-                + Marshal.PtrToStringAnsi(new System.IntPtr(system_properties.VendorId))
-            );
-            Logger.Debug(
-                "Max layers: "
-                + system_properties.GraphicsProperties.MaxLayerCount
-            );
-            Logger.Debug(
-                "Max swapchain size: "
-                + system_properties.GraphicsProperties.MaxSwapchainImageWidth
-                + "x"
-                + system_properties.GraphicsProperties.MaxSwapchainImageHeight
-            );
-            Logger.Debug(
-                "Orientation Tracking: "
-                + system_properties.TrackingProperties.OrientationTracking
-            );
-            Logger.Debug(
-                "tPosition Tracking: "
-                + system_properties.TrackingProperties.PositionTracking
-            );
-        }
-
-        private unsafe void PrintViewConfigViews(ViewConfigurationView[] viewconfig_views)
-        {
-            foreach (var viewconfig_view in viewconfig_views)
-            {
-                Logger.Debug("View Configuration View:");
-                Logger.Debug(
-                    "Resolution: Recommended "
-                    + viewconfig_view.RecommendedImageRectWidth + "x" + viewconfig_view.RecommendedImageRectHeight
-                    + " Max: " + viewconfig_view.MaxImageRectWidth + "x" + viewconfig_view.MaxImageRectHeight
-                );
-                Logger.Debug(
-                    "Swapchain Samples: Recommended"
-                    + viewconfig_view.RecommendedSwapchainSampleCount
-                    + " Max: " + viewconfig_view.MaxSwapchainSampleCount
-                );
-            }
-        }
-
-        private void ReleaseUnmanagedResources()
-        {
-            if (_unmanagedResourcesFreed)
-            {
-                return;
-            }
-
-            CheckResult(Xr.DestroyInstance(Instance), "DestroyInstance");
-            _unmanagedResourcesFreed = true;
-        }
-
-        internal Matrix createViewMatrix(Vector3 translation, Quaternion rotation)
+        private static Matrix CreateViewMatrix(Vector3 translation, Quaternion rotation)
         {
             Matrix rotationMatrix = Matrix.RotationQuaternion(rotation);
             Matrix translationMatrix = Matrix.Translation(translation);
@@ -843,7 +605,7 @@ namespace Stride.VirtualReality
             return viewMatrix;
         }
 
-        internal Matrix createProjectionFov(Fovf fov, float nearZ, float farZ)
+        private Matrix CreateProjectionFov(Fovf fov, float nearZ, float farZ)
         {
             Matrix result = Matrix.Identity;
 
@@ -907,21 +669,25 @@ namespace Stride.VirtualReality
 
             return result;
         }
-        internal static Quaternion ConvertToFocus(ref Quaternionf quat)
+
+        private static Quaternion ConvertToFocus(in Quaternionf quat)
         {
             return new Quaternion(-quat.X, -quat.Y, -quat.Z, quat.W);
         }
 
         public override void ReadEyeParameters(Eyes eye, float near, float far, ref Vector3 cameraPosition, ref Matrix cameraRotation, bool ignoreHeadRotation, bool ignoreHeadPosition, out Matrix view, out Matrix projection)
         {
+            if (views is null)
+                throw new InvalidOperationException();
+
             Matrix eyeMat, rot;
             Vector3 pos, scale;
 
             View eyeview = views[(int)eye];
 
-            projection = createProjectionFov(eyeview.Fov, near, far);
-            var adjustedHeadMatrix = createViewMatrix(new Vector3(-eyeview.Pose.Position.X, -eyeview.Pose.Position.Y, -eyeview.Pose.Position.Z),
-                                                      ConvertToFocus(ref eyeview.Pose.Orientation));
+            projection = CreateProjectionFov(eyeview.Fov, near, far);
+            var adjustedHeadMatrix = CreateViewMatrix(new Vector3(-eyeview.Pose.Position.X, -eyeview.Pose.Position.Y, -eyeview.Pose.Position.Z),
+                                                      ConvertToFocus(in eyeview.Pose.Orientation));
             if (ignoreHeadPosition)
             {
                 adjustedHeadMatrix.TranslationVector = Vector3.Zero;
@@ -945,20 +711,20 @@ namespace Stride.VirtualReality
         {
             var runtime_event = new EventDataBuffer()
             {
-                Type = StructureType.TypeEventDataBuffer,
+                Type = StructureType.EventDataBuffer,
                 Next = null
             };
             while (Xr.PollEvent(Instance, &runtime_event) == Result.Success)
             {
                 switch (runtime_event.Type)
                 {
-                    case StructureType.TypeEventDataInstanceLossPending:
+                    case StructureType.EventDataInstanceLossPending:
                         {
                             var loss_event = Unsafe.As<EventDataBuffer, EventDataInstanceLossPending>(ref runtime_event);
                             Logger.Warning("EVENT: instance loss pending at " + loss_event.LossTime + ". Destroying instance.");
                             break;
                         }
-                    case StructureType.TypeEventDataSessionStateChanged:
+                    case StructureType.EventDataSessionStateChanged:
                         {
                             var session_event = Unsafe.As<EventDataBuffer, EventDataSessionStateChanged>(ref runtime_event);
                             Logger.Debug("EVENT: session state changed " + state + " -> " + session_event.State);
@@ -978,11 +744,11 @@ namespace Stride.VirtualReality
                                         {
                                             SessionBeginInfo session_begin_info = new SessionBeginInfo()
                                             {
-                                                Type = StructureType.TypeSessionBeginInfo,
+                                                Type = StructureType.SessionBeginInfo,
                                                 Next = null,
                                                 PrimaryViewConfigurationType = ViewConfigurationType.PrimaryStereo,
                                             };
-                                            CheckResult(Xr.BeginSession(globalSession, &session_begin_info), "XrBeginSession");
+                                            Xr.BeginSession(globalSession, &session_begin_info).CheckResult();
                                             sessionRunning = true;
                                         }
                                         runFramecycle = true;
@@ -992,7 +758,7 @@ namespace Stride.VirtualReality
                                     {
                                         if(sessionRunning)
                                         {
-                                            CheckResult(Xr.EndSession(globalSession), "XrEndSession");
+                                            Xr.EndSession(globalSession).CheckResult();
                                             sessionRunning = false;
                                         }
                                         runFramecycle = false;
@@ -1001,18 +767,18 @@ namespace Stride.VirtualReality
                                 case SessionState.LossPending:
                                 case SessionState.Exiting:
                                     {
-                                        CheckResult(Xr.DestroySession(globalSession), "XrDestroySession");
+                                        Xr.DestroySession(globalSession).CheckResult();
                                         runFramecycle = false;
                                         break;
                                     }
                             }
                             break;
                         }
-                    case StructureType.TypeEventDataInteractionProfileChanged:
+                    case StructureType.EventDataInteractionProfileChanged:
                         {
                             Logger.Debug("EVENT: interaction profile changed");
                             var profile_changed_event = Unsafe.As<EventDataBuffer, EventDataInteractionProfileChanged>(ref runtime_event);
-                            CheckResult(Xr.GetCurrentInteractionProfile(profile_changed_event.Session, leftHandPath, ref handProfileState), "GetCurrentInteractionProfile");
+                            Xr.GetCurrentInteractionProfile(profile_changed_event.Session, leftHandPath, ref handProfileState).CheckResult();
                             Logger.Debug(
                                 "Profile changed to" + handProfileState.InteractionProfile.ToString()
                             );
@@ -1024,7 +790,7 @@ namespace Stride.VirtualReality
                             break;
                         }
                 }
-                runtime_event.Type = StructureType.TypeEventDataBuffer;
+                runtime_event.Type = StructureType.EventDataBuffer;
             }
 
 
@@ -1039,7 +805,7 @@ namespace Stride.VirtualReality
 
             ActionsSyncInfo actions_sync_info = new ActionsSyncInfo()
             {
-                Type = StructureType.TypeActionsSyncInfo,
+                Type = StructureType.ActionsSyncInfo,
                 Next = null,
                 CountActiveActionSets = 1,
                 ActiveActionSets = &active_actionsets,
@@ -1047,24 +813,38 @@ namespace Stride.VirtualReality
 
             Xr.SyncAction(globalSession, &actions_sync_info);
 
-            leftHand.Update(gameTime);
-            rightHand.Update(gameTime);
+            leftHand?.Update(gameTime);
+            rightHand?.Update(gameTime);
         }
 
         public override void Dispose()
         {
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-            foreach (var render_target in render_targets)
+            if (render_targets != null)
             {
-                render_target.Dispose();
+                foreach (var render_target in render_targets)
+                {
+                    render_target.Dispose();
+                }
             }
 #endif
 
-            CheckResult(Xr.DestroySpace(globalPlaySpace), "DestroySpace");
-            CheckResult(Xr.DestroyActionSet(globalActionSet), "DestroyActionSet");
-            CheckResult(Xr.DestroySwapchain(globalSwapchain), "DestroySwapchain");
-            CheckResult(Xr.DestroySession(globalSession), "DestroySession");
-            CheckResult(Xr.DestroyInstance(Instance), "DestroyInstance");
+            if (globalPlaySpace.Handle != 0)
+                Xr.DestroySpace(globalPlaySpace).CheckResult();
+
+            if (globalActionSet.Handle != 0)
+                Xr.DestroyActionSet(globalActionSet).CheckResult();
+
+            if (globalSwapchain.Handle != 0)
+                Xr.DestroySwapchain(globalSwapchain).CheckResult();
+
+            if (globalSession.Handle != 0)
+                Xr.DestroySession(globalSession).CheckResult();
+
+            if (Instance.Handle != 0)
+                Xr.DestroyInstance(Instance).CheckResult();
+
+            Xr.Dispose();
         }
     }
 }

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRUtils.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRUtils.cs
@@ -1,0 +1,295 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Silk.NET.Core.Native;
+using Silk.NET.Core;
+using Silk.NET.OpenXR;
+using Stride.Core.Diagnostics;
+
+namespace Stride.VirtualReality
+{
+    internal static unsafe class OpenXRUtils
+    {
+        public const string XR_KHR_D3D11_ENABLE_EXTENSION_NAME = "XR_KHR_D3D11_enable";
+
+        public static bool Success(this Result result) => result >= 0;
+
+        /// <summary>
+        /// A simple function which throws an exception if the given OpenXR result indicates an error has been raised.
+        /// </summary>
+        /// <param name="result">The OpenXR result in question.</param>
+        /// <returns>
+        /// The same result passed in, just in case it's meaningful and we just want to use this to filter out errors.
+        /// </returns>
+        /// <exception cref="OpenXRException">An exception for the given result if it indicates an error.</exception>
+        [DebuggerHidden]
+        [DebuggerStepThrough]
+        public static Result CheckResult(this Result result, [CallerArgumentExpression(nameof(result))] string methodName = "")
+        {
+            if (!result.Success())
+                throw new OpenXRException(result, methodName);
+
+            return result;
+        }
+
+        public static Instance CreateRuntime(this XR xr, IReadOnlyList<string> extensions, Logger logger)
+        {
+            LogApiLayers(xr, logger);
+
+            logger.Debug("Installing extensions");
+
+            var openXrExtensions = new List<String>();
+#if STRIDE_GRAPHICS_API_DIRECT3D11
+            openXrExtensions.Add(XR_KHR_D3D11_ENABLE_EXTENSION_NAME);
+#endif
+#if DEBUG_OPENXR
+            openXrExtensions.Add("XR_EXT_debug_utils");
+#endif
+            openXrExtensions.AddRange(extensions);
+
+            uint propCount = 0;
+            xr.EnumerateInstanceExtensionProperties((byte*)null, 0, &propCount, null);
+
+            Span<ExtensionProperties> props = new ExtensionProperties[propCount];
+            foreach (ref var prop in props)
+            {
+                prop.Type = StructureType.ExtensionProperties;
+                prop.Next = null;
+            }
+            xr.EnumerateInstanceExtensionProperties((byte*)null, propCount, &propCount, props);
+
+            logger.Debug("Supported extensions (" + propCount + "):");
+            var availableExtensions = new List<string>();
+            foreach (ref var prop in props)
+            {
+                fixed (void* nptr = prop.ExtensionName)
+                {
+                    var extension_name = Marshal.PtrToStringAnsi(new System.IntPtr(nptr));
+                    logger.Debug(extension_name);
+                    availableExtensions.Add(extension_name!);
+                }
+            }
+
+            openXrExtensions.RemoveAll(e => !availableExtensions.Contains(e));
+
+            logger.Debug("Available extensions of those enabled");
+            foreach (var e in openXrExtensions)
+            {
+                logger.Debug(e);
+            }
+
+#if STRIDE_GRAPHICS_API_DIRECT3D11
+            if (!availableExtensions.Contains("XR_KHR_D3D11_enable"))
+            {
+                logger.Error($"OpenXR error! Current implementation doesn't support Direct3D 11");
+                return default;
+            }
+#endif
+
+            var appInfo = new ApplicationInfo()
+            {
+                ApiVersion = new Version64(1, 0, 10)
+            };
+
+            // We've got to marshal our strings and put them into global, immovable memory. To do that, we use
+            // SilkMarshal.
+            Span<byte> appName = new Span<byte>(appInfo.ApplicationName, 128);
+            Span<byte> engName = new Span<byte>(appInfo.EngineName, 128);
+            SilkMarshal.StringIntoSpan(System.AppDomain.CurrentDomain.FriendlyName, appName);
+            SilkMarshal.StringIntoSpan("Stride", engName);
+
+            var requestedExtensions = SilkMarshal.StringArrayToPtr(openXrExtensions);
+            InstanceCreateInfo instanceCreateInfo = new InstanceCreateInfo
+            (
+                applicationInfo: appInfo,
+                enabledExtensionCount: (uint)openXrExtensions.Count,
+                enabledExtensionNames: (byte**)requestedExtensions,
+                createFlags: 0,
+                enabledApiLayerCount: 0,
+                enabledApiLayerNames: null
+            );
+
+            // Now we're ready to make our instance!
+            Instance instance = default;
+            {
+                var result = xr.CreateInstance(in instanceCreateInfo, ref instance);
+                if (!result.Success())
+                {
+                    logger.Error($"Failed to create OpenXR Runtime ({result})");
+                    return default;
+                }
+            }
+
+#if DEBUG_OPENXR
+            xr.InitializeDebugUtils(instance, logger);
+#endif
+
+            // This crashes on oculus
+            // For our benefit, let's log some information about the instance we've just created.
+            var properties = new InstanceProperties()
+            {
+                Type = StructureType.InstanceProperties,
+                Next = null,
+            };
+            CheckResult(xr.GetInstanceProperties(instance, ref properties), "GetInstanceProperties");
+
+            var runtimeName = Marshal.PtrToStringAnsi(new System.IntPtr(properties.RuntimeName));
+            var runtimeVersion = ((Version)(Version64)properties.RuntimeVersion).ToString(3);
+
+            logger.Info($"Using OpenXR Runtime \"{runtimeName}\" v{runtimeVersion}");
+
+            return instance;
+        }
+
+        public static ulong GetSystem(this XR xr, Instance instance, Logger logger)
+        {
+            if (instance.Handle == 0)
+                throw new ArgumentNullException(nameof(instance));
+
+            // We're creating a head-mounted-display (HMD, i.e. a VR headset) example, so we ask for a runtime which
+            // supports that form factor. The response we get is a ulong that is the System ID.
+            var getInfo = new SystemGetInfo(formFactor: FormFactor.HeadMountedDisplay)
+            {
+                Type = StructureType.SystemGetInfo
+            };
+
+            ulong systemId = default;
+            if (xr.GetSystem(instance, in getInfo, ref systemId).Success())
+            {
+                logger.Debug("Successfully got XrSystem with id " + systemId + " for HMD form factor");
+                return systemId;
+            }
+
+            return default;
+        }
+
+        public static void LogApiLayers(this XR xr, Logger logger)
+        {
+            uint count = 0;
+            CheckResult(xr.EnumerateApiLayerProperties(0, &count, null));
+
+            if (count == 0)
+            {
+                logger.Debug("No API Layers");
+                return;
+            }
+
+            var props = new ApiLayerProperties[count];
+            for (uint i = 0; i < count; i++)
+            {
+                props[i].Type = StructureType.ApiLayerProperties;
+                props[i].Next = null;
+            }
+
+            CheckResult(xr.EnumerateApiLayerProperties(count, &count, props));
+
+            logger.Debug("API Layers:");
+            for (uint i = 0; i < count; i++)
+            {
+                fixed (void* nptr = props[i].LayerName)
+                fixed (void* dptr = props[i].Description)
+                    logger.Debug(
+                        Marshal.PtrToStringAnsi(new System.IntPtr(nptr))
+                        + " "
+                        + props[i].LayerVersion
+                        + " "
+                        + Marshal.PtrToStringAnsi(new System.IntPtr(dptr))
+                    );
+            }
+        }
+
+        public static void LogSystemProperties(SystemProperties systemProperties, Logger logger)
+        {
+            logger.Debug(
+                "System properties: "
+                + Marshal.PtrToStringAnsi(new System.IntPtr(systemProperties.SystemName))
+                + ", vendor: "
+                + Marshal.PtrToStringAnsi(new System.IntPtr(systemProperties.VendorId))
+            );
+            logger.Debug(
+                "Max layers: "
+                + systemProperties.GraphicsProperties.MaxLayerCount
+            );
+            logger.Debug(
+                "Max swapchain size: "
+                + systemProperties.GraphicsProperties.MaxSwapchainImageWidth
+                + "x"
+                + systemProperties.GraphicsProperties.MaxSwapchainImageHeight
+            );
+            logger.Debug(
+                "Orientation Tracking: "
+                + systemProperties.TrackingProperties.OrientationTracking
+            );
+            logger.Debug(
+                "tPosition Tracking: "
+                + systemProperties.TrackingProperties.PositionTracking
+            );
+        }
+
+        public static void LogViewConfigViews(ViewConfigurationView[] viewconfig_views, Logger logger)
+        {
+            foreach (var viewconfig_view in viewconfig_views)
+            {
+                logger.Debug("View Configuration View:");
+                logger.Debug(
+                    "Resolution: Recommended "
+                    + viewconfig_view.RecommendedImageRectWidth + "x" + viewconfig_view.RecommendedImageRectHeight
+                    + " Max: " + viewconfig_view.MaxImageRectWidth + "x" + viewconfig_view.MaxImageRectHeight
+                );
+                logger.Debug(
+                    "Swapchain Samples: Recommended"
+                    + viewconfig_view.RecommendedSwapchainSampleCount
+                    + " Max: " + viewconfig_view.MaxSwapchainSampleCount
+                );
+            }
+        }
+
+        private delegate Result pfnCreateDebugUtilsMessengerEXT(Instance instance, DebugUtilsMessengerCreateInfoEXT* createInfo, DebugUtilsMessengerEXT* messenger);
+        private delegate Result pfnDestroyDebugUtilsMessengerEXT(DebugUtilsMessengerEXT messenger);
+
+        public static void InitializeDebugUtils(this XR Xr, Instance instance, Logger logger)
+        {
+            Silk.NET.Core.PfnVoidFunction xrCreateDebugUtilsMessengerEXT = new Silk.NET.Core.PfnVoidFunction();
+            CheckResult(Xr.GetInstanceProcAddr(instance, "xrCreateDebugUtilsMessengerEXT", ref xrCreateDebugUtilsMessengerEXT), "GetInstanceProcAddr::xrCreateDebugUtilsMessengerEXT");
+            Delegate create_debug_utils_messenger = Marshal.GetDelegateForFunctionPointer((IntPtr)xrCreateDebugUtilsMessengerEXT.Handle, typeof(pfnCreateDebugUtilsMessengerEXT));
+
+            // https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#debug-message-categorization
+            DebugUtilsMessengerCreateInfoEXT debug_info = new DebugUtilsMessengerCreateInfoEXT()
+            {
+                Type = StructureType.DebugUtilsMessengerCreateInfoExt,
+                MessageTypes = DebugUtilsMessageTypeFlagsEXT.GeneralBitExt
+                    | DebugUtilsMessageTypeFlagsEXT.ValidationBitExt
+                    | DebugUtilsMessageTypeFlagsEXT.PerformanceBitExt
+                    | DebugUtilsMessageTypeFlagsEXT.ConformanceBitExt,
+                MessageSeverities = DebugUtilsMessageSeverityFlagsEXT.VerboseBitExt
+                    | DebugUtilsMessageSeverityFlagsEXT.InfoBitExt
+                    | DebugUtilsMessageSeverityFlagsEXT.WarningBitExt
+                    | DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt,
+                UserCallback = (DebugUtilsMessengerCallbackFunctionEXT)DebugCallback,
+            };
+
+            DebugUtilsMessengerEXT xr_debug;
+            var result = create_debug_utils_messenger.DynamicInvoke(instance, new System.IntPtr(&debug_info), new System.IntPtr(&xr_debug));
+
+            uint DebugCallback(DebugUtilsMessageSeverityFlagsEXT severity, DebugUtilsMessageTypeFlagsEXT types, DebugUtilsMessengerCallbackDataEXT* msg, void* user_data)
+            {
+                // Print the debug message we got! There's a bunch more info we could
+                // add here too, but this is a pretty good start, and you can always
+                // add a breakpoint this line!
+                var function_name = Marshal.PtrToStringAnsi(new System.IntPtr(msg->FunctionName));
+                var message = Marshal.PtrToStringAnsi(new System.IntPtr(msg->Message));
+                logger.Warning(function_name + " " + message);
+
+                // Returning XR_TRUE here will force the calling function to fail
+                return 0;
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXrTouchController.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXrTouchController.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -7,10 +9,11 @@ using Stride.Games;
 
 namespace Stride.VirtualReality
 {
-    class OpenXrTouchController : TouchController
+    sealed class OpenXrTouchController : TouchController
     {
-        private string baseHandPath;
-        private OpenXRHmd baseHMD;
+        private readonly OpenXRHmd baseHMD;
+        private readonly OpenXRInput input;
+
         private SpaceLocation handLocation;
         private TouchControllerHand myHand;
 
@@ -19,21 +22,23 @@ namespace Stride.VirtualReality
         public Space myHandSpace;
         public Silk.NET.OpenXR.Action myHandAction;
 
-        public OpenXrTouchController(OpenXRHmd hmd, TouchControllerHand whichHand)
+        public OpenXrTouchController(OpenXRHmd hmd, OpenXRInput input, TouchControllerHand whichHand)
         {
-            baseHMD = hmd;
-            handLocation.Type = StructureType.TypeSpaceLocation;
+            this.baseHMD = hmd;
+            this.input = input;
+
+            handLocation.Type = StructureType.SpaceLocation;
             myHand = whichHand;
             myHandAction = OpenXRInput.MappedActions[(int)myHand, (int)OpenXRInput.HAND_PATHS.Position];
 
             ActionSpaceCreateInfo action_space_info = new ActionSpaceCreateInfo()
             {
-                Type = StructureType.TypeActionSpaceCreateInfo,
+                Type = StructureType.ActionSpaceCreateInfo,
                 Action = myHandAction,
                 PoseInActionSpace = new Posef(new Quaternionf(0f, 0f, 0f, 1f), new Vector3f(0f, 0f, 0f)),
             };
 
-            OpenXRHmd.CheckResult(baseHMD.Xr.CreateActionSpace(baseHMD.globalSession, in action_space_info, ref myHandSpace), "CreateActionSpace");
+            baseHMD.Xr.CreateActionSpace(baseHMD.globalSession, in action_space_info, ref myHandSpace).CheckResult();
         }
 
         private Vector3 currentPos;
@@ -48,14 +53,13 @@ namespace Stride.VirtualReality
         private Vector3 currentAngVel;
         public override Vector3 AngularVelocity => currentAngVel;
 
-        public override DeviceState State => (handLocation.LocationFlags & SpaceLocationFlags.SpaceLocationPositionValidBit) != 0 ? DeviceState.Valid : DeviceState.OutOfRange;
+        public override DeviceState State => (handLocation.LocationFlags & SpaceLocationFlags.PositionValidBit) != 0 ? DeviceState.Valid : DeviceState.OutOfRange;
 
         private Quaternion? holdOffset;
-        private float _holdoffset;
 
-        public override float Trigger => OpenXRInput.GetActionFloat(myHand, TouchControllerButton.Trigger, out _);
+        public override float Trigger => input.GetActionFloat(myHand, TouchControllerButton.Trigger, out _);
 
-        public override float Grip => OpenXRInput.GetActionFloat(myHand, TouchControllerButton.Grip, out _);
+        public override float Grip => input.GetActionFloat(myHand, TouchControllerButton.Grip, out _);
 
         public override bool IndexPointing => false;
 
@@ -73,24 +77,24 @@ namespace Stride.VirtualReality
         {
             TouchControllerButton button = index == 0 ? TouchControllerButton.Thumbstick : TouchControllerButton.Touchpad;
 
-            return new Vector2(OpenXRInput.GetActionFloat(myHand, button, out _, false),
-                               OpenXRInput.GetActionFloat(myHand, button, out _, true));
+            return new Vector2(input.GetActionFloat(myHand, button, out _, false),
+                               input.GetActionFloat(myHand, button, out _, true));
         }
 
         public override bool IsPressed(TouchControllerButton button)
         {
-            return OpenXRInput.GetActionBool(myHand, button, out _);
+            return input.GetActionBool(myHand, button, out _);
         }
 
         public override bool IsPressedDown(TouchControllerButton button)
         {
-            bool isDownNow = OpenXRInput.GetActionBool(myHand, button, out bool changed);
+            bool isDownNow = input.GetActionBool(myHand, button, out bool changed);
             return isDownNow && changed;
         }
 
         public override bool IsPressReleased(TouchControllerButton button)
         {
-            bool isDownNow = OpenXRInput.GetActionBool(myHand, button, out bool changed);
+            bool isDownNow = input.GetActionBool(myHand, button, out bool changed);
             return !isDownNow && changed;
         }
 
@@ -116,20 +120,20 @@ namespace Stride.VirtualReality
         {
             ActionStatePose hand_pose_state = new ActionStatePose()
             {
-                Type = StructureType.TypeActionStatePose,
+                Type = StructureType.ActionStatePose,
                 Next = null,
             };
 
             ActionStateGetInfo get_info = new ActionStateGetInfo()
             {
-                Type = StructureType.TypeActionStateGetInfo,
+                Type = StructureType.ActionStateGetInfo,
                 Action = myHandAction,
                 Next = null,
             };
 
             SpaceVelocity sv = new SpaceVelocity()
             {
-                Type = StructureType.TypeSpaceVelocity,
+                Type = StructureType.SpaceVelocity,
                 Next = null,
             };
 

--- a/sources/engine/Stride.VirtualReality/VRDeviceSystem.cs
+++ b/sources/engine/Stride.VirtualReality/VRDeviceSystem.cs
@@ -83,7 +83,7 @@ namespace Stride.VirtualReality
                         case VRApi.OpenXR:
                             {
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-                                Device = new OpenXRHmd(Game.GraphicsDevice);
+                                Device = OpenXRHmd.New();
 #endif
                                 break;
                             }


### PR DESCRIPTION
# PR Details

The essential part here is that `OpenXRHmd.CanInitialize` will now return false if no device is present. This ensures that the `VRDeviceSystem` sets up a dummy device which in turn prevents many parts from crashing.

## Description

To truly know whether or not an actual device is connected we first need to establish contact with the OpenXR runtime. Therefor code has been moved around a bit to be able to call various parts individually. Tested on two machines, one without any VR related things installed and another one with an actual device.

This commit also contains a bunch of code cleanups:
- Enables C# nullable feature on OpenXR files
- Adds null checks to various places
- Disposes XR API after shutting down the device
- Makes various fields and methods private
- Moves initialization code to a `OpenXRUtils` class to make dependencies more visible
- Turns `OpenXRInput` into a normal class holding a reference to the device
- Turns `CheckResult` into an extension method and simplifies its usage by letting C# infer the called method
- Introduces `OpenXRException` exception class carrying the inferred method and XR error code

## Related Issue

Probably causes conflicts with #2119 which we would offer to fix.

## Motivation and Context

The system shouldn't crash when no VR device is present.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
- [x] I did run a VR patch in vvvv with two machines, one having a device, and the other which doesn't
