### PR TITLE
Add back Windows specific CompilerApp to fix libraries with WPF references

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/Stride.Core.Assets.CompilerApp.csproj
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/Stride.Core.Assets.CompilerApp.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
-    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(StrideXplatEditorTargetFramework);$(StrideEditorTargetFramework)</TargetFrameworks>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
   </PropertyGroup>

--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -125,6 +125,7 @@
   <Target Name="_StridePrepareAssetCompiler">
     <PropertyGroup>
       <!-- First try NuGet layout, then git checkout -->
+      <StrideCompileAssetCommand Condition="'$(StrideCompileAssetCommand)' == '' And Exists('$(MSBuildThisFileDirectory)..\lib\net8.0-windows7.0\') And $(TargetFramework.Contains('-windows'))">$(MSBuildThisFileDirectory)..\lib\net8.0-windows7.0\Stride.Core.Assets.CompilerApp.dll</StrideCompileAssetCommand>
       <StrideCompileAssetCommand Condition="'$(StrideCompileAssetCommand)' == '' And Exists('$(MSBuildThisFileDirectory)..\lib\net8.0\')">$(MSBuildThisFileDirectory)..\lib\net8.0\Stride.Core.Assets.CompilerApp.dll</StrideCompileAssetCommand>
       <StrideCompileAssetCommand Condition="'$(StrideCompileAssetCommand)' == '' And Exists('$(MSBuildThisFileDirectory)..\Stride.Core.Assets.CompilerApp.csproj')">$(MSBuildThisFileDirectory)..\bin\$(Configuration)\net8.0\Stride.Core.Assets.CompilerApp.dll</StrideCompileAssetCommand>
     </PropertyGroup>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
May be controversial to bring the windows specific CompilerApp back.
Pinging @Jklawreszuk & @Kryptos-FR since they've spent a lot of time on the cross-platform transition side of things.
This does not remove the cross-platform version, but rather includes the Windows specific version and use that over the cross-platform version.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2244
The problem is referencing any Stride libraries that touch WPF code, the ModuleInitializer will try to load the WPF framework if it's not loaded, however WPF is Windows only, so it can't be loaded in any way except by having the Windows specific version.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
