### PR TITLE
[Font] Update SharpFont library for additional fixes

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.Sdl" Version="2.20.0" />
     <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.19.0" />
-    <PackageVersion Include="Stride.SharpFont" Version="1.0.0" />
+    <PackageVersion Include="Stride.SharpFont" Version="1.0.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Successor to #2281 
Must wait until pull at https://github.com/stride3d/SharpFont/pull/1 is merged and its nuget package has been updated to 1.0.1.

My understanding of Stride's build of SharpFont:
* vonderborch's repo, aka [SharpFont.NetStandard](https://github.com/vonderborch/SharpFont) did not contain any major changes compared to Robmaister's repo- it mainly moved files around (no code changes) and the single code change involved loading/switching 32bit/64bit dll, which Stride already does (I think). So the above pull only merged and modified from the latest of Robmaister's repo.
* Stride does not use `freetype6` as provided in Robmaister's branch which is only on v2.6 - Stride uses v2.6.3 https://github.com/stride3d/freetype/tree/2.6.3 (and is named `freetype`), as per this https://github.com/stride3d/stride/blob/master/deps/freetype/checkout.bat


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
