### PR TITLE
Requirements for fully custom Game runtime management

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -453,9 +453,9 @@ namespace Stride.Engine
             return Task.FromResult(true);
         }
 
-        internal override void LoadContentInternal()
+        public override void LoadContentDefault()
         {
-            base.LoadContentInternal();
+            base.LoadContentDefault();
             Script.AddTask(LoadContent);
         }
         protected virtual LogListener GetLogListener()

--- a/sources/engine/Stride.Games/Desktop/GamePlatformDesktop.cs
+++ b/sources/engine/Stride.Games/Desktop/GamePlatformDesktop.cs
@@ -27,7 +27,7 @@ using Stride.Core;
 
 namespace Stride.Games
 {
-    internal class GamePlatformDesktop : GamePlatform
+    public class GamePlatformDesktop : GamePlatform
     {
         public GamePlatformDesktop(GameBase game) : base(game)
         {
@@ -51,7 +51,7 @@ namespace Stride.Games
             }
         }
 
-        internal override GameWindow GetSupportedGameWindow(AppContextType type)
+        public override GameWindow GetSupportedGameWindow(AppContextType type)
         {
             switch (type)
             {

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -120,7 +120,7 @@ namespace Stride.Games
             deviceChangeWillBeFullScreen = null;
         }
 
-        protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
+        public override void SetSupportedOrientations(DisplayOrientation orientations)
         {
             // Desktop doesn't have orientation (unless on Windows 8?)
         }
@@ -166,7 +166,7 @@ namespace Stride.Games
             }
         }
 
-        internal override void Run()
+        public override void Run()
         {
             Debug.Assert(InitCallback != null, $"{nameof(InitCallback)} is null");
             Debug.Assert(RunCallback != null, $"{nameof(RunCallback)} is null");
@@ -298,7 +298,7 @@ namespace Stride.Games
             }
         }
 
-        internal override void Resize(int width, int height)
+        public override void Resize(int width, int height)
         {
             Control.ClientSize = new Size(width, height);
         }

--- a/sources/engine/Stride.Games/GameBase.cs
+++ b/sources/engine/Stride.Games/GameBase.cs
@@ -59,7 +59,7 @@ namespace Stride.Games
 
         private bool isMouseVisible;
 
-        internal object TickLock = new object();
+        public object TickLock = new object();
 
         #endregion
 
@@ -68,7 +68,7 @@ namespace Stride.Games
         /// <summary>
         /// Initializes a new instance of the <see cref="GameBase" /> class.
         /// </summary>
-        protected GameBase()
+        protected GameBase(GamePlatform platform = null)
         {
             // Internals
             Log = GlobalLogger.GetLogger(GetType().GetTypeInfo().Name);
@@ -96,7 +96,7 @@ namespace Stride.Games
             Services.AddService<IGameSystemCollection>(GameSystems);
 
             // Create Platform
-            gamePlatform = GamePlatform.Create(this);
+            gamePlatform = platform ?? GamePlatform.Create(this);
             gamePlatform.Activated += GamePlatform_Activated;
             gamePlatform.Deactivated += GamePlatform_Deactivated;
             gamePlatform.Exiting += GamePlatform_Exiting;
@@ -216,7 +216,7 @@ namespace Stride.Games
         /// Gets or sets a value indicating whether this instance should force exactly one update step per one draw step
         /// </summary>
         /// <value><c>true</c> if this instance forces one update step per one draw step; otherwise, <c>false</c>.</value>
-        protected internal bool ForceOneUpdatePerDraw { get; set; }
+        protected bool ForceOneUpdatePerDraw { get; set; }
 
         /// <summary>
         /// When <see cref="IsFixedTimeStep"/> is set, is it allowed to render frames between two steps when we have time to do so.
@@ -340,7 +340,7 @@ namespace Stride.Games
             forceElapsedTimeToZero = true;
         }
 
-        internal void InitializeBeforeRun()
+        public void InitializeBeforeRun()
         {
             try
             {
@@ -371,7 +371,7 @@ namespace Stride.Games
                     // Bind Graphics Context enabling initialize to use GL API eg. SetData to texture ...etc
                     BeginDraw();
 
-                    LoadContentInternal();
+                    LoadContentDefault();
 
                     IsRunning = true;
 
@@ -848,7 +848,7 @@ namespace Stride.Games
             GameSystems.Initialize();
         }
 
-        internal virtual void LoadContentInternal()
+        public virtual void LoadContentDefault()
         {
             GameSystems.LoadContent();
         }
@@ -978,7 +978,7 @@ namespace Stride.Games
 
             if (GameSystems.State != GameSystemState.ContentLoaded)
             {
-                LoadContentInternal();
+                LoadContentDefault();
             }
         }
 

