### PR TITLE
fix: Regression of new FBX importer on behalf of Noah

### DIFF
--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -102,8 +102,6 @@ namespace Stride.Importer.ThreeD
                 }
 
                 var scene = Initialize(inputFilename, outputFilename, importFlags, 0);
-
-                ExtractEmbededTexture(scene, inputFilename);
                 // If scene is null, something went wrong inside Assimp
                 if (scene == null)
                 {
@@ -115,6 +113,8 @@ namespace Stride.Importer.ThreeD
 
                     return null;
                 }
+
+                ExtractEmbededTexture(scene, inputFilename);
 
                 var materialNames = new Dictionary<IntPtr, string>();
                 var meshNames = new Dictionary<IntPtr, string>();

--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -217,7 +217,9 @@ namespace Stride.Importer.ThreeD
                     var meshInfo = ProcessMesh(scene, scene->MMeshes[i], meshNames);
                     
                     if (meshInfo == null)
-                    {continue;}
+                    {
+                        continue;
+                    }
 
                     foreach (var nodeIndex in meshIndexToNodeIndex[i])
                     {
@@ -846,15 +848,16 @@ namespace Stride.Importer.ThreeD
 
             // Build the indices data buffer
             var nbIndices = (int)(3 * mesh->MNumFaces);
-            byte[] indexBuffer = null;
             var is32BitIndex = mesh->MNumVertices > 65535;
             int arraySize = is32BitIndex ? sizeof(uint) * nbIndices : sizeof(ushort) * nbIndices;
 
             //Mesh has no vertices
             if(arraySize < 1) 
-            { return null; }
+            { 
+                return null; 
+            }
 
-            indexBuffer = new byte[arraySize];
+            byte[] indexBuffer = new byte[arraySize];
 
             fixed (byte* indexBufferPtr = &indexBuffer[0])
             {
@@ -945,10 +948,9 @@ namespace Stride.Importer.ThreeD
        
         private unsafe void ExtractEmbededTexture(Scene* scene, string importFieName)
         {
+            string dir = Path.GetDirectoryName(importFieName);
             for (uint i = 0; i < scene->MNumTextures; ++i)
             {
-                string dir = Path.GetDirectoryName(importFieName);
-                string depencendyDirName=Path.GetFileNameWithoutExtension(importFieName);
                 var texture=scene->MTextures[i];
                 string fullName = Path.Combine(dir,Path.GetFileName(texture->MFilename));
                 CreateTextureFile(texture, fullName);
@@ -963,8 +965,7 @@ namespace Stride.Importer.ThreeD
             fixed (byte* bufferPointer = buffer)
             {
                 var sourcePointer = (byte*)texture->PcData;
-       System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(bufferPointer, sourcePointer, (uint)arraySize);
-
+                System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(bufferPointer, sourcePointer, arraySize);
             }
             System.IO.File.WriteAllBytes(path, buffer);
         }


### PR DESCRIPTION
# PR Details

Adds Noahs Fix for a regression where the AssImp library didnt import FBX embedded textures.

## Description

Tested importing FBX file with embeeded textures [here](https://www.turbosquid.com/3d-models/emily-blender-2157992)
![image](https://github.com/stride3d/stride/assets/73259914/3c0734fb-3351-4d30-a34a-3d5e59a82b7f)


## Related Issue

https://github.com/stride3d/stride/issues/2213

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
