### PR TITLE
bug: Unable to Change CharacterComponent's collider shape properties without causing crash

### DIFF
--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -312,7 +312,7 @@ namespace Stride.Physics
 
             //make PairCachingGhostObject references in KinematicCharacter valid, therefore make new instance of kinematic character controller with updated NativeCollisionObject
             //keep references valid
-            if (NativeCollisionObject != null && KinematicCharacter != null)
+            if (KinematicCharacter != null)
             {
                 //very mediocre workaround to avoid the nullref when we remove character
                 Simulation simRef = Simulation;

--- a/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/CharacterComponent.cs
@@ -302,7 +302,7 @@ namespace Stride.Physics
 
         /// <summary>
         /// Reconstruct of character controller to avoid possible UAF issues
-        /// Context: On ColliderShape changes, when ComposeShape is ran to rebuild ColliderShape properties Disposing the old ColliderShape can cause UAF
+        /// Context: On ColliderShape changes, when ComposeShape is ran to rebuild ColliderShape properties, disposing the old ColliderShape can cause UAF
         /// issues inside KinematicCharacter and inside Simulation discreteDynamicWorld due to old disposed references to the native object.
         /// </summary>
         public override void ComposeShape()
@@ -310,8 +310,8 @@ namespace Stride.Physics
             //Disposing of ColliderShape should happen before we remove NativeCollisionObject and KinematicCharacter from Simulation
             base.ComposeShape();
 
-            //make PairCachingGhostObject references in KinematicCharacter valid, therefore make new instance of kinematic character controller with updated NativeCollisionObject
-            //keep references valid
+            //make PairCachingGhostObject references in KinematicCharacter valid, therefore make new instance of kinematic character controller with  
+            //updated NativeCollisionObject keep references valid
             if (KinematicCharacter != null)
             {
                 //very mediocre workaround to avoid the nullref when we remove character

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -583,7 +583,10 @@ namespace Stride.Engine
             }
         }
 
-        public void ComposeShape()
+        /// <summary>
+        /// Made virtual for added behavior in CharacterComponent with UAF exception
+        /// </summary>
+        public virtual void ComposeShape()
         {
             ColliderShapeChanged = false;
 


### PR DESCRIPTION
# PR Details

Assigning a new `ColliderShape` into `CharacterComponent` and running `ComposeShape()` causes a UAF related exception to be thrown. Related to an issue with the `KinematicCharacter` reference inside of the `discreteDynamicWorld` in the `Simulation` object. 

Solution would be to add additional setup to a overridden `ComposeShape()` method inside CharacterComponent. This setup would include the complete removal, reconstruction and reintegration of the KinematicCharacterController to the Simulation. Also added an additional function to try and maintain various physics properties onto the `KinematicCharacter` such as Gravity, Fallspeed, etc. 

## Related Issue

https://github.com/stride3d/stride/issues/2005

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
