### PR TITLE
fix: Add possibility to add ScriptComponent before running game

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -225,6 +225,15 @@ namespace Stride.Engine
 
             VRDeviceSystem = new VRDeviceSystem(Services);
             Services.AddService(VRDeviceSystem);
+            // Add the input manager
+            // Add it first so that it can obtained by the UI system
+            var inputSystem = new InputSystem(Services);
+            Input = inputSystem.Manager;
+            Services.AddService(Input);
+            GameSystems.Add(inputSystem);
+
+            EffectSystem = new EffectSystem(Services);
+            Services.AddService(EffectSystem);
 
             // Creates the graphics device manager
             GraphicsDeviceManager = new GraphicsDeviceManager(this);
@@ -336,13 +345,6 @@ namespace Stride.Engine
             // (Unless overriden by gameSystem.UpdateOrder)
             // ---------------------------------------------------------
 
-            // Add the input manager
-            // Add it first so that it can obtained by the UI system
-            var inputSystem = new InputSystem(Services);
-            Input = inputSystem.Manager;
-            Services.AddService(Input);
-            GameSystems.Add(inputSystem);
-
             // Initialize the systems
             base.Initialize();
 
@@ -362,9 +364,6 @@ namespace Stride.Engine
 
             GameSystems.Add(DebugTextSystem);
             GameSystems.Add(ProfilingSystem);
-
-            EffectSystem = new EffectSystem(Services);
-            Services.AddService(EffectSystem);
 
             // If requested in game settings, compile effects remotely and/or notify new shader requests
             EffectSystem.Compiler = EffectCompilerFactory.CreateEffectCompiler(Content.FileProvider, EffectSystem, Settings?.PackageName, Settings?.EffectCompilation ?? EffectCompilationMode.Local, Settings?.RecordUsedEffects ?? false);


### PR DESCRIPTION
# PR Details

## Description

This PR allows to add scripts using code approach. Before, following example will throw an exception: 

```cs
using Stride.Engine;

using var game = new Game();
game.Script.Add(new FooExampleScript()); // SyncScript logic doesnt matter
/*
Unhandled exception. Stride.Core.ServiceNotFoundException: Service [IContentManager] not found
   at Stride.Core.ServiceRegistryExtensions.GetSafeServiceAs[T](IServiceRegistry registry) in stride/sources/core/Stride.Core/ServiceRegistryExtensions.cs:line 23
   at Stride.Engine.ScriptComponent.Initialize(IServiceRegistry registry) in stride/sources/engine/Stride.Engine/Engine/ScriptComponent.cs:line 59
   at Stride.Engine.Processors.ScriptSystem.Add(ScriptComponent script) in stride/sources/engine/Stride.Engine/Engine/Processors/ScriptSystem.cs:line 164
   at Program.<Main>$(String[] args) in Program.cs:line 5
*/
game.Run();
```

This was fixed by registering Systems earlier 

## Motivation and Context

This way engine is more flexible and supports code only approach

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
