### PR TITLE
fix: use tryadd instead of containskey guard clause

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/ProcessBuilderRemote.cs
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/ProcessBuilderRemote.cs
@@ -56,10 +56,7 @@ namespace Stride.Core.Assets.CompilerApp
             {
                 foreach (var outputObject in outputObjects)
                 {
-                    if (!result.ContainsKey(outputObject.Key))
-                    {
-                        result.Add(outputObject.Key, outputObject.Value.ObjectId);
-                    }
+                    result.TryAdd(outputObject.Key, outputObject.Value.ObjectId);
                 }
             }
             return result;

--- a/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
@@ -268,7 +268,7 @@ namespace Stride.Core.Assets.Quantum
             {
                 var visitor = new AssetGraphVisitorBase(Definition);
                 // If we're in scenario where rootNode is an object node and index is not empty, we might already have the node in the dictionary so let's check this in Visiting
-                visitor.Visiting += (node, path) => { if (!nodesToReset.ContainsKey(node)) nodesToReset.Add(node, NodeIndex.Empty); };
+                visitor.Visiting += (node, path) => { nodesToReset.TryAdd(node, NodeIndex.Empty); };
                 visitor.Visit(rootNode);
             }
             // Then we reconcile (recursively) with the base.

--- a/sources/assets/Stride.Core.Assets/Analysis/AssetCollision.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/AssetCollision.cs
@@ -79,16 +79,10 @@ namespace Stride.Core.Assets.Analysis
                 var tuple = new Tuple<AssetId, UFile>(newId != AssetId.Empty ? newId : item.Id, newLocation ?? item.Location);
                 if (changed)
                 {
-                    if (!itemRemap.ContainsKey(item))
-                    {
-                        itemRemap.Add(item, tuple);
-                    }
+                    itemRemap.TryAdd(item, tuple);
                 }
 
-                if (!idRemap.ContainsKey(item.Id))
-                {
-                    idRemap.Add(item.Id, tuple);
-                }
+                idRemap.TryAdd(item.Id, tuple);
             }
 
             // Process assets

--- a/sources/assets/Stride.Core.Assets/AssetRegistry.cs
+++ b/sources/assets/Stride.Core.Assets/AssetRegistry.cs
@@ -601,10 +601,7 @@ namespace Stride.Core.Assets
                                     RegisteredDefaultAssetExtension[assetType] = extensions.FirstOrDefault();
                                     foreach (var extension in extensions)
                                     {
-                                        if (!RegisteredAssetFileExtensions.ContainsKey(extension))
-                                        {
-                                            RegisteredAssetFileExtensions.Add(extension, assetType);
-                                        }
+                                        RegisteredAssetFileExtensions.TryAdd(extension, assetType);
                                     }
                                 }
 

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
@@ -758,9 +758,7 @@ namespace Stride.Core.BuildEngine
             {
                 lock (builderContext.CommandsInProgress)
                 {
-                    if (!builderContext.CommandsInProgress.ContainsKey(commandHash))
-                        builderContext.CommandsInProgress.Add(commandHash, commandBuildStep);
-
+                    builderContext.CommandsInProgress.TryAdd(commandHash, commandBuildStep);
                     builder.ioMonitor.CommandStarted(commandBuildStep);
                 }
             }

--- a/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
+++ b/sources/core/Stride.Core.Design/Reflection/AssemblyContainer.cs
@@ -270,8 +270,7 @@ namespace Stride.Core.Reflection
                                             var assemblyName = Path.GetFileNameWithoutExtension(runtimeFile.Path);
 
                                             // TODO: Properly deal with file duplicates (same file in multiple package, or RID conflicts)
-                                            if (!dependenciesMapping.ContainsKey(assemblyName))
-                                                dependenciesMapping.Add(assemblyName, fullPath);
+                                            dependenciesMapping.TryAdd(assemblyName, fullPath);
                                         }
                                     }
                                 }
@@ -295,8 +294,7 @@ namespace Stride.Core.Reflection
                                             var assemblyName = Path.GetFileNameWithoutExtension(runtimeFile);
 
                                             // TODO: Properly deal with file duplicates (same file in multiple package, or RID conflicts)
-                                            if (!dependenciesMapping.ContainsKey(assemblyName))
-                                                dependenciesMapping.Add(assemblyName, runtimeFile);
+                                            dependenciesMapping.TryAdd(assemblyName, runtimeFile);
                                         }
                                     }
                                 }

--- a/sources/core/Stride.Core.Yaml/Schemas/SchemaBase.cs
+++ b/sources/core/Stride.Core.Yaml/Schemas/SchemaBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SharpYaml - Alexandre Mutel
+// Copyright (c) 2015 SharpYaml - Alexandre Mutel
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -347,9 +347,7 @@ namespace Stride.Core.Yaml.Schemas
             if (type == null)
                 throw new ArgumentNullException("type");
 
