### PR TITLE
Fix UI overridden margin in derived controls being reset

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum.Tests/Helpers/Types.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum.Tests/Helpers/Types.cs
@@ -137,11 +137,34 @@ namespace Stride.Core.Assets.Quantum.Tests.Helpers
             public static int MemberCount => 4 + 3; // 4 (number of members in Asset) + 3 (number of members in Types.MyAssetWithRef2)
         }
 
+        [DataContract]
+        [AssetDescription(FileExtension)]
+        public class MyAssetWithStructWithPrimitives : MyAssetBase
+        {
+            public StructWithPrimitives StructValue { get; set; }
+        }
 
         [DataContract]
         public struct StructWithList
         {
             public List<string> MyStrings { get; set; }
+        }
+
+        [DataContract]
+        [DataStyle(DataStyle.Compact)]
+        public struct StructWithPrimitives : IEquatable<StructWithPrimitives>
+        {
+            [DefaultValue(0)]
+            public int Value1 { get; set; }
+            [DefaultValue(0)]
+            public int Value2 { get; set; }
+
+            public override readonly bool Equals(object obj) => obj is StructWithPrimitives value && Equals(value);
+            public readonly bool Equals(StructWithPrimitives other) => Value1 == other.Value1 && Value2 == other.Value2;
+
+            public override readonly int GetHashCode() => HashCode.Combine(Value1, Value2);
+
+            public override string ToString() => $"(Value1: {Value1}, Value2: {Value2})";
         }
 
         public interface IMyInterface

--- a/sources/assets/Stride.Core.Assets.Quantum.Tests/TestReconcileWithBase.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum.Tests/TestReconcileWithBase.cs
@@ -46,6 +46,29 @@ MyString: MyDerivedString
         }
 
         [Fact]
