### PR TITLE
feat: Deprecate DataPointer in favor of Span

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameCameraPreviewService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameCameraPreviewService.cs
@@ -76,23 +76,18 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             borderPipelineState.State.PrimitiveType = PrimitiveType.LineStrip;
             borderPipelineState.State.RasterizerState = RasterizerStates.CullNone;
 
-            unsafe
+            var borderVertices = new[]
             {
-                var borderVertices = new[]
-                {
-                    new VertexPositionTexture(new Vector3(0.0f, 0.0f, 0.0f), Vector2.Zero),
-                    new VertexPositionTexture(new Vector3(0.0f, 1.0f, 0.0f), Vector2.Zero),
-                    new VertexPositionTexture(new Vector3(1.0f, 1.0f, 0.0f), Vector2.Zero),
-                    new VertexPositionTexture(new Vector3(1.0f, 0.0f, 0.0f), Vector2.Zero),
-                    new VertexPositionTexture(new Vector3(0.0f, 0.0f, 0.0f), Vector2.Zero),
-                    new VertexPositionTexture(new Vector3(0.0f, 1.0f, 0.0f), Vector2.Zero), // extra vertex so that left-top corner is not missing (likely due to rasterization rule)
-                };
-                fixed (VertexPositionTexture* borderVerticesPtr = borderVertices)
-                    borderVertexBuffer = Graphics.Buffer.Vertex.New(game.GraphicsDevice, new DataPointer(borderVerticesPtr, VertexPositionTexture.Size * borderVertices.Length));
-            }
+                new VertexPositionTexture(new Vector3(0.0f, 0.0f, 0.0f), Vector2.Zero),
+                new VertexPositionTexture(new Vector3(0.0f, 1.0f, 0.0f), Vector2.Zero),
+                new VertexPositionTexture(new Vector3(1.0f, 1.0f, 0.0f), Vector2.Zero),
+                new VertexPositionTexture(new Vector3(1.0f, 0.0f, 0.0f), Vector2.Zero),
+                new VertexPositionTexture(new Vector3(0.0f, 0.0f, 0.0f), Vector2.Zero),
+                new VertexPositionTexture(new Vector3(0.0f, 1.0f, 0.0f), Vector2.Zero), // extra vertex so that left-top corner is not missing (likely due to rasterization rule)
+            };
+            borderVertexBuffer = Graphics.Buffer.Vertex.New(game.GraphicsDevice, borderVertices);
 
-            var editorTopLevel = game.EditorSceneSystem.GraphicsCompositor.Game as EditorTopLevelCompositor;
-            if (editorTopLevel != null)
+            if (game.EditorSceneSystem.GraphicsCompositor.Game is EditorTopLevelCompositor editorTopLevel)
             {
                 // Display it as incrust
                 editorTopLevel.PostGizmoCompositors.Add(renderIncrustRenderer = new RenderIncrustRenderer(this));

--- a/sources/editor/Stride.Assets.Presentation/Thumbnails/AnimationThumbnailCompiler.cs
+++ b/sources/editor/Stride.Assets.Presentation/Thumbnails/AnimationThumbnailCompiler.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using Stride.Core.Assets;
 using Stride.Core.Assets.Analysis;
@@ -98,7 +100,7 @@ namespace Stride.Assets.Presentation.Thumbnails
                 }
             }
 
-            protected override void CustomizeThumbnail(Image image)
+            protected override unsafe void CustomizeThumbnail(Image image)
             {
                 base.CustomizeThumbnail(image);
 
@@ -130,7 +132,7 @@ namespace Stride.Assets.Presentation.Thumbnails
                     thumbnailBuilderHelper.GraphicsDevice.ColorSpace = oldColorSpace;
 
                     // Read back result to image
-                    thumbnailBuilderHelper.RenderTarget.GetData(thumbnailBuilderHelper.GraphicsContext.CommandList, thumbnailBuilderHelper.RenderTargetStaging, new DataPointer(image.PixelBuffer[0].DataPointer, image.PixelBuffer[0].BufferStride));
+                    thumbnailBuilderHelper.RenderTarget.GetData(thumbnailBuilderHelper.GraphicsContext.CommandList, thumbnailBuilderHelper.RenderTargetStaging, new Span<byte>((void*)image.PixelBuffer[0].DataPointer, image.PixelBuffer[0].BufferStride));
                     image.Description.Format = thumbnailBuilderHelper.RenderTarget.Format; // In case channels are swapped
                 }
             }

--- a/sources/editor/Stride.Editor/Thumbnails/ThumbnailBuildHelper.cs
+++ b/sources/editor/Stride.Editor/Thumbnails/ThumbnailBuildHelper.cs
@@ -84,7 +84,7 @@ namespace Stride.Editor.Thumbnails
         /// </summary>
         /// <param name="thumbnailImage">The thumbnail image.</param>
         /// <param name="dependencyBuildStatus">The dependency build status.</param>
-        public static void ApplyThumbnailStatus(Image thumbnailImage, LogMessageType dependencyBuildStatus)
+        public static unsafe void ApplyThumbnailStatus(Image thumbnailImage, LogMessageType dependencyBuildStatus)
         {
             // No warning or error, nothing to do (or maybe we should display a logo for "info"?)
             if (dependencyBuildStatus < LogMessageType.Warning)
@@ -106,12 +106,12 @@ namespace Stride.Editor.Thumbnails
                 }
 
                 // Read back result to image
