### PR TITLE
Fix: Fixed a NullReferenceException if printing null text

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -43,7 +43,7 @@ namespace Stride.Profiling
         {
             var msg = new DebugOverlayMessage 
             { 
-                Message = message,
+                Message = message ?? "",
                 Position = position,
                 TextColor = color ?? TextColor,
                 RemainingTime = timeOnScreen ?? DefaultOnScreenTime,

--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -43,7 +43,7 @@ namespace Stride.Profiling
         {
             var msg = new DebugOverlayMessage 
             { 
-                Message = message ?? "",
+                Message = message ?? string.Empty,
                 Position = position,
                 TextColor = color ?? TextColor,
                 RemainingTime = timeOnScreen ?? DefaultOnScreenTime,


### PR DESCRIPTION
Fixes this exception if using `DebugText.Print(null, ...)` by adding a plain null check inside the `Print` function.
```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=Stride.Graphics
  StackTrace:
   at Stride.Graphics.FastTextRenderer.DrawString(GraphicsContext graphicsContext, String text, Int32 x, Int32 y)
```

## Related Issue
None, this is just a trivial bug fix. I didn't decide to create a issue for this.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- N/A Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- N/A New feature (non-breaking change which adds functionality)
- N/A Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- N/A My change requires a change to the documentation.
- N/A I have added tests to cover my changes.
- N/A All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.** 
(by creating a new project, and using this script containing a single `DebugText.Print` call inside the `Update` method).