--- a/sources/engine/Stride.Games/GameContext.cs
+++ b/sources/engine/Stride.Games/GameContext.cs
@@ -61,27 +61,27 @@ namespace Stride.Games
         /// <summary>
         /// The requested width.
         /// </summary>
-        internal int RequestedWidth;
+        public int RequestedWidth;
 
         /// <summary>
         /// The requested height.
         /// </summary>
-        internal int RequestedHeight;
+        public int RequestedHeight;
 
         /// <summary>
         /// The requested back buffer format.
         /// </summary>
-        internal PixelFormat RequestedBackBufferFormat;
+        public PixelFormat RequestedBackBufferFormat;
 
         /// <summary>
         /// The requested depth stencil format.
         /// </summary>
-        internal PixelFormat RequestedDepthStencilFormat;
+        public PixelFormat RequestedDepthStencilFormat;
 
         /// <summary>
         /// The requested graphics profiles.
         /// </summary>
-        internal GraphicsProfile[] RequestedGraphicsProfile;
+        public GraphicsProfile[] RequestedGraphicsProfile;
 
         /// <summary>
         /// The device creation flags that will be used to create the <see cref="GraphicsDevice"/>.
@@ -98,7 +98,7 @@ namespace Stride.Games
         /// Product name of game.
         /// TODO: Provide proper access title through code and game studio
         /// </summary>
-        internal static string ProductName
+        public static string ProductName
         {
             get
             {

--- a/sources/engine/Stride.Games/GameContextFactory.cs
+++ b/sources/engine/Stride.Games/GameContextFactory.cs
@@ -41,6 +41,8 @@ namespace Stride.Games
                 case AppContextType.iOS:
                     res = NewGameContextiOS();
                     break;
+                case AppContextType.Custom:
+                    throw new InvalidOperationException("Custom Contexts can not be created by the factory. Consider using a built in context if you are unsure.");
             }
 
             if (res == null)

--- a/sources/engine/Stride.Games/GamePlatform.cs
+++ b/sources/engine/Stride.Games/GamePlatform.cs
@@ -30,7 +30,7 @@ using Stride.Graphics;
 
 namespace Stride.Games
 {
-    internal abstract class GamePlatform : ReferenceBase, IGraphicsDeviceFactory, IGamePlatform
+    public abstract class GamePlatform : ReferenceBase, IGraphicsDeviceFactory, IGamePlatform
     {
         private bool hasExitRan = false;
 
@@ -88,7 +88,7 @@ namespace Stride.Games
             }
         }
 
-        internal abstract GameWindow GetSupportedGameWindow(AppContextType type);
+        public abstract GameWindow GetSupportedGameWindow(AppContextType type);
 
         public virtual GameWindow CreateWindow(GameContext gameContext)
         {

--- a/sources/engine/Stride.Games/GameTime.cs
+++ b/sources/engine/Stride.Games/GameTime.cs
@@ -119,7 +119,7 @@ namespace Stride.Games
         }
 
 
-        internal void Update(TimeSpan totalGameTime, TimeSpan elapsedGameTime, bool incrementFrameCount)
+        public void Update(TimeSpan totalGameTime, TimeSpan elapsedGameTime, bool incrementFrameCount)
         {
             Total = totalGameTime;
             Elapsed = elapsedGameTime;
@@ -145,7 +145,7 @@ namespace Stride.Games
             }
         }
 
