### PR TITLE
Fixes depth calculation for MipMap views of 3D textures

### DIFF
--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -1264,7 +1264,7 @@ namespace Stride.Graphics
                     mipCount = this.MipLevels;
                     break;
                 case ViewType.Single:
-                    arrayOrDepthCount = 1;
+                    arrayOrDepthCount = ViewDimension == TextureDimension.Texture3D ? CalculateMipSize(Depth, mipIndex) : 1;
                     mipCount = 1;
                     break;
                 case ViewType.MipBand:


### PR DESCRIPTION
# PR Details

When creating a single MipMap slice view of a texture the Depth is calculated correctly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
