### PR TITLE
feat: Hide default font name for SystemFontProvider, change default font

### DIFF
--- a/samples/Games/JumpyJet/Assets/Shared/Font.sdfnt
+++ b/samples/Games/JumpyJet/Assets/Shared/Font.sdfnt
@@ -2,7 +2,5 @@
 Id: f10885f3-72a0-469e-9ba2-6ca635fee4e7
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !RuntimeRasterizedSpriteFontType {}

--- a/samples/Games/SpaceEscape/Assets/Shared/Font.sdfnt
+++ b/samples/Games/SpaceEscape/Assets/Shared/Font.sdfnt
@@ -2,7 +2,5 @@
 Id: aa317d9b-bbd3-4240-9ad6-11efad9c4d4d
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !RuntimeRasterizedSpriteFontType {}

--- a/samples/Graphics/SpriteFonts/Assets/Shared/AliasedFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/AliasedFont.sdfnt
@@ -2,9 +2,7 @@
 Id: 5376e512-4179-43b6-9d7c-75b0a1ea6f9c
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !OfflineRasterizedSpriteFontType
     Size: 40.0
     CharacterSet: null

--- a/samples/Graphics/SpriteFonts/Assets/Shared/AntialiasedFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/AntialiasedFont.sdfnt
@@ -2,9 +2,7 @@
 Id: 5b5f75d3-4f7f-4325-b957-fd50161e104c
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !OfflineRasterizedSpriteFontType
     Size: 40.0
     CharacterSet: null

--- a/samples/Graphics/SpriteFonts/Assets/Shared/BoldFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/BoldFont.sdfnt
@@ -3,7 +3,6 @@ Id: 4f741cf1-f3b2-4eda-837b-e29f8597c47d
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
 FontSource: !SystemFontProvider
-    FontName: Arial
     Style: Bold
 FontType: !RuntimeRasterizedSpriteFontType
     Size: 22.0

--- a/samples/Graphics/SpriteFonts/Assets/Shared/ClearTypeFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/ClearTypeFont.sdfnt
@@ -2,9 +2,7 @@
 Id: bdc10dde-cc94-45e6-88ee-bd5fe156f982
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !OfflineRasterizedSpriteFontType
     Size: 40.0
     CharacterSet: null

--- a/samples/Graphics/SpriteFonts/Assets/Shared/DynamicFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/DynamicFont.sdfnt
@@ -2,8 +2,6 @@
 Id: cbbbd736-43d0-490e-b3e4-28207140d6cc
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !RuntimeRasterizedSpriteFontType
     Size: 22.0

--- a/samples/Graphics/SpriteFonts/Assets/Shared/ItalicFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/ItalicFont.sdfnt
@@ -3,7 +3,6 @@ Id: 5fad01ad-2649-4de9-8a81-b117e320a2ef
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
 FontSource: !SystemFontProvider
-    FontName: Arial
     Style: Italic
 FontType: !RuntimeRasterizedSpriteFontType
     Size: 22.0

--- a/samples/Graphics/SpriteFonts/Assets/Shared/StaticFont.sdfnt
+++ b/samples/Graphics/SpriteFonts/Assets/Shared/StaticFont.sdfnt
@@ -2,9 +2,7 @@
 Id: b6582bd2-276e-4b0e-a0f1-8682e271ab59
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !OfflineRasterizedSpriteFontType
     Size: 36.0
     CharacterSet: null

--- a/samples/Input/GravitySensor/Assets/Shared/SpriteFont.sdfnt
+++ b/samples/Input/GravitySensor/Assets/Shared/SpriteFont.sdfnt
@@ -2,8 +2,6 @@
 Id: e69c3c0c-baca-4e05-9c03-a3f95cdeb5ed
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !RuntimeRasterizedSpriteFontType
     Size: 21.33333

--- a/sources/engine/Stride.Assets/SpriteFont/SpriteFontAssetFactories.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/SpriteFontAssetFactories.cs
@@ -11,7 +11,7 @@ namespace Stride.Assets.SpriteFont
         {
             return new SpriteFontAsset
             {
-                FontSource = new SystemFontProvider("Arial"),
+                FontSource = new SystemFontProvider(),
                 FontType = new OfflineRasterizedSpriteFontType()
                 {
                     CharacterRegions = { new CharacterRegion(' ', (char)127) }                 
@@ -31,7 +31,7 @@ namespace Stride.Assets.SpriteFont
         {
             return new SpriteFontAsset
             {
-                FontSource = new SystemFontProvider("Arial"),
+                FontSource = new SystemFontProvider(),
                 FontType = new RuntimeRasterizedSpriteFontType(),
             };
         }
@@ -48,7 +48,7 @@ namespace Stride.Assets.SpriteFont
         {
             return new SpriteFontAsset
             {
-                FontSource = new SystemFontProvider("Arial"),
+                FontSource = new SystemFontProvider(),
                 FontType = new SignedDistanceFieldSpriteFontType()
                 {
                     CharacterRegions = { new CharacterRegion(' ', (char)127) }

--- a/sources/engine/Stride.Engine.Tests/GameAssets/Font.sdfnt
+++ b/sources/engine/Stride.Engine.Tests/GameAssets/Font.sdfnt
@@ -2,8 +2,6 @@
 Id: e3beb255-7a4c-46a6-8f8a-65703d344614
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
-FontSource: !SystemFontProvider
-    FontName: Arial
-    Style: Regular
+FontSource: !SystemFontProvider {}
 FontType: !RuntimeRasterizedSpriteFontType
     Size: 16.0

--- a/sources/engine/Stride.Engine/AssetPackage/Assets/Shared/StrideDefaultFont.sdfnt
+++ b/sources/engine/Stride.Engine/AssetPackage/Assets/Shared/StrideDefaultFont.sdfnt
@@ -3,7 +3,6 @@ Id: c90f3988-0544-4cbe-993f-13af7d9c23c6
 SerializedVersion: {Stride: 2.0.0.0}
 Tags: []
 FontSource: !SystemFontProvider
-    FontName: Courier New
     Style: Bold
 FontType: !RuntimeRasterizedSpriteFontType
     Size: 10.66666


### PR DESCRIPTION
# PR Details

My PR tries to hide default default font name for SystemFontProvider. I also changed default font name from `Courier New` to `Arial` for sake of consistency - (Almost) all samples are using `Arial` font anyway.
In addition, `Arial` is a sans-serif font - these types of fonts are more popular and easier to read.

- [x] - This also fixes samples / templates for systems where Arial font is not available (i.e Linux)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (kinda, because this changes font :P)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
