### PR TITLE
feat: No Physics Shapes On The CharacterComponent Causes Unhandled Exception 

### DIFF
--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -264,7 +264,6 @@ namespace Stride.Physics
                 logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
                     $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
                 return;
-                //throw new InvalidOperationException("Attempted to call a Physics function that is available only when the Entity has been already added to the Scene.");
             }
 
             KinematicCharacter.SetWalkDirection(velocity * Simulation.FixedTimeStep);

--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -27,9 +27,7 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
-                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
-                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                LogPhysicsFunctionError();
                 return;
             }
             BulletSharp.Math.Vector3 bV3 = jumpDirection;
@@ -43,9 +41,7 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
-                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
-                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                LogPhysicsFunctionError();
                 return;
             }
             KinematicCharacter.Jump();
@@ -216,9 +212,7 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
-                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
-                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                LogPhysicsFunctionError();
                 return;
             }
 
@@ -240,9 +234,7 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
-                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
-                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                LogPhysicsFunctionError();
                 return;
             }
 
@@ -259,10 +251,7 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                //What was nice about the exception is users can see where this function was called to help trace
-                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
-                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
-                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                LogPhysicsFunctionError();
                 return;
             }
 
@@ -321,6 +310,17 @@ namespace Stride.Physics
             KinematicCharacter = null;
 
             base.OnDetach();
+        }
+
+        /// <summary>
+        /// Run specific error when physics functions are called on components that do not have proper setup.
+        /// Captures good tracing info for debugging purposes.
+        /// </summary>
+        private void LogPhysicsFunctionError()
+        {
+            StackFrame frame = new StackTrace(true).GetFrame(2);
+            logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
+                $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
         }
     }
 }

--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -279,7 +279,6 @@ namespace Stride.Physics
         [DataMemberIgnore]
         internal BulletSharp.KinematicCharacterController KinematicCharacter;
 
-        //called after collider shapes are attached to character comp?
         protected override void OnAttach()
         {
             NativeCollisionObject = new BulletSharp.PairCachingGhostObject

--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Engine;
@@ -26,7 +27,10 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
+                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
+                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                return;
             }
             BulletSharp.Math.Vector3 bV3 = jumpDirection;
             KinematicCharacter.Jump(ref bV3);
@@ -39,7 +43,10 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
+                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
+                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                return;
             }
             KinematicCharacter.Jump();
         }
@@ -209,7 +216,10 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
+                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
+                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                return;
             }
 
             //we assume that the user wants to teleport in world/entity space
@@ -230,7 +240,10 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is avaliable only when the Entity has been already added to the Scene.");
+                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
+                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
+                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                return;
             }
 
             KinematicCharacter.SetWalkDirection(movement);
@@ -246,7 +259,12 @@ namespace Stride.Physics
         {
             if (KinematicCharacter == null)
             {
-                throw new InvalidOperationException("Attempted to call a Physics function that is available only when the Entity has been already added to the Scene.");
+                //What was nice about the exception is users can see where this function was called to help trace
+                StackFrame frame = new StackTrace(true).GetFrame(1); //for capturing tracing info
+                logger.Error($"Component:[{this}] attempted to call a Physics function that is available only when the Entity has been already added to the Scene. " +
+                    $"This may be due to a {this} without any physical shapes.\nLocation: {frame.GetFileName()} at Line Number: {frame.GetFileLineNumber()} from Method: {frame.GetMethod().Name} ");
+                return;
+                //throw new InvalidOperationException("Attempted to call a Physics function that is available only when the Entity has been already added to the Scene.");
             }
 
             KinematicCharacter.SetWalkDirection(velocity * Simulation.FixedTimeStep);
@@ -262,6 +280,7 @@ namespace Stride.Physics
         [DataMemberIgnore]
         internal BulletSharp.KinematicCharacterController KinematicCharacter;
 
+        //called after collider shapes are attached to character comp?
         protected override void OnAttach()
         {
             NativeCollisionObject = new BulletSharp.PairCachingGhostObject

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -642,27 +642,22 @@ namespace Stride.Engine
         {
             Data = data;
 
+            if (ColliderShapes.Count == 0 && ColliderShape == null)
+            {
+                logger.Error($"Entity {{Entity.Name}} has a PhysicsComponent without any collider shape.");
+                return; //no shape no purpose
+            }
+
             //this is mostly required for the game studio gizmos
             if (Simulation.DisableSimulation)
             {
-                //Give warning if CharacterComponent doesnt have collider shapes
-                if(this is CharacterComponent && ColliderShapes.Count == 0 && ColliderShape == null)
-                {
-                    logger.Warning($"Entity {this} has no physical shapes attatched to CharacterComponent.");
-                }
-
                 return;
             }
 
             //this is not optimal as UpdateWorldMatrix will end up being called twice this frame.. but we need to ensure that we have valid data.
             Entity.Transform.UpdateWorldMatrix();
 
-            if (ColliderShapes.Count == 0 && ColliderShape == null)
-            {
-                logger.Error($"Entity {Entity.Name} has a PhysicsComponent without any collider shape.");
-                return; //no shape no purpose
-            }
-            else if (ColliderShape == null)
+            if (ColliderShape == null)
             {
                 ComposeShape();
                 if (ColliderShape == null)

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -646,7 +646,7 @@ namespace Stride.Engine
             if (Simulation.DisableSimulation)
             {
                 //Give warning if CharacterComponent doesnt have collider shapes
-                if(this is CharacterComponent && ColliderShapes.Count == 0)
+                if(this is CharacterComponent && ColliderShapes.Count == 0 && ColliderShape == null)
                 {
                     logger.Warning($"Entity {this} has no physical shapes attatched to CharacterComponent.");
                 }

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -645,6 +645,12 @@ namespace Stride.Engine
             //this is mostly required for the game studio gizmos
             if (Simulation.DisableSimulation)
             {
+                //Give warning if character doesnt have collider shapes
+                if(this is CharacterComponent && ColliderShapes.Count == 0)
+                {
+                    logger.Warning($"Entity {this} has no physical shapes attatched CharacterComponent.");
+                }
+
                 return;
             }
 

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -701,6 +701,9 @@ namespace Stride.Engine
             }
         }
 
+        /// <summary>
+        /// Called whenever an entity with this component is added to scene.
+        /// </summary>
         protected virtual void OnAttach()
         {
             //set pre-set post deserialization properties

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -645,10 +645,10 @@ namespace Stride.Engine
             //this is mostly required for the game studio gizmos
             if (Simulation.DisableSimulation)
             {
-                //Give warning if character doesnt have collider shapes
+                //Give warning if CharacterComponent doesnt have collider shapes
                 if(this is CharacterComponent && ColliderShapes.Count == 0)
                 {
-                    logger.Warning($"Entity {this} has no physical shapes attatched CharacterComponent.");
+                    logger.Warning($"Entity {this} has no physical shapes attatched to CharacterComponent.");
                 }
 
                 return;


### PR DESCRIPTION
# PR Details

Having no Physics shapes on character component causes unhandled exceptions when user tries to use physics methods on corresponding character component. (Note: Originally showed as a bug)
Originally threw: Unhandled Exception: System.InvalidOperationException: Attempted to call a Physics function that is available only when the Entity has been already added to the Scene.


Now gives warning from logger when a character component has no shapes and shows error via logger when physics method is ran on character component (Much earlier than original exception). Also gives good logging info to user as to where the physics method was called for tracing purposes.

## Related Issue

Issue: https://github.com/stride3d/stride/issues/760

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
