### PR TITLE
Overwrite dialog fix

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -598,7 +598,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                         Directory.CreateDirectory(Path.GetDirectoryName(finalPath));
                         if (File.Exists(finalPath))
                         {
-                            message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(file.FullPath);
+                            message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(finalPath);
 
                             copyResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -539,7 +539,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         {
             var path = directory.Path;
             var message = Tr._p("Message", "Do you want to place the resource in the default location ?");
-            var finalPath = Path.Combine(directory.Package.Package.ResourceFolders[0], path, file.GetFileName());
+            var finalPath = Path.GetFullPath(Path.Combine(directory.Package.Package.ResourceFolders[0], path, file.GetFileName()));
             var pathResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (pathResult == MessageBoxResult.No)
             {


### PR DESCRIPTION
# PR Details

Changes asset file import overwrite dialog to show the correct file being replaced.

## Description

There is a bug in the current dialog that prompts if it is okay to overwrite the source file instead of the destination file. This PR corrects that so that it shows the correct file that is about to be replaced.

Additionally, added Path.GetFullPath to use/show the proper directory separator in an OS agnostic way as seen in other places in the project. 

## Related Issue

No issue created, but can easily be reproduced by importing an external resource twice and choosing to use the default location.

## Motivation and Context

The current dialog makes it seem as if Stride is going to modify a file outside of the project, which is not true. This should help eliminate that confusion.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
