### PR TITLE
feat: FlexibleProcessing as alternative to EntityComponentProcessor for lightweight, abstract and typesafe processing in idiomatic c#

### DIFF
--- a/sources/engine/Stride.Engine.Tests/TestEntityManager.cs
+++ b/sources/engine/Stride.Engine.Tests/TestEntityManager.cs
@@ -9,7 +9,10 @@ using Xunit;
 using Stride.Core;
 using Stride.Core.Collections;
 using Stride.Engine.Design;
+using Stride.Engine.FlexibleProcessing;
 using Stride.Engine.Processors;
+using Stride.Games;
+using Stride.Rendering;
 
 namespace Stride.Engine.Tests
 {
@@ -450,6 +453,112 @@ namespace Stride.Engine.Tests
             Assert.True(addChildCheck);
             Assert.True(removeChildCheck);
             Assert.True(prevRootAsChildCheck);
+        }
+
+        [Fact]
+        public void TestFlexibleProcessor()
+        {
+            var registry = new ServiceRegistry();
+            var entityManager = new CustomEntityManager(registry);
+
+            var compTest = new CompTest();
+            var entity = new Entity();
+
+            entityManager.Add(entity);
+
+            entity.Add(compTest);
+            Assert.True(compTest.Added);
+            Assert.True(compTest.Proc.SystemAddedRan);
+
+            entityManager.Update(new());
+            Assert.True(compTest.Updated);
+
+            entity.Remove(compTest);
+            Assert.True(compTest.Removed);
+            Assert.True(compTest.Proc.SystemRemovedRan);
+
+            // Try again with an entity with a pre-existing comp
+            compTest = new CompTest();
+            entity = new Entity();
+            entity.Add(compTest);
+
+            entityManager.Add(entity);
+
+            Assert.True(compTest.Added);
+            Assert.True(compTest.Proc.SystemAddedRan);
+
+            entityManager.Draw(null);
+            Assert.True(compTest.Drawn);
+
+            // and removing the entity itself instead of removing the component
+            entityManager.Remove(entity);
+            Assert.True(compTest.Removed);
+            Assert.True(compTest.Proc.SystemRemovedRan);
+
+
+            compTest.Proc.SystemUpdated = false;
+            entityManager.Update(new());
+            Assert.False(compTest.Proc.SystemUpdated);
+
+            compTest.Proc.SystemDrawn = false;
+            entityManager.Draw(null);
+            Assert.False(compTest.Proc.SystemDrawn);
+        }
+    }
+
+
+    public class CompTest : EntityComponent, IComponent<CompTest.ProcTest, CompTest>
+    {
+        public bool Added, Updated, Drawn, Removed;
+        public ProcTest Proc;
+
+        public class ProcTest : IComponent<ProcTest, CompTest>.IProcessor, IUpdateProcessor, IDrawProcessor
+        {
+            public int Order => 10;
+
+            public List<CompTest> Instances = new();
+            public bool SystemAddedRan, SystemRemovedRan, SystemUpdated, SystemDrawn;
+
+            public void OnComponentAdded(CompTest item)
+            {
+                Instances.Add(item);
+                item.Added = true;
+                item.Proc = this;
+            }
+
+            public void OnComponentRemoved(CompTest item)
+            {
+                item.Removed = true;
+                Instances.Remove(item);
+            }
+
+            public void Update(GameTime gTime)
+            {
+                SystemUpdated = true;
+                foreach (var instance in Instances)
+                {
+                    instance.Updated = true;
+                }
+            }
+
+            public void Draw(RenderContext context)
+            {
+                SystemDrawn = true;
+                foreach (var instance in Instances)
+                {
+                    instance.Drawn = true;
+                }
+            }
+
+            public void SystemAdded(IServiceRegistry registry)
+            {
+                SystemAddedRan = true;
+            }
+
+            public void SystemRemoved()
+            {
+                SystemRemovedRan = true;
+            }
         }
     }
 

