### PR TITLE
refactor: Make FastList Obsolete

### DIFF
--- a/sources/core/Stride.Core/Collections/FastList.cs
+++ b/sources/core/Stride.Core/Collections/FastList.cs
@@ -13,11 +13,13 @@ using Stride.Core.Serialization.Serializers;
 namespace Stride.Core.Collections
 {
     /// <summary>
-    /// Similar to <see cref="List{T}"/>, with direct access to underlying array.
+    /// <para>Similar to <see cref="List{T}"/>, with direct access to underlying array.</para>
+    /// <para>It is recommended to use Spans instead: <see href="https://github.com/stride3d/stride/discussions/2298#discussioncomment-9779439"/></para>
     /// </summary>
     /// <typeparam name="T">The type of elements in the list.</typeparam>
     [DataSerializer(typeof(ListAllSerializer<,>), Mode = DataSerializerGenericMode.TypeAndGenericArguments)]
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
+    [Obsolete(".NET Lists can be faster in the latest .NET versions.")]
     public class FastList<T> : IList<T>, IReadOnlyList<T>, ICollection<T>, IEnumerable<T>, IEnumerable
     {
         // Fields
@@ -27,6 +29,7 @@ namespace Stride.Core.Collections
         /// Gets the items.
         /// </summary>
         [DataMemberIgnore]
+        [Obsolete("Its best to use a List<T> instead of FastList<T> and iterate through the list as a Span for peak performance.")]
         public T[] Items { get; private set; }
 
         private int size;


### PR DESCRIPTION
# PR Details

Added info on the deprecation of FasLists list. Better alternatives have been made easier since .NET 5+ to make the base List class twice as fast.

![339938102-cbc58c9c-406b-4465-a928-d65fe006928c](https://github.com/stride3d/stride/assets/73259914/7c3f533a-1fdf-4920-bf04-dde1b08f8cee)


## Related Issue

https://github.com/stride3d/stride/discussions/2298

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
