### PR TITLE
fix: Replace ToWindowsPath with ToOSPath

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/PackageBuilder.cs
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/PackageBuilder.cs
@@ -195,7 +195,7 @@ namespace Stride.Core.Assets.CompilerApp
             {
                 // Note: check if file exists (since it could be an "implicit package" from csproj)
                 if (File.Exists(package.FullPath))
-                    inputs.Add(package.FullPath.ToWindowsPath());
+                    inputs.Add(package.FullPath.ToOSPath());
 
                 // TODO: optimization: for nuget packages, directly use sha512 file rather than individual assets for faster checking
 
@@ -203,7 +203,7 @@ namespace Stride.Core.Assets.CompilerApp
                 foreach (var assetFolder in package.AssetFolders)
                 {
                     if (Directory.Exists(assetFolder.Path))
-                        inputs.Add(assetFolder.Path.ToWindowsPath() + @"\**\*.*");
+                        inputs.Add(assetFolder.Path.ToOSPath() + "/**/*.*".Replace('/', Path.DirectorySeparatorChar));
                 }
 
                 // List project assets
@@ -215,7 +215,7 @@ namespace Stride.Core.Assets.CompilerApp
                     {
                         // Make sure it is not already covered by one of the previously registered asset folders
                         if (!package.AssetFolders.Any(assetFolder => assetFolder.Path.Contains(assetItem.FullPath)))
-                            inputs.Add(assetItem.FullPath.ToWindowsPath());
+                            inputs.Add(assetItem.FullPath.ToOSPath());
                     }
                 }
 
@@ -233,7 +233,7 @@ namespace Stride.Core.Assets.CompilerApp
             {
                 if (inputObject.Key.Type == UrlType.File)
                 {
-                    inputs.Add(new UFile(inputObject.Key.Path).ToWindowsPath());
+                    inputs.Add(new UFile(inputObject.Key.Path).ToOSPath());
                 }
             }
 

--- a/sources/assets/Stride.Core.Assets.CompilerApp/Tasks/PackAssets.cs
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/Tasks/PackAssets.cs
@@ -41,7 +41,7 @@ namespace Stride.Core.Assets.CompilerApp.Tasks
 
             void RegisterItem(UFile targetFilePath)
             {
-                generatedItems.Add((targetFilePath.ToWindowsPath(), UPath.Combine("stride", targetFilePath.MakeRelative(outputPath)).ToWindowsPath()));
+                generatedItems.Add((targetFilePath.ToOSPath(), UPath.Combine("stride", targetFilePath.MakeRelative(outputPath)).ToOSPath()));
             }
 
             void TryCopyDirectory(UDirectory sourceDirectory, UDirectory targetDirectory, string exclude = null)
@@ -70,7 +70,7 @@ namespace Stride.Core.Assets.CompilerApp.Tasks
 
                 if (resourcesTargetToSource.TryGetValue(targetFilePath, out var otherResourceFilePath))
                 {
-                    logger.Error($"Could not copy resource file [{targetFilePath.MakeRelative(resourceOutputPath)}] because it exists in multiple locations: [{resourceFilePath.ToWindowsPath()}] and [{otherResourceFilePath.ToWindowsPath()}]");
+                    logger.Error($"Could not copy resource file [{targetFilePath.MakeRelative(resourceOutputPath)}] because it exists in multiple locations: [{resourceFilePath.ToOSPath()}] and [{otherResourceFilePath.ToOSPath()}]");
                 }
                 else
                 {
@@ -85,7 +85,7 @@ namespace Stride.Core.Assets.CompilerApp.Tasks
                     }
                     catch (Exception e)
                     {
-                        logger.Error($"Could not copy resource file from [{resourceFilePath.ToWindowsPath()}] to [{targetFilePath.MakeRelative(resourceOutputPath)}]", e);
+                        logger.Error($"Could not copy resource file from [{resourceFilePath.ToOSPath()}] to [{targetFilePath.MakeRelative(resourceOutputPath)}]", e);
                     }
                 }
             }

--- a/sources/assets/Stride.Core.Assets.Tests/TestAssetUpgrade.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestAssetUpgrade.cs
@@ -136,7 +136,7 @@ namespace Stride.Core.Assets.Tests
             AssetFileSerializer.Save(outputFilePath, asset, null);
 
             var logger = new LoggerResult();
-            var context = new AssetMigrationContext(null, loadingFilePath.ToReference(), loadingFilePath.FilePath.ToWindowsPath(), logger);
+            var context = new AssetMigrationContext(null, loadingFilePath.ToReference(), loadingFilePath.FilePath.ToOSPath(), logger);
             Assert.Equal(AssetMigration.MigrateAssetIfNeeded(context, loadingFilePath, "TestPackage"), needMigration);
 
             if (needMigration)

--- a/sources/assets/Stride.Core.Assets/AssetItemExtensions.cs
+++ b/sources/assets/Stride.Core.Assets/AssetItemExtensions.cs
@@ -18,7 +18,7 @@ namespace Stride.Core.Assets
         {
             var assetFullPath = assetItem.FullPath;
             var projectFullPath = (assetItem.Package.Container as SolutionProject)?.FullPath;
-            return assetFullPath.MakeRelative(projectFullPath.GetFullDirectory()).ToWindowsPath();
+            return assetFullPath.MakeRelative(projectFullPath.GetFullDirectory()).ToOSPath();
         }
 
         /// <summary>

