### PR TITLE
Added IsPressed, IsDown, & IsReleased for virtual buttons to Inputmanager

### DIFF
--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -481,7 +481,19 @@ namespace Stride.Input
                 pair.Value.Listeners.Remove(listener);
             }
         }
-        
+
+        /// <summary>
+        /// Gets a binding value for the specified name and the specified config extract from the current <see cref="VirtualButtonConfigSet"/>.
+        /// </summary>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="bindingName">Name of the binding.</param>
+        /// <returns>The value of the binding.</returns>
+        [Obsolete("This method is obsolete. Call GetVirtualButtonValue instead.")]
+        public virtual float GetVirtualButton(int configIndex, object bindingName)
+        {
+            return GetVirtualButtonValue(configIndex, bindingName);
+        }
+
         /// <summary>
         /// Gets a binding value for the specified name and the specified config extract from the current <see cref="VirtualButtonConfigSet"/>.
         /// </summary>

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -18,6 +18,25 @@ namespace Stride.Input
     /// </summary>
     public partial class InputManager : ComponentBase
     {
+        /// <summary>
+        /// The state of each Virtualbutton in a config.
+        /// </summary>
+        private class VirtualButtonsState
+        {
+            public Dictionary<object, float> Values { get; } = new Dictionary<object, float>();
+            public Dictionary<object, bool> Pressed { get; } = new Dictionary<object, bool>();
+            public Dictionary<object, bool> Down { get; } = new Dictionary<object, bool>();
+            public Dictionary<object, bool> Released { get; } = new Dictionary<object, bool>();
+
+            public void Clear()
+            {
+                Values.Clear();
+                Pressed.Clear();
+                Down.Clear();
+                Released.Clear();
+            }
+        }
+        
         //this is used in some mobile platform for accelerometer stuff
         internal const float G = 9.81f;
         internal const float DesiredSensorUpdateRate = 60;
@@ -35,7 +54,7 @@ namespace Stride.Input
         private readonly List<GestureEvent> currentGestureEvents = new List<GestureEvent>();
 
         private readonly Dictionary<GestureConfig, GestureRecognizer> gestureConfigToRecognizer = new Dictionary<GestureConfig, GestureRecognizer>();
-        private readonly List<Dictionary<object, float>> virtualButtonValues = new List<Dictionary<object, float>>();
+        private readonly List<VirtualButtonsState> virtualButtonStates = new List<VirtualButtonsState>();
 
         // Mapping of device guid to device
         private readonly Dictionary<Guid, IInputDevice> devicesById = new Dictionary<Guid, IInputDevice>();
@@ -433,7 +452,7 @@ namespace Stride.Input
             }
 
             // Update virtual buttons
-            UpdateVirtualButtonValues();
+            UpdateVirtualButtonStates();
 
             // Update gestures
             UpdateGestureEvents(gameTime.Elapsed);
@@ -466,19 +485,69 @@ namespace Stride.Input
         /// <summary>
         /// Gets a binding value for the specified name and the specified config extract from the current <see cref="VirtualButtonConfigSet"/>.
         /// </summary>
-        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/></param>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
         /// <param name="bindingName">Name of the binding.</param>
         /// <returns>The value of the binding.</returns>
