### PR TITLE
fix: Update Texture reload to prevent crash due to wrong type.

### DIFF
--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -405,15 +405,8 @@ namespace Stride.Core.Serialization.Contents
         
         public Type GetType(string url)
         {
-            if(LoadedAssetUrls.TryGetValue(url, out var reference))
-            {
-                if (reference.Object != null)
-                {
-                    return reference.Object.GetType();
-                }
-            }
-
-            return null;
+            _ = LoadedAssetUrls.TryGetValue(url, out var reference);
+            return reference.Object?.GetType();
         }
 
         internal Reference FindDeserializedObject(string url, Type objType)

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -402,6 +402,19 @@ namespace Stride.Core.Serialization.Contents
 
             return result;
         }
+        
+        public Type GetType(string url)
+        {
+            if(LoadedAssetUrls.TryGetValue(url, out var reference))
+            {
+                if (reference.Object != null)
+                {
+                    return reference.Object.GetType();
+                }
+            }
+
+            return null;
+        }
 
         internal Reference FindDeserializedObject(string url, Type objType)
         {

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -402,11 +402,17 @@ namespace Stride.Core.Serialization.Contents
 
             return result;
         }
-        
-        public Type GetType(string url)
+
+        public bool TryGetLoadedAsset(string url, out object asset)
         {
-            _ = LoadedAssetUrls.TryGetValue(url, out var reference);
-            return reference.Object?.GetType();
+            if (LoadedAssetUrls.TryGetValue(url, out var reference))
+            {
+                asset = reference.Object;
+                return true;
+            }
+
+            asset = null;
+            return false;
         }
 
         internal Reference FindDeserializedObject(string url, Type objType)

--- a/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
@@ -46,9 +46,13 @@ namespace Stride.Graphics.Data
                             {
                                 var assetManager = services.GetService<ContentManager>();
                                 assetManager.TryGetAssetUrl(graphicsResource, out var url);
-                                var textureDataReloaded = assetManager.Load<Image>(url);
-                                ((Texture)graphicsResource).Recreate(textureDataReloaded.ToDataBox());
-                                assetManager.Unload(textureDataReloaded);
+
+                                if (assetManager.GetType(url) == typeof(Image))
+                                {
+                                    var textureDataReloaded = assetManager.Load<Image>(url);
+                                    ((Texture)graphicsResource).Recreate(textureDataReloaded.ToDataBox());
+                                    assetManager.Unload(textureDataReloaded);
+                                }
                             };
                         }
                     }

--- a/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
@@ -53,6 +53,12 @@ namespace Stride.Graphics.Data
                                     ((Texture)graphicsResource).Recreate(textureDataReloaded.ToDataBox());
                                     assetManager.Unload(textureDataReloaded);
                                 }
+                                if(assetManager.GetType(url) == typeof(Texture))
+                                {
+                                    var textureDataReloaded = assetManager.Load<Texture>(url);
+                                    ((Texture)graphicsResource).Recreate();
+                                    assetManager.Unload(textureDataReloaded);
+                                }
                             };
                         }
                     }

--- a/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
@@ -53,7 +53,7 @@ namespace Stride.Graphics.Data
                                     ((Texture)graphicsResource).Recreate(image.ToDataBox());
                                     assetManager.Unload(textureDataReloaded);
                                 }
-                                if (textureDataReloaded is Texture)
+                                else if (textureDataReloaded is Texture)
                                 {
                                     ((Texture)graphicsResource).Recreate();
                                     assetManager.Unload(textureDataReloaded);

--- a/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureContentSerializer.cs
@@ -46,16 +46,15 @@ namespace Stride.Graphics.Data
                             {
                                 var assetManager = services.GetService<ContentManager>();
                                 assetManager.TryGetAssetUrl(graphicsResource, out var url);
+                                var textureDataReloaded = assetManager.Load<object>(url);
 
-                                if (assetManager.GetType(url) == typeof(Image))
+                                if (textureDataReloaded is Image image)
                                 {
-                                    var textureDataReloaded = assetManager.Load<Image>(url);
-                                    ((Texture)graphicsResource).Recreate(textureDataReloaded.ToDataBox());
+                                    ((Texture)graphicsResource).Recreate(image.ToDataBox());
                                     assetManager.Unload(textureDataReloaded);
                                 }
-                                if(assetManager.GetType(url) == typeof(Texture))
+                                if (textureDataReloaded is Texture)
                                 {
-                                    var textureDataReloaded = assetManager.Load<Texture>(url);
                                     ((Texture)graphicsResource).Recreate();
                                     assetManager.Unload(textureDataReloaded);
                                 }


### PR DESCRIPTION
# PR Details

when reloading a Texture it would try to pass in a value of type Image to the content manager for an asset that of type Texture.

## Description

This adds a new method to the Content loader to check the type of an asset from the URL.

This also adds that check to the Texture class to determine how it should be treated when reloading.

## Related Issue

https://github.com/stride3d/stride/issues/2008
https://github.com/stride3d/stride/issues/1493

## Motivation and Context

Its the start of a fix for a seemingly larger problem with disposing of the graphics device when the game is in fullscreen.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