-            if (!mapTypeToShortTag.ContainsKey(type))
-                mapTypeToShortTag.Add(type, tag);
-
+            mapTypeToShortTag.TryAdd(type, tag);
             if (isDefault)
             {
                 mapShortTagToType[tag] = type;

--- a/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
+++ b/sources/core/Stride.Core/Reflection/AssemblyRegistry.cs
@@ -162,8 +162,7 @@ namespace Stride.Core.Reflection
 
         public static void RegisterScanTypes([NotNull] Assembly assembly, ScanTypes types)
         {
-            if (!AssemblyToScanTypes.ContainsKey(assembly))
-                AssemblyToScanTypes.Add(assembly, types);
+            AssemblyToScanTypes.TryAdd(assembly, types);
         }
 
         public static ScanTypes GetScanTypes([NotNull] Assembly assembly)

--- a/sources/core/Stride.Core/Serialization/DataSerializerFactory.cs
+++ b/sources/core/Stride.Core/Serialization/DataSerializerFactory.cs
@@ -142,8 +142,7 @@ namespace Stride.Core.Serialization
             lock (Lock)
             {
                 // Register it (so that we can get it back if unregistered)
-                if (!AvailableAssemblySerializers.ContainsKey(assemblySerializers.Assembly))
-                    AvailableAssemblySerializers.Add(assemblySerializers.Assembly, assemblySerializers);
+                AvailableAssemblySerializers.TryAdd(assemblySerializers.Assembly, assemblySerializers);
 
                 // Check if already loaded
                 if (AssemblySerializers.Contains(assemblySerializers))
@@ -267,10 +266,7 @@ namespace Stride.Core.Serialization
 
                 foreach (var assemblySerializer in assemblySerializerPerProfile.Value)
                 {
-                    if (!dataSerializers.ContainsKey(assemblySerializer.ObjectType))
-                    {
-                        dataSerializers.Add(assemblySerializer.ObjectType, assemblySerializer);
-                    }
+                    dataSerializers.TryAdd(assemblySerializer.ObjectType, assemblySerializer);
                 }
             }
         }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameNavigationMeshService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameNavigationMeshService.cs
