### PR TITLE
Fix crash on exit for fullscreen

### DIFF
--- a/sources/engine/Stride.Games/Desktop/GameForm.cs
+++ b/sources/engine/Stride.Games/Desktop/GameForm.cs
@@ -156,6 +156,8 @@ namespace Stride.Games
         /// </summary>
         public event EventHandler<EventArgs> FullscreenToggle;
 
+        public event EventHandler<EventArgs> DisableFullScreen;
+
         protected bool enableFullscreenToggle = true;
 
         /// <summary>
@@ -290,6 +292,11 @@ namespace Stride.Games
             FullscreenToggle?.Invoke(this, e);
         }
 
+        private void OnDisableFullScreen(EventArgs e)
+        {
+            DisableFullScreen?.Invoke(this, e);
+        }
+
         protected override void OnClientSizeChanged(EventArgs e)
         {
             base.OnClientSizeChanged(e);
@@ -371,7 +378,7 @@ namespace Stride.Games
                         //also remove full screen if this is the case
                         if (IsFullScreen && !isSwitchingFullScreen) //exit full screen on alt-tab if in fullscreen
                         {
-                            OnFullscreenToggle(new EventArgs());
+                            OnDisableFullScreen(new EventArgs());
                         }
                     }
                     break;

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -157,6 +157,7 @@ namespace Stride.Games
                 //gameForm.AppDeactivated += OnDeactivated;
                 gameForm.UserResized += OnClientSizeChanged;
                 gameForm.FullscreenToggle += OnFullscreenToggle;
+                gameForm.DisableFullScreen += OnDisableFullScreen;
                 gameForm.FormClosing += OnClosing;
             }
             else

--- a/sources/engine/Stride.Games/GameBase.cs
+++ b/sources/engine/Stride.Games/GameBase.cs
@@ -996,8 +996,11 @@ namespace Stride.Games
 
         private void GraphicsDeviceService_DeviceReset(object sender, EventArgs e)
         {
-            resumeManager.OnReload();
-            resumeManager.OnRecreate();
+            if (!IsExiting)
+            {
+                resumeManager.OnReload();
+                resumeManager.OnRecreate();
+            }
         }
 
         private void GraphicsDeviceService_DeviceResetting(object sender, EventArgs e)

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -304,6 +304,16 @@ namespace Stride.Games
             IsFullscreen = !IsFullscreen;
         }
 
+        protected void OnDisableFullScreen(object source, EventArgs e)
+        {
+            IsFullscreen = false;
+        }
+
+        protected void EnableFullscreen(object source, EventArgs e)
+        {
+            IsFullscreen = true;
+        }
+
         protected void OnClosing(object source, EventArgs e)
         {
             var handler = Closing;

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -591,9 +591,6 @@ namespace Stride.Games
             {
                 if (GraphicsDevice.Presenter != null)
                 {
-                    // Make sure that the Presenter is reverted to window before shuting down
-                    // otherwise the Direct3D11.Device will generate an exception on Dispose()
-                    GraphicsDevice.Presenter.IsFullScreen = false;
                     GraphicsDevice.Presenter.Dispose();
                     GraphicsDevice.Presenter = null;
                 }

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -630,19 +630,19 @@ namespace Stride.Games
         {
             // Setup preferred parameters before passing them to the factory
             var preferredParameters = new GameGraphicsParameters
-                {
-                    PreferredBackBufferWidth = PreferredBackBufferWidth,
-                    PreferredBackBufferHeight = PreferredBackBufferHeight,
-                    PreferredBackBufferFormat = PreferredBackBufferFormat,
-                    PreferredDepthStencilFormat = PreferredDepthStencilFormat,
-                    PreferredRefreshRate = PreferredRefreshRate,
-                    PreferredFullScreenOutputIndex = PreferredFullScreenOutputIndex,
-                    IsFullScreen = IsFullScreen,
-                    PreferredMultisampleCount = PreferredMultisampleCount,
-                    SynchronizeWithVerticalRetrace = SynchronizeWithVerticalRetrace,
-                    PreferredGraphicsProfile = (GraphicsProfile[])PreferredGraphicsProfile.Clone(),
-                    ColorSpace = PreferredColorSpace,
-                    RequiredAdapterUid = RequiredAdapterUid,
+            {
+                PreferredBackBufferWidth = PreferredBackBufferWidth,
+                PreferredBackBufferHeight = PreferredBackBufferHeight,
+                PreferredBackBufferFormat = PreferredBackBufferFormat,
+                PreferredDepthStencilFormat = PreferredDepthStencilFormat,
+                PreferredRefreshRate = PreferredRefreshRate,
+                PreferredFullScreenOutputIndex = PreferredFullScreenOutputIndex,
+                IsFullScreen = IsFullScreen,
+                PreferredMultisampleCount = PreferredMultisampleCount,
+                SynchronizeWithVerticalRetrace = SynchronizeWithVerticalRetrace,
+                PreferredGraphicsProfile = (GraphicsProfile[])PreferredGraphicsProfile.Clone(),
+                ColorSpace = PreferredColorSpace,
+                RequiredAdapterUid = RequiredAdapterUid,
             };
 
             // Remap to Srgb backbuffer if necessary
@@ -1028,7 +1028,7 @@ namespace Stride.Games
                         OnPreparingDeviceSettings(this, new PreparingDeviceSettingsEventArgs(graphicsDeviceInformation));
 
                         isFullScreen = graphicsDeviceInformation.PresentationParameters.IsFullScreen;
-                        game.Window.BeginScreenDeviceChange(graphicsDeviceInformation.PresentationParameters.IsFullScreen);
+                        game.Window.BeginScreenDeviceChange(isFullScreen);
                         isBeginScreenDeviceChange = true;
                         bool needToCreateNewDevice = true;
 
@@ -1051,7 +1051,7 @@ namespace Stride.Games
                                     GraphicsDevice.Presenter.Resize(newWidth, newHeight, newFormat);
 
                                     // Change full screen if needed
-                                    GraphicsDevice.Presenter.IsFullScreen = graphicsDeviceInformation.PresentationParameters.IsFullScreen;
+                                    GraphicsDevice.Presenter.IsFullScreen = isFullScreen;
 
                                     needToCreateNewDevice = false;
                                 }

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -239,7 +239,7 @@ namespace Stride.Graphics
             backBuffer.OnDestroyed();
             backBuffer.LifetimeState = GraphicsResourceLifetimeState.Destroyed;
 
-            swapChain.Dispose();
+            swapChain?.Dispose();
             swapChain = null;
 
             base.OnDestroyed();


### PR DESCRIPTION
# PR Details

Recreate was being called even when the game was exiting, causing disposed references to be called.

## Description

This adds a check on recreate if the game is exiting to skip the recreate function.

## Related Issue

https://github.com/stride3d/stride/issues/2008

## Motivation and Context

crash bad.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
