### PR TITLE
fix: PublishSingleFile Launch Crash

### DIFF
--- a/sources/core/Stride.Core/PlatformFolders.cs
+++ b/sources/core/Stride.Core/PlatformFolders.cs
@@ -186,6 +186,8 @@ namespace Stride.Core
         {
 #if STRIDE_PLATFORM_ANDROID
             return GetApplicationExecutableDirectory();
+#elif STRIDE_PLATFORM_DESKTOP
+            return Path.GetDirectoryName(AppContext.BaseDirectory);
 #else
             return Path.GetDirectoryName(typeof(PlatformFolders).Assembly.Location);
 #endif


### PR DESCRIPTION
# PR Details
Stride applications built for Windows will crash when PublishSingleFile is set to true.

## Description
When a Stride application is launched, `Assembly.Location` is used to find the executable directory and create cache folders. This returns a null value when PublishSingleFile is true. It is instead recommended to use `AppContext.BaseDirectory` to check for the executable directory.

Additional Info: https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/stride3d/stride/issues/2204

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
