### PR TITLE
Fixes assembly load failure when building Stride based project on clean machine (2. attempt)

### DIFF
--- a/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
+++ b/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
@@ -40,5 +40,9 @@
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.Extensions.Primitives.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Stride.NuGetResolver*.dll" />
     </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(StrideXplatEditorTargetFramework)' ">
+      <!-- Needed by NuGet.Packaging in cross platform builds (see https://github.com/stride3d/stride/issues/2232) -->
+      <BuildOutputInPackage Include="$(OutputPath)System.Security.Cryptography.Pkcs.dll" />
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
# PR Details

This is the second attempt to get a grip on #2232. My previous attempt caused build errors in other projects (like Stride.ConnectionRouter) not having `System.Security.Cryptography.Pkcs.dll` in their output folder. Whether or not that particular dll is in the build output folder seems to depend on the target framework of the project including Stride.NuGetResolver.
I've added a check, the solution seems to build fine now (seems I was a bit sloppy in this regard in my previous attempt, sorry for that).

## Related Issue

#2232 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