--- a/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IComponent.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Engine.FlexibleProcessing
+{
+    /// <summary>
+    /// Defines a Processor/component or system/component relationship, <see cref="EntityComponent"/> implementing this interface
+    /// will be sent to the <typeparamref name="TProcessor"/> defined. Enabling component addition and removal tracking as well as batching operations over components.
+    /// </summary>
+    /// <typeparam name="TProcessor">The system which collects those components and iterates over them</typeparam>
+    /// <typeparam name="TThis">The type name implementing this interface</typeparam>
+    public interface IComponent<TProcessor, TThis> : IMarkedComponent where TProcessor : IComponent<TProcessor, TThis>.IProcessor, new() where TThis : IComponent<TProcessor, TThis>
+    {
+        public interface IProcessor : IProcessorBase
+        {
+            /// <summary> Occurs right after a component is added to the scene </summary>
+            void OnComponentAdded(TThis item);
+            /// <summary> Occurs right after a component is removed from the scene </summary>
+            void OnComponentRemoved(TThis item);
+            void IProcessorBase.OnComponentAdded(IMarkedComponent comp) => OnComponentAdded((TThis)comp);
+            void IProcessorBase.OnComponentRemoved(IMarkedComponent comp) => OnComponentRemoved((TThis)comp);
+        }
+    }
+
+    /// <summary>
+    /// Dummy interface used to quickly filter out components that aren't marked for processing, do not use.
+    /// </summary>
+    public interface IMarkedComponent;
+}

--- a/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IDrawProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IDrawProcessor.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Rendering;
+
+namespace Stride.Engine.FlexibleProcessing
+{
+    public interface IDrawProcessor
+    {
+        /// <summary>
+        /// The order of the processor, smaller values execute first
+        /// </summary>
+        /// <remarks> Only evaluated once after instantiation </remarks>
+        int Order { get; }
+
+        void Draw(RenderContext context);
+    }
+}

--- a/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IProcessorBase.cs
+++ b/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IProcessorBase.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core;
+
+namespace Stride.Engine.FlexibleProcessing
+{
+    public interface IProcessorBase
+    {
+        /// <summary> Occurs right after the first component handled by this processor is added to the scene, but before <see cref="OnComponentAdded"/> </summary>
+        void SystemAdded(IServiceRegistry registryParam);
+        /// <summary> Occurs right after the last component handled by this processor is removed from the scene, after the call to <see cref="OnComponentRemoved"/> </summary>
+        void SystemRemoved();
+        /// <summary> Occurs right after a component is added to the scene </summary>
+        void OnComponentAdded(IMarkedComponent comp);
+        /// <summary> Occurs right after a component is removed from the scene </summary>
+        void OnComponentRemoved(IMarkedComponent comp);
+    }
+}

--- a/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IUpdateProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/FlexibleProcessing/IUpdateProcessor.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Games;
+
+namespace Stride.Engine.FlexibleProcessing
+{
+    public interface IUpdateProcessor
+    {
+        /// <summary>
+        /// The order of the processor, smaller values execute first
+        /// </summary>
+        /// <remarks> Only evaluated once after instantiation </remarks>
+        int Order { get; }
+
+        void Update(GameTime gameTime);
+    }
+
+}