+        public void TestStructWithPrimitivesOverrideMember()
+        {
+            const string primitiveMemberBaseYaml = @"!Stride.Core.Assets.Quantum.Tests.Helpers.Types+MyAssetWithStructWithPrimitives,Stride.Core.Assets.Quantum.Tests
+Id: 10000000-0000-0000-0000-000000000000
+Tags: []
+StructValue: {}
+";
+            const string primitiveMemberOverriddenYaml = @"!Stride.Core.Assets.Quantum.Tests.Helpers.Types+MyAssetWithStructWithPrimitives,Stride.Core.Assets.Quantum.Tests
+Id: 30000000-0000-0000-0000-000000000000
+Archetype: 10000000-0000-0000-0000-000000000000:MyAsset
+Tags: []
+StructValue*: {Value1: 10, Value2: 20}
+";
+            var expectedOverriddenValue = new Types.StructWithPrimitives { Value1 = 10, Value2 = 20 };
+            var context = DeriveAssetTest<Types.MyAssetWithStructWithPrimitives, Types.MyAssetBasePropertyGraph>.LoadFromYaml(primitiveMemberBaseYaml, primitiveMemberOverriddenYaml);
+            Assert.Equal(default, context.BaseAsset.StructValue);
+            Assert.Equal(expectedOverriddenValue, context.DerivedAsset.StructValue);
+            context.DerivedGraph.ReconcileWithBase();
+            Assert.Equal(default, context.BaseAsset.StructValue);
+            Assert.Equal(expectedOverriddenValue, context.DerivedAsset.StructValue);
+        }
+
+        [Fact]
         public void TestCollectionMismatchItem()
         {
             const string baseYaml = @"!Stride.Core.Assets.Quantum.Tests.Helpers.Types+MyAsset2,Stride.Core.Assets.Quantum.Tests

--- a/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
@@ -291,7 +291,11 @@ namespace Stride.Core.Assets.Quantum
         /// </summary>
         /// <returns>A new instance of <see cref="GraphVisitorBase"/> for reconciliation.</returns>
         [NotNull]
-        public virtual GraphVisitorBase CreateReconcilierVisitor()
+        [Obsolete($"To be removed in future releases. Use {nameof(CreateReconcilerVisitor)} instead.")]
+        public virtual GraphVisitorBase CreateReconcilierVisitor() => CreateReconcilerVisitor();
+
+        [NotNull]
+        public virtual GraphVisitorBase CreateReconcilerVisitor()
         {
             return new AssetGraphVisitorBase(Definition);
         }
@@ -748,7 +752,7 @@ namespace Stride.Core.Assets.Quantum
         {
             var memberNode = assetNode as AssetMemberNode;
             var objectNode = assetNode as IAssetObjectNodeInternal;
-            // Non-overridable members should not be reconcilied.
+            // Non-overridable members should not be reconciled.
             if (assetNode?.BaseNode == null || !memberNode?.CanOverride == true)
                 return;
 

--- a/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
@@ -217,14 +217,14 @@ namespace Stride.Core.Assets.Quantum
         private void ReconcileWithBase([NotNull] IAssetNode rootNode, Dictionary<IGraphNode, NodeIndex> nodesToReset = null)
         {
             // Two passes: first pass will reconcile almost everything, but skip object reference.
-            // The reason is that the target of the reference might not exist yet (might need to be reconcilied)
-            var visitor = CreateReconcilierVisitor();
-            visitor.Visiting += (node, path) => ReconcileWithBaseNode((IAssetNode)node, false, nodesToReset);
+            // The reason is that the target of the reference might not exist yet (might need to be reconciled)
+            var visitor = CreateReconcilerVisitor();
+            visitor.Visiting += (node, path) => ReconcileWithBaseNode((IAssetNode)node, path, reconcileObjectReference: false, nodesToReset);
             visitor.Visit(rootNode);
             // Second pass: this one should only reconcile remaining object reference.
             // TODO: these two passes could be improved!
-            visitor = CreateReconcilierVisitor();
-            visitor.Visiting += (node, path) => ReconcileWithBaseNode((IAssetNode)node, true, nodesToReset);
+            visitor = CreateReconcilerVisitor();
+            visitor.Visiting += (node, path) => ReconcileWithBaseNode((IAssetNode)node, path, reconcileObjectReference: true, nodesToReset);
             visitor.Visit(rootNode);
         }
 
@@ -744,7 +744,7 @@ namespace Stride.Core.Assets.Quantum
             BaseContentChanged?.Invoke(e, node);
         }
 
-        private void ReconcileWithBaseNode(IAssetNode assetNode, bool reconcileObjectReference, Dictionary<IGraphNode, NodeIndex> nodesToReset)
+        private void ReconcileWithBaseNode(IAssetNode assetNode, GraphNodePath currentPath, bool reconcileObjectReference, Dictionary<IGraphNode, NodeIndex> nodesToReset)
         {
             var memberNode = assetNode as AssetMemberNode;
             var objectNode = assetNode as IAssetObjectNodeInternal;
@@ -758,7 +758,7 @@ namespace Stride.Core.Assets.Quantum
             // Reconcile occurs only when the node is not overridden.
             if (memberNode != null)
             {
-                if (ShouldReconcileMember(memberNode, reconcileObjectReference, nodesToReset))
+                if (ShouldReconcileMember(memberNode, currentPath, reconcileObjectReference, nodesToReset))
                 {
                     // If we have no setter, we cannot reconcile this property. Usually it means that the value is already correct (eg. it's an instance of the correct type,
                     // or it's a value that cannot change), so we'll just keep going and try to reconcile the children of this member.
@@ -946,7 +946,7 @@ namespace Stride.Core.Assets.Quantum
             }
         }
 
-        private bool ShouldReconcileMember([NotNull] IAssetMemberNode memberNode, bool reconcileObjectReference, Dictionary<IGraphNode, NodeIndex> nodesToReset)
+        private bool ShouldReconcileMember([NotNull] IAssetMemberNode memberNode, GraphNodePath currentPath, bool reconcileObjectReference, Dictionary<IGraphNode, NodeIndex> nodesToReset)
         {
             var localValue = memberNode.Retrieve();
             var baseValue = memberNode.BaseNode.Retrieve();
@@ -984,6 +984,16 @@ namespace Stride.Core.Assets.Quantum
                 var localRef = AttachedReferenceManager.GetAttachedReference(localValue);
                 var baseRef = AttachedReferenceManager.GetAttachedReference(baseValue);
                 return localRef?.Id != baseRef?.Id || localRef?.Url != baseRef?.Url;
+            }
+
+            // Value type, check if it is a child of a value type that has been overridden
+            foreach (var pathNode in currentPath)
+            {
+                if (pathNode is IAssetMemberNode assetMemberNode && assetMemberNode.IsContentOverridden())
+                {
+                    // We are inside a struct that was overridden, so we are actually considered overridden
+                    return false;
+                }
             }
 
             // Value type, we check for equality

--- a/sources/presentation/Stride.Core.Quantum/IGraphNode.cs
+++ b/sources/presentation/Stride.Core.Quantum/IGraphNode.cs
@@ -31,7 +31,7 @@ namespace Stride.Core.Quantum
         ITypeDescriptor Descriptor { get; }
 
         /// <summary>
-        /// Gets wheither this node holds a reference or is a direct value.
+        /// Gets whether this node holds a reference or is a direct value.
         /// </summary>
         bool IsReference { get; }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
As per #2048, Margin is a struct `Thickness`, with itself holding float fields (`Left`, `Right`, etc).
If an object has a `Thickness` struct as a field/property and you override it in a derived asset, it is marked as overridden, however the fields of the `Thickness` are not marked overridden.
When `AssetPropertyGraph` encounters the `Thickness`'s fields it was not aware its parent has been marked overridden so it mistaken itself as not overridden and overwrites itself with the value from the base asset.

This change ensures any encountered member (field/property) that is a value type must check if it is part of another value type that may be marked overridden, and reject taking the base asset's value if this is the case.

2nd commit is to fix some typos.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2048 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
