### PR TITLE
fix: Change the error to a warning when searching for font path

### DIFF
--- a/sources/engine/Stride.Assets/SpriteFont/SystemFontProvider.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/SystemFontProvider.cs
@@ -78,10 +78,11 @@ namespace Stride.Assets.SpriteFont
             if (OperatingSystem.IsLinux())
             {
                 var fontPath = GetFontPathLinux(result);
-                if (fontPath == null && FontName != GetDefaultFontName())
+                var defaultFont = GetDefaultFontName();
+                if (fontPath == null && FontName != defaultFont)
                 {
-                    result?.Warning($"Cannot find font family '{FontName}'. Loading default font '{GetDefaultFontName()}' instead");
-                    FontName = GetDefaultFontName();
+                    result?.Warning($"Cannot find font family '{FontName}'. Loading default font '{defaultFont}' instead");
+                    FontName = defaultFont;
                     fontPath = GetFontPathLinux(result);
                 }
                 return fontPath;
@@ -109,7 +110,7 @@ namespace Stride.Assets.SpriteFont
                     return file;
                 }
             }
-            result?.Error($"Cannot find style '{Style}' for font family '{FontName}'. Make sure it is installed on this machine.");
+            result?.Warning($"Cannot find style '{Style}' for font family '{FontName}'. Make sure it is installed on this machine.");
             return null;
         }
 


### PR DESCRIPTION
# PR Details

This PR includes a fix for searching the font path on Linux. Previously when a font did not exist CompilerApp ignored the search for a default font, because of error.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built an engine and run the *game* to try this change out.**
