### PR TITLE
fix: importing effects to the EffectCompileLog 

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/EffectCompilerServerSession.cs
+++ b/sources/editor/Stride.Assets.Presentation/EffectCompilerServerSession.cs
@@ -173,6 +173,14 @@ namespace Stride.Assets.Presentation
         private void CheckEffectLogAsset(PackageViewModel package)
         {
             var newEffectLogViewModel = package.Assets.FirstOrDefault(x => x.Name == EffectLogAsset.DefaultFile) as EffectLogViewModel;
+            if (newEffectLogViewModel is null && session.CurrentProject is not null)
+            {
+                // Check if the EffectLog asset exists in any of the active project's referenced local projects
+                var projectDependencies = session.CurrentProject.PackageContainer.FlattenedDependencies.Where(x => x.Type == DependencyType.Project).ToList();
+                var localPackageDependencies = session.LocalPackages.Where(pkgViewModel => projectDependencies.Any(projDep => projDep.Package == pkgViewModel.Package));
+                var localPackagesAssets = localPackageDependencies.SelectMany(x => x.Assets);
+                newEffectLogViewModel = localPackagesAssets.FirstOrDefault(x => x.Name == EffectLogAsset.DefaultFile) as EffectLogViewModel;
+            }
             var newEffectLogText = newEffectLogViewModel?.Text;
 
             if (newEffectLogText != effectLogText // Asset changed?


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Only one fix:
1. When checking for effect log changes, `EffectCompilerServerSession` should try to find any existing EffectCompilerLog asset in the active project (or its referenced projects, eg. the Game project) if the current package it's looking at does not contain one, and reuse that.
This is because there can only be one EffectCompilerLog asset (see #2361 for the related problem)


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #301, but this only fixes it so it reuses the existing EffectCompilerLog asset if it exists, however if none exists it will generate the log asset in the active project's asset folder.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