-                thumbnailBuilderHelper.RenderTarget.GetData(thumbnailBuilderHelper.GraphicsContext.CommandList, thumbnailBuilderHelper.RenderTargetStaging, new DataPointer(thumbnailImage.PixelBuffer[0].DataPointer, thumbnailImage.PixelBuffer[0].BufferStride));
+                thumbnailBuilderHelper.RenderTarget.GetData(thumbnailBuilderHelper.GraphicsContext.CommandList, thumbnailBuilderHelper.RenderTargetStaging, new Span<byte>((void*)thumbnailImage.PixelBuffer[0].DataPointer, thumbnailImage.PixelBuffer[0].BufferStride));
                 thumbnailImage.Description.Format = thumbnailBuilderHelper.RenderTarget.Format; // In case channels are swapped
             }
         }
 
-        public void Combine(Texture texture, Image image)
+        public unsafe void Combine(Texture texture, Image image)
         {
             lock (thumbnailLock)
             {
@@ -121,7 +121,7 @@ namespace Stride.Editor.Thumbnails
                 }
 
                 // Read back result to image
-                RenderTarget.GetData(GraphicsContext.CommandList, RenderTargetStaging, new DataPointer(image.PixelBuffer[0].DataPointer, image.PixelBuffer[0].BufferStride));
+                RenderTarget.GetData(GraphicsContext.CommandList, RenderTargetStaging, new Span<byte>((void*)image.PixelBuffer[0].DataPointer, image.PixelBuffer[0].BufferStride));
                 image.Description.Format = RenderTarget.Format; // In case channels are swapped
             }
         }

--- a/sources/engine/Stride.Graphics/Buffer.Constant.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Constant.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Stride.Games;
 
 namespace Stride.Graphics
@@ -78,7 +79,7 @@ namespace Stride.Graphics
             /// <returns>A constant buffer</returns>
             public static Buffer<T> New<T>(GraphicsDevice device, T[] value, GraphicsResourceUsage usage = GraphicsResourceUsage.Dynamic) where T : unmanaged
             {
-                return Buffer.New(device, value, BufferFlags.ConstantBuffer, usage);
+                return Buffer.New(device, value, BufferFlags.ConstantBuffer, usage:usage);
             }
 
             /// <summary>
@@ -88,6 +89,19 @@ namespace Stride.Graphics
             /// <param name="value">The value to initialize the constant buffer.</param>
             /// <param name="usage">The usage of this resource.</param>
             /// <returns>A constant buffer</returns>
