### PR TITLE
Audio emitter multiple references to same asset bugfix

### DIFF
--- a/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
@@ -168,22 +168,27 @@ namespace Stride.Engine
             ControllerCollectionChanged?.Invoke(this, new ControllerCollectionChangedEventArgs(Entity, oldController, this, NotifyCollectionChangedAction.Remove));
         }
 
-        void SoundAdded(SoundBase sound)
+        private void SoundAdded(SoundBase sound)
         {
             AttachSound(sound);
-            if (!SoundMultiplicities.ContainsKey(sound))
-                SoundMultiplicities[sound] = 0;
-            SoundMultiplicities[sound]++;
+            SoundMultiplicities.TryGetValue(sound, out var v);
+            SoundMultiplicities[sound] = v+1;
         }
-        void SoundRemoved(SoundBase sound)
+
+        private void SoundRemoved(SoundBase sound)
         {
-            SoundMultiplicities[sound]--;
-            if (SoundMultiplicities[sound] == 0)
+            var val = SoundMultiplicities[sound];
+            if (val == 1)
             {
                 DetachSound(sound);
                 SoundMultiplicities.Remove(sound);
             }
+            else
+            {
+                SoundMultiplicities[sound] = val-1;
+            }
         }
+
         private void OnSoundsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs args)
         {
             switch (args.Action)


### PR DESCRIPTION
This fixes the bug where changing the parent of an entity with an audio emitter component referencing the same sound asset multiple times would cause a crash.

# PR Details

Previously when the parent of such an entity was changed, there would be a crash because detach would be called on the same SoundBase object for each corresponding key in Sounds. Now, when an entry is removed from Sounds in AudioEmitterComponent, the corresponding SoundBase is only detached if there are no other keys referencing it in Sounds.

## Description

This is accomplished by maintaining a dictionary mapping each SoundBase to its set of keys in Sounds, and only detaching a SoundBase when its set of Sound keys is empty. This implementation still keeps just one AudioEmitterSoundController per SoundBase.

## Related Issue

https://github.com/stride3d/stride/issues/2024

## Motivation and Context

Users may occasionally want the same sound asset to have multiple references from the same audio emitter (especially during early game development), so Stride should allow it instead of crashing unexpectedly when a parent of the object is set during runtime.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x ] **I have built and run the editor to try this change out.**
