### PR TITLE
Fix implicit truncation of vector type shader warning

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapCasterAlphaDithered.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapCasterAlphaDithered.sdsl
@@ -31,7 +31,7 @@ namespace Stride.Rendering.Shadows
         {
             base.PSMain();
 
-            int2 coord = streams.ShadingPosition % 4;
+            int2 coord = int2(streams.ShadingPosition.xy % 4.0);
             float bayer = BayerMatrix[coord.x+coord.y*4];
             clip( -1.01 + bayer + streams.ColorTarget.a * 1.01 );
         }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Explicitly declare the data components used in the modulo operator & the data conversion to take place (ie. float modulo and convert to int2 data type).

## Description

<!--- Describe your changes in detail -->
See above.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Using material Transparency -> Dithered Shadows (enabled by default) on a model would trigger "implicit truncation of vector type" warning at run-time.
Feature was introduced in #1256

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`streams.ShadingPosition` is `float4` data type. The original code would do a float modulo operation returning a `float4` and implicit convert to int2. This would trigger a warning due to zw components being dropped.
While the explicit `int2(...)` is probably not needed, it's better to spell it out that we're not the same data type.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

Full disclosure: I did not build/run the editor. I tested the original line & modified line on a local project with a custom shader. The original line triggered the warning on the project, and the modified line did not trigger the warning - the app did not crash.