@@ -598,8 +598,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
 
         private async Task UpdateNavigationMeshLink(AssetViewModel asset)
         {
-            if (!navigationMeshAssets.ContainsKey(asset.Id))
-                navigationMeshAssets.Add(asset.Id, asset);
+            navigationMeshAssets.TryAdd(asset.Id, asset);
 
             // Either add or remove the navigation mesh to the navigation mesh manager, which will then handle loading the navigation mesh whenever it gets compiler
             //  and then call NavigationMeshManagerOnChanged to update the shown navigation mesh

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButton.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButton.cs
@@ -175,16 +175,12 @@ namespace Stride.Input
 
         private static void Register(VirtualButton virtualButton)
         {
-            if (!mapIp.ContainsKey(virtualButton.Id))
+            if (mapIp.TryAdd(virtualButton.Id, virtualButton))
             {
-                mapIp.Add(virtualButton.Id, virtualButton);
                 registered.Add(virtualButton);
             }
 
-            if (!mapName.ContainsKey(virtualButton.Name))
-            {
-                mapName.Add(virtualButton.Name, virtualButton);
-            }
+            mapName.TryAdd(virtualButton.Name, virtualButton);
         }
     }
 }

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -760,10 +760,8 @@ namespace Stride.Engine
                 {
                     if(ignoreCollisionBuffer == null)
                         ignoreCollisionBuffer = new Dictionary<PhysicsComponent, CollisionState>();
-                    if(ignoreCollisionBuffer.ContainsKey(other))
+                    if(!ignoreCollisionBuffer.TryAdd(other, state))
                         ignoreCollisionBuffer[other] = state;
-                    else
-                        ignoreCollisionBuffer.Add(other, state);
                 }
                 else
                 {

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -758,7 +758,7 @@ namespace Stride.Engine
             {
                 if(ignoreCollisionBuffer != null || other.ignoreCollisionBuffer == null)
                 {
-                    ignoreCollisionBuffer ??= new Dictionary<PhysicsComponent, CollisionState>();
+                    ignoreCollisionBuffer ??= [];
                     ignoreCollisionBuffer[other] = state;
                 }
                 else

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -758,10 +758,8 @@ namespace Stride.Engine
             {
                 if(ignoreCollisionBuffer != null || other.ignoreCollisionBuffer == null)
                 {
-                    if(ignoreCollisionBuffer == null)
-                        ignoreCollisionBuffer = new Dictionary<PhysicsComponent, CollisionState>();
-                    if(!ignoreCollisionBuffer.TryAdd(other, state))
-                        ignoreCollisionBuffer[other] = state;
+                    ignoreCollisionBuffer ??= new Dictionary<PhysicsComponent, CollisionState>();
+                    ignoreCollisionBuffer[other] = state;
                 }
                 else
                 {

--- a/sources/engine/Stride.Physics/Engine/PhysicsShapesRenderingService.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsShapesRenderingService.cs
@@ -167,10 +167,7 @@ namespace Stride.Physics.Engine
                                 debugPrimitive = shape.CreateUpdatableDebugPrimitive(graphicsDevice);
                                 updatableDebugMeshCache[shape] = debugPrimitive;
                             }
-                            if (!updatableDebugMeshes.ContainsKey(shape))
-                            {
-                                updatableDebugMeshes.Add(shape, debugPrimitive);
-                            }
+                            updatableDebugMeshes.TryAdd(shape, debugPrimitive);
                         }
                         else if (type == typeof(CapsuleColliderShape) || type == typeof(ConvexHullColliderShape) || type == typeof(StaticMeshColliderShape))
                         {

--- a/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
+++ b/sources/shaders/Stride.Core.Shaders/Convertor/HlslToGlslConvertor.cs
@@ -1013,8 +1013,7 @@ namespace Stride.Core.Shaders.Convertor
                     {
                         Expression conditionExpression;
 
-                        if (!methodInvocationHandled.ContainsKey(methodInvocationExpression))
-                            methodInvocationHandled.Add(methodInvocationExpression, true);
+                        methodInvocationHandled.TryAdd(methodInvocationExpression, true);
 
                         base.Visit(statement);
 
@@ -1040,8 +1039,8 @@ namespace Stride.Core.Shaders.Convertor
 
                     if (methodInvocationExpression.Arguments.Count == 3)
                     {
-                        if (!methodInvocationHandled.ContainsKey(methodInvocationExpression))
-                            methodInvocationHandled.Add(methodInvocationExpression, true);
+                        methodInvocationHandled.TryAdd(methodInvocationExpression, true);
+
                         base.Visit(statement);
 
                         var sinAssign =

--- a/sources/shaders/Stride.Core.Shaders/Grammar/ShaderLanguageData.cs
+++ b/sources/shaders/Stride.Core.Shaders/Grammar/ShaderLanguageData.cs
@@ -52,8 +52,7 @@ namespace Stride.Core.Shaders.Grammar
             else if (tokenInfo.TokenCategory == TokenCategory.Typename || tokenInfo.TokenCategory == TokenCategory.Keyword)
             {
                 var keyMap = (tokenInfo.IsCaseInsensitive) ? caseInsensitiveKeywordToTerminal : keywordToTerminal;
-                if (!keyMap.ContainsKey(term.Name))
-                    keyMap.Add(term.Name, term);
+                keyMap.TryAdd(term.Name, term);
             }
             else
             {

--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -444,9 +444,7 @@ namespace Stride.Importer.ThreeD
                 tempNames.Add(itemName);
 
                 // count the occurences of this name
-                if (!itemNameTotalCount.ContainsKey(itemName))
-                    itemNameTotalCount.Add(itemName, 1);
-                else
+                if (!itemNameTotalCount.TryAdd(itemName, 1))
                     itemNameTotalCount[itemName]++;
             }
 
@@ -457,9 +455,7 @@ namespace Stride.Importer.ThreeD
 
                 if (itemNameTotalCount[itemName] > 1)
                 {
-                    if (!itemNameCurrentCount.ContainsKey(itemName))
-                        itemNameCurrentCount.Add(itemName, 1);
-                    else
+                    if (!itemNameCurrentCount.TryAdd(itemName, 1))
                         itemNameCurrentCount[itemName]++;
 
                     itemName = itemName + "_" + itemNameCurrentCount[itemName].ToString(CultureInfo.InvariantCulture);
@@ -1293,9 +1289,7 @@ namespace Stride.Importer.ThreeD
             var referenceName = attachedReference.Url;
 
             // find a new and correctName
-            if (!textureNameCount.ContainsKey(referenceName))
-                textureNameCount.Add(referenceName, 1);
-            else
+            if (!textureNameCount.TryAdd(referenceName, 1))
             {
                 int count = textureNameCount[referenceName];
                 textureNameCount[referenceName] = count + 1;

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/FreeImageWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/FreeImageWrapper.cs
@@ -4323,15 +4323,12 @@ namespace FreeImageAPI
 				return result;
 			}
 			tag = new MetadataTag(_tag, model);
-			if (metaDataSearchHandler.ContainsKey(result))
+			if (!metaDataSearchHandler.TryAdd(result, model))
 			{
 				metaDataSearchHandler[result] = model;
 			}
-			else
-			{
-				metaDataSearchHandler.Add(result, model);
-			}
-			return result;
+
+            return result;
 		}
 
 		/// <summary>

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/FreeImageWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/FreeImageWrapper.cs
@@ -4323,11 +4323,9 @@ namespace FreeImageAPI
 				return result;
 			}
 			tag = new MetadataTag(_tag, model);
-			if (!metaDataSearchHandler.TryAdd(result, model))
-			{
-				metaDataSearchHandler[result] = model;
-			}
 
+			metaDataSearchHandler[result] = model;
+			
             return result;
 		}
 


### PR DESCRIPTION
# PR Details

Uses the new NET8 TryAdd instead of ContainsKey  guard clause + Add
It's faster as you dont need a double lookup in the dictionary

## Related Issue

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