--- a/sources/engine/Stride.Engine/Engine/FlexibleProcessing/ProcessorManager.cs
+++ b/sources/engine/Stride.Engine/Engine/FlexibleProcessing/ProcessorManager.cs
@@ -42,7 +42,7 @@ namespace Stride.Engine.FlexibleProcessing
 
         public void IntroduceComponent(EntityComponent _component)
         {
-            if (_component is IMarkedComponent component == false)
+            if (_component is not IMarkedComponent component)
                 return;
 
             var componentType = component.GetType();
@@ -101,7 +101,7 @@ namespace Stride.Engine.FlexibleProcessing
 
         public void RemoveComponent(EntityComponent _component)
         {
-            if (_component is IMarkedComponent component == false)
+            if (_component is not IMarkedComponent component)
                 return;
 
             foreach (var procIndex in compTypeToProcessorIndices[component.GetType()])

--- a/sources/engine/Stride.Engine/Engine/FlexibleProcessing/ProcessorManager.cs
+++ b/sources/engine/Stride.Engine/Engine/FlexibleProcessing/ProcessorManager.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Stride.Core;
+using Stride.Core.Diagnostics;
+using Stride.Games;
+using Stride.Rendering;
+
+namespace Stride.Engine.FlexibleProcessing
+{
+    public class ProcessorManager
+    {
+        /// <summary> Every processor created during runtime </summary>
+        /// <remarks>
+        /// Processor removed still have their slot filled in, with a null <see cref="ProcessorData.Instance"/> to remove insertion cost.
+        /// </remarks>
+        private readonly List<ProcessorData> processors = new();
+
+        /// <summary> Takes the type of the component and returns an array of the processors which handle this component </summary>
+        /// <remarks> Value is an array of indices pointing into the <see cref="processors"/> array </remarks>
+        private readonly Dictionary<Type, int[]> compTypeToProcessorIndices = new();
+
+        /// <summary> Takes the type of the processor and returns its position in the <see cref="processors"/> array </summary>
+        private readonly Dictionary<Type, int> typeToIndex = new();
+
+        /// <summary> The list of <see cref="IUpdateProcessor"/> sorted by its <see cref="IUpdateProcessor.Order"/> </summary>
+        private readonly SortedList<ProcessorSortingKey, UpdateData> processorsToUpdate = new();
+
+        /// <summary> The list of <see cref="IDrawProcessor"/> sorted by its <see cref="IDrawProcessor.Order"/> </summary>
+        private readonly SortedList<ProcessorSortingKey, DrawData> processorsToDraw = new();
+
+
+        private readonly IServiceRegistry registry;
+
+        public ProcessorManager(IServiceRegistry registryParam)
+        {
+            registry = registryParam;
+        }
+
+        public void IntroduceComponent(EntityComponent _component)
+        {
+            if (_component is IMarkedComponent component == false)
+                return;
+
+            var componentType = component.GetType();
+            if (compTypeToProcessorIndices.TryGetValue(componentType, out var processorsIndex) == false) // Create cache for this type
+            {
+                // One component may have multiple different IComponent<,>, we must handle each definition independently
+                // To do so we have to iterate over all the interfaces this component may contain
+                var interfaces = componentType.GetInterfaces();
+                var processorsForThisType = new List<int>();
+                foreach (var type in interfaces)
+                {
+                    if (type.IsGenericType == false)
+                        continue;
+
+                    if (typeof(IComponent<,>) != type.GetGenericTypeDefinition())
+                        continue; // This interface is not IComponent<,>
+
+                    var processorType = type.GenericTypeArguments[0];
+                    if (typeToIndex.TryGetValue(processorType, out var procIndex) == false)
+                    {
+                        processors.Add(new(null, processorType, 0));
+                        typeToIndex[processorType] = procIndex = processors.Count - 1;
+                    }
+
+                    processorsForThisType.Add(procIndex);
+                }
+
+                compTypeToProcessorIndices[componentType] = processorsIndex = processorsForThisType.ToArray();
+            }
+
+            foreach (var procIndex in processorsIndex)
+            {
+                var pData = processors[procIndex];
+                pData.ComponentCount++;
+
+                if (pData.Instance == null) // if the processor hasn't been created yet or was previously removed
+                {
+                    pData.Instance = (IProcessorBase)Activator.CreateInstance(pData.Type)!;
+                    if (pData.Instance is IUpdateProcessor update)
+                        processorsToUpdate.Add(new(update.Order, pData.Type), new(update, new ProfilingKey(GameProfilingKeys.GameUpdate, GetType().Name)));
+                    if (pData.Instance is IDrawProcessor draw)
+                        processorsToDraw.Add(new(draw.Order, pData.Type), new(draw, new ProfilingKey(GameProfilingKeys.GameDraw, GetType().Name)));
+
+                    processors[procIndex] = pData; // Set beforehand just in case SystemAdded adds a component
+                    pData.Instance!.SystemAdded(registry);
+                    pData = processors[procIndex]; // Refresh local for the same reason
+                }
+                else
+                {
+                    processors[procIndex] = pData;
+                }
+
+                pData.Instance!.OnComponentAdded(component);
+            }
+        }
+
+        public void RemoveComponent(EntityComponent _component)
+        {
+            if (_component is IMarkedComponent component == false)
+                return;
+
+            foreach (var procIndex in compTypeToProcessorIndices[component.GetType()])
+            {
+                var pData = processors[procIndex];
+                pData.ComponentCount--;
+                processors[procIndex] = pData;
+                pData.Instance!.OnComponentRemoved(component);
+
+                if (pData.ComponentCount == 0 && processors[procIndex].ComponentCount == 0) // Double check in case OnEntityComponentRemoved added a component
+                {
+                    var system = pData.Instance!;
+                    pData.Instance = null;
+                    processors[procIndex] = pData;
+                    system.SystemRemoved();
+                    if (system is IUpdateProcessor update)
+                    {
+                        for (int i = 0; i < processorsToUpdate.Count; i++)
+                        {
+                            var val = processorsToUpdate.GetValueAtIndex(i);
+                            if (ReferenceEquals(val.Instance, update))
+                            {
+                                processorsToUpdate.RemoveAt(i);
+                                break;
+                            }
+                        }
+                    }
+
+                    if (system is IDrawProcessor draw)
+                    {
+                        for (int i = 0; i < processorsToDraw.Count; i++)
+                        {
+                            var val = processorsToDraw.GetValueAtIndex(i);
+                            if (ReferenceEquals(val.Instance, draw))
+                            {
+                                processorsToDraw.RemoveAt(i);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Update(GameTime gameTime)
+        {
+            foreach (var (_, processor) in processorsToUpdate)
+            {
+                using (Profiler.Begin(processor.ProfilingKey))
+                {
+                    processor.Instance.Update(gameTime);
+                }
+            }
+        }
+
+        public void Draw(RenderContext context)
+        {
+            foreach (var (_, processor) in processorsToDraw)
+            {
+                using (Profiler.Begin(processor.ProfilingKey))
+                {
+                    processor.Instance.Draw(context);
+                }
+            }
+        }
+
+        private record struct UpdateData(IUpdateProcessor Instance, ProfilingKey ProfilingKey);
+        private record struct DrawData(IDrawProcessor Instance, ProfilingKey ProfilingKey);
+        private record struct ProcessorData(IProcessorBase? Instance, Type Type, int ComponentCount);
+
+        private readonly record struct ProcessorSortingKey(int Order, Type Type) : IComparable<ProcessorSortingKey>
+        {
+            public int CompareTo(ProcessorSortingKey other)
+            {
+                int comp = Order.CompareTo(other.Order);
+                if (comp == 0)
+                    return string.Compare(Type.FullName, other.Type.FullName, StringComparison.Ordinal);
+
+                return comp;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# PR Details
This PR enables building of processors from interfaces, enabling unrelated types to be processed by the same system. 

The current processor implementation force users to derive from the same root type to build their logic, this does not work well with the fact that we have different 'Script' variant which have all their specific use. It becomes a composition issue when more abstract concepts, like event functions, are introduced. 

A good example of that is when components should manipulate physics object, it is preferable to do so in lockstep with the physics engine's tick. But those component may also require an async or update loop to process inputs. We would be forced to either create another new 'script' type which users have to derive from which would split their logic between two different types, or tie it to one of the other 'script', both solutions would introduce additional overhead while not being practical.

Example usage:
```cs
public class MyComponent : StartupScript, IPhysicsTick
{
    public void Tick(float deltaTime){ }
}

public interface IPhysicsTick : IComponent<IPhysicsTick.PhysicsTickProc, IPhysicsTick>
{
    void Tick(float deltaTime);
    public class PhysicsTickProc : IProcessor, IUpdateProcessor
    {
        public int Order => 5;
        public List<IPhysicsTick> Components = new();
        public void SystemAdded(IServiceRegistry registryParam) { }
        public void SystemRemoved() { }
        public void OnComponentAdded(IPhysicsTick item) => Components.Add(item);
        public void OnComponentRemoved(IPhysicsTick item) => Components.Remove(item);
        public void Update(GameTime gameTime)
        {
            foreach (var comp in Components)
                comp.Tick((float)gameTime.Elapsed.TotalSeconds);
        }
    }
}

```
Implementer may include additional processing during the `OnComponentAdded` step to reduce or elide virtual calls

## Related Issue
Introduced for usage in #2131 

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
