### PR TITLE
Remove signed blend indices due to dropping OpenGL ES 2 support

### DIFF
--- a/sources/engine/Stride.Assets.Models/ImportModelCommand.Model.cs
+++ b/sources/engine/Stride.Assets.Models/ImportModelCommand.Model.cs
@@ -27,13 +27,12 @@ namespace Stride.Assets.Models
 
         public bool Allow32BitIndex { get; set; }
         public int MaxInputSlots { get; set; }
-        public bool AllowUnsignedBlendIndices { get; set; }
         public bool DeduplicateMaterials { get; set; }
         public List<ModelMaterial> Materials { get; set; }
         public string EffectName { get; set; }
 
         public List<IModelModifier> ModelModifiers { get; set; }
-        
+
         /// <summary>
         /// Checks if the vertex buffer input slots for the model are supported by the target graphics profile level
         /// </summary>
@@ -85,7 +84,7 @@ namespace Stride.Assets.Models
             {
                 if (SkeletonUrl != null)
                 {
-                    // Load the skeleton 
+                    // Load the skeleton
                     skeleton = contentManager.Load<Skeleton>(SkeletonUrl);
                 }
                 else

--- a/sources/engine/Stride.Assets.Models/ImportThreeDCommand.cs
+++ b/sources/engine/Stride.Assets.Models/ImportThreeDCommand.cs
@@ -34,10 +34,7 @@ namespace Stride.Assets.Models
 
         private Stride.Importer.ThreeD.MeshConverter CreateMeshConverter(ICommandContext commandContext)
         {
-            return new Stride.Importer.ThreeD.MeshConverter(commandContext.Logger)
-            {
-                AllowUnsignedBlendIndices = this.AllowUnsignedBlendIndices,
-            };
+            return new Stride.Importer.ThreeD.MeshConverter(commandContext.Logger);
         }
 
         protected override Model LoadModel(ICommandContext commandContext, ContentManager contentManager)

--- a/sources/engine/Stride.Assets.Models/ModelAssetCompiler.cs
+++ b/sources/engine/Stride.Assets.Models/ModelAssetCompiler.cs
@@ -41,7 +41,6 @@ namespace Stride.Assets.Models
             var renderingSettings = gameSettingsAsset.GetOrCreate<RenderingSettings>();
             var allow32BitIndex = renderingSettings.DefaultGraphicsProfile >= GraphicsProfile.Level_9_2;
             var maxInputSlots = renderingSettings.DefaultGraphicsProfile >= GraphicsProfile.Level_10_1 ? 32 : 16;
-            var allowUnsignedBlendIndices = context.GetGraphicsPlatform(assetItem.Package) != GraphicsPlatform.OpenGLES;
             var extension = asset.Source.GetFileExtension();
 
             // Find skeleton asset, if any
@@ -62,7 +61,6 @@ namespace Stride.Assets.Models
             importModelCommand.Location = targetUrlInStorage;
             importModelCommand.Allow32BitIndex = allow32BitIndex;
             importModelCommand.MaxInputSlots = maxInputSlots;
-            importModelCommand.AllowUnsignedBlendIndices = allowUnsignedBlendIndices;
             importModelCommand.Materials = asset.Materials;
             importModelCommand.ScaleImport = asset.ScaleImport;
             importModelCommand.PivotPosition = asset.PivotPosition;

--- a/sources/engine/Stride.Rendering/Rendering/Skinning/TransformationSkinning.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Skinning/TransformationSkinning.sdsl
@@ -5,15 +5,9 @@
 /// </summary>
 /// <remarks>
 /// SkinningMaxBones: Macro - number of threads on the X axis.
-/// STRIDE_GRAPHICS_API_OPENGLES: Macro - flag to activate on for opengl es 2.0 platforms (int4 attributes like blend indices are not supported).
 /// </remarks>
 #ifndef SkinningMaxBones
 # define SkinningMaxBones 4
-#endif
-
-// TODO: use STRIDE_GRAPHICS_API_OPENGLES20 because opengl es 3.0 supports int4 atributes.
-#ifndef STRIDE_GRAPHICS_API_OPENGLES
-# define STRIDE_GRAPHICS_API_OPENGLES false
 #endif
 
 shader TransformationSkinning : TransformationBase, PositionStream4, Transformation
@@ -25,12 +19,7 @@ shader TransformationSkinning : TransformationBase, PositionStream4, Transformat
     }
 
     stage stream float4 BlendWeights : BLENDWEIGHT;
-#if STRIDE_GRAPHICS_API_OPENGLES
-    stage stream float4 BlendIndices : BLENDINDICES;
-    //stage stream int4 BlendIndices : BLENDINDICES;
-#else
     stage stream uint4 BlendIndices : BLENDINDICES;
-#endif
 
     stage stream float4x4 skinningBlendMatrix;
 

--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -63,9 +63,6 @@ namespace Stride.Importer.ThreeD
 
         private readonly Silk.NET.Assimp.Assimp assimp = Silk.NET.Assimp.Assimp.GetApi();
 
