### PR TITLE
#2214  Vulkan uses gl_InstanceIndex and gl_VertexIndex instead of gl_InstanceId and gl_VertexId as the latter are not supported. 

### DIFF
--- a/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
@@ -141,8 +141,8 @@ namespace Stride.Core.Shaders.Convertor
                 switch (pipelineStage)
                 {
                     case PipelineStage.Vertex:
-                        builtinInputs.Add("SV_VertexID", "gl_VertexID");
-                        builtinInputs.Add("SV_InstanceID", "gl_InstanceID");
+                        builtinInputs.Add("SV_VertexID", isVulkan ? "gl_VertexIndex" : "gl_VertexID");
+                        builtinInputs.Add("SV_InstanceID", isVulkan ? "gl_InstanceIndex" :  "gl_InstanceID");
                         if (shaderModel < ShaderModel.Model40)
                         {
                             builtinOutputs.Add("POSITION", "gl_Position");
@@ -199,6 +199,7 @@ namespace Stride.Core.Shaders.Convertor
                    { "gl_FragData", VectorType.Float4}, // array
                    { "gl_FrontFacing", ScalarType.Bool}, 
                    { "gl_InstanceID", ScalarType.Int },
+                   { "gl_InstanceIndex", ScalarType.Int },
                    { "gl_InvocationID", ScalarType.Int},
                    { "gl_Layer", ScalarType.Int},
                    { "gl_NumSamples", ScalarType.Int},
@@ -214,6 +215,7 @@ namespace Stride.Core.Shaders.Convertor
                    { "gl_SamplePosition", VectorType.Float2},
                    { "gl_TessCoord", VectorType.Float3},
                    { "gl_VertexID", ScalarType.Int},
+                   { "gl_VertexIndex", ScalarType.Int},
                    { "gl_ViewportIndex", ScalarType.Int},
                 };
             }


### PR DESCRIPTION
# PR Details

Vulkan uses gl_InstanceIndex and gl_VertexIndex instead of gl_InstanceId and gl_VertexId as the latter are not supported. 

## Related Issue

https://github.com/stride3d/stride/issues/2214

## Motivation and Context

gl_InstanceId and gl_VertexId are removed in https://github.com/KhronosGroup/GLSL/blob/main/extensions/khr/GL_KHR_vulkan_glsl.txt 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
