### PR TITLE
feat: Custom Depth Test Function for Materials

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/MaterialPass.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MaterialPass.cs
@@ -44,6 +44,11 @@ namespace Stride.Rendering
         public CullMode? CullMode;
 
         /// <summary>
+        /// Overrides depth clip for this material.
+        /// </summary>
+        public CompareFunction? DepthFunction;
+
+        /// <summary>
         /// Overrides the blend state for this material.
         /// </summary>
         public BlendStateDescription? BlendState;

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialAttributes.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialAttributes.cs
@@ -173,9 +173,9 @@ namespace Stride.Rendering.Materials
         public CullMode CullMode { get; set; }
 
         /// <summary>
-        /// The test used to figure out whether the material should be drawn when beind other models
+        /// The test used to figure out whether the material should be drawn when behind other models
         /// </summary>
-        /// <userdoc>The test used to figure out whether the material should be drawn when beind other models</userdoc>
+        /// <userdoc>The test used to figure out whether the material should be drawn when behind other models</userdoc>
         [Display("Depth Function", "Misc")]
         [DataMember(135)]
         [DefaultValue(CompareFunction.Less)]

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialAttributes.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialAttributes.cs
@@ -173,6 +173,15 @@ namespace Stride.Rendering.Materials
         public CullMode CullMode { get; set; }
 
         /// <summary>
+        /// The test used to figure out whether the material should be drawn when beind other models
+        /// </summary>
+        /// <userdoc>The test used to figure out whether the material should be drawn when beind other models</userdoc>
+        [Display("Depth Function", "Misc")]
+        [DataMember(135)]
+        [DefaultValue(CompareFunction.Less)]
+        public CompareFunction DepthFunction { get; set; } = CompareFunction.Less;
+
+        /// <summary>
         /// Gets or sets the clear coat shading features for the material.
         /// </summary>
         /// <userdoc>Use clear-coat shading to simulate vehicle paint</userdoc>
@@ -198,8 +207,7 @@ namespace Stride.Rendering.Materials
             // TODO: Should we apply it to any Diffuse Model?
             var isEnergyConservative = (Specular as MaterialSpecularMapFeature)?.IsEnergyConservative ?? false;
 
-            var lambert = DiffuseModel as IEnergyConservativeDiffuseModelFeature;
-            if (lambert != null)
+            if (DiffuseModel is IEnergyConservativeDiffuseModelFeature lambert)
             {
                 lambert.IsEnergyConservative = isEnergyConservative;
             }
@@ -227,8 +235,8 @@ namespace Stride.Rendering.Materials
 
             // If hair shading is enabled, ignore the transparency feature to avoid errors during shader compilation.
             // Allowing the transparency feature while hair shading is on makes no sense anyway.
-            if (!(SpecularModel is MaterialSpecularHairModelFeature) &&
-                !(DiffuseModel is MaterialDiffuseHairModelFeature))
+            if (SpecularModel is not MaterialSpecularHairModelFeature &&
+                DiffuseModel is not MaterialDiffuseHairModelFeature)
             {
                 context.Visit(Transparency);
             }
@@ -244,6 +252,15 @@ namespace Stride.Rendering.Materials
                 if (context.MaterialPass.CullMode == null)
                 {
                     context.MaterialPass.CullMode = CullMode;
+                }
+            }
+
+            // Only set the DepthFunction when the pass is not overriden (Only based on assumptions from how CullMode operates, not exactly sure how/when this would be used) 
+            if (context.Step == MaterialGeneratorStep.GenerateShader && DepthFunction != CompareFunction.Less)
+            {
+                if (context.MaterialPass.DepthFunction == null)
+                {
+                    context.MaterialPass.DepthFunction = DepthFunction;
                 }
             }
         }

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
@@ -66,6 +66,7 @@ namespace Stride.Rendering.Materials
             public int PermutationCounter; // Dirty counter against material.Parameters.PermutationCounter
             public ParameterCollection MaterialParameters; // Protect against changes of Material.Parameters instance (happens with editor fast reload)
             public CullMode? CullMode;
+            public CompareFunction? DepthFunction;
 
             public ShaderSource VertexStageSurfaceShaders;
             public ShaderSource VertexStageStreamInitializer;
@@ -92,6 +93,7 @@ namespace Stride.Rendering.Materials
             {
                 MaterialPass = materialPass;
                 CullMode = materialPass.CullMode;
+                DepthFunction = materialPass.DepthFunction;
             }
         }
 
@@ -179,6 +181,12 @@ namespace Stride.Rendering.Materials
                 {
                     materialInfo.CullMode = material.CullMode;
                     renderMesh.IsPreviousScalingNegative = renderMesh.IsScalingNegative;
+                    resetPipelineState = true;
+                }
+
+                if (materialInfo != null && materialInfo.DepthFunction != material.DepthFunction)
+                {
+                    materialInfo.DepthFunction = material.DepthFunction;
                     resetPipelineState = true;
                 }
 

--- a/sources/engine/Stride.Rendering/Rendering/MeshPipelineProcessor.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshPipelineProcessor.cs
@@ -65,6 +65,9 @@ namespace Stride.Rendering
 
             pipelineState.RasterizerState.CullMode = cullMode;
 
+            if (renderMesh.MaterialInfo.DepthFunction is {} newDepthFunction)
+                pipelineState.DepthStencilState.DepthBufferFunction = newDepthFunction;
+
             if (isMultisample)
             {
                 pipelineState.RasterizerState.MultisampleCount = output.MultisampleCount;


### PR DESCRIPTION
# PR Details
Provides the ability for users to set custom depth testing functions per material for special effects
![image](https://github.com/user-attachments/assets/195a6713-eb2b-431b-b3f0-f9c3bae8a055)
Here, a sphere clipped into another sphere by using the `Greater` depth function
![image](https://github.com/user-attachments/assets/fe48fd0c-6ff0-400c-9ce4-600e09820ce1)
![image](https://github.com/user-attachments/assets/a82b3608-6a76-4fcf-8093-38540ba03305)
This is often used for bullet impacts, selections in RTS, previews in level editors ...

## Related Issue
None afaict.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