-        public bool AllowUnsignedBlendIndices { get; set; }
-
-
         private string vfsInputFilename;
         private string vfsOutputFilename;
         private string vfsInputPath;
@@ -717,34 +714,18 @@ namespace Stride.Importer.ThreeD
             }
 
             var blendIndicesOffset = vertexStride;
-            var controlPointIndices16 = (AllowUnsignedBlendIndices && totalClusterCount > 256) || (!AllowUnsignedBlendIndices && totalClusterCount > 128);
+            var controlPointIndices16 = totalClusterCount > 256;
             if (vertexIndexToBoneIdWeight.Count > 0)
             {
                 if (controlPointIndices16)
                 {
-                    if (AllowUnsignedBlendIndices)
-                    {
-                        vertexElements.Add(new VertexElement("BLENDINDICES", 0, PixelFormat.R16G16B16A16_UInt, vertexStride));
-                        vertexStride += sizeof(ushort) * 4;
-                    }
-                    else
-                    {
-                        vertexElements.Add(new VertexElement("BLENDINDICES", 0, PixelFormat.R16G16B16A16_SInt, vertexStride));
-                        vertexStride += sizeof(short) * 4;
-                    }
+                    vertexElements.Add(new VertexElement("BLENDINDICES", 0, PixelFormat.R16G16B16A16_UInt, vertexStride));
+                    vertexStride += sizeof(ushort) * 4;
                 }
                 else
                 {
-                    if (AllowUnsignedBlendIndices)
-                    {
-                        vertexElements.Add(new VertexElement("BLENDINDICES", 0, PixelFormat.R8G8B8A8_UInt, vertexStride));
-                        vertexStride += sizeof(byte) * 4;
-                    }
-                    else
-                    {
-                        vertexElements.Add(new VertexElement("BLENDINDICES", 0, PixelFormat.R8G8B8A8_SInt, vertexStride));
-                        vertexStride += sizeof(sbyte) * 4;
-                    }
+                    vertexElements.Add(new VertexElement("BLENDINDICES", 0, PixelFormat.R8G8B8A8_UInt, vertexStride));
+                    vertexStride += sizeof(byte) * 4;
                 }
             }
 
@@ -821,17 +802,11 @@ namespace Stride.Importer.ThreeD
                         {
                             if (controlPointIndices16)
                             {
-                                if (AllowUnsignedBlendIndices)
-                                    ((ushort*)(vbPointer + blendIndicesOffset))[bone] = (ushort)vertexIndexToBoneIdWeight[(int)i][bone].Item1;
-                                else
-                                    ((short*)(vbPointer + blendIndicesOffset))[bone] = vertexIndexToBoneIdWeight[(int)i][bone].Item1;
+                                ((ushort*)(vbPointer + blendIndicesOffset))[bone] = (ushort)vertexIndexToBoneIdWeight[(int)i][bone].Item1;
                             }
                             else
                             {
-                                if (AllowUnsignedBlendIndices)
-                                    (vbPointer + blendIndicesOffset)[bone] = (byte)vertexIndexToBoneIdWeight[(int)i][bone].Item1;
-                                else
-                                    ((sbyte*)(vbPointer + blendIndicesOffset))[bone] = (sbyte)vertexIndexToBoneIdWeight[(int)i][bone].Item1;
+                                (vbPointer + blendIndicesOffset)[bone] = (byte)vertexIndexToBoneIdWeight[(int)i][bone].Item1;
                             }
 
                             ((float*)(vbPointer + blendWeightOffset))[bone] = vertexIndexToBoneIdWeight[(int)i][bone].Item2;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Primary aim is to fix `TransformationSkinning.sdsl` shader where skinning wasn't working on Android, due to mismatched data type being passed from app to shader. Due to dropping OpenGL ES 2, blend indices can now just behave like non-ES 2 versions (ie. just use `uint` data type, instead of using `float`).

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2284 where the background info/problem arose from.

Here's my understanding of the original intention/code:
OpenGL ES 2 did not support passing `int`/`uint` data types, so needed a workaround to use `float` instead.
https://github.com/stride3d/stride/blob/1fc0d5137750a8c3d8acd5f89e3b63c75b6bea7f/sources/engine/Stride.Rendering/Rendering/Skinning/TransformationSkinning.sdsl#L28-L33
As seen in this code (and the comments I removed from the `TransformationSkinning.sdsl` file), the workaround for ES 2 was supposed to be to use `float4`.

However, it turns out the importer only passed signed or unsigned integer types:
https://github.com/stride3d/stride/blob/1fc0d5137750a8c3d8acd5f89e3b63c75b6bea7f/sources/tools/Stride.Importer.3D/MeshConverter.cs#L724-L753
This was still incorrect and should have been passing a float type.
Side note: even though this file is the new importer, this bug goes all the way back to the original importer.

Anyway, OpenGL ES3+ now supports `int`/`uint` data types, so the above no longer needs a workaround.
I have tested this on an Android project and the model is skinned properly now.



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
