### PR TITLE
fix: PhysicsComponent created with GetOrCreate<T> is unusable

### DIFF
--- a/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
+++ b/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
@@ -37,7 +37,7 @@ namespace Stride.Physics.Tests
                 if (hitResult.Succeeded)
                 {
                     return true;
-                }                
+                }
             }
 
             return false;
@@ -242,6 +242,51 @@ namespace Stride.Physics.Tests
                 Assert.True(hit.Succeeded);
                 Assert.Equal(0.0f, (new Vector3(-2.861034E-06f, 3.889218E-06f, -1f) - hit.Normal).Length(), 3f);
                 Assert.Equal(0.0f, (new Vector3(-5.366335f, -0.08297831f, -17.9267f) - hit.Point).Length(), 3f);
+
+                game.Exit();
+            });
+            RunGameTest(game);
+        }
+
+        /// <summary>
+        /// Verify PhysicsComponent creation through the use of GetOrCreate<T>
+        /// If component is added this way, must ensure ColliderShape is properly setup if added later
+        /// </summary>
+        [Fact]
+        public void VerifyColliderShapeSetup()
+        {
+            var game = new ColliderShapesTest();
+            game.Script.AddTask(async () =>
+            {
+                game.ScreenShotAutomationEnabled = false;
+                await game.Script.NextFrame();
+                await game.Script.NextFrame();
+
+                var simulation = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Simulation").Get<StaticColliderComponent>().Simulation;
+                var cube = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "CubePrefab1");
+                
+                var body = cube.GetOrCreate<RigidbodyComponent>();
+
+                //verify values not properly set up
+                Assert.Null(body.ColliderShape);
+                Assert.Equal(RigidBodyTypes.Static, body.RigidBodyType);
+                Assert.False(body.OverrideGravity);
+
+                //for further debug, can set breakpoint and check body.Simulation.discreteDynamicWorld.CollisionObjectArray before and after
+                //the collider shape is attached to see it properly added
+
+                //add collider shape
+                body.ColliderShape = new SphereColliderShape(false, 1.0f);
+                //check if proper colliderShape setup took place
+                Assert.True(body.ColliderShape != null);
+                Assert.Equal(ColliderShapeTypes.Sphere, body.ColliderShape.Type);
+                Assert.Equal(RigidBodyTypes.Dynamic, body.RigidBodyType);
+
+                body.OverrideGravity = true;
+                //to verify InternalRigidBody was properly set up we can change properties such as Mass or OverrideGravity 
+                //that normally would return void if there are no InternalRigidBody values
+                Assert.True(body.OverrideGravity);
+
 
                 game.Exit();
             });

--- a/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
+++ b/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
@@ -264,7 +264,7 @@ namespace Stride.Physics.Tests
 
                 var simulation = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Simulation").Get<StaticColliderComponent>().Simulation;
                 var cube = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "CubePrefab1");
-                
+
                 var body = cube.GetOrCreate<RigidbodyComponent>();
 
                 //verify values not properly set up

--- a/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
+++ b/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
@@ -264,7 +264,7 @@ namespace Stride.Physics.Tests
 
                 var simulation = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "Simulation").Get<StaticColliderComponent>().Simulation;
                 var cube = game.SceneSystem.SceneInstance.RootScene.Entities.First(ent => ent.Name == "CubePrefab1");
-
+                
                 var body = cube.GetOrCreate<RigidbodyComponent>();
 
                 //verify values not properly set up

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -89,7 +89,7 @@ namespace Stride.Physics
                 {
                     return;
                 }
-
+                    
 
                 var inertia = ColliderShape.InternalShape.CalculateLocalInertia(value);
                 InternalRigidBody.SetMassProps(value, inertia);
@@ -205,7 +205,7 @@ namespace Stride.Physics
                 {
                     return;
                 }