-        public virtual float GetVirtualButton(int configIndex, object bindingName)
+        public virtual float GetVirtualButtonValue(int configIndex, object bindingName)
         {
-            if (VirtualButtonConfigSet == null || configIndex < 0 || configIndex >= virtualButtonValues.Count)
+            if (VirtualButtonConfigSet == null || configIndex < 0 || configIndex >= virtualButtonStates.Count)
             {
                 return 0.0f;
             }
-
-            float value;
-            virtualButtonValues[configIndex].TryGetValue(bindingName, out value);
+            
+            virtualButtonStates[configIndex].Values.TryGetValue(bindingName, out float value);
             return value;
+        }
+
+        /// <summary>
+        /// Determines whether the specified binding in the specified config in the current <see cref="VirtualButtonConfigSet"/> was pressed since the previous Update. 
+        /// </summary>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="bindingName">Name of the binding.</param>
+        /// <returns><c>true</c> if the binding was pressed; otherwise, <c>false</c>.</returns>
+        public virtual bool IsVirtualButtonPressed(int configIndex, object bindingName)
+        {
+            if (VirtualButtonConfigSet == null || configIndex < 0 || configIndex >= virtualButtonStates.Count)
+            {
+                return false;
+            }
+            
+            virtualButtonStates[configIndex].Pressed.TryGetValue(bindingName, out bool isPressed);
+            return isPressed;
+        }
+        
+        /// <summary>
+        /// Determines whether the specified binding in the specified config in the current <see cref="VirtualButtonConfigSet"/> is currently pressed down. 
+        /// </summary>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="bindingName">Name of the binding.</param>
+        /// <returns><c>true</c> if the binding is currently pressed down; otherwise, <c>false</c>.</returns>
+        public virtual bool IsVirtualButtonDown(int configIndex, object bindingName)
+        {
+            if (VirtualButtonConfigSet == null || configIndex < 0 || configIndex >= virtualButtonStates.Count)
+            {
+                return false;
+            }
+            
+            virtualButtonStates[configIndex].Down.TryGetValue(bindingName, out bool isDown);
+            return isDown;
+        }
+        
+        /// <summary>
+        /// Determines whether the specified binding in the specified config in the current <see cref="VirtualButtonConfigSet"/> was released since the previous Update. 
+        /// </summary>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="bindingName">Name of the binding.</param>
+        /// <returns><c>true</c> if the binding was released; otherwise, <c>false</c>.</returns>
+        public virtual bool IsVirtualButtonReleased(int configIndex, object bindingName)
+        {
+            if (VirtualButtonConfigSet == null || configIndex < 0 || configIndex >= virtualButtonStates.Count)
+            {
+                return false;
+            }
+            
+            virtualButtonStates[configIndex].Released.TryGetValue(bindingName, out bool isReleased);
+            return isReleased;
         }
 
         /// <summary>
@@ -901,33 +970,38 @@ namespace Stride.Input
             }
         }
 
-        private void UpdateVirtualButtonValues()
+        private void UpdateVirtualButtonStates()
         {
-            if (VirtualButtonConfigSet != null)
+            if (VirtualButtonConfigSet == null)
             {
-                for (int i = 0; i < VirtualButtonConfigSet.Count; i++)
+                return;
+            }
+
+            for (int i = 0; i < VirtualButtonConfigSet.Count; i++)
+            {
+                var config = VirtualButtonConfigSet[i];
+
+                VirtualButtonsState configState;
+                if (i == virtualButtonStates.Count)
                 {
-                    var config = VirtualButtonConfigSet[i];
+                    configState = new VirtualButtonsState();
+                    virtualButtonStates.Add(configState);
+                }
+                else
+                {
+                    configState = virtualButtonStates[i];
+                }
 
-                    Dictionary<object, float> mapNameToValue;
-                    if (i == virtualButtonValues.Count)
-                    {
-                        mapNameToValue = new Dictionary<object, float>();
-                        virtualButtonValues.Add(mapNameToValue);
-                    }
-                    else
-                    {
-                        mapNameToValue = virtualButtonValues[i];
-                    }
+                configState.Clear();
 
-                    mapNameToValue.Clear();
-
-                    if (config != null)
+                if (config != null)
+                {
+                    foreach (object name in config.BindingNames)
                     {
-                        foreach (var name in config.BindingNames)
-                        {
-                            mapNameToValue[name] = config.GetValue(this, name);
-                        }
+                        configState.Values[name] = config.GetValue(this, name);
+                        configState.Pressed[name] = config.IsPressed(this, name);
+                        configState.Down[name] = config.IsDown(this, name);
+                        configState.Released[name] = config.IsReleased(this, name);
                     }
                 }
             }

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonBinding.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonBinding.cs
@@ -46,6 +46,33 @@ namespace Stride.Input
             return Button != null ? Button.GetValue(manager) : 0.0f;
         }
 
