### PR TITLE
Update guillotine packer documentation link

### DIFF
--- a/sources/core/Stride.Core.Mathematics/GuillotinePacker.cs
+++ b/sources/core/Stride.Core.Mathematics/GuillotinePacker.cs
@@ -8,7 +8,7 @@ namespace Stride.Core.Mathematics
 {
     /// <summary>
     /// Implementation of a "Guillotine" packer.
-    /// More information at https://en.wikipedia.org/wiki/Guillotine_cutting.
+    /// More information at https://github.com/juj/RectangleBinPack/blob/master/RectangleBinPack.pdf.
     /// </summary>
     public class GuillotinePacker
     {

--- a/sources/core/Stride.Core.Mathematics/GuillotinePacker.cs
+++ b/sources/core/Stride.Core.Mathematics/GuillotinePacker.cs
@@ -8,7 +8,7 @@ namespace Stride.Core.Mathematics
 {
     /// <summary>
     /// Implementation of a "Guillotine" packer.
-    /// More information at http://clb.demon.fi/files/RectangleBinPack.pdf.
+    /// More information at https://en.wikipedia.org/wiki/Guillotine_cutting.
     /// </summary>
     public class GuillotinePacker
     {


### PR DESCRIPTION
# PR Details
- Replace link in `GuillotinePacker` documentation

## Description
While browsing the `Core.Mathematics` namespace, I noticed that the link to http://clb.demon.fi/files/RectangleBinPack.pdf seems to have rotted. After a bit of googling, I think I was able to find the author's github and a link to the PDF there.

## Related Issue
None, just a documentation change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
