### PR TITLE
GitHub docs improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve.
+about: Create a bug report to help us improve Stride.
 title: ''
 labels: 'bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a bug report to help us improve.
 title: ''
 labels: 'bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Stride Docs
+    url: https://github.com/stride3d/stride-docs/issues
+    about: Please report documentation issues in the Stride Docs repository.
+
+  - name: Stride Website
+    url: https://github.com/stride3d/stride-website/issues
+    about: Please report website issues in the Stride Website repository.
+
+  - name: Stride Community Toolkit
+    url: https://github.com/stride3d/stride-community-toolkit/issues
+    about: Please report community toolkit issues in the Stride Community Toolkit repository.

--- a/.github/ISSUE_TEMPLATE/documentation_update.md
+++ b/.github/ISSUE_TEMPLATE/documentation_update.md
@@ -6,9 +6,6 @@ labels: 'area-Doc'
 assignees: ''
 ---
 
-> [!NOTE]
-> If you would like to address Stride Docs manual or tutorials, please create an issue at https://github.com/stride3d/stride-docs/issues.
-
 **Describe the update or improvement you would like to see**
 A clear and concise description of what you want to change or improve in the documentation.
 
@@ -24,4 +21,4 @@ Add any other context or screenshots about the documentation update here.
 **Proposed changes**
 If you have a specific change in mind, you can suggest the text or code snippet here.
 
-Thank you for helping improve Stride's documentation!
+<!--- Thank you for helping improve Stride's documentation! --->

--- a/.github/ISSUE_TEMPLATE/documentation_update.md
+++ b/.github/ISSUE_TEMPLATE/documentation_update.md
@@ -1,0 +1,27 @@
+---
+name: Documentation Update
+about: Suggest updates or improvements to XML comments (Stride API), README.md, or other documentation files.
+title: '[Docs] '
+labels: 'area-Doc'
+assignees: ''
+---
+
+> [!NOTE]
+> If you would like to address Stride Docs manual or tutorials, please create an issue at https://github.com/stride3d/stride-docs/issues.
+
+**Describe the update or improvement you would like to see**
+A clear and concise description of what you want to change or improve in the documentation.
+
+**Is this related to a specific part of the documentation?**
+Provide the file name(s) and section(s) if applicable (e.g., README.md, XML comments in XYZ.cs).
+
+**Why is this update needed?**
+Explain why this documentation update is important. How will it benefit the community or improve the project?
+
+**Additional context**
+Add any other context or screenshots about the documentation update here.
+
+**Proposed changes**
+If you have a specific change in mind, you can suggest the text or code snippet here.
+
+Thank you for helping improve Stride's documentation!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for this project.
 title: ''
 labels: 'enhancement'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,11 +20,12 @@ A clear and concise description of any alternative solutions or features you've 
 Add any other context or screenshots about the feature request here.
 
 Here are some questions that can aid in the description of the feature request:
-- What are the usecases?
-- What kind of options/settings are expected/wanted?
+
+- What are the use cases?
+- What kind of options or settings are expected or wanted?
 - What would the (pseudo) code look like?
-- Is the feature affecting behaviour in the editor? 
-  - if so: how should this look in the editor?
-- Is there a component or datastructure? 
-- what kind of documentation is needed or needs to be updated?
+- Does the feature affect behavior in the editor?
+  - If so, how should this look in the editor?
+- Is there a component or data structure involved?
+- What kind of documentation is needed or needs to be updated?
 - Should there be an example project?


### PR DESCRIPTION
# PR Details

GitHub issue templates improvements. Some grammar fixes and consistency fixes, including a new template for Docs and optional links to other repositories added.

## Description

GitHub issues don't have a template related to Stride engine docs referring to XML comments and any markup files updates.

## Related Issue

N/a

## Motivation and Context

Workflow improvements

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