-        internal void Reset(TimeSpan totalGameTime)
+        public void Reset(TimeSpan totalGameTime)
         {
             Update(totalGameTime, TimeSpan.Zero, false);
             accumulatedElapsedTime = TimeSpan.Zero;

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -203,7 +203,7 @@ namespace Stride.Games
         /// Allow the GraphicsDeviceManager to set the actual window state after applying the device changes.
         /// </summary>
         /// <param name="isReallyFullscreen"></param>
-        internal void SetIsReallyFullscreen(bool isReallyFullscreen)
+        public void SetIsReallyFullscreen(bool isReallyFullscreen)
         {
             isFullscreen = isReallyFullscreen;
         }
@@ -225,19 +225,19 @@ namespace Stride.Games
 
         #region Methods
 
-        protected internal abstract void Initialize(GameContext gameContext);
+        public abstract void Initialize(GameContext gameContext);
 
-        internal bool Exiting;
+        public bool Exiting;
 
-        internal Action InitCallback;
+        public Action InitCallback;
 
-        internal Action RunCallback;
+        public Action RunCallback;
 
-        internal Action ExitCallback;
+        public Action ExitCallback;
         
         private bool isFullscreen;
 
-        internal abstract void Run();
+        public abstract void Run();
 
         /// <summary>
         /// Sets the size of the client area and triggers the <see cref="ClientSizeChanged"/> event.
@@ -253,7 +253,7 @@ namespace Stride.Games
         /// Only used internally by the device managers when they adapt the window size to the backbuffer size.
         /// Resizes the window, without sending the resized event.
         /// </summary>
-        internal abstract void Resize(int width, int height);
+        public abstract void Resize(int width, int height);
 
         public virtual IMessageLoop CreateUserManagedMessageLoop()
         {
@@ -261,9 +261,9 @@ namespace Stride.Games
             throw new PlatformNotSupportedException();
         }
 
-        internal IServiceRegistry Services { get; set; }
+        public IServiceRegistry Services { get; set; }
 
-        protected internal abstract void SetSupportedOrientations(DisplayOrientation orientations);
+        public abstract void SetSupportedOrientations(DisplayOrientation orientations);
 
         protected void OnActivated(object source, EventArgs e)
         {
@@ -319,12 +319,12 @@ namespace Stride.Games
 
         #endregion
 
-        internal void OnPause()
+        public void OnPause()
         {
             OnDeactivated(this, EventArgs.Empty);
         }
 
-        internal void OnResume()
+        public void OnResume()
         {
             OnActivated(this, EventArgs.Empty);
         }
@@ -332,7 +332,7 @@ namespace Stride.Games
 
     public abstract class GameWindow<TK> : GameWindow
     {
-        protected internal sealed override void Initialize(GameContext gameContext)
+        public sealed override void Initialize(GameContext gameContext)
         {
             var context = gameContext as GameContext<TK>;
             if (context != null)
@@ -346,7 +346,7 @@ namespace Stride.Games
             }
         }
 
-        internal GameContext<TK> GameContext;
+        public GameContext<TK> GameContext;
 
         protected abstract void Initialize(GameContext<TK> context);
     }

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -100,7 +100,7 @@ namespace Stride.Games
         /// </summary>
         /// <param name="game">The game.</param>
         /// <exception cref="System.ArgumentNullException">The game instance cannot be null.</exception>
-        internal GraphicsDeviceManager(GameBase game)
+        public GraphicsDeviceManager(GameBase game)
         {
             this.game = game;
             if (this.game == null)

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -83,7 +83,7 @@ namespace Stride.Games
             deviceChangeWillBeFullScreen = null;
         }
 
-        protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
+        public override void SetSupportedOrientations(DisplayOrientation orientations)
         {
             // Desktop doesn't have orientation (unless on Windows 8?)
         }
@@ -133,7 +133,7 @@ namespace Stride.Games
             OnClosing(this, new EventArgs());
         }
 
-        internal override void Run()
+        public override void Run()
         {
             Debug.Assert(InitCallback != null, $"{nameof(InitCallback)} is null");
             Debug.Assert(RunCallback != null, $"{nameof(RunCallback)} is null");
@@ -269,7 +269,7 @@ namespace Stride.Games
             }
         }
 
-        internal override void Resize(int width, int height)
+        public override void Resize(int width, int height)
         {
             window.ClientSize = new Size2(width, height);
         }

--- a/sources/engine/Stride.Graphics/AppContextType.cs
+++ b/sources/engine/Stride.Graphics/AppContextType.cs
@@ -58,11 +58,14 @@ namespace Stride.Games
         /// </summary>
         UWPCoreWindow,
 
-#pragma warning disable SA1300 // Element must begin with upper-case letter
         /// <summary>
         /// Game running on iOS in a iPhoneOSGameView.
         /// </summary>
         iOS,
-#pragma warning restore SA1300 // Element must begin with upper-case letter
+
+        /// <summary>
+        /// Game running on a custom context.
+        /// </summary>
+        Custom,
     }
 }

--- a/sources/engine/Stride/Graphics/ImageSerializer.cs
+++ b/sources/engine/Stride/Graphics/ImageSerializer.cs
@@ -7,7 +7,7 @@ using Stride.Core.Serialization.Contents;
 
 namespace Stride.Graphics
 {
-    internal class ImageSerializer : ContentSerializerBase<Image>
+    public class ImageSerializer : ContentSerializerBase<Image>
     {
         public override void Serialize(ContentSerializerContext context, SerializationStream stream, Image textureData)
         {


### PR DESCRIPTION
# PR Details

The amount of internal features for Stride makes it very difficult and cumbersome to make any custom root/base features for the engine. This PR opens up a lot of those features to be accessible to any dev just referencing the released Nugets.

Now devs should be able to:
- create completely custom windows using any UI framework (Examples will be needed but probably in an external repo for a POC)
- create custom game lifetime management (hopefully for both headless and new window run Stride game)
- generally more availability to make Stride customizable without scaring users by requiring them to touch the source
- I need to look into it more but with the changes here to the `GameBase`, can we use this for separating game and window logic? (can do more exploration in a separate PR/demo repo)

## Related Issue

https://github.com/stride3d/stride/issues/870 
https://github.com/stride3d/stride/pull/1315 (Takes the initial work done by @TheKeyblader and adds a few more)
https://github.com/stride3d/stride/pull/1474 
https://github.com/stride3d/stride/issues/1629 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
