### PR TITLE
[GameStudio] Prevents a null IMemberNode to update

### DIFF
--- a/sources/presentation/Stride.Core.Quantum/NodeAccessor.cs
+++ b/sources/presentation/Stride.Core.Quantum/NodeAccessor.cs
@@ -57,13 +57,13 @@ namespace Stride.Core.Quantum
         /// <param name="value">The new value to set.</param>
         public void UpdateValue(object value)
         {
-            if (Index != NodeIndex.Empty)
+            if (IsItem)
             {
                 ((IObjectNode)Node).Update(value, Index);
             }
-            else
+            else if (IsMember)
             {
-                (Node as IMemberNode)?.Update(value);
+                ((IMemberNode)Node).Update(value);
             }
         }
 

--- a/sources/presentation/Stride.Core.Quantum/NodeAccessor.cs
+++ b/sources/presentation/Stride.Core.Quantum/NodeAccessor.cs
@@ -63,7 +63,7 @@ namespace Stride.Core.Quantum
             }
             else
             {
-                ((IMemberNode)Node).Update(value);
+                (Node as IMemberNode)?.Update(value);
             }
         }
 


### PR DESCRIPTION
# PR Details
Fixed an error when duplicating an Entity with a not null `List<T>` variable crashes the editor. This happen when T is something referenceable in a scene like Entities or Components.

When trying to cast a Node as IMemberNode, it resulted in a null and the editor crashing, this PR just prevent to call Update on a null.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue
#2255

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
