### PR TITLE
feat: Enable to build engine and modeling related projects on any OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Ask for help or report issues:
 ### Prerequisites
 
 1. **Latest** [Git](https://git-scm.com/downloads) **with Large File Support** selected in the setup on the components dialog and for convenience a git UI client like [GitExtensions](https://gitextensions.github.io/).
-2. [.NET SDK 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+2. [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
    - Run `dotnet --info` in a console or powershell window to see which versions you have installed  
 3. [Visual Studio 2022](https://www.visualstudio.com/downloads/) with the following workloads:
    - `.NET desktop development` with `.NET Framework 4.7.2 targeting pack` (should be enabled by default)
@@ -69,7 +69,6 @@ Ask for help or report issues:
      - `C++/CLI support for v143 build tools (Latest)` **(not enabled by default)**
    - Optional (to target iOS/Android): `.NET Multi-paltform App UI development` and `Android SDK setup` individual component (enabled by default), then in Visual Studio go to `Tools > Android > Android SDK Manager` and install `NDK` (version 20.1+) from `Tools` tab.
    - Optional (to build VSIX package): `Visual Studio extension development`
-4. **[FBX SDK 2019.0 VS2015](https://www.autodesk.com/developer-network/platform-technologies/fbx-sdk-2019-0)**
 
 ### Build Stride
 

--- a/sources/engine/Stride.Assets.Models/Stride.Assets.Models.csproj
+++ b/sources/engine/Stride.Assets.Models/Stride.Assets.Models.csproj
@@ -4,7 +4,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>$(StrideAssemblyProcessorDefaultOptions)</StrideAssemblyProcessorOptions>
     <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/sources/targets/Stride.Core.props
+++ b/sources/targets/Stride.Core.props
@@ -57,7 +57,8 @@
     <Platform>AnyCPU</Platform>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(StrideRuntime)' == 'true' ">
+  <PropertyGroup Condition=" '$(StrideRuntime)' == 'true' ">  
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <!-- Add net8.0 no matter what (needed for references) -->
     <StrideRuntimeTargetFrameworks>net8.0</StrideRuntimeTargetFrameworks>
     <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Windows;')) And '$(StrideExplicitWindowsRuntime)' == 'true'">$(StrideRuntimeTargetFrameworks);net8.0-windows7.0</StrideRuntimeTargetFrameworks>

--- a/sources/tools/Stride.Importer.3D/Stride.Importer.3D.csproj
+++ b/sources/tools/Stride.Importer.3D/Stride.Importer.3D.csproj
@@ -4,7 +4,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>$(StrideAssemblyProcessorDefaultOptions)</StrideAssemblyProcessorOptions>
     <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/sources/tools/Stride.Importer.Common/Stride.Importer.Common.csproj
+++ b/sources/tools/Stride.Importer.Common/Stride.Importer.Common.csproj
@@ -4,7 +4,6 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>$(StrideAssemblyProcessorDefaultOptions)</StrideAssemblyProcessorOptions>
     <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
# PR Details

## Description

This PR enables to build following projects : 
- Stride.Assets.Models, Stride.Importer.Common, Stride.Importer.3D - these were restricted to win, because Visual c++ only available for NET FW - this is no longer the case
- Stride.Games, Stride.Input - for some reason  Stride.Core.prop adds net8.0-windows as Runtime framework but there is no windows specific code for both projects (**update**: Stride.Games is being used for GameStudio with WinForms). I restricted to windows only just in case

## Motivation and Context

Make less windows restricted experience

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