--- a/sources/assets/Stride.Core.Assets/Compiler/ItemListCompiler.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/ItemListCompiler.cs
@@ -89,7 +89,7 @@ namespace Stride.Core.Assets.Compiler
                 AssetCompiled?.Invoke(this, new AssetCompiledArgs(assetItem, resultPerAssetType));
 
                 // TODO: See if this can be unified with PackageBuilder.BuildStepProcessed
-                var assetFullPath = assetItem.FullPath.ToWindowsPath();
+                var assetFullPath = assetItem.FullPath.ToOSPath();
                 foreach (var message in resultPerAssetType.Messages)
                 {
                     var assetMessage = AssetLogMessage.From(null, assetItem.ToReference(), message, assetFullPath);
@@ -106,7 +106,7 @@ namespace Stride.Core.Assets.Compiler
 
                 // TODO: Big review of the log infrastructure of CompilerApp & BuildEngine!
                 // Assign module string to all command build steps
-                SetAssetLogger(resultPerAssetType.BuildSteps, assetItem.Package, assetItem.ToReference(), assetItem.FullPath.ToWindowsPath());
+                SetAssetLogger(resultPerAssetType.BuildSteps, assetItem.Package, assetItem.ToReference(), assetItem.FullPath.ToOSPath());
 
                 foreach (var buildStep in resultPerAssetType.BuildSteps)
                 {

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -631,7 +631,7 @@ namespace Stride.Core.Assets
 
                 // Find the .csproj next to .sdpkg (if any)
                 // Note that we use package.FullPath since we must first perform package upgrade from 3.0 to 3.1+ (might move package in .csproj folder)
-                var projectPath = Path.ChangeExtension(package.FullPath.ToWindowsPath(), ".csproj");
+                var projectPath = Path.ChangeExtension(package.FullPath.ToOSPath(), ".csproj");
                 if (File.Exists(projectPath))
                 {
                     return new SolutionProject(package, Guid.NewGuid(), projectPath);
@@ -881,8 +881,8 @@ namespace Stride.Core.Assets
                 loggerResult?.Progress(progressMessage, i, assetFiles.Count);
 
                 var task = cancelToken.HasValue ?
-                    System.Threading.Tasks.Task.Factory.StartNew(() => LoadAsset(new AssetMigrationContext(this, assetFile.ToReference(), assetFile.FilePath.ToWindowsPath(), log), assetFile), cancelToken.Value) : 
-                    System.Threading.Tasks.Task.Factory.StartNew(() => LoadAsset(new AssetMigrationContext(this, assetFile.ToReference(), assetFile.FilePath.ToWindowsPath(), log), assetFile));
+                    System.Threading.Tasks.Task.Factory.StartNew(() => LoadAsset(new AssetMigrationContext(this, assetFile.ToReference(), assetFile.FilePath.ToOSPath(), log), assetFile), cancelToken.Value) : 
+                    System.Threading.Tasks.Task.Factory.StartNew(() => LoadAsset(new AssetMigrationContext(this, assetFile.ToReference(), assetFile.FilePath.ToOSPath(), log), assetFile));
 
                 tasks.Add(task);
             }
@@ -1054,7 +1054,7 @@ namespace Stride.Core.Assets
                 // If csproj, we might need to compile it
                 if (projectReference != null)
                 {
-                    var fullProjectLocation = projectReference.Location.ToWindowsPath();
+                    var fullProjectLocation = projectReference.Location.ToOSPath();
                     if (loadParameters.AutoCompileProjects || string.IsNullOrWhiteSpace(assemblyPath))
                     {
                         assemblyPath = VSProjectHelper.GetOrCompileProjectAssembly(Session?.SolutionPath, fullProjectLocation, forwardingLogger, "Build", loadParameters.AutoCompileProjects, loadParameters.BuildConfiguration, extraProperties: loadParameters.ExtraCompileProperties, onlyErrors: true);

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -119,7 +119,7 @@ namespace Stride.Core.Assets
             }
             catch (Exception ex)
             {
-                log.Error($"Unexpected exception while loading project [{project.FullPath.ToWindowsPath()}]", ex);
+                log.Error($"Unexpected exception while loading project [{project.FullPath.ToOSPath()}]", ex);
             }
 
             foreach (var packageReference in packageReferences)
@@ -182,7 +182,7 @@ namespace Stride.Core.Assets
                     try
                     {
                         var projectFile = project.FullPath;
-                        var msbuildProject = VSProjectHelper.LoadProject(projectFile.ToWindowsPath());
+                        var msbuildProject = VSProjectHelper.LoadProject(projectFile.ToOSPath());
                         var isProjectDirty = false;
 
                         foreach (var packageReference in msbuildProject.GetItems("PackageReference").ToList())
@@ -238,7 +238,7 @@ namespace Stride.Core.Assets
                 }
                 catch (Exception ex)
                 {
-                    log.Error($"Unexpected exception while loading project [{project.FullPath.ToWindowsPath()}]", ex);
+                    log.Error($"Unexpected exception while loading project [{project.FullPath.ToOSPath()}]", ex);
                 }
             }
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -340,7 +340,7 @@ namespace Stride.Core.Assets
                 return;
 
             var projectFile = FullPath;
-            var msbuildProject = VSProjectHelper.LoadProject(projectFile.ToWindowsPath());
+            var msbuildProject = VSProjectHelper.LoadProject(projectFile.ToOSPath());
             var isProjectDirty = false;
 
             if (e.OldItems != null && e.OldItems.Count > 0)
@@ -380,7 +380,7 @@ namespace Stride.Core.Assets
                             isProjectDirty = true;
                             break;
                         case DependencyType.Project:
-                            msbuildProject.AddItem("ProjectReference", ((UFile)dependency.MSBuildProject).MakeRelative(projectFile.GetFullDirectory()).ToWindowsPath());
+                            msbuildProject.AddItem("ProjectReference", ((UFile)dependency.MSBuildProject).MakeRelative(projectFile.GetFullDirectory()).ToOSPath());
                             isProjectDirty = true;
                             break;
                     }
@@ -646,7 +646,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
                 // Enable reference analysis caching during loading
                 AssetReferenceAnalysis.EnableCaching = true;
 
-                project = LoadProject(logger, projectPath.ToWindowsPath(), loadParametersArg);
+                project = LoadProject(logger, projectPath.ToOSPath(), loadParametersArg);
                 Projects.Add(project);
 
                 package = project.Package;
@@ -1045,7 +1045,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
                                     Microsoft.Build.Evaluation.Project project;
                                     if (!vsProjs.TryGetValue(projectFullPath, out project))
                                     {
-                                        project = VSProjectHelper.LoadProject(projectFullPath.ToWindowsPath());
+                                        project = VSProjectHelper.LoadProject(projectFullPath.ToOSPath());
                                         vsProjs.Add(projectFullPath, project);
                                     }
                                     var projectItem = project.Items.FirstOrDefault(x => (x.ItemType == "Compile" || x.ItemType == "None") && x.EvaluatedInclude == projectInclude);
@@ -1058,7 +1058,7 @@ MinimumVisualStudioVersion = {0}".ToFormat(DefaultVisualStudioVersion);
                                     var generatorAsset = assetItem.Asset as IProjectFileGeneratorAsset;
                                     if (generatorAsset != null)
                                     {
-                                        var generatedAbsolutePath = assetItem.GetGeneratedAbsolutePath().ToWindowsPath();
+                                        var generatedAbsolutePath = assetItem.GetGeneratedAbsolutePath().ToOSPath();
 
                                         File.Delete(generatedAbsolutePath);
 

--- a/sources/core/Stride.Core.Design.Tests/TestUPath.cs
+++ b/sources/core/Stride.Core.Design.Tests/TestUPath.cs
@@ -330,7 +330,7 @@ namespace Stride.Core.Design.Tests
         }
 
         [Fact]
-        public void TestUPathToWindowsPath()
+        public void TestUPathToOSPath()
         {
             // TODO
         }

--- a/sources/core/Stride.Core.Design/IO/UPath.cs
+++ b/sources/core/Stride.Core.Design/IO/UPath.cs
@@ -284,18 +284,7 @@ namespace Stride.Core.IO
         {
             return FullPath;
         }
-
-        /// <summary>
-        /// Converts this path to a Windows path (/ replaced by \)
-        /// </summary>
-        /// <returns>A string representation of this path in windows form.</returns>
-        [NotNull]
-        [Obsolete("Use ToOSPath() instead")]
-        public string ToWindowsPath()
-        {
-            return FullPath.Replace('/', '\\');
-        }
-
+        
         /// <summary>
         /// Converts this path to a OS path, 
         /// by replacing each separator with the current operating system

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EditorLightingViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EditorLightingViewModel.cs
@@ -109,7 +109,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
         private async Task CaptureCubemap()
         {
             var filepath = await ServiceProvider.Get<IDialogService>().SaveFilePickerAsync(
-                editor.Session.SolutionPath?.GetFullDirectory().ToWindowsPath(),
+                editor.Session.SolutionPath?.GetFullDirectory().ToOSPath(),
                 [new FilePickerFilter("DDS texture") { Patterns = ["*.dds"] }],
                 "dds");
             if (filepath is not null)

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/VisualScriptEditorViewModel.Diagnostics.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/VisualScriptEditorViewModel.Diagnostics.cs
@@ -46,7 +46,7 @@ namespace Stride.Assets.Presentation.AssetEditors.VisualScriptEditor
 
             try
             {
-                var generatedAbsolutePath = assetItem.GetGeneratedAbsolutePath()?.ToWindowsPath();
+                var generatedAbsolutePath = assetItem.GetGeneratedAbsolutePath()?.ToOSPath();
                 if (generatedAbsolutePath == null)
                     return;
 

--- a/sources/editor/Stride.Assets.Presentation/StrideDefaultAssetsPlugin.cs
+++ b/sources/editor/Stride.Assets.Presentation/StrideDefaultAssetsPlugin.cs
@@ -99,7 +99,7 @@ namespace Stride.Assets.Presentation
                 var packageFile = PackageStore.Instance.GetPackageFileName(packageInfo.Name, new PackageVersionRange(new PackageVersion(packageInfo.Version)));
                 if (packageFile is null)
                     throw new InvalidOperationException($"Could not find package {packageInfo.Name} {packageInfo.Version}. Ensure packages have been resolved.");
-                var package = Package.Load(logger, packageFile.ToWindowsPath());
+                var package = Package.Load(logger, packageFile.ToOSPath());
                 if (logger.HasErrors)
                     throw new InvalidOperationException($"Could not load package {packageInfo.Name}:{Environment.NewLine}{logger.ToText()}");
 

--- a/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/NewGameTemplateGenerator.cs
@@ -332,13 +332,13 @@ namespace Stride.Assets.Presentation.Templates
             try
             {
                 var resources = UPath.Combine(package.RootDirectory, (UDirectory)"Resources");
-                Directory.CreateDirectory(resources.ToWindowsPath());
+                Directory.CreateDirectory(resources.ToOSPath());
 
                 // TODO: Hardcoded due to the fact that part of the template is in another folder in dev build
                 // We might want to extend TemplateFolder to support those cases
                 var dataDirectory = ProjectTemplateGeneratorHelper.GetTemplateDataDirectory(parameters.Description);
-                var skyboxFullPath = UPath.Combine(dataDirectory, skyboxFilename).ToWindowsPath();
-                File.Copy(skyboxFullPath, UPath.Combine(resources, skyboxFilename).ToWindowsPath(), true);
+                var skyboxFullPath = UPath.Combine(dataDirectory, skyboxFilename).ToOSPath();
+                File.Copy(skyboxFullPath, UPath.Combine(resources, skyboxFilename).ToOSPath(), true);
             }
             catch (Exception ex)
             {

--- a/sources/editor/Stride.Assets.Presentation/Templates/SoundFromFileTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/SoundFromFileTemplateGenerator.cs
@@ -46,7 +46,7 @@ namespace Stride.Assets.Presentation.Templates
                 {
                     using (var media = new FFmpegMedia())
                     {
-                        media.Open(soundAsset.Source.ToWindowsPath());
+                        media.Open(soundAsset.Source.ToOSPath());
                         var audioStreams = media.Streams.OfType<AudioStream>().ToList();
                         foreach (var audioTrack in audioStreams)
                         {

--- a/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/TemplateSampleGenerator.cs
@@ -322,7 +322,7 @@ namespace Stride.Assets.Presentation.Templates
             if (!await updateTemplate.PrepareForRun(updateParameters) || !updateTemplate.Run(updateParameters))
             {
                 // Remove the created project
-                var path = Path.GetDirectoryName(parameters.Session.SolutionPath.ToWindowsPath());
+                var path = Path.GetDirectoryName(parameters.Session.SolutionPath.ToOSPath());
                 try
                 {
                     Directory.Delete(path ?? "", true);

--- a/sources/editor/Stride.Assets.Presentation/Templates/UpdatePlatformsTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/UpdatePlatformsTemplateGenerator.cs
@@ -116,7 +116,7 @@ namespace Stride.Assets.Presentation.Templates
             var templateGameLibrary = PrepareTemplate(parameters, "ProjectLibrary.Game/ProjectLibrary.Game.ttproj", PlatformType.Shared, null, null, ProjectType.Library);
             var options = ProjectTemplateGeneratorHelper.GetOptions(parameters);
             var newGameTargetFrameworks = templateGameLibrary.GeneratePart(@"..\Common.TargetFrameworks.targets.t4", logger, options);
-            PatchGameProject(newGameTargetFrameworks, gameProject.FullPath.ToWindowsPath());
+            PatchGameProject(newGameTargetFrameworks, gameProject.FullPath.ToOSPath());
 
             // Generate missing platforms
             bool forceGenerating = parameters.GetTag(ForcePlatformRegenerationKey);

--- a/sources/editor/Stride.Assets.Presentation/Templates/VideoFromFileTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/VideoFromFileTemplateGenerator.cs
@@ -44,7 +44,7 @@ namespace Stride.Assets.Presentation.Templates
             {
                 using (var media = new FFmpegMedia())
                 {
-                    media.Open(file.ToWindowsPath());
+                    media.Open(file.ToOSPath());
                     
                     var videoStream = media.Streams.OfType<VideoStream>().FirstOrDefault();
                     if (videoStream != null)

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -245,7 +245,7 @@ namespace Stride.Assets.Presentation.ViewModel
                 var dialogResult = projectViewModel.Session.Dialogs.BlockingMessageBox(
                     string.Format(
                         Tr._p("Message", "The following source files in the {0} project have been deleted externally, but have unsaved changes in Game Studio. Do you want to delete these files?\r\n\r\n{1}"),
-                       Path.GetFileName(project.FilePath), string.Join("\r\n", dirtyAssetsToDelete.Select(x => x.AssetItem.FullPath.ToWindowsPath()))),
+                       Path.GetFileName(project.FilePath), string.Join("\r\n", dirtyAssetsToDelete.Select(x => x.AssetItem.FullPath.ToOSPath()))),
                     MessageBoxButton.OKCancel);
                 if (dialogResult == MessageBoxResult.Cancel)
                     return false;

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/ScriptSourceFileAssetViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/ScriptSourceFileAssetViewModel.cs
@@ -196,7 +196,7 @@ namespace Stride.Assets.Presentation.ViewModel
             Dispatcher.Invoke(() =>
             {
                 // Update source file location with latest FullPath (in case it changed)
-                workspace.UpdateFilePath(DocumentId?.Result, FullPath.ToWindowsPath());
+                workspace.UpdateFilePath(DocumentId?.Result, FullPath.ToOSPath());
 
                 // TODO: This doesn't take into account the case where you move and then undo,
                 //  to fix this case the file would need to check for modifications after it has been moved
@@ -243,7 +243,7 @@ namespace Stride.Assets.Presentation.ViewModel
             AssetItem.UpdateSourceFolders();
 
             // Capture full path before going in a Task (might be renamed in between)
-            var fullPath = AssetItem.FullPath.ToWindowsPath();
+            var fullPath = AssetItem.FullPath.ToOSPath();
 
             DocumentId = Task.Run(async () =>
             {
@@ -252,7 +252,7 @@ namespace Stride.Assets.Presentation.ViewModel
                 workspace = await strideAssets.Code.Workspace;
 
                 AssetItem.UpdateSourceFolders();
-                var sourceProject = ((SolutionProject)AssetItem.Package.Container).FullPath.ToWindowsPath();
+                var sourceProject = ((SolutionProject)AssetItem.Package.Container).FullPath.ToOSPath();
                 if (sourceProject == null)
                     throw new InvalidOperationException($"Could not find project associated to asset [{AssetItem}]");
 

--- a/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/SessionTemplateGenerator.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/SessionTemplateGenerator.cs
@@ -120,7 +120,7 @@ Cache/
         protected void WriteGitIgnore(SessionTemplateGeneratorParameters parameters)
         {
             var fileName = UFile.Combine(parameters.OutputDirectory, ".gitignore");
-            File.WriteAllText(fileName.ToWindowsPath(), GitIgnore);
+            File.WriteAllText(fileName.ToOSPath(), GitIgnore);
         }
 
         private void EnsureGraphs(SessionTemplateGeneratorParameters parameters)

--- a/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/ExistingProjectViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/ViewModels/ExistingProjectViewModel.cs
@@ -28,7 +28,7 @@ namespace Stride.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels
 
         public string Name => Path.GetFileNameWithoutExtension();
 
-        public string Description => Path.ToWindowsPath();
+        public string Description => Path.ToOSPath();
 
         public string FullDescription => "";
 
@@ -55,7 +55,7 @@ namespace Stride.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels
 
         private void Explore()
         {
-            var startInfo = new ProcessStartInfo("explorer.exe", $"/select,{this.Path.ToWindowsPath()}") { UseShellExecute = true };
+            var startInfo = new ProcessStartInfo("explorer.exe", $"/select,{this.Path.ToOSPath()}") { UseShellExecute = true };
             var explorer = new Process { StartInfo = startInfo };
             explorer.Start();
         }

--- a/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/VisualStudioService.cs
@@ -81,7 +81,7 @@ namespace Stride.Core.Assets.Editor.Services
             }
             else
             {
-                startInfo.FileName = session.SolutionPath.ToWindowsPath();
+                startInfo.FileName = session.SolutionPath.ToOSPath();
                 startInfo.UseShellExecute = true;
             }
             try

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -720,7 +720,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             editorPath = Environment.ExpandEnvironmentVariables(editorPath);
             try
             {
-                var path = asset.AssetItem.FullPath.ToWindowsPath();
+                var path = asset.AssetItem.FullPath.ToOSPath();
                 if (!File.Exists(path))
                 {
                     await Dialogs.MessageBoxAsync(Tr._p("Message", "You need to save the file before you can open it."), MessageBoxButton.OK, MessageBoxImage.Information);

--- a/sources/editor/Stride.GameStudio/Plugin/StrideEditorPlugin.cs
+++ b/sources/editor/Stride.GameStudio/Plugin/StrideEditorPlugin.cs
@@ -37,7 +37,7 @@ namespace Stride.GameStudio.Plugin
                 if (package != null)
                 {
                     // In package, we override editor build directory to be per-project and be shared with game build directory
-                    buildDirectory = $"{package.PackagePath.GetFullDirectory().ToWindowsPath()}\\obj\\stride\\assetbuild\\data";
+                    buildDirectory = new UFile($"{package.PackagePath.GetFullDirectory()}\\obj\\stride\\assetbuild\\data").ToOSPath();
                 }
 
                 // Attempt to create the directory to ensure it is valid.

--- a/sources/editor/Stride.GameStudio/ViewModels/DebuggingViewModel.cs
+++ b/sources/editor/Stride.GameStudio/ViewModels/DebuggingViewModel.cs
@@ -405,8 +405,8 @@ namespace Stride.GameStudio.ViewModels
                     if (!string.IsNullOrEmpty(Session.SolutionPath))
                     {
                         var solutionPath = UPath.Combine(Environment.CurrentDirectory, Session.SolutionPath);
-                        extraProperties.Add("SolutionPath", solutionPath.ToWindowsPath());
-                        extraProperties.Add("SolutionDir", solutionPath.GetParent().ToWindowsPath() + "\\");
+                        extraProperties.Add("SolutionPath", solutionPath.ToOSPath());
+                        extraProperties.Add("SolutionDir", solutionPath.GetParent().ToOSPath() + Path.DirectorySeparatorChar);
                     }
                     else
                     {

--- a/sources/editor/Stride.GameStudio/ViewModels/GameStudioViewModel.cs
+++ b/sources/editor/Stride.GameStudio/ViewModels/GameStudioViewModel.cs
@@ -87,9 +87,9 @@ namespace Stride.GameStudio.ViewModels
 
         protected override async Task RestartAndOpenSession(UFile sessionPath)
         {
-            if (sessionPath != null && !File.Exists(sessionPath.ToWindowsPath()))
+            if (sessionPath != null && !File.Exists(sessionPath.ToOSPath()))
             {
-                await ServiceProvider.Get<IDialogService>().MessageBoxAsync(Tr._p("Message", "The file {0} does not exist.").ToFormat(sessionPath.ToWindowsPath()));
+                await ServiceProvider.Get<IDialogService>().MessageBoxAsync(Tr._p("Message", "The file {0} does not exist.").ToFormat(sessionPath.ToOSPath()));
                 return;
             }
             if (sessionPath == null)
@@ -101,7 +101,7 @@ namespace Stride.GameStudio.ViewModels
             if (sessionPath == null)
                 return;
 
-            restartArguments = $"\"{sessionPath.ToWindowsPath()}\"";
+            restartArguments = $"\"{sessionPath.ToOSPath()}\"";
             await CloseAndRestart();
         }
 

--- a/sources/engine/Stride.Assets.Tests/TestSceneUpgrader.cs
+++ b/sources/engine/Stride.Assets.Tests/TestSceneUpgrader.cs
@@ -35,7 +35,7 @@ namespace Stride.Assets.Tests
 
                 var file = new PackageLoadingAssetFile(sceneFile, Path.GetDirectoryName(sceneFile));
 
-                var context = new AssetMigrationContext(null, file.ToReference(), file.FilePath.ToWindowsPath(), logger);
+                var context = new AssetMigrationContext(null, file.ToReference(), file.FilePath.ToOSPath(), logger);
                 var needMigration = AssetMigration.MigrateAssetIfNeeded(context, file, "Stride");
 
                 foreach (var message in logger.Messages)

--- a/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
+++ b/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
@@ -118,7 +118,7 @@ namespace Stride.Assets.Effect
                 }
 
                 var outputClassFile = effectName + "." + fieldName + "." + compilerParameters.EffectParameters.Platform + "." + compilerParameters.EffectParameters.Profile + ".cs";
-                var fullOutputClassFile = Path.Combine(outputDirectory.ToWindowsPath(), outputClassFile);
+                var fullOutputClassFile = Path.Combine(outputDirectory.ToOSPath(), outputClassFile);
 
                 commandContext.Logger.Verbose($"Writing shader bytecode to .cs source [{fullOutputClassFile}]");
                 using (var stream = new FileStream(fullOutputClassFile, FileMode.Create, FileAccess.Write, FileShare.Write))

--- a/sources/engine/Stride.Assets/Media/SoundAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Media/SoundAssetCompiler.cs
@@ -53,7 +53,7 @@ namespace Stride.Assets.Media
                 {
                     var channels = Parameters.Spatialized ? 1 : 2;
                     var commandLine = "  -hide_banner -loglevel error" + // hide most log output
-                                      $" -i \"{assetSource.ToWindowsPath()}\"" + // input file
+                                      $" -i \"{assetSource.ToOSPath()}\"" + // input file
                                       $" -f f32le -acodec pcm_f32le -ac {channels} -ar {Parameters.SampleRate}" + // codec
                                       $" -map 0:{Parameters.Index}" + // stream index
                                       $" -y \"{tempFile}\""; // output file (always overwrite)

--- a/sources/engine/Stride.Assets/Media/VideoAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Media/VideoAssetCompiler.cs
@@ -107,7 +107,7 @@ namespace Stride.Assets.Media
                     FFmpegUtils.Initialize();
                     using (var media = new FFmpegMedia())
                     {
-                        media.Open(assetSource.ToWindowsPath());
+                        media.Open(assetSource.ToOSPath());
 
                         // Get the first video stream
                         videoStream = media.Streams.OfType<VideoStream>().FirstOrDefault();
@@ -194,7 +194,7 @@ namespace Stride.Assets.Media
 
                             var commandLine = "  -hide_banner -loglevel error" + // hide most log output
                                               "  -nostdin" + // no interaction (background process)
-                                              $" -i \"{assetSource.ToWindowsPath()}\"" + // input file
+                                              $" -i \"{assetSource.ToOSPath()}\"" + // input file
                                               $"{trimmingOptions}" + 
                                               "  -f mp4 -vcodec " + targetCodecFormat + // codec
                                               channelFlag + // audio channels
@@ -213,7 +213,7 @@ namespace Stride.Assets.Media
                                 videoAsset.Source.GetFileName()));
 
                             // Use temporary file
-                            tempFile = assetSource.ToWindowsPath();
+                            tempFile = assetSource.ToOSPath();
                         }
 
                         var dataUrl = Url + "_Data";

--- a/sources/engine/Stride.Assets/Scripts/VisualScriptAsset.cs
+++ b/sources/engine/Stride.Assets/Scripts/VisualScriptAsset.cs
@@ -164,7 +164,7 @@ namespace Stride.Assets.Scripts
 
         public VisualScriptCompilerResult Compile(AssetItem assetItem)
         {
-            var generatedAbsolutePath = assetItem.GetGeneratedAbsolutePath().ToWindowsPath();
+            var generatedAbsolutePath = assetItem.GetGeneratedAbsolutePath().ToOSPath();
 
             var compilerOptions = new VisualScriptCompilerOptions
             {

--- a/sources/engine/Stride.Assets/StridePackageUpgrader.cs
+++ b/sources/engine/Stride.Assets/StridePackageUpgrader.cs
@@ -95,7 +95,7 @@ namespace Stride.Assets
                 if (assetFile.Deleted)
                     continue;
 
-                var context = new AssetMigrationContext(dependentPackage, assetFile.ToReference(), assetFile.FilePath.ToWindowsPath(), log);
+                var context = new AssetMigrationContext(dependentPackage, assetFile.ToReference(), assetFile.FilePath.ToOSPath(), log);
                 AssetMigration.MigrateAssetIfNeeded(context, assetFile, dependencyName, maxVersion);
             }
         }
@@ -143,7 +143,7 @@ namespace Stride.Assets
             {
                 try
                 {
-                    var project = VSProjectHelper.LoadProject(projectFullPath.ToWindowsPath());
+                    var project = VSProjectHelper.LoadProject(projectFullPath.ToOSPath());
                     var isProjectDirty = false;
                     
                     List<Microsoft.Build.Evaluation.ProjectItem> packageReferences = new();

--- a/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
+++ b/sources/engine/Stride.Assets/Templates/ProjectTemplateGeneratorHelper.cs
@@ -67,7 +67,7 @@ namespace Stride.Assets.Templates
 
             // Setup the ProjectGameGuid to be accessible from exec (in order to be able to link to the game project.
             AddOption(parameters, "ProjectGameGuid", (package.Container as SolutionProject)?.Id ?? Guid.Empty);
-            AddOption(parameters, "ProjectGameRelativePath", (package.Container as SolutionProject)?.FullPath.MakeRelative(parameters.OutputDirectory).ToWindowsPath());
+            AddOption(parameters, "ProjectGameRelativePath", (package.Container as SolutionProject)?.FullPath.MakeRelative(parameters.OutputDirectory).ToOSPath());
             AddOption(parameters, "PackageGameAssemblyName", package.Meta.Name);
 
             // Sample templates still have .Game in their name
@@ -79,7 +79,7 @@ namespace Stride.Assets.Templates
             AddOption(parameters, "PackageGameDisplayName", package.Meta.Title ?? packageNameWithoutGame);
             // Escape illegal characters for the short name
             AddOption(parameters, "PackageGameNameShort", Utilities.BuildValidClassName(packageNameWithoutGame.Replace(" ", string.Empty)));
-            AddOption(parameters, "PackageGameRelativePath", package.FullPath.MakeRelative(parameters.OutputDirectory).ToWindowsPath());
+            AddOption(parameters, "PackageGameRelativePath", package.FullPath.MakeRelative(parameters.OutputDirectory).ToOSPath());
 
             // Override namespace
             AddOption(parameters, "Namespace", parameters.Namespace ?? Utilities.BuildValidNamespaceName(packageNameWithoutGame));
@@ -123,7 +123,7 @@ namespace Stride.Assets.Templates
                 AddOption(parameters, "TargetFramework", platform.Platform.TargetFramework);
                 AddOption(parameters, "RuntimeIdentifier", platform.Platform.RuntimeIdentifier);
 
-                var projectDirectory = Path.GetDirectoryName(projectFullPath.ToWindowsPath());
+                var projectDirectory = Path.GetDirectoryName(projectFullPath.ToOSPath());
                 if (projectDirectory != null && Directory.Exists(projectDirectory))
                 {
                     try
@@ -154,7 +154,7 @@ namespace Stride.Assets.Templates
             foreach (var project in projectsToRemove)
             {
                 var projectFullPath = project.FullPath;
-                var projectDirectory = Path.GetDirectoryName(projectFullPath.ToWindowsPath());
+                var projectDirectory = Path.GetDirectoryName(projectFullPath.ToOSPath());
                 if (projectDirectory != null && Directory.Exists(projectDirectory))
                 {
                     try

--- a/sources/engine/Stride.SpriteStudio.Offline/SpriteStudioXmlImport.cs
+++ b/sources/engine/Stride.SpriteStudio.Offline/SpriteStudioXmlImport.cs
@@ -325,7 +325,7 @@ namespace Stride.SpriteStudio.Offline
             var nameSpace = xmlDoc.Root.Name.Namespace;
 
             var cellMaps = xmlDoc.Descendants(nameSpace + "cellmapNames").Descendants(nameSpace + "value").ToList();
-            return cellMaps.Select(cellMap => UPath.Combine(file.GetFullDirectory(), new UFile(cellMap.Value))).All(fileName => File.Exists(fileName.ToWindowsPath()));
+            return cellMaps.Select(cellMap => UPath.Combine(file.GetFullDirectory(), new UFile(cellMap.Value))).All(fileName => File.Exists(fileName.ToOSPath()));
         }
     }
 }

--- a/sources/launcher/Stride.Launcher/Launcher.cs
+++ b/sources/launcher/Stride.Launcher/Launcher.cs
@@ -65,7 +65,7 @@ namespace Stride.LauncherApp
         [NotNull]
         internal static NugetStore InitializeNugetStore()
         {
-            var thisExeDirectory = new UFile(Assembly.GetEntryAssembly().Location).GetFullDirectory().ToWindowsPath();
+            var thisExeDirectory = new UFile(Assembly.GetEntryAssembly().Location).GetFullDirectory().ToOSPath();
             var store = new NugetStore(thisExeDirectory);
             return store;
         }
@@ -195,7 +195,7 @@ namespace Stride.LauncherApp
             try
             {
                 // Kill all running processes
-                var path = new UFile(Assembly.GetEntryAssembly().Location).GetFullDirectory().ToWindowsPath();
+                var path = new UFile(Assembly.GetEntryAssembly().Location).GetFullDirectory().ToOSPath();
                 if (!UninstallHelper.CloseProcessesInPath(DisplayMessage, "Stride", path))
                     return LauncherErrorCode.UninstallCancelled; // User cancelled
 

--- a/sources/launcher/Stride.Launcher/ViewModels/RecentProjectViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/RecentProjectViewModel.cs
@@ -39,7 +39,7 @@ namespace Stride.LauncherApp.ViewModels
 
         public string Name { get; private set; }
 
-        public string FullPath => fullPath.ToWindowsPath();
+        public string FullPath => fullPath.ToOSPath();
 
         public string StrideVersionName { get { return strideVersionName; } private set { SetValue(ref strideVersionName, value); } }
 
@@ -71,7 +71,7 @@ namespace Stride.LauncherApp.ViewModels
 
         private void Explore()
         {
-            var startInfo = new ProcessStartInfo("explorer.exe", $"/select,{fullPath.ToWindowsPath()}") { UseShellExecute = true };
+            var startInfo = new ProcessStartInfo("explorer.exe", $"/select,{fullPath.ToOSPath()}") { UseShellExecute = true };
             var explorer = new Process { StartInfo = startInfo };
             explorer.Start();
         }

--- a/sources/launcher/Stride.Launcher/ViewModels/StrideDevVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/StrideDevVersionViewModel.cs
@@ -45,7 +45,7 @@ namespace Stride.LauncherApp.ViewModels
         public override bool CanDelete => isDevRedirect;
 
         /// <inheritdoc/>
-        public override string InstallPath => path.ToWindowsPath();
+        public override string InstallPath => path.ToOSPath();
 
 
         // This property is not used because a dev verison cannot be downloaded.

--- a/sources/presentation/Stride.Core.Presentation.Dialogs/DialogService.cs
+++ b/sources/presentation/Stride.Core.Presentation.Dialogs/DialogService.cs
@@ -151,7 +151,7 @@ namespace Stride.Core.Presentation.Dialogs
         {
             var dialog = CreateFileOpenModalDialog();
             dialog.AllowMultiSelection = false;
-            dialog.InitialDirectory = initialPath.ToWindowsPath();
+            dialog.InitialDirectory = initialPath.ToOSPath();
             if (filters is not null)
                 dialog.Filters.AddRange(filters?.Select(x => new FileDialogFilter(x.Name, string.Join(';', x.Patterns))));
 
@@ -165,7 +165,7 @@ namespace Stride.Core.Presentation.Dialogs
         {
             var dialog = CreateFileOpenModalDialog();
             dialog.AllowMultiSelection = true;
-            dialog.InitialDirectory = initialPath.ToWindowsPath();
+            dialog.InitialDirectory = initialPath.ToOSPath();
             if (filters is not null)
                 dialog.Filters.AddRange(filters?.Select(x => new FileDialogFilter(x.Name, string.Join(';', x.Patterns))));
 
@@ -176,7 +176,7 @@ namespace Stride.Core.Presentation.Dialogs
         async Task<UDirectory> IDialogService.OpenFolderPickerAsync(UDirectory initialPath)
         {
             var dialog = CreateFolderOpenModalDialog();
-            dialog.InitialDirectory = initialPath.ToWindowsPath();
+            dialog.InitialDirectory = initialPath.ToOSPath();
 
             var result = await dialog.ShowModal();
             return result == DialogResult.Ok
@@ -189,7 +189,7 @@ namespace Stride.Core.Presentation.Dialogs
             var dialog = CreateFileSaveModalDialog();
             dialog.DefaultExtension = defaultExtension;
             dialog.DefaultFileName = defaultFileName;
-            dialog.InitialDirectory = initialPath.ToWindowsPath();
+            dialog.InitialDirectory = initialPath.ToOSPath();
             if (filters is not null)
                 dialog.Filters.AddRange(filters?.Select(x => new FileDialogFilter(x.Name, string.Join(';', x.Patterns))));
 

--- a/sources/tools/Stride.Core.Translation.Extractor/Extractors/CSharpExtractor.cs
+++ b/sources/tools/Stride.Core.Translation.Extractor/Extractors/CSharpExtractor.cs
@@ -55,7 +55,7 @@ namespace Stride.Core.Translation.Extractor
         {
             var lineNumberLookup = new LineNumberLookup();
             // Read all content
-            var content = File.ReadAllText(file.ToWindowsPath());
+            var content = File.ReadAllText(file.ToOSPath());
             // Remove comments
             content = RemoveComments(content);
             // Read content again to build the line number lookup

--- a/sources/tools/Stride.Core.Translation.Extractor/Extractors/XamlExtractor.cs
+++ b/sources/tools/Stride.Core.Translation.Extractor/Extractors/XamlExtractor.cs
@@ -22,12 +22,12 @@ namespace Stride.Core.Translation.Extractor
             try
             {
                 // Read all content
-                var reader = new XamlXmlReader(file.ToWindowsPath(), new XamlXmlReaderSettings { ProvideLineInfo = true });
+                var reader = new XamlXmlReader(file.ToOSPath(), new XamlXmlReaderSettings { ProvideLineInfo = true });
                 return DoExtractMessagesFromFile(file, reader);
             }
             catch (XamlException ex)
             {
-                Console.Error.WriteLine($"{file.ToWindowsPath()}: {ex.Message}");
+                Console.Error.WriteLine($"{file.ToOSPath()}: {ex.Message}");
                 return Enumerable.Empty<Message>();
             }
         }

--- a/sources/tools/Stride.VisualStudio.Commands/StrideCommands.cs
+++ b/sources/tools/Stride.VisualStudio.Commands/StrideCommands.cs
@@ -113,7 +113,7 @@ namespace Stride.VisualStudio.Commands
             {
                 foreach (var assetFolder in package.AssetFolders)
                 {
-                    var fullPath = assetFolder.Path.ToWindowsPath();
+                    var fullPath = assetFolder.Path.ToOSPath();
                     if (Directory.Exists(fullPath))
                     {
                         assetsPaths.Add(fullPath);


### PR DESCRIPTION
# PR Details

ToWindowsPath method is obsolete because ToOSPath is more universal and it shouldnt break current codebase.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
