### PR TITLE
fix: Use OperatingSystem.IsXyz instead of RuntimeInformation.IsOSPlatform

### DIFF
--- a/deps/Stride.GitVersioning/Nerdbank.GitVersioning/GitExtensions.cs
+++ b/deps/Stride.GitVersioning/Nerdbank.GitVersioning/GitExtensions.cs
@@ -343,15 +343,15 @@ namespace Nerdbank.GitVersioning
         /// <returns>Receives the directory that native binaries are expected.</returns>
         public static string FindLibGit2NativeBinaries(string basePath)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return Path.Combine(basePath, "lib", "win32", IntPtr.Size == 4 ? "x86" : "x64");
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return Path.Combine(basePath, "lib", "linux", IntPtr.Size == 4 ? "x86" : "x86_64");
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return Path.Combine(basePath, "lib", "osx");
             }

--- a/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSessionPublicHelper.cs
@@ -117,7 +117,7 @@ namespace Stride.Core.Assets
                 .GetField("CurrentHost", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             if (currentHostField != null)
             {
-                currentHostField.SetValue(null, Path.Combine(new DirectoryInfo(dotNetSdkPath).Parent.Parent.FullName, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet"));
+                currentHostField.SetValue(null, Path.Combine(new DirectoryInfo(dotNetSdkPath).Parent.Parent.FullName, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet"));
             }
         }
 

--- a/sources/core/Stride.Core/Platform.cs
+++ b/sources/core/Stride.Core/Platform.cs
@@ -19,24 +19,16 @@ namespace Stride.Core
         /// The current running <see cref="PlatformType"/>.
         /// </summary>
         public static readonly PlatformType Type = PlatformType.UWP;
-#elif STRIDE_PLATFORM_ANDROID
-        /// <summary>
-        /// The current running <see cref="PlatformType"/>.
-        /// </summary>
-        public static readonly PlatformType Type = PlatformType.Android;
-#elif STRIDE_PLATFORM_IOS
-        /// <summary>
-        /// The current running <see cref="PlatformType"/>.
-        /// </summary>
-        public static readonly PlatformType Type = PlatformType.iOS;
 #else
         /// <summary>
         /// The current running <see cref="PlatformType"/>.
         /// </summary>
         public static readonly PlatformType Type
-            = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? PlatformType.Windows
-            : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? PlatformType.Linux
-            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? PlatformType.macOS
+            = OperatingSystem.IsWindows() ? PlatformType.Windows
+            : OperatingSystem.IsLinux()  ? PlatformType.Linux
+            : OperatingSystem.IsMacOS() ? PlatformType.macOS
+            : OperatingSystem.IsAndroid() ? PlatformType.Android
+            : OperatingSystem.IsIOS() ? PlatformType.iOS
             : PlatformType.Windows; // For now we use Windows as fallback, but it might be better to throw an exception?
 #endif
 


### PR DESCRIPTION
# PR Details


## Description

PR replaces all occurrences of IsOSPlatform in favor of the more modern OperatingSystem.IsXyz available in NET5+.
## Related Issue

None

## Motivation and Context

The main motivation is less preprocessor directives and modernizing the code. In theory, methods should be faster because they are constants

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
