### PR TITLE
tests: Disable TestBlockingWindow, our Teamcity agent does not support it yet.

### DIFF
--- a/sources/presentation/Stride.Core.Presentation.Tests/TestWindowsManager.cs
+++ b/sources/presentation/Stride.Core.Presentation.Tests/TestWindowsManager.cs
@@ -54,7 +54,7 @@ namespace Stride.Core.Presentation.Tests
             HideBlocking,
         }
 
-        [Theory]
+        [Theory(Skip = "The teamcity agent is currently running as a service, it cannot handle windowing operations. Will need to set it up as users before enabling this one again")]
         [InlineData(Step.ShowMain, Step.HideMain, Step.ShowModal, Step.HideModal, Step.ShowBlocking, Step.HideBlocking)]
         [InlineData(Step.ShowMain, Step.HideMain, Step.ShowBlocking, Step.HideBlocking, Step.ShowModal, Step.HideModal)]
         [InlineData(Step.ShowMain, Step.HideMain, Step.ShowBlocking, Step.ShowModal, Step.HideBlocking, Step.HideModal)]


### PR DESCRIPTION
# PR Details
Paraphrasing Xen2 on these tests failing: 
https://teamcity.stride3d.net/buildConfiguration/Engine_Tests_WindowsSimple/25284?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&expandBuildTestsSection=true&expandBuildDeploymentsSection=false

> We currently run Teamcity as a service (using some system account).  Since it runs in the background without real UI, it behaves differently.
> This wasn't happening before because I was launching the teamcity agent as a specific user. I set it up in this user startup -- however it's annoying because I need to either  login the user manually since it can't start without the user being logon (I also tried auto login, but I forgot if it worked or if login to init UI was necessary?).
> On April 21st, I had to reinstall teamcity agent from scratch because it was broken, so I decided to put it as a service again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
