### PR TITLE
Fix shader bool generics to appear in the editor

### DIFF
--- a/sources/engine/Stride.Assets/Materials/ComputeShaderClassHelper.cs
+++ b/sources/engine/Stride.Assets/Materials/ComputeShaderClassHelper.cs
@@ -16,6 +16,7 @@ namespace Stride.Assets.Materials
         private static readonly Dictionary<string, Type> ComputeColorParameterTypeMapping = new Dictionary<string, Type>
         {
             {"Texture2D", typeof(ComputeColorParameterTexture) },
+            {"bool", typeof(ComputeColorParameterBool) },
             {"int", typeof(ComputeColorParameterInt) },
             {"float", typeof(ComputeColorParameterFloat) },
             {"float2", typeof(ComputeColorParameterFloat2) },

--- a/sources/engine/Stride.Rendering/Rendering/Materials/ComputeColors/ComputeColorParameter.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/ComputeColors/ComputeColorParameter.cs
@@ -42,6 +42,16 @@ namespace Stride.Rendering.Materials.ComputeColors
         }
     }
 
+    [DataContract("ComputeColorParameterBool")]
+    public class ComputeColorParameterBool : ComputeColorParameterValue<bool>
+    {
+        public ComputeColorParameterBool()
+            : base()
+        {
+            Value = false;
+        }
+    }
+
     [DataContract("ComputeColorParameterFloat")]
     public class ComputeColorParameterFloat : ComputeColorParameterValue<float>
     {

--- a/sources/engine/Stride.Rendering/Rendering/Materials/ComputeColors/ComputeShaderClassBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/ComputeColors/ComputeShaderClassBase.cs
@@ -105,40 +105,39 @@ namespace Stride.Rendering.Materials.ComputeColors
                 foreach (var genericKey in Generics.Keys)
                 {
                     var generic = Generics[genericKey];
-                    if (generic is ComputeColorParameterTexture)
+                    if (generic is ComputeColorParameterTexture paramTexture)
                     {
-                        var textureParameter = (ComputeColorParameterTexture)generic;
-                        var textureKey = context.GetTextureKey(textureParameter.Texture, baseKeys);
+                        var textureKey = context.GetTextureKey(paramTexture.Texture, baseKeys);
                         mixinGenerics.Add(textureKey.ToString());
                     }
-                    else if (generic is ComputeColorParameterSampler)
+                    else if (generic is ComputeColorParameterSampler paramSampler)
                     {
-                        var pk = context.GetSamplerKey((ComputeColorParameterSampler)generic);
+                        var pk = context.GetSamplerKey(paramSampler);
                         mixinGenerics.Add(pk.ToString());
                     }
-                    else if (generic is ComputeColorParameterFloat)
+                    else if (generic is ComputeColorParameterFloat paramFloat)
                     {
-                        mixinGenerics.Add(((ComputeColorParameterFloat)generic).Value.ToString(CultureInfo.InvariantCulture));
+                        mixinGenerics.Add(paramFloat.Value.ToString(CultureInfo.InvariantCulture));
                     }
-                    else if (generic is ComputeColorParameterInt)
+                    else if (generic is ComputeColorParameterInt paramInt)
                     {
-                        mixinGenerics.Add(((ComputeColorParameterInt)generic).Value.ToString(CultureInfo.InvariantCulture));
+                        mixinGenerics.Add(paramInt.Value.ToString(CultureInfo.InvariantCulture));
                     }
-                    else if (generic is ComputeColorParameterFloat2)
+                    else if (generic is ComputeColorParameterFloat2 paramFloat2)
                     {
-                        mixinGenerics.Add(MaterialUtility.GetAsShaderString(((ComputeColorParameterFloat2)generic).Value));
+                        mixinGenerics.Add(MaterialUtility.GetAsShaderString(paramFloat2.Value));
                     }
-                    else if (generic is ComputeColorParameterFloat3)
+                    else if (generic is ComputeColorParameterFloat3 paramFloat3)
                     {
-                        mixinGenerics.Add(MaterialUtility.GetAsShaderString(((ComputeColorParameterFloat3)generic).Value));
+                        mixinGenerics.Add(MaterialUtility.GetAsShaderString(paramFloat3.Value));
                     }
-                    else if (generic is ComputeColorParameterFloat4)
+                    else if (generic is ComputeColorParameterFloat4 paramFloat4)
                     {
-                        mixinGenerics.Add(MaterialUtility.GetAsShaderString(((ComputeColorParameterFloat4)generic).Value));
+                        mixinGenerics.Add(MaterialUtility.GetAsShaderString(paramFloat4.Value));
                     }
-                    else if (generic is ComputeColorStringParameter)
+                    else if (generic is ComputeColorStringParameter paramString)
                     {
-                        mixinGenerics.Add(((ComputeColorStringParameter)generic).Value);
+                        mixinGenerics.Add(paramString.Value);
                     }
                     else if (generic is ComputeColorParameterBool paramBool)
                     {

--- a/sources/engine/Stride.Rendering/Rendering/Materials/ComputeColors/ComputeShaderClassBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/ComputeColors/ComputeShaderClassBase.cs
@@ -140,6 +140,10 @@ namespace Stride.Rendering.Materials.ComputeColors
                     {
                         mixinGenerics.Add(((ComputeColorStringParameter)generic).Value);
                     }
+                    else if (generic is ComputeColorParameterBool paramBool)
+                    {
+                        mixinGenerics.Add(paramBool.Value ? "true" : "false");
+                    }
                     else
                     {
                         throw new Exception("[Material] Unknown node type: " + generic.GetType());


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Bug in editor where declaring a shader, eg.
```
shader MyShader<bool ShaderArg>
{
}
```
won't show the bool argument in the editor when used as a material shader, and you won't be able to build the shader due to the missing parameter.

This fix exposes the bool argument to the editor and allows it to save/load properly.

Also added a separate commit to simplify the type checking.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
