### PR TITLE
[OpenXR] Adds a minimal API to request and control Passthrough

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Silk.NET.OpenGLES" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.OpenXR" Version="2.20.0" />
+    <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.Sdl" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.19.0" />
     <PackageVersion Include="Stride.SharpFont" Version="1.0.0" />

--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -185,6 +185,7 @@ namespace Stride.Rendering.Compositing
                     vrSystem.RequireMirror = VRSettings.CopyMirror;
                     vrSystem.MirrorWidth = GraphicsDevice.Presenter.BackBuffer.Width;
                     vrSystem.MirrorHeight = GraphicsDevice.Presenter.BackBuffer.Height;
+                    vrSystem.RequestPassthrough = VRSettings.RequestPassthrough;
 
                     vrSystem.Enabled = true; //careful this will trigger the whole chain of initialization!
                     vrSystem.Visible = true;

--- a/sources/engine/Stride.Engine/Rendering/Compositing/VRRendererSettings.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/VRRendererSettings.cs
@@ -41,6 +41,9 @@ namespace Stride.Rendering.Compositing
         [DataMember(40)]
         public List<VROverlayRenderer> Overlays { get; } = new List<VROverlayRenderer>();
 
+        [DataMember(50)]
+        public bool RequestPassthrough { get; set; }
+
         [DataMemberIgnore]
         public RenderView[] RenderViews = { new RenderView(), new RenderView() };
 

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRExt_FB_passthrough.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRExt_FB_passthrough.cs
@@ -1,0 +1,107 @@
+using Silk.NET.Core;
+using Silk.NET.Core.Contexts;
+using Silk.NET.OpenXR;
+using Silk.NET.OpenXR.Extensions.FB;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Stride.VirtualReality
+{
+    internal unsafe class OpenXRExt_FB_Passthrough
+    {
+        private readonly Session session;
+        private readonly FBPassthrough api;
+        private readonly PassthroughFB handle;
+        private readonly CompositionLayerPassthroughFB* compositionlayer;
+
+        private PassthroughLayerFB passthrough_Layer;
+
+        public OpenXRExt_FB_Passthrough(XR xr, Session session, Instance instance)
+        {
+            this.session = session;
+
+            api = new FBPassthrough(new LamdaNativeContext(TryGetProcAddress));
+
+            var passthroughCreateInfo = new PassthroughCreateInfoFB
+            {
+                Next = null,
+                Flags = 0,
+                Type = StructureType.PassthroughCreateInfoFB
+            };
+            api.CreatePassthroughFB(session, passthroughCreateInfo, ref handle).CheckResult();
+
+            this.compositionlayer = (CompositionLayerPassthroughFB*)Marshal.AllocHGlobal(sizeof(CompositionLayerPassthroughFB));
+            Unsafe.InitBlockUnaligned((byte*)this.compositionlayer, 0, (uint)sizeof(CompositionLayerPassthroughFB));
+
+            bool TryGetProcAddress(string n, out nint fptr)
+            {
+                PfnVoidFunction function;
+                var result = xr.GetInstanceProcAddr(instance, n, ref function);
+                if (result.Success())
+                {
+                    fptr = function;
+                    return true;
+                }
+                else
+                {
+                    fptr = default;
+                    return false;
+                }
+            }
+        }
+
+        public bool Enabled
+        {
+            get => passthrough_Layer.Handle != default;
+            set 
+            {
+                if (value != Enabled) 
+                { 
+                    if (value)
+                    {
+                        //start the extension
+                        api.PassthroughStartFB(handle).CheckResult();
+
+                        //create the layer
+                        var passthroughLayerCreateInfo = new PassthroughLayerCreateInfoFB
+                        {
+                            Next = null,
+                            Flags = PassthroughFlagsFB.IsRunningATCreationBitFB,
+                            Passthrough = handle,
+                            Purpose = PassthroughLayerPurposeFB.ReconstructionFB,
+                            Type = StructureType.PassthroughLayerCreateInfoFB
+                        };
+
+                        api.CreatePassthroughLayerFB(session, in passthroughLayerCreateInfo, ref passthrough_Layer).CheckResult();
+                    }
+                    else
+                    {
+                        api.DestroyPassthroughLayerFB(passthrough_Layer);
+                        passthrough_Layer = default;
+
+                        api.PassthroughPauseFB(handle);
+                    }
+                }
+            }
+        }
+
+        internal unsafe CompositionLayerPassthroughFB* GetCompositionLayer()
+        {
+            compositionlayer->Next = null;
+            compositionlayer->Flags = CompositionLayerFlags.BlendTextureSourceAlphaBit;
+            compositionlayer->LayerHandle = passthrough_Layer;
+            compositionlayer->Type = StructureType.CompositionLayerPassthroughFB;
+            return this.compositionlayer;
+        }
+
+        internal unsafe void Destroy()
+        {
+            Enabled = false;
+            api.DestroyPassthroughFB(handle);
+            Marshal.FreeHGlobal(new nint(compositionlayer));
+            api.Dispose();
+        }
+    }
+}

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
@@ -20,7 +20,11 @@ namespace Stride.VirtualReality
         // Public static variable to add extensions to the initialization of the openXR session
         public static List<string> extensions = new List<string>();
 
