### PR TITLE
fix: VS component check should only be performed for Win OS

### DIFF
--- a/sources/engine/Stride.Assets/StrideConfig.cs
+++ b/sources/engine/Stride.Assets/StrideConfig.cs
@@ -235,6 +235,8 @@ namespace Stride.Assets
         /// <returns>true if any of the components in the dictionary are available, false otherwise</returns>
         internal static bool IsVSComponentAvailableAnyVersion(IDictionary<Version, string> vsVersionToComponent)
         {
+            if (!OperatingSystem.IsWindows()) 
+                return false;
             if (vsVersionToComponent == null) { throw new ArgumentNullException("vsVersionToComponent"); }
 
             foreach (var pair in vsVersionToComponent)


### PR DESCRIPTION
# PR Details

## Description

IsVSComponentAvailableAnyVersion method currently may throw exception if executed on platform other than Windows - this prevents AssetCompilerApp from running e.g. on Linux.

## Motivation and Context

This PR is a part of making AssetCompiler crossplatform.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
