### PR TITLE
[Tests] Added new Test Case for ContentManager

### DIFF
--- a/sources/core/Stride.Core.Tests/TestContentManager.cs
+++ b/sources/core/Stride.Core.Tests/TestContentManager.cs
@@ -168,6 +168,27 @@ namespace Stride.Core.Tests
         }
 
         [Fact]
+        public void VerifyLoadedData()
+        {
+            var b1 = new B();
+            b1.A = new A { I = 18 };
+
+            var databaseProvider = CreateDatabaseProvider();
+            var assetManager1 = new ContentManager(databaseProvider);
+            var assetManager2 = new ContentManager(databaseProvider);
+
+            assetManager1.Save("test", b1);
+            var b2 = assetManager2.Load<B>("test");
+
+            //verify asset is loaded
+            Assert.True(assetManager2.IsLoaded("test"));
+
+            //verify the b2 object matches the url lookup and returns true
+            Assert.True(assetManager2.TryGetAssetUrl(b2, out var url));
+            Assert.Equal("test", url);
+        }
+
+        [Fact]
         public void SimpleSaveData()
         {
             var b1 = new B();

--- a/sources/core/Stride.Core.Tests/TestContentManager.cs
+++ b/sources/core/Stride.Core.Tests/TestContentManager.cs
@@ -177,15 +177,16 @@ namespace Stride.Core.Tests
             var assetManager1 = new ContentManager(databaseProvider);
             var assetManager2 = new ContentManager(databaseProvider);
 
-            assetManager1.Save("test", b1);
-            var b2 = assetManager2.Load<B>("test");
+            string b1Name = "test";
+            assetManager1.Save(b1Name, b1);
+            var b2 = assetManager2.Load<B>(b1Name);
 
             //verify asset is loaded
-            Assert.True(assetManager2.IsLoaded("test"));
+            Assert.True(assetManager2.IsLoaded(b1Name));
 
             //verify the b2 object matches the url lookup and returns true
-            Assert.True(assetManager2.TryGetAssetUrl(b2, out var url));
-            Assert.Equal("test", url);
+            Assert.True(assetManager2.TryGetAssetUrl(b2, out var urlResult));
+            Assert.Equal(b1Name, urlResult);
         }
 
         [Fact]


### PR DESCRIPTION
Tests saved object verification for use of isLoaded and TryGetAssetUrl functions.

# PR Details

Noticed that coverage in ContentManager required more test cases. Aimed at making a test case to increase coverage.

## Description

Added a test case named VerifyLoadedData that creates Test Classes B and A, the normal databaseProvider class as well as 2 assetManagers. We then save our B class with a urlName of "test". We then load this asset and check if the asset is properly loaded. After we run TryGetAssetUrl to lookup the B class object and verify the url output with the resulting urlName.

## Related Issue

None found.

## Motivation and Context

After some discussions in the discord, it was recommended to look in this area as a place to add more test cases for the existing test suite. Test coverage could be improved here.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
