### PR TITLE
fix: Adjust coping exe to nuget package lib folder

### DIFF
--- a/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
+++ b/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
@@ -32,7 +32,7 @@
   </Target>
   <Target Name="_StrideIncludeNuGetResolver">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(OutputPath)$(AssemblyName).exe" />
+      <BuildOutputInPackage Condition="Exists('$(OutputPath)$(AssemblyName).exe')" Include="$(OutputPath)$(AssemblyName).exe" />
       <BuildOutputInPackage Include="$(OutputPath)NuGet*.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Newtonsoft.Json.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll" />


### PR DESCRIPTION
# PR Details

PR relates to my other recent PR (https://github.com/stride3d/stride/pull/2279). 
When now Asset.CompilerApp is a cross-platform project, the project does not generate an exe file which may cause an error when generating a nuget package, because currently `Stride.NuGetResolver.Targets.projitems` tries to copy Asset.CompilerApp.exe even though it does not exist. 

Probably when Gamestudio will be cross-platform this file should be revisited.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
