### PR TITLE
Revert "Add ToOSPath() for msdfgen executable" to fix compilation error

### DIFF
--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontImporter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontImporter.cs
@@ -129,7 +129,7 @@ namespace Stride.Assets.SpriteFont.Compiler
                 return;
 
             // Get the msdfgen.exe location
-            var msdfgen = ToolLocator.LocateTool("msdfgen").ToOSPath() ?? throw new AssetException("Failed to compile a font asset, msdfgen was not found.");
+            var msdfgen = ToolLocator.LocateTool("msdfgen") ?? throw new AssetException("Failed to compile a font asset, msdfgen was not found.");
 
             msdfgenExe = msdfgen.FullPath;
             tempDir = $"{Environment.GetEnvironmentVariable("TEMP")}\\";


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reverts 3a9b4d6a5a2e3ef4d51c6cc408074bd4491572c3 ("Adjust ToolLocator for all platforms") to fix a compilation error.

## Related Issue
None.

## Motivation and Context
Fixed a compilation error caused by https://github.com/stride3d/stride/pull/2142/commits/3a9b4d6a5a2e3ef4d51c6cc408074bd4491572c3 (https://github.com/stride3d/stride/pull/2142)

## Types of changes

- [N/A] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [N/A] My change requires a change to the documentation.
- [N/A] I have added tests to cover my changes.
- [?] All new and existing tests passed. (Not sure, but it could fix "Windows D3D11" and "Tests Windows Simple"). 
- [x] **I have built and run the editor to try this change out.**
