### PR TITLE
Fix getting app exe path when using PublishSingleFile

### DIFF
--- a/sources/core/Stride.Core.Design/Settings/AppSettingsProvider.cs
+++ b/sources/core/Stride.Core.Design/Settings/AppSettingsProvider.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Reflection;
 using Stride.Core.Yaml;
 
 namespace Stride.Core.Settings
@@ -14,9 +13,9 @@ namespace Stride.Core.Settings
         /// <inheritdoc/>
         public AppSettings LoadAppSettings()
         {
-            var execFilePath = Assembly.GetEntryAssembly()?.Location;
+            var execFilePath = PlatformFolders.ApplicationExecutablePath;
 
-            if (execFilePath == null)
+            if (string.IsNullOrEmpty(execFilePath))
                 return new AppSettings();
 
             var settingsFilePath = Path.ChangeExtension(execFilePath, SettingsExtension);

--- a/sources/core/Stride.Core/PlatformFolders.cs
+++ b/sources/core/Stride.Core/PlatformFolders.cs
@@ -155,7 +155,12 @@ namespace Stride.Core
 #if STRIDE_PLATFORM_ANDROID
             return PlatformAndroid.Context.PackageCodePath;
 #elif STRIDE_PLATFORM_DESKTOP || STRIDE_PLATFORM_MONO_MOBILE
-            return Assembly.GetEntryAssembly()?.Location;
+            var appPath = Assembly.GetEntryAssembly()?.Location;
+            if (string.IsNullOrEmpty(appPath))
+            {
+                appPath = Environment.ProcessPath;
+            }
+            return appPath;
 #else
             return null;
 #endif

--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using Stride.Audio;
+using Stride.Core;
 using Stride.Core.Diagnostics;
 using Stride.Core.IO;
 using Stride.Core.Mathematics;
@@ -428,7 +428,7 @@ namespace Stride.Engine
                     && Input.IsKeyDown(Keys.C)
                     && Input.IsKeyReleased(Keys.F12))
                 {
-                    var currentFilePath = Assembly.GetEntryAssembly().Location;
+                    var currentFilePath = PlatformFolders.ApplicationExecutablePath;
                     var timeNow = DateTime.Now.ToString("s", CultureInfo.InvariantCulture).Replace(':', '_');
                     var newFileName = Path.Combine(
                         Path.GetDirectoryName(currentFilePath),

--- a/sources/engine/Stride.Games/Desktop/GamePlatformDesktop.cs
+++ b/sources/engine/Stride.Games/Desktop/GamePlatformDesktop.cs
@@ -23,7 +23,6 @@
 #if STRIDE_PLATFORM_DESKTOP
 using System;
 using System.IO;
-using System.Reflection;
 using Stride.Core;
 
 namespace Stride.Games
@@ -46,7 +45,8 @@ namespace Stride.Games
         {
             get
             {
-                var assemblyUri = new Uri(Assembly.GetEntryAssembly().Location);
+                var appPath = PlatformFolders.ApplicationExecutablePath ?? PlatformFolders.ApplicationBinaryDirectory;
+                var assemblyUri = new Uri(appPath);
                 return Path.GetDirectoryName(assemblyUri.LocalPath);
             }
         }

--- a/sources/engine/Stride.Games/GameContext.cs
+++ b/sources/engine/Stride.Games/GameContext.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Reflection;
+using Stride.Core;
 using Stride.Graphics;
 
 namespace Stride.Games
@@ -122,8 +123,7 @@ namespace Stride.Games
 #if STRIDE_PLATFORM_UWP
                 return string.Empty;
 #else
-                var assembly = Assembly.GetEntryAssembly();
-                return assembly?.Location;
+                return PlatformFolders.ApplicationExecutablePath ?? string.Empty;
 #endif
             }
         }


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Use `PlatformFolders.ApplicationExecutablePath` instead of `Assembly.GetEntryAssembly().Location`

https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility
Under 'API incompatibility' `Assembly.Location` is not available with single file deployment.
https://learn.microsoft.com/en-us/dotnet/api/system.environment.processpath?view=net-8.0
`Environment.ProcessPath` can be used as a fallback, but do note that even that can return null.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2304 where Icon is set via `GameContext.ProductLocation`

Also fixes the super secret LeftCtrl + C+ F1 screenshot command in PublishSingleFile.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
