### PR TITLE
[Editor] Fix displaying & editing project User Settings

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/Components/Properties/PackageSettingsWrapper.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/Properties/PackageSettingsWrapper.cs
@@ -92,6 +92,7 @@ namespace Stride.Core.Assets.Editor.Components.Properties
 
         internal bool HasExecutables { get; set; }
 
+        [DataMember]
         [MemberCollection(ReadOnly = true)]
         [Category]
         [NonIdentifiableCollectionItems]


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
`[DataMember]` makes the user settings appear again, probably was caused by #1875

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2347

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
