### PR TITLE
fix: [Graphics] Fix occasional overflow occuring when interfacing with fonts.

### DIFF
--- a/THIRD PARTY.md
+++ b/THIRD PARTY.md
@@ -19,7 +19,7 @@ Stride uses the following open-source products.
 * [Recast & Detour](https://github.com/recastnavigation/recastnavigation) (zlib License)
 * [SDL2](https://www.libsdl.org/) (zlib License)
 * [SharpDX](http://sharpdx.org/) (MIT License)
-* [SharpFont](https://github.com/Robmaister/SharpFont) (MIT License)
+* [SharpFont](https://github.com/vonderborch/SharpFont) (MIT License)
 * [Vortice.Vulkan](https://github.com/amerkoleci/Vortice.Vulkan) (MIT License)
 * [SharpYaml](https://github.com/xoofx/SharpYaml) (MIT License)
 * [SlimMath](https://code.google.com/p/slimmath/) (MIT License)

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.Sdl" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.19.0" />
-    <PackageVersion Include="Stride.SharpFont" Version="1.0.0" />
+    <PackageVersion Include="SharpFont.NetStandard" Version="1.0.5" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />

--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Silk.NET.OpenGLES.Extensions.EXT" />
     <PackageReference Include="Silk.NET.Sdl" />
     <PackageReference Include="Silk.NET.Windowing.Sdl" Condition="'$(TargetFramework)' == '$(StrideFrameworkAndroid)' Or '$(TargetFramework)' == '$(StrideFrameworkiOS)'" />
-    <PackageReference Include="Stride.SharpFont" />
+    <PackageReference Include="SharpFont.NetStandard" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="FrameworkResources.resx">


### PR DESCRIPTION
# PR Details
See title, this can often be seen when running tests like `TestDynamicSpriteFont`, more below.

## Related Issue
Similar to #1700
And https://github.com/Robmaister/SharpFont/issues/121 which is on the repo of the source we currently run on.
If you follow that issue you can see that it hasn't yet been addressed, thankfully [SharpFont.NetStandard](https://github.com/vonderborch/SharpFont) did.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
