### PR TITLE
fix: strdiag001 on file scoped classes

### DIFF
--- a/sources/core/Stride.Core.CompilerServices.Tests/AnalyzerTests/STRDIAG001_Test.cs
+++ b/sources/core/Stride.Core.CompilerServices.Tests/AnalyzerTests/STRDIAG001_Test.cs
@@ -21,8 +21,7 @@ public class STRDIAG001_Test
         string sourceCode = string.Format(ClassTemplates.BasicClassTemplate, "private class InnerClass { }");
         TestHelper.ExpectNoDiagnosticsErrors(sourceCode);
     }
-    // TODO: Enable with .NET8 merge as we need a higher C# version
-    [Fact(Skip = "file scoped classes won't compile")]
+    [Fact]
     public void Error_On_file_scope_Class_with_DataContract()
     {
         string sourceCode = "using Stride.Core; [DataContract] file class FileScopeClass { }";

--- a/sources/core/Stride.Core.CompilerServices/Analyzers/STRDIAG001InvalidDataContract.cs
+++ b/sources/core/Stride.Core.CompilerServices/Analyzers/STRDIAG001InvalidDataContract.cs
@@ -49,7 +49,10 @@ public class STRDIAG001InvalidDataContract : DiagnosticAnalyzer
         if (!symbol.HasAttribute(dataContractAttribute))
             return;
 
-        if(!symbol.IsVisibleToSerializer(hasDataMemberAttribute: true))
+        if (symbol.IsFileLocal)
+            Rule.ReportDiagnostics(context, symbol);
+
+        if (!symbol.IsVisibleToSerializer(hasDataMemberAttribute: true))
             Rule.ReportDiagnostics(context, symbol);
     }
 }


### PR DESCRIPTION
# PR Details

file scope didnt work as its not an accessor like public internal, this is now fixed

## Related Issue

fix #2263

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes. ( was just disabled )
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.** ( doesnt affect editor at all )