+            public static Buffer New(GraphicsDevice device, ReadOnlySpan<byte> value, GraphicsResourceUsage usage = GraphicsResourceUsage.Dynamic)
+            {
+                return Buffer.New(device, value, 0, BufferFlags.ConstantBuffer, usage:usage);
+            }
+
+            /// <summary>
+            /// Creates a new constant buffer with <see cref="GraphicsResourceUsage.Dynamic"/> usage.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the constant buffer.</param>
+            /// <param name="usage">The usage of this resource.</param>
+            /// <returns>A constant buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, GraphicsResourceUsage usage = GraphicsResourceUsage.Dynamic)
             {
                 return Buffer.New(device, value, 0, BufferFlags.ConstantBuffer, usage);

--- a/sources/engine/Stride.Graphics/Buffer.Index.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Index.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Stride.Games;
 
 namespace Stride.Graphics
@@ -79,7 +80,7 @@ namespace Stride.Graphics
             /// <returns>A index buffer</returns>
             public static Buffer<T> New<T>(GraphicsDevice device, T[] value, GraphicsResourceUsage usage = GraphicsResourceUsage.Immutable) where T : unmanaged
             {
-                return Buffer.New(device, value, BufferFlags.IndexBuffer, usage);
+                return Buffer.New(device, (ReadOnlySpan<T>)value, BufferFlags.IndexBuffer, usage:usage);
             }
 
             /// <summary>
@@ -102,6 +103,19 @@ namespace Stride.Graphics
             /// <param name="value">The value to initialize the index buffer.</param>
             /// <param name="usage">The usage of this resource.</param>
             /// <returns>A index buffer</returns>
+            public static Buffer New(GraphicsDevice device, ReadOnlySpan<byte> value, GraphicsResourceUsage usage = GraphicsResourceUsage.Immutable)
+            {
+                return Buffer.New(device, value, 0, BufferFlags.IndexBuffer, PixelFormat.None, usage);
+            }
+
+            /// <summary>
+            /// Creates a new index buffer with <see cref="GraphicsResourceUsage.Immutable"/> uasge by default.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the index buffer.</param>
+            /// <param name="usage">The usage of this resource.</param>
+            /// <returns>A index buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, GraphicsResourceUsage usage = GraphicsResourceUsage.Immutable)
             {
                 return Buffer.New(device, value, 0, BufferFlags.IndexBuffer, usage);

--- a/sources/engine/Stride.Graphics/Buffer.Raw.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Raw.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Stride.Games;
 
 namespace Stride.Graphics
@@ -86,7 +87,7 @@ namespace Stride.Graphics
             /// <returns>A Raw buffer</returns>
             public static Buffer<T> New<T>(GraphicsDevice device, T[] value, BufferFlags additionalBindings = BufferFlags.None, GraphicsResourceUsage usage = GraphicsResourceUsage.Default) where T : unmanaged
             {
-                return Buffer.New(device, value, BufferFlags.RawBuffer | additionalBindings, usage);
+                return Buffer.New(device, (ReadOnlySpan<T>)value, BufferFlags.RawBuffer | additionalBindings, usage:usage);
             }
 
             /// <summary>
@@ -97,6 +98,20 @@ namespace Stride.Graphics
             /// <param name="additionalBindings">The additional bindings (for example, to create a combined raw/index buffer, pass <see cref="BufferFlags.IndexBuffer" />)</param>
             /// <param name="usage">The usage of this resource.</param>
             /// <returns>A Raw buffer</returns>
+            public static Buffer New(GraphicsDevice device, ReadOnlySpan<byte> value, BufferFlags additionalBindings = BufferFlags.None, GraphicsResourceUsage usage = GraphicsResourceUsage.Default)
+            {
+                return Buffer.New(device, value, 0, BufferFlags.RawBuffer | additionalBindings, usage:usage);
+            }
+
+            /// <summary>
+            /// Creates a new Raw buffer with <see cref="GraphicsResourceUsage.Default"/> uasge by default.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the Raw buffer.</param>
+            /// <param name="additionalBindings">The additional bindings (for example, to create a combined raw/index buffer, pass <see cref="BufferFlags.IndexBuffer" />)</param>
+            /// <param name="usage">The usage of this resource.</param>
+            /// <returns>A Raw buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, BufferFlags additionalBindings = BufferFlags.None, GraphicsResourceUsage usage = GraphicsResourceUsage.Default)
             {
                 return Buffer.New(device, value, 0, BufferFlags.RawBuffer | additionalBindings, usage);

--- a/sources/engine/Stride.Graphics/Buffer.Structured.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Structured.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Stride.Games;
 
 namespace Stride.Graphics
@@ -86,7 +87,7 @@ namespace Stride.Graphics
                 if (isUnorderedAccess)
                     bufferFlags |= BufferFlags.UnorderedAccess;
 
-                return Buffer.New(device, value, bufferFlags);
+                return Buffer.New(device, (ReadOnlySpan<T>)value, bufferFlags);
             }
 
             /// <summary>
@@ -97,6 +98,25 @@ namespace Stride.Graphics
             /// <param name="elementSize">Size of the element.</param>
             /// <param name="isUnorderedAccess">if set to <c>true</c> this buffer supports unordered access (RW in HLSL).</param>
             /// <returns>A Structured buffer</returns>
+            public static Buffer New(GraphicsDevice device, ReadOnlySpan<byte> value, int elementSize, bool isUnorderedAccess = false)
+            {
+                var bufferFlags = BufferFlags.StructuredBuffer | BufferFlags.ShaderResource;
+
+                if (isUnorderedAccess)
+                    bufferFlags |= BufferFlags.UnorderedAccess;
+
+                return Buffer.New(device, value, elementSize, bufferFlags);
+            }
+
+            /// <summary>
+            /// Creates a new Structured buffer <see cref="GraphicsResourceUsage.Default" /> usage.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the Structured buffer.</param>
+            /// <param name="elementSize">Size of the element.</param>
+            /// <param name="isUnorderedAccess">if set to <c>true</c> this buffer supports unordered access (RW in HLSL).</param>
+            /// <returns>A Structured buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, int elementSize, bool isUnorderedAccess = false)
             {
                 var bufferFlags = BufferFlags.StructuredBuffer | BufferFlags.ShaderResource;
@@ -152,7 +172,7 @@ namespace Stride.Graphics
             public static Buffer<T> New<T>(GraphicsDevice device, T[] value) where T : unmanaged
             {
                 const BufferFlags BufferFlags = BufferFlags.StructuredAppendBuffer | BufferFlags.ShaderResource | BufferFlags.UnorderedAccess;
-                return Buffer.New(device, value, BufferFlags);
+                return Buffer.New(device, (ReadOnlySpan<T>)value, BufferFlags);
             }
 
             /// <summary>
@@ -162,6 +182,20 @@ namespace Stride.Graphics
             /// <param name="value">The value to initialize the StructuredAppend buffer.</param>
             /// <param name="elementSize">Size of the element.</param>
             /// <returns>A StructuredAppend buffer</returns>
+            public static Buffer New(GraphicsDevice device, ReadOnlySpan<byte> value, int elementSize)
+            {
+                const BufferFlags BufferFlags = BufferFlags.StructuredAppendBuffer | BufferFlags.ShaderResource | BufferFlags.UnorderedAccess;
+                return Buffer.New(device, value, elementSize, BufferFlags);
+            }
+
+            /// <summary>
+            /// Creates a new StructuredAppend buffer <see cref="GraphicsResourceUsage.Default" /> usage.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the StructuredAppend buffer.</param>
+            /// <param name="elementSize">Size of the element.</param>
+            /// <returns>A StructuredAppend buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, int elementSize)
             {
                 const BufferFlags BufferFlags = BufferFlags.StructuredAppendBuffer | BufferFlags.ShaderResource | BufferFlags.UnorderedAccess;
@@ -213,7 +247,7 @@ namespace Stride.Graphics
             public static Buffer New<T>(GraphicsDevice device, T[] value) where T : unmanaged
             {
                 const BufferFlags BufferFlags = BufferFlags.StructuredCounterBuffer | BufferFlags.ShaderResource | BufferFlags.UnorderedAccess;
-                return Buffer.New(device, value, BufferFlags);
+                return Buffer.New(device, (ReadOnlySpan<T>)value, BufferFlags);
             }
 
             /// <summary>
@@ -223,6 +257,20 @@ namespace Stride.Graphics
             /// <param name="value">The value to initialize the StructuredCounter buffer.</param>
             /// <param name="elementSize">Size of the element.</param>
             /// <returns>A StructuredCounter buffer</returns>
+            public static Buffer New(GraphicsDevice device, ReadOnlySpan<byte> value, int elementSize)
+            {
+                const BufferFlags BufferFlags = BufferFlags.StructuredCounterBuffer | BufferFlags.ShaderResource | BufferFlags.UnorderedAccess;
+                return Buffer.New(device, value, elementSize, BufferFlags);
+            }
+
+            /// <summary>
+            /// Creates a new StructuredCounter buffer <see cref="GraphicsResourceUsage.Default" /> usage.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the StructuredCounter buffer.</param>
+            /// <param name="elementSize">Size of the element.</param>
+            /// <returns>A StructuredCounter buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, int elementSize)
             {
                 const BufferFlags BufferFlags = BufferFlags.StructuredCounterBuffer | BufferFlags.ShaderResource | BufferFlags.UnorderedAccess;

--- a/sources/engine/Stride.Graphics/Buffer.Typed.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Typed.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Stride.Games;
 
 namespace Stride.Graphics
@@ -61,6 +62,21 @@ namespace Stride.Graphics
             /// <returns>A Typed buffer</returns>
             public static Buffer<T> New<T>(GraphicsDevice device, T[] value, PixelFormat viewFormat, bool isUnorderedAccess = false, GraphicsResourceUsage usage = GraphicsResourceUsage.Default) where T : unmanaged
             {
+                return Buffer.New(device, (ReadOnlySpan<T>)value, BufferFlags.ShaderResource | (isUnorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), viewFormat, usage);
+            }
+
+            /// <summary>
+            /// Creates a new Typed buffer <see cref="GraphicsResourceUsage.Default" /> uasge.
+            /// </summary>
+            /// <typeparam name="T">Type of the Typed buffer to get the sizeof from</typeparam>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the Typed buffer.</param>
+            /// <param name="viewFormat">The view format of the buffer.</param>
+            /// <param name="isUnorderedAccess">if set to <c>true</c> this buffer supports unordered access (RW in HLSL).</param>
+            /// <param name="usage">The usage of this resource.</param>
+            /// <returns>A Typed buffer</returns>
+            public static Buffer<T> New<T>(GraphicsDevice device, ReadOnlySpan<T> value, PixelFormat viewFormat, bool isUnorderedAccess = false, GraphicsResourceUsage usage = GraphicsResourceUsage.Default) where T : unmanaged
+            {
                 return Buffer.New(device, value, BufferFlags.ShaderResource | (isUnorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), viewFormat, usage);
             }
 
@@ -73,6 +89,7 @@ namespace Stride.Graphics
             /// <param name="isUnorderedAccess">if set to <c>true</c> this buffer supports unordered access (RW in HLSL).</param>
             /// <param name="usage">The usage of this resource.</param>
             /// <returns>A Typed buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, PixelFormat viewFormat, bool isUnorderedAccess = false, GraphicsResourceUsage usage = GraphicsResourceUsage.Default)
             {
                 return Buffer.New(device, value, 0, BufferFlags.ShaderResource | (isUnorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), viewFormat, usage);

--- a/sources/engine/Stride.Graphics/Buffer.Vertex.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Vertex.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Stride.Games;
 
 namespace Stride.Graphics
@@ -82,7 +83,7 @@ namespace Stride.Graphics
             /// <returns>A Vertex buffer</returns>
             public static Buffer<T> New<T>(GraphicsDevice device, T[] value, GraphicsResourceUsage usage = GraphicsResourceUsage.Immutable) where T : unmanaged
             {
-                return Buffer.New(device, value, BufferFlags.VertexBuffer, usage);
+                return Buffer.New(device, (ReadOnlySpan<T>)value, BufferFlags.VertexBuffer, usage:usage);
             }
 
             /// <summary>
@@ -105,6 +106,19 @@ namespace Stride.Graphics
             /// <param name="value">The value to initialize the Vertex buffer.</param>
             /// <param name="usage">The usage of this resource.</param>
             /// <returns>A Vertex buffer</returns>
+            public static Buffer New(GraphicsDevice device, Span<byte> value, GraphicsResourceUsage usage = GraphicsResourceUsage.Immutable)
+            {
+                return Buffer.New(device, value, 0, BufferFlags.VertexBuffer, usage:usage);
+            }
+
+            /// <summary>
+            /// Creates a new Vertex buffer with <see cref="GraphicsResourceUsage.Immutable"/> uasge by default.
+            /// </summary>
+            /// <param name="device">The <see cref="GraphicsDevice"/>.</param>
+            /// <param name="value">The value to initialize the Vertex buffer.</param>
+            /// <param name="usage">The usage of this resource.</param>
+            /// <returns>A Vertex buffer</returns>
+            [Obsolete("Use span instead")]
             public static Buffer New(GraphicsDevice device, DataPointer value, GraphicsResourceUsage usage = GraphicsResourceUsage.Immutable)
             {
                 return Buffer.New(device, value, 0, BufferFlags.VertexBuffer, usage);

--- a/sources/engine/Stride.Graphics/FastTextRenderer.cs
+++ b/sources/engine/Stride.Graphics/FastTextRenderer.cs
@@ -112,7 +112,7 @@ namespace Stride.Graphics
 
             graphicsContext.CommandList.UnmapSubresource(mappedIndices);
 
-            indexBufferBinding = new IndexBufferBinding(Buffer.Index.New(graphicsContext.CommandList.GraphicsDevice, new DataPointer(indexPointer, indexBufferSize)), true, indexBufferLength);
+            indexBufferBinding = new IndexBufferBinding(Buffer.Index.New(graphicsContext.CommandList.GraphicsDevice, new ReadOnlySpan<byte>((void*)indexPointer, indexBufferSize)), true, indexBufferLength);
 
             // Create vertex buffers
             vertexBuffers = new Buffer[VertexBufferCount];

--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -757,8 +757,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe bool GetData<TData>(CommandList commandList, Texture stagingTexture, TData[] toData, int arraySlice = 0, int mipSlice = 0, bool doNotWait = false) where TData : unmanaged
         {
-            fixed (TData* to = toData)
-                return GetData(commandList, stagingTexture, new DataPointer(to, toData.Length * Unsafe.SizeOf<TData>()), arraySlice, mipSlice, doNotWait);
+            return GetData(commandList, stagingTexture, toData.AsSpan(), arraySlice, mipSlice, doNotWait);
         }
 
         /// <summary>
@@ -776,8 +775,7 @@ namespace Stride.Graphics
         /// </remarks>
         public unsafe void SetData<TData>(CommandList commandList, TData[] fromData, int arraySlice = 0, int mipSlice = 0, ResourceRegion? region = null) where TData : unmanaged
         {
-            fixed (TData* from = fromData)
-                SetData(commandList, new DataPointer(from, fromData.Length * Unsafe.SizeOf<TData>()), arraySlice, mipSlice, region);
+            SetData(commandList, fromData.AsSpan(), arraySlice, mipSlice, region);
         }
 
         /// <summary>
@@ -794,7 +792,27 @@ namespace Stride.Graphics
         /// <remarks>
         /// This method is only working when called from the main thread that is accessing the main <see cref="GraphicsDevice"/>.
         /// </remarks>
+        [Obsolete("Use span instead")]
         public unsafe bool GetData(CommandList commandList, Texture stagingTexture, DataPointer toData, int arraySlice = 0, int mipSlice = 0, bool doNotWait = false)
+        {
+            return GetData(commandList, stagingTexture, new Span<byte>((void*)toData.Pointer, toData.Size), arraySlice, mipSlice, doNotWait);
+        }
+
+        /// <summary>
+        /// Copies the content of this texture from GPU memory to a pointer on CPU memory using a specific staging resource.
+        /// </summary>
+        /// <param name="commandList">The command list.</param>
+        /// <param name="stagingTexture">The staging texture used to transfer the texture to.</param>
+        /// <param name="toData">The pointer to data in CPU memory.</param>
+        /// <param name="arraySlice">The array slice index. This value must be set to 0 for Texture 3D.</param>
+        /// <param name="mipSlice">The mip slice index.</param>
+        /// <param name="doNotWait">if set to <c>true</c> this method will return immediately if the resource is still being used by the GPU for writing. Default is false</param>
+        /// <returns><c>true</c> if data was correctly retrieved, <c>false</c> if <paramref name="doNotWait"/> flag was true and the resource is still being used by the GPU for writing.</returns>
+        /// <exception cref="System.ArgumentException">When strides is different from optimal strides, and TData is not the same size as the pixel format, or Width * Height != toData.Length</exception>
+        /// <remarks>
+        /// This method is only working when called from the main thread that is accessing the main <see cref="GraphicsDevice"/>.
+        /// </remarks>
+        public unsafe bool GetData<T>(CommandList commandList, Texture stagingTexture, Span<T> toData, int arraySlice = 0, int mipSlice = 0, bool doNotWait = false) where T : unmanaged
         {
             if (stagingTexture == null) throw new ArgumentNullException("stagingTexture");
             var device = GraphicsDevice;
@@ -816,9 +834,11 @@ namespace Stride.Graphics
             // MipMap Stride
             int mipMapSize = mipmap.MipmapSize;
 
+            int destLengthInBytes = toData.Length * sizeof(T);
+
             // Check size validity of data to copy to
-            if (toData.Size > mipMapSize)
-                throw new ArgumentException($"Size of toData ({toData.Size} bytes) is not compatible expected size ({mipMapSize} bytes) : Width * Height * Depth * sizeof(PixelFormat) size in bytes");
+            if (destLengthInBytes > mipMapSize)
+                throw new ArgumentException($"Size of toData ({destLengthInBytes} bytes) is not compatible expected size ({mipMapSize} bytes) : Width * Height * Depth * sizeof(PixelFormat) size in bytes");
 
             // Copy the actual content of the texture to the staging resource
             if (!ReferenceEquals(this, stagingTexture))
@@ -845,42 +865,45 @@ namespace Stride.Graphics
             // The fast way: If same stride, we can directly copy the whole texture in one shot
             if (box.RowPitch == rowStride && boxDepthStride == textureDepthStride && !isFlippedTexture)
             {
-                Unsafe.CopyBlockUnaligned((void*)toData.Pointer, (void*)box.DataPointer, (uint)mipMapSize);
+                fixed(void* destPtr = toData)
+                    Unsafe.CopyBlockUnaligned(destPtr, (void*)box.DataPointer, (uint)mipMapSize);
             }
             else
             {
                 // Otherwise, the long way by copying each scanline
                 var sourcePerDepthPtr = (byte*)box.DataPointer;
-                var destPtr = (byte*)toData.Pointer;
-
-                // Iterate on all depths
-                for (int j = 0; j < depth; j++)
+                fixed (T* ptr = toData)
                 {
-                    var sourcePtr = sourcePerDepthPtr;
-                    // Iterate on each line
+                    byte* destPtr = (byte*)ptr;
+                    // Iterate on all depths
+                    for (int j = 0; j < depth; j++)
+                    {
+                        var sourcePtr = sourcePerDepthPtr;
+                        // Iterate on each line
 
-                    if (isFlippedTexture)
-                    {
-                        sourcePtr += box.RowPitch * (height - 1);
-                        for (int i = height - 1; i >= 0; i--)
+                        if (isFlippedTexture)
                         {
-                            // Copy a single row
-                            Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
-                            sourcePtr -= box.RowPitch;
-                            destPtr += rowStride;
+                            sourcePtr += box.RowPitch * (height - 1);
+                            for (int i = height - 1; i >= 0; i--)
+                            {
+                                // Copy a single row
+                                Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
+                                sourcePtr -= box.RowPitch;
+                                destPtr += rowStride;
+                            }
                         }
-                    }
-                    else
-                    {
-                        for (int i = 0; i < height; i++)
+                        else
                         {
-                            // Copy a single row
-                            Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
-                            sourcePtr += box.RowPitch;
-                            destPtr += rowStride;
+                            for (int i = 0; i < height; i++)
+                            {
+                                // Copy a single row
+                                Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
+                                sourcePtr += box.RowPitch;
+                                destPtr += rowStride;
+                            }
                         }
+                        sourcePerDepthPtr += box.SlicePitch;
                     }
-                    sourcePerDepthPtr += box.SlicePitch;
                 }
             }
 
@@ -902,7 +925,25 @@ namespace Stride.Graphics
         /// <remarks>
         /// See unmanaged documentation for usage and restrictions.
         /// </remarks>
+        [Obsolete("Use span instead")]
         public unsafe void SetData(CommandList commandList, DataPointer fromData, int arraySlice = 0, int mipSlice = 0, ResourceRegion? region = null)
+        {
+            SetData(commandList, new Span<byte>((void*)fromData.Pointer, fromData.Size), arraySlice, mipSlice, region);
+        }
+
+        /// <summary>
+        /// Copies the content an data on CPU memory to this texture into GPU memory.
+        /// </summary>
+        /// <param name="commandList">The <see cref="CommandList"/>.</param>
+        /// <param name="fromData">The data to copy from.</param>
+        /// <param name="arraySlice">The array slice index. This value must be set to 0 for Texture 3D.</param>
+        /// <param name="mipSlice">The mip slice index.</param>
+        /// <param name="region">Destination region</param>
+        /// <exception cref="System.ArgumentException">When strides is different from optimal strides, and TData is not the same size as the pixel format, or Width * Height != toData.Length</exception>
+        /// <remarks>
+        /// See unmanaged documentation for usage and restrictions.
+        /// </remarks>
+        public unsafe void SetData<T>(CommandList commandList, Span<T> fromData, int arraySlice = 0, int mipSlice = 0, ResourceRegion? region = null) where T : unmanaged
         {
             if (commandList == null) throw new ArgumentNullException("commandList");
             if (region.HasValue && this.Usage != GraphicsResourceUsage.Default)
@@ -948,76 +989,81 @@ namespace Stride.Graphics
             // Size Of actual texture data
             int sizeOfTextureData = textureDepthStride * depth;
 
+            int fromDataSizeInBytes = fromData.Length * sizeof(T);
+
             // Check size validity of data to copy to
-            if (fromData.Size < sizeOfTextureData)
-                throw new ArgumentException($"Size of fromData ({fromData.Size} bytes) is not compatible expected size must be at least {sizeOfTextureData} bytes : Width * Height * Depth * sizeof(PixelFormat) size in bytes");
+            if (fromDataSizeInBytes < sizeOfTextureData)
+                throw new ArgumentException($"Size of fromData ({fromDataSizeInBytes} bytes) is not compatible expected size must be at least {sizeOfTextureData} bytes : Width * Height * Depth * sizeof(PixelFormat) size in bytes");
 
             // Calculate the subResourceIndex for a Texture
             int subResourceIndex = this.GetSubResourceIndex(arraySlice, mipSlice);
 
-            // If this texture is declared as default usage, we use UpdateSubresource that supports sub resource region.
-            if (this.Usage == GraphicsResourceUsage.Default)
+            fixed (void* pointer = fromData)
             {
-                // If using a specific region, we need to handle this case
-                if (region.HasValue)
+                // If this texture is declared as default usage, we use UpdateSubresource that supports sub resource region.
+                if (this.Usage == GraphicsResourceUsage.Default)
                 {
-                    var regionValue = region.Value;
-                    var sourceDataPtr = fromData.Pointer;
-
-                    // Workaround when using region with a deferred context and a device that does not support CommandList natively
-                    // see http://blogs.msdn.com/b/chuckw/archive/2010/07/28/known-issue-direct3d-11-updatesubresource-and-deferred-contexts.aspx
-                    if (commandList.GraphicsDevice.NeedWorkAroundForUpdateSubResource)
+                    // If using a specific region, we need to handle this case
+                    if (region.HasValue)
                     {
-                        if (IsBlockCompressed)
+                        var regionValue = region.Value;
+                        nint sourceDataPtr = (nint)pointer;
+
+                        // Workaround when using region with a deferred context and a device that does not support CommandList natively
+                        // see http://blogs.msdn.com/b/chuckw/archive/2010/07/28/known-issue-direct3d-11-updatesubresource-and-deferred-contexts.aspx
+                        if (commandList.GraphicsDevice.NeedWorkAroundForUpdateSubResource)
                         {
-                            regionValue.Left /= 4;
-                            regionValue.Right /= 4;
-                            regionValue.Top /= 4;
-                            regionValue.Bottom /= 4;
+                            if (IsBlockCompressed)
+                            {
+                                regionValue.Left /= 4;
+                                regionValue.Right /= 4;
+                                regionValue.Top /= 4;
+                                regionValue.Bottom /= 4;
+                            }
+                            sourceDataPtr = new IntPtr((byte*)sourceDataPtr - (regionValue.Front * textureDepthStride) - (regionValue.Top * rowStride) - (regionValue.Left * sizePerElement));
                         }
-                        sourceDataPtr = new IntPtr((byte*)sourceDataPtr - (regionValue.Front * textureDepthStride) - (regionValue.Top * rowStride) - (regionValue.Left * sizePerElement));
+                        commandList.UpdateSubresource(this, subResourceIndex, new DataBox(sourceDataPtr, rowStride, textureDepthStride), regionValue);
                     }
-                    commandList.UpdateSubresource(this, subResourceIndex, new DataBox(sourceDataPtr, rowStride, textureDepthStride), regionValue);
+                    else
+                    {
+                        commandList.UpdateSubresource(this, subResourceIndex, new DataBox((nint)pointer, rowStride, textureDepthStride));
+                    }
                 }
                 else
                 {
-                    commandList.UpdateSubresource(this, subResourceIndex, new DataBox(fromData.Pointer, rowStride, textureDepthStride));
-                }
-            }
-            else
-            {
-                var mappedResource = commandList.MapSubresource(this, subResourceIndex, this.Usage == GraphicsResourceUsage.Dynamic ? MapMode.WriteDiscard : MapMode.Write);
-                var box = mappedResource.DataBox;
+                    var mappedResource = commandList.MapSubresource(this, subResourceIndex, this.Usage == GraphicsResourceUsage.Dynamic ? MapMode.WriteDiscard : MapMode.Write);
+                    var box = mappedResource.DataBox;
 
-                // If depth == 1 (Texture, Texture or TextureCube), then depthStride is not used
-                var boxDepthStride = this.Depth == 1 ? box.SlicePitch : textureDepthStride;
+                    // If depth == 1 (Texture, Texture or TextureCube), then depthStride is not used
+                    var boxDepthStride = this.Depth == 1 ? box.SlicePitch : textureDepthStride;
 
-                // The fast way: If same stride, we can directly copy the whole texture in one shot
-                if (box.RowPitch == rowStride && boxDepthStride == textureDepthStride)
-                {
-                    Unsafe.CopyBlockUnaligned((void*)box.DataPointer, (void*)fromData.Pointer, (uint)sizeOfTextureData);
-                }
-                else
-                {
-                    // Otherwise, the long way by copying each scanline
-                    var destPerDepthPtr = (byte*)box.DataPointer;
-                    var sourcePtr = (byte*)fromData.Pointer;
-
-                    // Iterate on all depths
-                    for (int j = 0; j < depth; j++)
+                    // The fast way: If same stride, we can directly copy the whole texture in one shot
+                    if (box.RowPitch == rowStride && boxDepthStride == textureDepthStride)
                     {
-                        var destPtr = destPerDepthPtr;
-                        // Iterate on each line
-                        for (int i = 0; i < height; i++)
-                        {
-                            Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
-                            destPtr += box.RowPitch;
-                            sourcePtr += rowStride;
-                        }
-                        destPerDepthPtr += box.SlicePitch;
+                        Unsafe.CopyBlockUnaligned((void*)box.DataPointer, pointer, (uint)sizeOfTextureData);
                     }
+                    else
+                    {
+                        // Otherwise, the long way by copying each scanline
+                        var destPerDepthPtr = (byte*)box.DataPointer;
+                        var sourcePtr = (byte*)pointer;
+
+                        // Iterate on all depths
+                        for (int j = 0; j < depth; j++)
+                        {
+                            var destPtr = destPerDepthPtr;
+                            // Iterate on each line
+                            for (int i = 0; i < height; i++)
+                            {
+                                Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
+                                destPtr += box.RowPitch;
+                                sourcePtr += rowStride;
+                            }
+                            destPerDepthPtr += box.SlicePitch;
+                        }
+                    }
+                    commandList.UnmapSubresource(mappedResource);
                 }
-                commandList.UnmapSubresource(mappedResource);
             }
         }
 
@@ -1153,7 +1199,7 @@ namespace Stride.Graphics
         /// <param name="commandList">The command list.</param>
         /// <param name="stagingTexture">The staging texture used to temporary transfer the image from the GPU to CPU.</param>
         /// <exception cref="ArgumentException">If stagingTexture is not a staging texture.</exception>
-        public Image GetDataAsImage(CommandList commandList, Texture stagingTexture)
+        public unsafe Image GetDataAsImage(CommandList commandList, Texture stagingTexture)
         {
             if (stagingTexture == null) throw new ArgumentNullException("stagingTexture");
             if (stagingTexture.Usage != GraphicsResourceUsage.Staging)
@@ -1167,7 +1213,7 @@ namespace Stride.Graphics
                     for (int mipLevel = 0; mipLevel < image.Description.MipLevels; mipLevel++)
                     {
                         var pixelBuffer = image.PixelBuffer[arrayIndex, mipLevel];
-                        GetData(commandList, stagingTexture, new DataPointer(pixelBuffer.DataPointer, pixelBuffer.BufferStride), arrayIndex, mipLevel);
+                        GetData(commandList, stagingTexture, new Span<byte>((byte*)pixelBuffer.DataPointer, pixelBuffer.BufferStride), arrayIndex, mipLevel);
                     }
                 }
             }

--- a/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
@@ -263,20 +263,16 @@ namespace Stride.Physics
                     .GetValue(buffer.GraphicsDevice);
 
                 output = new byte[buffer.SizeInBytes];
-                fixed (byte* window = output)
+                if (buffer.Description.Usage == GraphicsResourceUsage.Staging)
                 {
-                    var ptr = new DataPointer(window, output.Length);
-                    if (buffer.Description.Usage == GraphicsResourceUsage.Staging)
-                    {
-                        // Directly if this is a staging resource
-                        buffer.GetData(commandList, buffer, ptr);
-                    }
-                    else
-                    {
-                        // inefficient way to use the Copy method using dynamic staging texture
-                        using var throughStaging = buffer.ToStaging();
-                        buffer.GetData(commandList, throughStaging, ptr);
-                    }
+                    // Directly if this is a staging resource
+                    buffer.GetData(commandList, buffer, output);
+                }
+                else
+                {
+                    // inefficient way to use the Copy method using dynamic staging texture
+                    using var throughStaging = buffer.ToStaging();
+                    buffer.GetData(commandList, throughStaging, output);
                 }
 
                 return output;

--- a/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/InstancingRenderFeature.cs
@@ -100,12 +100,9 @@ namespace Stride.Rendering
             }
         }
 
-        private static unsafe void SetBufferData<TData>(CommandList commandList, Buffer buffer, TData[] fromData, int elementCount) where TData : unmanaged
+        private static void SetBufferData<TData>(CommandList commandList, Buffer buffer, TData[] fromData, int elementCount) where TData : unmanaged
         {
-            fixed (void* from = fromData) {
-                var dataPointer = new DataPointer(from, Math.Min(elementCount, fromData.Length) * Unsafe.SizeOf<TData>());
-                buffer.SetData(commandList, dataPointer);
-            }
+            buffer.SetData(commandList, (ReadOnlySpan<TData>)fromData.AsSpan(0, Math.Min(elementCount, fromData.Length)));
         }
 
         public override void PrepareEffectPermutations(RenderDrawContext context)

--- a/sources/engine/Stride.Video/VideoTexture.cs
+++ b/sources/engine/Stride.Video/VideoTexture.cs
@@ -104,11 +104,11 @@ namespace Stride.Video
             originalTargetTexture = null;
         }
 
-        public void UpdateTopLevelMipmapFromData(GraphicsContext context, VideoImage image)
+        public unsafe void UpdateTopLevelMipmapFromData(GraphicsContext context, VideoImage image)
         {
             // "videoComponent.Target" contains the mip mapped video texture at this point.
             // We now copy the new video frame directly into the video texture's first mip level:
-            DataPointer dataPointer = new DataPointer(image.Buffer, image.BufferSize);
+            var dataPointer = new Span<byte>((void*)image.Buffer, image.BufferSize);
             renderTargetMipMaps[0].SetData(context.CommandList, dataPointer, 0, 0);
         }
 

--- a/sources/engine/Stride/Graphics/DataPointer.cs
+++ b/sources/engine/Stride/Graphics/DataPointer.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace Stride.Graphics
 {
+    [Obsolete("Use System.Span instead")]
     public struct DataPointer
     {
         public unsafe DataPointer(void* pointer, int size)

--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -504,9 +504,26 @@ namespace Stride.Graphics
         /// <param name="loadAsSRGB">Indicate if the image should be loaded as an sRGB texture</param>
         /// <returns>An new image.</returns>
         /// <remarks>If <paramref name="makeACopy"/> is set to false, the returned image is now the holder of the unmanaged pointer and will release it on Dispose. </remarks>
+        [Obsolete("Use span instead")]
         public static Image Load(DataPointer dataBuffer, bool makeACopy = false, bool loadAsSRGB = false)
         {
             return Load(dataBuffer.Pointer, dataBuffer.Size, makeACopy, loadAsSRGB);
+        }
+
+        /// <summary>
+        /// Loads an image from an unmanaged memory pointer.
+        /// </summary>
+        /// <param name="dataBuffer">Pointer to an unmanaged memory. If <paramref name="makeACopy"/> is false, this buffer must be allocated with <see cref="Utilities.AllocateMemory"/>.</param>
+        /// <param name="makeACopy">True to copy the content of the buffer to a new allocated buffer, false otherwise.</param>
+        /// <param name="loadAsSRGB">Indicate if the image should be loaded as an sRGB texture</param>
+        /// <returns>An new image.</returns>
+        /// <remarks>If <paramref name="makeACopy"/> is set to false, the returned image is now the holder of the unmanaged pointer and will release it on Dispose. </remarks>
+        public static unsafe Image Load(Span<byte> dataBuffer, bool makeACopy = false, bool loadAsSRGB = false)
+        {
+            fixed (void* ptr = dataBuffer)
+            {
+                return Load((nint)ptr, dataBuffer.Length, makeACopy, loadAsSRGB);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details
DataPointer are just the more rigid and error prone version of what Span provides, marked that type as deprecated, created new signatures providing support for spans instead and moved over the engine calls to that one instead.

One thing I tried to tackle is replacing `T[]` with `Span<T>` to reduce the ridiculous amount of signatures Buffer and its variants already hosts, but arrays do not implicitly convert to spans when the function they are passed into is generic. Replacing all cases of `T[]` with `Span<T>` would fail to find the method. We'll have to mark those methods as obsolete as well if we want to clean that up.

## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