-        public static OpenXRHmd? New(bool requestPassthrough)
+        /// <summary>
+        /// Creates a VR device using OpenXR.
+        /// </summary>
+        /// <param name="requestPassthrough">Whether or not the XR_FB_passthrough extension should be enabled (if available).</param>
+        internal static OpenXRHmd? New(bool requestPassthrough)
         {
             // Create our API object for OpenXR.
             var xr = XR.GetApi();
@@ -62,6 +66,7 @@ namespace Stride.VirtualReality
 
         // Passthrough
         private OpenXRExt_FB_Passthrough? passthroughExt;
+        private bool passthroughRequested;
 
         private GraphicsDevice? baseDevice;
 
@@ -133,6 +138,7 @@ namespace Stride.VirtualReality
         {
             Xr = xr;
             VRApi = VRApi.OpenXR;
+            passthroughRequested = requestPassthrough;
 
             var requestedExtensions = new List<string>(extensions);
             if (requestPassthrough)
@@ -361,8 +367,11 @@ namespace Stride.VirtualReality
 
         public override IDisposable StartPassthrough()
         {
+            if (!passthroughRequested)
+                throw new InvalidOperationException("The passthrough mode needs to be enabled at device creation");
+
             if (!SupportsPassthrough)
-                throw new NotSupportedException();
+                throw new NotSupportedException("The device does not support passthrough mode");
 
             if (passthroughExt is null)
                 passthroughExt = new OpenXRExt_FB_Passthrough(Xr, globalSession, Instance);

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
@@ -11,6 +11,7 @@ using Silk.NET.Core;
 using System.Diagnostics;
 using Silk.NET.Core.Native;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 
 namespace Stride.VirtualReality
 {
@@ -19,7 +20,7 @@ namespace Stride.VirtualReality
         // Public static variable to add extensions to the initialization of the openXR session
         public static List<string> extensions = new List<string>();
 
-        public static OpenXRHmd? New()
+        public static OpenXRHmd? New(bool requestPassthrough)
         {
             // Create our API object for OpenXR.
             var xr = XR.GetApi();
@@ -30,7 +31,7 @@ namespace Stride.VirtualReality
             }
 
             // Takes ownership on API object
-            return new OpenXRHmd(xr);
+            return new OpenXRHmd(xr, requestPassthrough);
         }
 
         // API Objects for accessing OpenXR
@@ -59,6 +60,9 @@ namespace Stride.VirtualReality
         private bool sessionRunning = false;
         private SessionState state = SessionState.Unknown;
 
+        // Passthrough
+        private OpenXRExt_FB_Passthrough? passthroughExt;
+
         private GraphicsDevice? baseDevice;
 
         private Size2 renderSize;
@@ -75,6 +79,7 @@ namespace Stride.VirtualReality
         // array of view_count containers for submitting swapchains with rendered VR frames
         private CompositionLayerProjectionView[]? projection_views;
         private View[]? views;
+        private readonly unsafe List<IntPtr> compositionLayers = new();
 
         public override Size2 ActualRenderFrameSize
         {
@@ -124,12 +129,18 @@ namespace Stride.VirtualReality
 
         public override TrackedItem[]? TrackedItems => null;
 
-        private OpenXRHmd(XR xr)
+        private OpenXRHmd(XR xr, bool requestPassthrough)
         {
             Xr = xr;
             VRApi = VRApi.OpenXR;
-            Instance = OpenXRUtils.CreateRuntime(xr, extensions, Logger);
+
+            var requestedExtensions = new List<string>(extensions);
+            if (requestPassthrough)
+                requestedExtensions.Add(OpenXRUtils.XR_FB_PASSTHROUGH_EXTENSION_NAME);
+
+            Instance = OpenXRUtils.CreateRuntime(xr, requestedExtensions, Logger);
             SystemId = Instance.Handle != 0 ? OpenXRUtils.GetSystem(xr, Instance, Logger) : default;
+            SupportsPassthrough = requestPassthrough && Xr.IsInstanceExtensionPresent(null, OpenXRUtils.XR_FB_PASSTHROUGH_EXTENSION_NAME);
         }
 
         public override unsafe void Enable(GraphicsDevice device, GraphicsDeviceManager graphicsDeviceManager, bool requireMirror, int mirrorWidth, int mirrorHeight)
@@ -348,6 +359,22 @@ namespace Stride.VirtualReality
             Xr.StringToPath(Instance, "/user/hand/left", ref leftHandPath);
         }
 
+        public override IDisposable StartPassthrough()
+        {
+            if (!SupportsPassthrough)
+                throw new NotSupportedException();
+
+            if (passthroughExt is null)
+                passthroughExt = new OpenXRExt_FB_Passthrough(Xr, globalSession, Instance);
+
+            if (passthroughExt.Enabled)
+                throw new InvalidOperationException("Passthrough already started");
+
+            passthroughExt.Enabled = true;
+
+            return new AnonymousDisposable(() => passthroughExt.Enabled = false);
+        }
+
         private void EndNullFrame()
         {
             FrameEndInfo frame_end_info = new FrameEndInfo()
@@ -492,7 +519,7 @@ namespace Stride.VirtualReality
             #if STRIDE_GRAPHICS_API_DIRECT3D11
             if (render_targets is null)
                 return;
-            #endif
+#endif
 
             // if we didn't wait a frame, don't commit
             if (begunFrame == false)
@@ -503,18 +530,19 @@ namespace Stride.VirtualReality
             if (swapImageCollected)
             {
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-            Debug.Assert(commandList.NativeDeviceContext == baseDevice.NativeDeviceContext);
-            // Logger.Warning("Blit render target");
-            baseDevice.NativeDeviceContext.CopyResource(renderFrame.NativeRenderTargetView.Resource, render_targets[swapchainPointer].Resource);
+                Debug.Assert(commandList.NativeDeviceContext == baseDevice.NativeDeviceContext);
+                // Logger.Warning("Blit render target");
+                baseDevice.NativeDeviceContext.CopyResource(renderFrame.NativeRenderTargetView.Resource, render_targets[swapchainPointer].Resource);
 #endif
 
-            // Release the swapchain image
-            // Logger.Warning("ReleaseSwapchainImage");
-            var releaseInfo = new SwapchainImageReleaseInfo() { 
-                Type = StructureType.SwapchainImageReleaseInfo,
-                Next = null,
-            };
-            Xr.ReleaseSwapchainImage(globalSwapchain, in releaseInfo).CheckResult();
+                // Release the swapchain image
+                // Logger.Warning("ReleaseSwapchainImage");
+                var releaseInfo = new SwapchainImageReleaseInfo()
+                {
+                    Type = StructureType.SwapchainImageReleaseInfo,
+                    Next = null,
+                };
+                Xr.ReleaseSwapchainImage(globalSwapchain, in releaseInfo).CheckResult();
 
                 for (var eye = 0; eye < 2; eye++)
                 {
@@ -524,28 +552,40 @@ namespace Stride.VirtualReality
 
                 unsafe
                 {
-                fixed (CompositionLayerProjectionView* projection_views_ptr = &projection_views[0])
-                {
-                    var projectionLayer = new CompositionLayerProjection
-                    (
-                        viewCount: (uint)projection_views.Length,
-                        views: projection_views_ptr,
-                        space: globalPlaySpace
-                    );
-
-                    var layerPointer = (CompositionLayerBaseHeader*)&projectionLayer;
-                    var frameEndInfo = new FrameEndInfo()
+                    // Add composition layers from extensions
+                    compositionLayers.Clear();
+                    if (passthroughExt != null && passthroughExt.Enabled)
                     {
-                        Type = StructureType.FrameEndInfo,
-                        DisplayTime = globalFrameState.PredictedDisplayTime,
-                        EnvironmentBlendMode = EnvironmentBlendMode.Opaque,
-                        LayerCount = 1,
-                        Layers = &layerPointer,
-                        Next = null,
-                    };
+                        var layer = passthroughExt.GetCompositionLayer();
+                        compositionLayers.Add(new IntPtr(layer));
+                    }
 
-                    //Logger.Warning("EndFrame");
-                    Xr.EndFrame(globalSession, in frameEndInfo).CheckResult();
+                    fixed (CompositionLayerProjectionView* projection_views_ptr = &projection_views[0])
+                    {
+                        var projectionLayer = new CompositionLayerProjection
+                        (
+                            viewCount: (uint)projection_views.Length,
+                            views: projection_views_ptr,
+                            space: globalPlaySpace,
+                            layerFlags: compositionLayers.Count > 0 ? CompositionLayerFlags.BlendTextureSourceAlphaBit : 0
+                        );
+
+                        compositionLayers.Add(new IntPtr(&projectionLayer));
+                        fixed (nint* layersPtr = CollectionsMarshal.AsSpan(compositionLayers))
+                        {
+                            var frameEndInfo = new FrameEndInfo()
+                            {
+                                Type = StructureType.FrameEndInfo,
+                                DisplayTime = globalFrameState.PredictedDisplayTime,
+                                EnvironmentBlendMode = EnvironmentBlendMode.Opaque,
+                                LayerCount = (uint)compositionLayers.Count,
+                                Layers = (CompositionLayerBaseHeader**)layersPtr,
+                                Next = null,
+                            };
+
+                            //Logger.Warning("EndFrame");
+                            Xr.EndFrame(globalSession, in frameEndInfo).CheckResult();
+                        }
                     }
                 }
             }
@@ -842,6 +882,8 @@ namespace Stride.VirtualReality
 
             if (globalSwapchain.Handle != 0)
                 Xr.DestroySwapchain(globalSwapchain).CheckResult();
+
+            passthroughExt?.Destroy();
 
             if (globalSession.Handle != 0)
                 Xr.DestroySession(globalSession).CheckResult();

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRUtils.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRUtils.cs
@@ -18,6 +18,7 @@ namespace Stride.VirtualReality
     internal static unsafe class OpenXRUtils
     {
         public const string XR_KHR_D3D11_ENABLE_EXTENSION_NAME = "XR_KHR_D3D11_enable";
+        public const string XR_FB_PASSTHROUGH_EXTENSION_NAME = "XR_FB_passthrough";
 
         public static bool Success(this Result result) => result >= 0;
 

--- a/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
+++ b/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Silk.NET.OpenXR" />
+    <PackageReference Include="Silk.NET.OpenXR.Extensions.FB" />
   </ItemGroup>
   <Import Project="$(StrideSdkTargets)" />
 </Project>

--- a/sources/engine/Stride.VirtualReality/VRDevice.cs
+++ b/sources/engine/Stride.VirtualReality/VRDevice.cs
@@ -74,7 +74,8 @@ namespace Stride.VirtualReality
         /// Starts a passthrough. When enabled the scene is rendered on top of the camera image of the device.
         /// </summary>
         /// <returns>A disposable which will stop the passthrough on dispose.</returns>
-        /// <exception cref="NotSupportedException">Thrown if passthrough is not supported by the device.</exception>
+        /// <exception cref="NotSupportedException">Thrown if the passthrough mode is not supported by the device.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if the passthrough mode is already enabled.</exception>
         public virtual IDisposable StartPassthrough()
         {
             throw new NotSupportedException();

--- a/sources/engine/Stride.VirtualReality/VRDevice.cs
+++ b/sources/engine/Stride.VirtualReality/VRDevice.cs
@@ -54,6 +54,13 @@ namespace Stride.VirtualReality
 
         public bool SupportsOverlays { get; protected set; } = false;
 
+        /// <summary>
+        /// Whether or not passthrough is supported by the device. 
+        /// It needs to be requested on device creation by enabling <see cref="VRDeviceSystem.RequestPassthrough"/>.
+        /// If supported, passthrough can be started (and stopped) with the <see cref="StartPassthrough"/> method.
+        /// </summary>
+        public bool SupportsPassthrough { get; protected set; } = false;
+
         public virtual VROverlay CreateOverlay(int width, int height, int mipLevels, int sampleCount)
         {
             return null;
@@ -61,6 +68,16 @@ namespace Stride.VirtualReality
 
         public virtual void ReleaseOverlay(VROverlay overlay)
         {         
+        }
+
+        /// <summary>
+        /// Starts a passthrough. When enabled the scene is rendered on top of the camera image of the device.
+        /// </summary>
+        /// <returns>A disposable which will stop the passthrough on dispose.</returns>
+        /// <exception cref="NotSupportedException">Thrown if passthrough is not supported by the device.</exception>
+        public virtual IDisposable StartPassthrough()
+        {
+            throw new NotSupportedException();
         }
 
         public abstract void Enable(GraphicsDevice device, GraphicsDeviceManager graphicsDeviceManager, bool requireMirror, int mirrorWidth, int mirrorHeight);

--- a/sources/engine/Stride.VirtualReality/VRDeviceSystem.cs
+++ b/sources/engine/Stride.VirtualReality/VRDeviceSystem.cs
@@ -33,6 +33,8 @@ namespace Stride.VirtualReality
 
         public int MirrorHeight;
 
+        public bool RequestPassthrough;
+
         public bool PreviousUseCustomProjectionMatrix;
 
         public bool PreviousUseCustomViewMatrix;
@@ -83,7 +85,7 @@ namespace Stride.VirtualReality
                         case VRApi.OpenXR:
                             {
 #if STRIDE_GRAPHICS_API_DIRECT3D11
-                                Device = OpenXRHmd.New();
+                                Device = OpenXRHmd.New(RequestPassthrough);
 #endif
                                 break;
                             }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow up on #2119 and #2121. It adds the following new public APIs:
- `VRDeviceSystem.RequestPassthrough` - needs to be set in order for the OpenXR extension to get considered.
- `VRRendererSettings.RequestPassthrough` - can be set in GameStudio and get passed to the VR device system by the `ForwardRenderer`
- `VRDevice.SupportsPassthrough` - does the device support it?
- `VRDevice.StartPassthrough` - needs to be called by user code to turn the feature on

The PR is a little bit different to the original one not exposing internal classes to the user. Not entirly sure here what is the best approach. It's only supported by OpenXR and there also by some devices, but having to cast on these types manually in Stride game code seems awkward as well.

## Related Issue

#2119 and #2121 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