-
+                    
 
                 if (value)
                 {

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -89,7 +89,7 @@ namespace Stride.Physics
                 {
                     return;
                 }
-                    
+
 
                 var inertia = ColliderShape.InternalShape.CalculateLocalInertia(value);
                 InternalRigidBody.SetMassProps(value, inertia);
@@ -205,7 +205,7 @@ namespace Stride.Physics
                 {
                     return;
                 }
-                    
+
 
                 if (value)
                 {

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -85,7 +85,11 @@ namespace Stride.Physics
 
                 mass = value;
 
-                if (InternalRigidBody == null) return;
+                if (InternalRigidBody == null)
+                {
+                    return;
+                }
+                    
 
                 var inertia = ColliderShape.InternalShape.CalculateLocalInertia(value);
                 InternalRigidBody.SetMassProps(value, inertia);
@@ -114,7 +118,11 @@ namespace Stride.Physics
                     return;
 
                 if (InternalRigidBody == null)
+                {
+                    //When setting ColliderShape, setup could have been previously skipped when PhysicsComponent is created using GetOrCreate
+                    OnAttach();
                     return;
+                }
 
                 if (NativeCollisionObject != null)
                     NativeCollisionObject.CollisionShape = value.InternalShape;
@@ -193,7 +201,11 @@ namespace Stride.Physics
             {
                 overrideGravity = value;
 
-                if (InternalRigidBody == null) return;
+                if (InternalRigidBody == null)
+                {
+                    return;
+                }
+                    
 
                 if (value)
                 {

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -119,8 +119,8 @@ namespace Stride.Physics
 
                 if (InternalRigidBody == null)
                 {
-                    //When setting ColliderShape, setup could have been previously skipped when PhysicsComponent is created using GetOrCreate
-                    OnAttach();
+                    //When setting ColliderShape, setup could have been previously skipped (eg when PhysicsComponent is created using GetOrCreate)
+                    ReAttach();
                     return;
                 }
 
@@ -353,6 +353,7 @@ namespace Stride.Physics
 
         protected override void OnDetach()
         {
+
             MotionState.Dispose();
             MotionState.Clear();
 

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -332,7 +332,7 @@ namespace Stride.Engine
 
 
         private Dictionary<PhysicsComponent, CollisionState> ignoreCollisionBuffer;
-        
+
 
         #region Ignore or Private/Internal
 
@@ -467,9 +467,9 @@ namespace Stride.Engine
             {
                 derivedTransformation = BoneWorldMatrix;
             }
-            
+
             derivedTransformation.Decompose(out Vector3 scale, out Matrix rotation, out Vector3 translation);
-            
+
             var translationMatrix = Matrix.Translation(translation);
             Matrix.Multiply(ref rotation, ref translationMatrix, out derivedTransformation);
 
@@ -571,7 +571,7 @@ namespace Stride.Engine
         public void UpdatePhysicsTransformation(bool forceUpdateTransform = true)
         {
             DerivePhysicsTransformation(out var transform, forceUpdateTransform);
-            
+
             //finally copy back to bullet
             PhysicsWorldTransform = transform;
 
@@ -603,10 +603,10 @@ namespace Stride.Engine
             CanScaleShape = true;
             foreach (var desc in ColliderShapes)
             {
-                if(desc is ColliderShapeAssetDesc)
+                if (desc is ColliderShapeAssetDesc)
                     CanScaleShape = false;
             }
-            
+
             var services = Entity?.EntityManager?.Services;
             if (ColliderShapes.Count == 1) //single shape case
             {
@@ -670,9 +670,9 @@ namespace Stride.Engine
 
             OnAttach();
 
-            if(ignoreCollisionBuffer != null && NativeCollisionObject != null)
+            if (ignoreCollisionBuffer != null && NativeCollisionObject != null)
             {
-                foreach(var kvp in ignoreCollisionBuffer)
+                foreach (var kvp in ignoreCollisionBuffer)
                 {
                     IgnoreCollisionWith(kvp.Key, kvp.Value);
                 }
@@ -781,9 +781,9 @@ namespace Stride.Engine
         public void IgnoreCollisionWith(PhysicsComponent other, CollisionState state)
         {
             var otherNative = other.NativeCollisionObject;
-            if(NativeCollisionObject == null || other.NativeCollisionObject == null)
+            if (NativeCollisionObject == null || other.NativeCollisionObject == null)
             {
-                if(ignoreCollisionBuffer != null || other.ignoreCollisionBuffer == null)
+                if (ignoreCollisionBuffer != null || other.ignoreCollisionBuffer == null)
                 {
                     ignoreCollisionBuffer ??= [];
                     ignoreCollisionBuffer[other] = state;
@@ -794,52 +794,52 @@ namespace Stride.Engine
                 }
                 return;
             }
-            
-            switch(state)
+
+            switch (state)
             {
                 // Note that we're calling 'SetIgnoreCollisionCheck' on both objects as bullet doesn't
                 // do it itself ; One of the object in the pair will report that it doesn't ignore
                 // collision with the other even though you set the other as ignoring the former.
                 case CollisionState.Ignore:
-                {
-                    // Bullet uses an array per collision object to store all of the objects to ignore,
-                    // when calling this method it adds the referenced object without checking for duplicates,
-                    // so if a user where to call 'Ignore' of this function on this object n-times he'll have to call it
-                    // that same amount of time to re-detect them instead of just once.
-                    // We're calling false here to remove a previous ignore if there was any and re-ignoring
-                    // to force it to have only a single instance.
-                    otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
-                    NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
-                    otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, true);
-                    NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, true);
-                    break;
-                }
+                    {
+                        // Bullet uses an array per collision object to store all of the objects to ignore,
+                        // when calling this method it adds the referenced object without checking for duplicates,
+                        // so if a user where to call 'Ignore' of this function on this object n-times he'll have to call it
+                        // that same amount of time to re-detect them instead of just once.
+                        // We're calling false here to remove a previous ignore if there was any and re-ignoring
+                        // to force it to have only a single instance.
+                        otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
+                        NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
+                        otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, true);
+                        NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, true);
+                        break;
+                    }
                 case CollisionState.Detect:
-                {
-                    otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
-                    NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
-                    break;
-                }
+                    {
+                        otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
+                        NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
+                        break;
+                    }
             }
         }
 
         public bool IsIgnoringCollisionWith(PhysicsComponent other)
         {
-            if(ignoreCollisionBuffer != null)
+            if (ignoreCollisionBuffer != null)
             {
                 return ignoreCollisionBuffer.TryGetValue(other, out var state) && state == CollisionState.Ignore;
             }
-            else if(other.ignoreCollisionBuffer != null)
+            else if (other.ignoreCollisionBuffer != null)
             {
                 return other.IsIgnoringCollisionWith(this);
             }
-            else if(other.NativeCollisionObject == null || NativeCollisionObject == null)
+            else if (other.NativeCollisionObject == null || NativeCollisionObject == null)
             {
                 return false;
             }
             else
             {
-                return ! NativeCollisionObject.CheckCollideWith(other.NativeCollisionObject);
+                return !NativeCollisionObject.CheckCollideWith(other.NativeCollisionObject);
             }
         }
 

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -332,7 +332,7 @@ namespace Stride.Engine
 
 
         private Dictionary<PhysicsComponent, CollisionState> ignoreCollisionBuffer;
-
+        
 
         #region Ignore or Private/Internal
 
@@ -467,9 +467,9 @@ namespace Stride.Engine
             {
                 derivedTransformation = BoneWorldMatrix;
             }
-
+            
             derivedTransformation.Decompose(out Vector3 scale, out Matrix rotation, out Vector3 translation);
-
+            
             var translationMatrix = Matrix.Translation(translation);
             Matrix.Multiply(ref rotation, ref translationMatrix, out derivedTransformation);
 
@@ -571,7 +571,7 @@ namespace Stride.Engine
         public void UpdatePhysicsTransformation(bool forceUpdateTransform = true)
         {
             DerivePhysicsTransformation(out var transform, forceUpdateTransform);
-
+            
             //finally copy back to bullet
             PhysicsWorldTransform = transform;
 
@@ -603,10 +603,10 @@ namespace Stride.Engine
             CanScaleShape = true;
             foreach (var desc in ColliderShapes)
             {
-                if (desc is ColliderShapeAssetDesc)
+                if(desc is ColliderShapeAssetDesc)
                     CanScaleShape = false;
             }
-
+            
             var services = Entity?.EntityManager?.Services;
             if (ColliderShapes.Count == 1) //single shape case
             {
@@ -670,9 +670,9 @@ namespace Stride.Engine
 
             OnAttach();
 
-            if (ignoreCollisionBuffer != null && NativeCollisionObject != null)
+            if(ignoreCollisionBuffer != null && NativeCollisionObject != null)
             {
-                foreach (var kvp in ignoreCollisionBuffer)
+                foreach(var kvp in ignoreCollisionBuffer)
                 {
                     IgnoreCollisionWith(kvp.Key, kvp.Value);
                 }
@@ -781,9 +781,9 @@ namespace Stride.Engine
         public void IgnoreCollisionWith(PhysicsComponent other, CollisionState state)
         {
             var otherNative = other.NativeCollisionObject;
-            if (NativeCollisionObject == null || other.NativeCollisionObject == null)
+            if(NativeCollisionObject == null || other.NativeCollisionObject == null)
             {
-                if (ignoreCollisionBuffer != null || other.ignoreCollisionBuffer == null)
+                if(ignoreCollisionBuffer != null || other.ignoreCollisionBuffer == null)
                 {
                     ignoreCollisionBuffer ??= [];
                     ignoreCollisionBuffer[other] = state;
@@ -794,52 +794,52 @@ namespace Stride.Engine
                 }
                 return;
             }
-
-            switch (state)
+            
+            switch(state)
             {
                 // Note that we're calling 'SetIgnoreCollisionCheck' on both objects as bullet doesn't
                 // do it itself ; One of the object in the pair will report that it doesn't ignore
                 // collision with the other even though you set the other as ignoring the former.
                 case CollisionState.Ignore:
-                    {
-                        // Bullet uses an array per collision object to store all of the objects to ignore,
-                        // when calling this method it adds the referenced object without checking for duplicates,
-                        // so if a user where to call 'Ignore' of this function on this object n-times he'll have to call it
-                        // that same amount of time to re-detect them instead of just once.
-                        // We're calling false here to remove a previous ignore if there was any and re-ignoring
-                        // to force it to have only a single instance.
-                        otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
-                        NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
-                        otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, true);
-                        NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, true);
-                        break;
-                    }
+                {
+                    // Bullet uses an array per collision object to store all of the objects to ignore,
+                    // when calling this method it adds the referenced object without checking for duplicates,
+                    // so if a user where to call 'Ignore' of this function on this object n-times he'll have to call it
+                    // that same amount of time to re-detect them instead of just once.
+                    // We're calling false here to remove a previous ignore if there was any and re-ignoring
+                    // to force it to have only a single instance.
+                    otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
+                    NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
+                    otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, true);
+                    NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, true);
+                    break;
+                }
                 case CollisionState.Detect:
-                    {
-                        otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
-                        NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
-                        break;
-                    }
+                {
+                    otherNative.SetIgnoreCollisionCheck(NativeCollisionObject, false);
+                    NativeCollisionObject.SetIgnoreCollisionCheck(otherNative, false);
+                    break;
+                }
             }
         }
 
         public bool IsIgnoringCollisionWith(PhysicsComponent other)
         {
-            if (ignoreCollisionBuffer != null)
+            if(ignoreCollisionBuffer != null)
             {
                 return ignoreCollisionBuffer.TryGetValue(other, out var state) && state == CollisionState.Ignore;
             }
-            else if (other.ignoreCollisionBuffer != null)
+            else if(other.ignoreCollisionBuffer != null)
             {
                 return other.IsIgnoringCollisionWith(this);
             }
-            else if (other.NativeCollisionObject == null || NativeCollisionObject == null)
+            else if(other.NativeCollisionObject == null || NativeCollisionObject == null)
             {
                 return false;
             }
             else
             {
-                return !NativeCollisionObject.CheckCollideWith(other.NativeCollisionObject);
+                return ! NativeCollisionObject.CheckCollideWith(other.NativeCollisionObject);
             }
         }
 

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -680,6 +680,32 @@ namespace Stride.Engine
             }
         }
 
+        /// <summary>
+        /// Ran when properties of Components may not be fully setup and need to be reintegrated (eg GetOrCreate<RigidbodyComponent> and adding collidershapes)
+        /// </summary>
+        internal void ReAttach()
+        {
+            //TODO: Could consider fully detaching and then rebuilding, but ideally this would cause null refs on Rigidbody OnDetach calls
+            //Shouldnt call detach, because at this point the user has added new components and this runs as a check to rebuild as needed.
+            //Entire wipes to rebuild causes loss in the data that the user has just added (and is slower)
+
+            Entity.Transform.UpdateWorldMatrix();
+
+            BoneIndex = -1;
+
+            OnAttach();
+
+            //ensure ignore collisions
+            if (ignoreCollisionBuffer != null && NativeCollisionObject != null)
+            {
+                foreach (var kvp in ignoreCollisionBuffer)
+                {
+                    IgnoreCollisionWith(kvp.Key, kvp.Value);
+                }
+                ignoreCollisionBuffer = null;
+            }
+        }
+
         internal void Detach()
         {
             Data = null;


### PR DESCRIPTION
# PR Details

When using `GetOrCreate<T>` to create physics components such as `Rigidbody` component, certain properties such as `ColliderShape` are not properly setup. Setting other properties afterwards result in a no-op.

Added a `ReAttach` method to `PhysicsComponent` that can run and reconfigure those properties when `ColliderShapes` is added. Also added a Test case to showcase. 

## Related Issue

Issue: https://github.com/stride3d/stride/issues/1504

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
