### PR TITLE
fix: fullscreen and game exit windowing crashes

### DIFF
--- a/sources/engine/Stride.Games/Desktop/GameForm.cs
+++ b/sources/engine/Stride.Games/Desktop/GameForm.cs
@@ -156,6 +156,8 @@ namespace Stride.Games
         /// </summary>
         public event EventHandler<EventArgs> FullscreenToggle;
 
+        public event EventHandler<EventArgs> DisableFullScreen;
+
         protected bool enableFullscreenToggle = true;
 
         /// <summary>
@@ -290,6 +292,15 @@ namespace Stride.Games
             FullscreenToggle?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Raises the DisableFullScreen event
+        /// <Summary>
+        /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
+        private void OnDisableFullScreen(EventArgs e)
+        {
+            DisableFullScreen?.Invoke(this, e);
+        }
+
         protected override void OnClientSizeChanged(EventArgs e)
         {
             base.OnClientSizeChanged(e);
@@ -371,7 +382,7 @@ namespace Stride.Games
                         //also remove full screen if this is the case
                         if (IsFullScreen && !isSwitchingFullScreen) //exit full screen on alt-tab if in fullscreen
                         {
-                            OnFullscreenToggle(new EventArgs());
+                            OnDisableFullScreen(new EventArgs());
                         }
                     }
                     break;

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -157,6 +157,7 @@ namespace Stride.Games
                 //gameForm.AppDeactivated += OnDeactivated;
                 gameForm.UserResized += OnClientSizeChanged;
                 gameForm.FullscreenToggle += OnFullscreenToggle;
+                gameForm.DisableFullScreen += OnDisableFullScreen;
                 gameForm.FormClosing += OnClosing;
             }
             else

--- a/sources/engine/Stride.Games/GameBase.cs
+++ b/sources/engine/Stride.Games/GameBase.cs
@@ -996,8 +996,11 @@ namespace Stride.Games
 
         private void GraphicsDeviceService_DeviceReset(object sender, EventArgs e)
         {
-            resumeManager.OnReload();
-            resumeManager.OnRecreate();
+            if (!IsExiting)
+            {
+                resumeManager.OnReload();
+                resumeManager.OnRecreate();
+            }
         }
 
         private void GraphicsDeviceService_DeviceResetting(object sender, EventArgs e)

--- a/sources/engine/Stride.Games/GameContext.cs
+++ b/sources/engine/Stride.Games/GameContext.cs
@@ -78,7 +78,7 @@ namespace Stride.Games
         internal PixelFormat RequestedDepthStencilFormat;
 
         /// <summary>
-        /// THe requested graphics profiles.
+        /// The requested graphics profiles.
         /// </summary>
         internal GraphicsProfile[] RequestedGraphicsProfile;
 

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -304,6 +304,16 @@ namespace Stride.Games
             IsFullscreen = !IsFullscreen;
         }
 
+        protected void OnDisableFullScreen(object source, EventArgs e)
+        {
+            IsFullscreen = false;
+        }
+
+        protected void EnableFullscreen(object source, EventArgs e)
+        {
+            IsFullscreen = true;
+        }
+
         protected void OnClosing(object source, EventArgs e)
         {
             var handler = Closing;

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -309,11 +309,6 @@ namespace Stride.Games
             IsFullscreen = false;
         }
 
-        protected void EnableFullscreen(object source, EventArgs e)
-        {
-            IsFullscreen = true;
-        }
-
         protected void OnClosing(object source, EventArgs e)
         {
             var handler = Closing;

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -200,7 +200,7 @@ namespace Stride.Games
         }
 
         /// <summary>
-        /// Allow the GraphicsDeviceMagnager to set the actual window state after applying the device changes.
+        /// Allow the GraphicsDeviceManager to set the actual window state after applying the device changes.
         /// </summary>
         /// <param name="isReallyFullscreen"></param>
         internal void SetIsReallyFullscreen(bool isReallyFullscreen)

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -591,9 +591,6 @@ namespace Stride.Games
             {
                 if (GraphicsDevice.Presenter != null)
                 {
-                    // Make sure that the Presenter is reverted to window before shuting down
-                    // otherwise the Direct3D11.Device will generate an exception on Dispose()
-                    GraphicsDevice.Presenter.IsFullScreen = false;
                     GraphicsDevice.Presenter.Dispose();
                     GraphicsDevice.Presenter = null;
                 }

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -239,7 +239,7 @@ namespace Stride.Graphics
             backBuffer.OnDestroyed();
             backBuffer.LifetimeState = GraphicsResourceLifetimeState.Destroyed;
 
-            swapChain?.Dispose();
+            swapChain.Dispose();
             swapChain = null;
 
             base.OnDestroyed();

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -239,7 +239,7 @@ namespace Stride.Graphics
             backBuffer.OnDestroyed();
             backBuffer.LifetimeState = GraphicsResourceLifetimeState.Destroyed;
 
-            swapChain.Dispose();
+            swapChain?.Dispose();
             swapChain = null;
 
             base.OnDestroyed();

--- a/sources/engine/Stride.Graphics/ResumeManager.cs
+++ b/sources/engine/Stride.Graphics/ResumeManager.cs
@@ -105,9 +105,6 @@ namespace Stride.Graphics
 
         public void OnDestroyed()
         {
-            // Destroy presenter first (so that its backbuffer and render target are destroyed properly before other resources)
-            graphicsDevice.Presenter?.OnDestroyed();
-
             foreach (var resource in graphicsDevice.Resources)
             {
                 resource.OnDestroyed();


### PR DESCRIPTION
# PR Details

There were 2 different issues here. One was an issue with the OnToggle event causing the switch from fullscreen to windowed to be reset to true within the same call causing an exception.

The other issue was with the exit game call trying to recreate a disposed graphics device in the GameBase class.

## Related Issue

https://github.com/stride3d/stride/issues/2008
https://github.com/stride3d/stride/issues/1493

## Motivation and Context

Window changes shouldnt cause a crash.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
