### PR TITLE
fix: [Build] Rollback OperatingSystem.IsXYZ for net472 project

### DIFF
--- a/deps/Stride.GitVersioning/Nerdbank.GitVersioning/GitExtensions.cs
+++ b/deps/Stride.GitVersioning/Nerdbank.GitVersioning/GitExtensions.cs
@@ -343,15 +343,15 @@ namespace Nerdbank.GitVersioning
         /// <returns>Receives the directory that native binaries are expected.</returns>
         public static string FindLibGit2NativeBinaries(string basePath)
         {
-            if (OperatingSystem.IsWindows())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return Path.Combine(basePath, "lib", "win32", IntPtr.Size == 4 ? "x86" : "x64");
             }
-            if (OperatingSystem.IsLinux())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 return Path.Combine(basePath, "lib", "linux", IntPtr.Size == 4 ? "x86" : "x86_64");
             }
-            if (OperatingSystem.IsMacOS())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return Path.Combine(basePath, "lib", "osx");
             }


### PR DESCRIPTION
# PR Details
Those signatures don't exist in 472 and it prevents release.

## Related Issue
#2247 

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
