### PR TITLE
[Physics] Adding margins to convex hull colliders (Issue1577)

### DIFF
--- a/sources/engine/Stride.Assets/Physics/ColliderShapeAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Physics/ColliderShapeAssetCompiler.cs
@@ -135,6 +135,7 @@ namespace Stride.Assets.Physics
                     ConvexHullColliderShapeDesc convexHullDescClone = new ConvexHullColliderShapeDesc
                     {
                         Scaling = convexHullDesc.Scaling,
+                        Margin = convexHullDesc.Margin,
                         LocalOffset = convexHullDesc.LocalOffset,
                         LocalRotation = convexHullDesc.LocalRotation,
                         Decomposition = convexHullDesc.Decomposition,

--- a/sources/engine/Stride.Physics/ColliderShape.cs
+++ b/sources/engine/Stride.Physics/ColliderShape.cs
@@ -137,6 +137,12 @@ namespace Stride.Physics
         {
         }
 
+        public float Margin
+        {
+            get { return InternalShape.Margin; }
+            set { InternalShape.Margin = value; }
+        }
+
         public Matrix DebugPrimitiveMatrix;
 
         internal bool NeedsCustomCollisionCallback;

--- a/sources/engine/Stride.Physics/Data/ConvexHullColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/ConvexHullColliderShapeDesc.cs
@@ -50,6 +50,12 @@ namespace Stride.Physics
         public Vector3 Scaling = Vector3.One;
 
         /// <userdoc>
+        /// The Margin of the generated convex hull.
+        /// </userdoc>
+        [DataMember(48)]
+        public float Margin { get; set; }
+
+        /// <userdoc>
         /// If this is not checked, the contained parameters are ignored and only a simple convex hull of the model will be generated.
         /// </userdoc>
         [DataMember(50)]
@@ -84,6 +90,7 @@ namespace Stride.Physics
                     shape = new ConvexHullColliderShape(ConvexHulls[0][0], ConvexHullsIndices[0][0], Scaling)
                     {
                         NeedsCustomCollisionCallback = true,
+                        Margin = Margin,
                     };
 
                     //shape.UpdateLocalTransformations();
@@ -107,6 +114,7 @@ namespace Stride.Physics
                     if (indices.Count == 0) continue;
 
                     var subHull = new ConvexHullColliderShape(verts, indices, Scaling);
+                    subHull.Margin = Margin;
                     //subHull.UpdateLocalTransformations();
                     subCompound.AddChildShape(subHull);
                 }
@@ -134,6 +142,7 @@ namespace Stride.Physics
                     if (indices[0].Count == 0) continue;
 
                     var subHull = new ConvexHullColliderShape(verts[0], indices[0], Scaling);
+                    subHull.Margin = Margin;
                     //subHull.UpdateLocalTransformations();
                     compound.AddChildShape(subHull);
                 }

--- a/sources/engine/Stride.Physics/Data/ConvexHullColliderShapeDesc.cs
+++ b/sources/engine/Stride.Physics/Data/ConvexHullColliderShapeDesc.cs
@@ -51,9 +51,10 @@ namespace Stride.Physics
 
         /// <userdoc>
         /// The Margin of the generated convex hull.
+        /// Default = 0.04f
         /// </userdoc>
         [DataMember(48)]
-        public float Margin { get; set; }
+        public float Margin { get; set; } = 0.04f;
 
         /// <userdoc>
         /// If this is not checked, the contained parameters are ignored and only a simple convex hull of the model will be generated.


### PR DESCRIPTION
# PR Details

Allow specification of margin for collider shapes. Shows to be useful for ConvexHull colliders. 

## Description

Margin property now able to be set on ConvexHull collider shape. Added margin getter and setting vars onto ConvexHullColliderShape as well as the viewable field in the properties box for the user to adjust. The base class ColliderShape contains where margin is defined as recommened so all collider shapes can potentially benefit from the new variable.

## Related Issue

Link to issue: 
https://github.com/stride3d/stride/issues/1577

Link to initial discussion: 
https://github.com/stride3d/stride/discussions/1574

## Motivation and Context

Originally reported as a missing field that solves an issue related to a test project not being able to adjust the corresponding collider. This margin not being able to be adjusted was causing unintended collisions and not allowing the user to be able to properly set up their ConvexHullCollider properties to fix the problem in the property box.

For additonal testing, I made a fork of the users orignal project that showcases the issue here: 
https://github.com/dloe/StrideEngineIssue1577_RigidBodyPhysicsBugProject

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] **I have built and run the editor to try this change out.**
