### PR TITLE
fix: Get correct PackageCompiler.SdkDirectory for all platforms

### DIFF
--- a/sources/assets/Stride.Core.Assets/Compiler/PackageCompiler.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/PackageCompiler.cs
@@ -19,12 +19,16 @@ namespace Stride.Core.Assets.Compiler
 
         static PackageCompiler()
         {
+            SdkDirectory = GetSdkDirectory();
+        }
+
+        private static string GetSdkDirectory()
+        {
             // Compute StrideSdkDir from this assembly
-            // TODO Move this code to a reusable method
             var codeBase = typeof(PackageCompiler).Assembly.Location;
-            var uri = new UriBuilder(codeBase);
-            var path = Path.GetDirectoryName(Uri.UnescapeDataString(uri.Path));
-            SdkDirectory = Path.GetFullPath(Path.Combine(path, @"..\.."));
+            // from ../bin/Debug/net{version} -> ../bin
+            var path = Path.GetDirectoryName(codeBase);
+            return Path.GetFullPath(Path.Combine(path, $"..{Path.DirectorySeparatorChar}.."));
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details
 
## Description

PR simplifies getting correct SdkDirectory path. The previous way of moving folders two up, used `UriBuilder`, but it threw an exception on Unix systems

## Motivation and Context

This PR is a part of making AssetCompiler crossplatform.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
