### PR TITLE
fix: Rollback one of the TryAdd introduced through #2299, VS Package is still on net472

### DIFF
--- a/sources/core/Stride.Core.Yaml/Schemas/SchemaBase.cs
+++ b/sources/core/Stride.Core.Yaml/Schemas/SchemaBase.cs
@@ -347,7 +347,9 @@ namespace Stride.Core.Yaml.Schemas
             if (type == null)
                 throw new ArgumentNullException("type");
 
-            mapTypeToShortTag.TryAdd(type, tag);
+            if (!mapTypeToShortTag.ContainsKey(type))
+                mapTypeToShortTag.Add(type, tag);
+
             if (isDefault)
             {
                 mapShortTagToType[tag] = type;


### PR DESCRIPTION
# PR Details
See title, TryAdd doesn't exist on net472

## Related Issue
#2299

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
