### PR TITLE
fix: [DirectoryWatcher] - Folders are case sensitive on Linux

### DIFF
--- a/sources/core/Stride.Core.IO/DirectoryWatcher.Desktop.cs
+++ b/sources/core/Stride.Core.IO/DirectoryWatcher.Desktop.cs
@@ -135,7 +135,7 @@ namespace Stride.Core.IO
 
             if (path != null && Directory.Exists(path))
             {
-                info = new DirectoryInfo(path.ToLowerInvariant());
+                info = new DirectoryInfo(OperatingSystem.IsLinux() ? path :  path.ToLowerInvariant());
             }
             else
             {
@@ -326,7 +326,7 @@ namespace Stride.Core.IO
         {
             public DirectoryWatcherItem(DirectoryInfo path)
             {
-                Path = path.FullName.ToLowerInvariant();
+                Path = OperatingSystem.IsLinux() ? path.FullName : path.FullName.ToLowerInvariant();
             }
 
             public DirectoryWatcherItem Parent;

--- a/sources/core/Stride.Core.IO/DirectoryWatcher.Desktop.cs
+++ b/sources/core/Stride.Core.IO/DirectoryWatcher.Desktop.cs
@@ -135,6 +135,7 @@ namespace Stride.Core.IO
 
             if (path != null && Directory.Exists(path))
             {
+                // TODO : Need to investigate later whether ToLower method is safe to remove for Windows OS
                 info = new DirectoryInfo(OperatingSystem.IsLinux() ? path :  path.ToLowerInvariant());
             }
             else
@@ -326,7 +327,8 @@ namespace Stride.Core.IO
         {
             public DirectoryWatcherItem(DirectoryInfo path)
             {
-                Path = OperatingSystem.IsLinux() ? path.FullName : path.FullName.ToLowerInvariant();
+                // TODO : Need to investigate later whether ToLower method is safe to remove for Windows OS
+                Path = OperatingSystem.IsLinux() ? path.FullName : path.FullName.ToLowerInvariant(); 
             }
 
             public DirectoryWatcherItem Parent;


### PR DESCRIPTION
# PR Details

For some reason Path is transformed to lowercase, but on Linux distros it causes a runtime error - "The directory name .... does not exist" during game runtime.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
