### PR TITLE
fix: Repair Projectwatcher on Projects referencing each other

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
@@ -232,12 +232,16 @@ namespace Stride.Assets.Presentation.AssetEditors
 
                 var needProjectReload = string.Equals(trackedAssembly.Project.FilePath, changedFile, StringComparison.OrdinalIgnoreCase);
 
+
+                var directoryName = Path.GetDirectoryName(trackedAssembly.Project.FilePath) + "\\";
+                var changedFileDirectoryName = Path.GetDirectoryName(changedFile) + "\\";
+
                 // Also check for .cs file changes (DefaultItems auto import *.cs, with some excludes such as obj subfolder)
                 // TODO: Check actual unevaluated .csproj to get the auto includes/excludes?
                 if (needProjectReload == false
                     && ((e.ChangeType == FileEventChangeType.Deleted || e.ChangeType == FileEventChangeType.Renamed || e.ChangeType == FileEventChangeType.Created)
                     && Path.GetExtension(changedFile)?.ToLowerInvariant() == ".cs"
-                    && changedFile.StartsWith(Path.GetDirectoryName(trackedAssembly.Project.FilePath), StringComparison.OrdinalIgnoreCase)))
+                    && changedFileDirectoryName.StartsWith(directoryName, StringComparison.OrdinalIgnoreCase)))
                 {
                     needProjectReload = true;
                 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/ProjectWatcher.cs
@@ -232,8 +232,8 @@ namespace Stride.Assets.Presentation.AssetEditors
 
                 var needProjectReload = string.Equals(trackedAssembly.Project.FilePath, changedFile, StringComparison.OrdinalIgnoreCase);
 
-                var directoryName = Path.GetDirectoryName(trackedAssembly.Project.FilePath) + "\\";
-                var changedFileDirectoryName = Path.GetDirectoryName(changedFile) + "\\";
+                var directoryName = Path.GetDirectoryName(trackedAssembly.Project.FilePath) + Path.DirectorySeparatorChar;
+                var changedFileDirectoryName = Path.GetDirectoryName(changedFile) + Path.DirectorySeparatorChar;
 
                 // Also check for .cs file changes (DefaultItems auto import *.cs, with some excludes such as obj subfolder)
                 // TODO: Check actual unevaluated .csproj to get the auto includes/excludes?
@@ -382,7 +382,7 @@ namespace Stride.Assets.Presentation.AssetEditors
                 var host = await RoslynHost;
                 msbuildWorkspace = MSBuildWorkspace.Create(ImmutableDictionary<string, string>.Empty, host.HostServices);
             }
-            await msbuildWorkspace.OpenSolutionAsync(session.SolutionPath.ToWindowsPath());
+            await msbuildWorkspace.OpenSolutionAsync(session.SolutionPath.ToOSPath());
 
             // Try up to 10 times (1 second)
             const int retryCount = 10;
@@ -391,7 +391,7 @@ namespace Stride.Assets.Presentation.AssetEditors
                 try
                 {
 
-                    var project = msbuildWorkspace.CurrentSolution.Projects.FirstOrDefault(x => x.FilePath == projectPath.ToWindowsPath());
+                    var project = msbuildWorkspace.CurrentSolution.Projects.FirstOrDefault(x => x.FilePath == projectPath.ToOSPath());
                     if (msbuildWorkspace.Diagnostics.Count > 0)
                     {
                         // There was an issue compiling the project


### PR DESCRIPTION
# PR Details

The Issue was if you have the Projects

```
...\\...\\FancyGame\\FancyGame.csproj
...\\...\\FancyGame.Test\\FancyGame.Test.csproj
```
Then the first one to compare the starts with path is always the root project of the game

now if you change the file `...\\...\\FancyGame.Test\\Bob.cs` the path comparison starts with the first project and a normal StartsWith , which results in true the directory path of the file `...\\...\\FancyGame.Test` starts with the root projects directory path `...\\...\\FancyGame` so the root project gets reloaded as lowest level of the dependencies of the solution.. but that isnt true FancyGame.Test is lower and has the file but it isnt even checked as the first trigger yields


## Related Issue

fix #2200

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