+        /// <summary>
+        /// Gets the pressed state for a particular binding.
+        /// </summary>
+        /// <returns><c>true</c> when pressed since the last frame; otherwise, <c>false</c>.</returns>
+        public virtual bool IsPressed(InputManager manager)
+        {
+            return Button != null ? Button.IsPressed(manager) : false;
+        }
+        
+        /// <summary>
+        /// Gets the held down state for a particular binding.
+        /// </summary>
+        /// <returns><c>true</c> when currently held down; otherwise, <c>false</c>.</returns>
+        public virtual bool IsDown(InputManager manager)
+        {
+            return Button != null ? Button.IsDown(manager) : false;
+        }
+        
+        /// <summary>
+        /// Gets the pressed state for a particular binding.
+        /// </summary>
+        /// <returns><c>true</c> when released since the last frame; otherwise, <c>false</c>.</returns>
+        public virtual bool IsReleased(InputManager manager)
+        {
+            return Button != null ? Button.IsReleased(manager) : false;
+        }
+
         public override string ToString()
         {
             return string.Format("[{0}] => {1}", Name, Button);

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
@@ -38,8 +38,7 @@ namespace Stride.Input
         public virtual float GetValue(InputManager inputManager, object name)
         {
             float value = 0.0f;
-            List<VirtualButtonBinding> bindingsPerName;
-            if (mapBindings.TryGetValue(name, out bindingsPerName))
+            if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
             {
                 foreach (var virtualButtonBinding in bindingsPerName)
                 {
@@ -52,6 +51,54 @@ namespace Stride.Input
             }
 
             return value;
+        }
+
+        public virtual bool IsPressed(InputManager inputManager, object name)
+        {
+            if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
+            {
+                foreach (var virtualButtonBinding in bindingsPerName)
+                {
+                    if (virtualButtonBinding.IsPressed(inputManager))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+        
+        public virtual bool IsReleased(InputManager inputManager, object name)
+        {
+            if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
+            {
+                foreach (var virtualButtonBinding in bindingsPerName)
+                {
+                    if (virtualButtonBinding.IsReleased(inputManager))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+        
+        public virtual bool IsDown(InputManager inputManager, object name)
+        {
+            if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
+            {
+                foreach (var virtualButtonBinding in bindingsPerName)
+                {
+                    if (virtualButtonBinding.IsDown(inputManager))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private void Bindings_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
@@ -35,6 +35,10 @@ namespace Stride.Input
             }
         }
 
+        /// <summary>
+        /// Gets the value for a particular binding.
+        /// </summary>
+        /// <returns>Value of the binding</returns>
         public virtual float GetValue(InputManager inputManager, object name)
         {
             float value = 0.0f;
@@ -53,6 +57,10 @@ namespace Stride.Input
             return value;
         }
 
+        /// <summary>
+        /// Gets the pressed state for a particular binding.
+        /// </summary>
+        /// <returns><c>true</c> when pressed since the last frame; otherwise, <c>false</c>.</returns>
         public virtual bool IsPressed(InputManager inputManager, object name)
         {
             if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
@@ -69,13 +77,17 @@ namespace Stride.Input
             return false;
         }
         
-        public virtual bool IsReleased(InputManager inputManager, object name)
+        /// <summary>
+        /// Gets the held down state for a particular binding.
+        /// </summary>
+        /// <returns><c>true</c> when currently held down; otherwise, <c>false</c>.</returns>
+        public virtual bool IsDown(InputManager inputManager, object name)
         {
             if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
             {
                 foreach (var virtualButtonBinding in bindingsPerName)
                 {
-                    if (virtualButtonBinding.IsReleased(inputManager))
+                    if (virtualButtonBinding.IsDown(inputManager))
                     {
                         return true;
                     }
@@ -85,13 +97,17 @@ namespace Stride.Input
             return false;
         }
         
-        public virtual bool IsDown(InputManager inputManager, object name)
+        /// <summary>
+        /// Gets the pressed state for a particular binding.
+        /// </summary>
+        /// <returns><c>true</c> when released since the last frame; otherwise, <c>false</c>.</returns>
+        public virtual bool IsReleased(InputManager inputManager, object name)
         {
             if (mapBindings.TryGetValue(name, out List<VirtualButtonBinding> bindingsPerName))
             {
                 foreach (var virtualButtonBinding in bindingsPerName)
                 {
-                    if (virtualButtonBinding.IsDown(inputManager))
+                    if (virtualButtonBinding.IsReleased(inputManager))
                     {
                         return true;
                     }

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfigSet.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfigSet.cs
@@ -30,5 +30,38 @@ namespace Stride.Input
             var config = this[configIndex];
             return config != null ? config.GetValue(inputManager, name) : 0.0f;
         }
+
+        public virtual bool IsPressed(InputManager inputManager, int configIndex, object name)
+        {
+            if (configIndex < 0 || configIndex >= Count)
+            {
+                return false;
+            }
+
+            var config = this[configIndex];
+            return config != null ? config.IsPressed(inputManager, name) : false;
+        }
+        
+        public virtual bool IsDown(InputManager inputManager, int configIndex, object name)
+        {
+            if (configIndex < 0 || configIndex >= Count)
+            {
+                return false;
+            }
+
+            var config = this[configIndex];
+            return config != null ? config.IsDown(inputManager, name) : false;
+        }
+        
+        public virtual bool IsReleased(InputManager inputManager, int configIndex, object name)
+        {
+            if (configIndex < 0 || configIndex >= Count)
+            {
+                return false;
+            }
+
+            var config = this[configIndex];
+            return config != null ? config.IsReleased(inputManager, name) : false;
+        }
     }
 }

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfigSet.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfigSet.cs
@@ -20,6 +20,13 @@ namespace Stride.Input
         {
         }
 
+        /// <summary>
+        /// Gets a binding value for the specified name and the specified config extract from the <see cref="VirtualButtonConfigSet"/>.
+        /// </summary>
+        /// <param name="inputManager">The <see cref="InputManager"/> to used to get the device input.</param>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="name">Name of the binding.</param>
+        /// <returns>The value of the binding.</returns>
         public virtual float GetValue(InputManager inputManager, int configIndex, object name)
         {
             if (configIndex < 0 || configIndex >= Count)
@@ -31,6 +38,13 @@ namespace Stride.Input
             return config != null ? config.GetValue(inputManager, name) : 0.0f;
         }
 
+        /// <summary>
+        /// Determines whether the specified binding in the specified config in the <see cref="VirtualButtonConfigSet"/> was pressed since the previous Update. 
+        /// </summary>
+        /// <param name="inputManager">The <see cref="InputManager"/> to used to get device input.</param>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="name">Name of the binding.</param>
+        /// <returns><c>true</c> if the binding was pressed; otherwise, <c>false</c>.</returns>
         public virtual bool IsPressed(InputManager inputManager, int configIndex, object name)
         {
             if (configIndex < 0 || configIndex >= Count)
@@ -42,6 +56,13 @@ namespace Stride.Input
             return config != null ? config.IsPressed(inputManager, name) : false;
         }
         
+        /// <summary>
+        /// Determines whether the specified binding in the specified config in the <see cref="VirtualButtonConfigSet"/> is currently pressed down. 
+        /// </summary>
+        /// <param name="inputManager">The <see cref="InputManager"/> to used to get device input.</param>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="name">Name of the binding.</param>
+        /// <returns><c>true</c> if the binding is currently pressed down; otherwise, <c>false</c>.</returns>
         public virtual bool IsDown(InputManager inputManager, int configIndex, object name)
         {
             if (configIndex < 0 || configIndex >= Count)
@@ -53,6 +74,13 @@ namespace Stride.Input
             return config != null ? config.IsDown(inputManager, name) : false;
         }
         
+        /// <summary>
+        /// Determines whether the specified binding in the specified config in the <see cref="VirtualButtonConfigSet"/> was released since the previous Update. 
+        /// </summary>
+        /// <param name="inputManager">The <see cref="InputManager"/> to used to get device input.</param>
+        /// <param name="configIndex">An index to a <see cref="VirtualButtonConfig"/> stored in the <see cref="VirtualButtonConfigSet"/>.</param>
+        /// <param name="name">Name of the binding.</param>
+        /// <returns><c>true</c> if the binding was released; otherwise, <c>false</c>.</returns>
         public virtual bool IsReleased(InputManager inputManager, int configIndex, object name)
         {
             if (configIndex < 0 || configIndex >= Count)


### PR DESCRIPTION
# PR Details

Added `IsVirtualButtonPressed`/`Down`/`Released` methods to the InputManager and surrounding classes.

## Description

Added `IsVirtualButtonPressed`, `IsVirtualButtonDown` and `IsVirtualButtonReleased` methods to the `InputManager`, mirroring the `GetVirtualButton` method.  Added `IsPressed` .etc methods to `VirtualButtonBinding`, `VirtualButtonConfig` and `VirtualButtonSet`. Again, mirring the `GetValue` methods.

Renamed `GetVirtualButton` to `GetVirtualButtonValue`.

## Motivation and Context

Allows pressed, down, and release states to be used with VirtualButtons from the InputManager.

Renamed  `GetVirtualButton` to `GetVirtualButtonValue` since now that there are more `VirtualButton` methods it was confusing as to what it was doing (not actually getting a VirtualButton, but reading a input value from one). And matches the termonoligy in the rest of the API were it is refered to by `GetValue`.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
