### PR TITLE
Revert "fix: assembly load failure when building Stride based project on clean machine"

### DIFF
--- a/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
+++ b/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
@@ -39,8 +39,6 @@
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.Extensions.FileSystemGlobbing.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.Extensions.Primitives.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Stride.NuGetResolver*.dll" />
-      <!-- Needed by NuGet.Packaging see https://github.com/stride3d/stride/issues/2232 -->
-      <BuildOutputInPackage Include="$(OutputPath)System.Security.Cryptography.Pkcs.dll" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Reverts stride3d/stride#2308
Visual Studio solutions and Stride.ConnectionRouter fail to pack the dll as they don't have the referenced dll in their output path
https://teamcity.stride3d.net/buildConfiguration/Engine_Tests_WindowsSimple/25642?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true&expandBuildProblemsSection=true

Could you look into this @azeno ?

Now naively adding a condition to this `BuildOutputInPackage` works but best to check if those projects actually need this dll.