### PR TITLE
Fix restoring NuGet packages in the editor

### DIFF
--- a/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
+++ b/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
@@ -18,13 +18,13 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config;.exe</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <UseWPF Condition="'$(StrideNuGetResolverUI)' == 'true'">true</UseWPF>
   </PropertyGroup>
-  <PropertyGroup>
-  </PropertyGroup>
   <Target Name="NuGetResolverModuleInitializerGenerate" BeforeTargets="BeforeCompile;CoreCompile" DependsOnTargets="PrepareForBuild">
     <PropertyGroup>
       <NuGetResolverModuleInitializerFile>$(IntermediateOutputPath)$(MSBuildProjectName).NuGetResolverEntryPoint$(DefaultLanguageSourceExtension)</NuGetResolverModuleInitializerFile>
+      <NuGetResolverTargetFramework>$(TargetFramework)</NuGetResolverTargetFramework>
+      <NuGetResolverTargetFramework Condition="'$(TargetPlatformVersion)' != '' and !$(TargetFramework.EndsWith(TargetPlatformVersion))">$(TargetFramework)$(TargetPlatformVersion)</NuGetResolverTargetFramework>
     </PropertyGroup>
-    <WriteLinesToFile File="$(NuGetResolverModuleInitializerFile)" Overwrite="true" Lines="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)NuGetResolverModuleInitializer.cs')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK','&quot;$(TargetFramework)&quot;')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_PACKAGE_NAME','&quot;$(PackageId)&quot;')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_PACKAGE_VERSION','&quot;$(PackageVersion)&quot;'))" />
+    <WriteLinesToFile File="$(NuGetResolverModuleInitializerFile)" Overwrite="true" Lines="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)NuGetResolverModuleInitializer.cs')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK','&quot;$(NuGetResolverTargetFramework)&quot;')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_PACKAGE_NAME','&quot;$(PackageId)&quot;')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_PACKAGE_VERSION','&quot;$(PackageVersion)&quot;'))" />
     <ItemGroup>
       <FileWrites Include="$(NuGetResolverModuleInitializerFile)" />
       <Compile Include="$(NuGetResolverModuleInitializerFile)" />


### PR DESCRIPTION
Fix restoring NuGet packages in the editor

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Finer details regarding the TFM are explained in the comments of #2426
When using shorthand TFM (eg. `net8.0-windows`), MSBuild sets the default platform version in `TargetPlatformVersion` when not explicitly set and the expanded canonical version (eg. `net8.0-windows7.0`) is passed to packaging to NuGet.
NuGet resolver requires the canonical form of the target framework moniker (TFM) when the OS/platform has been specified
ie. [framework]-[platform][platform_version]
This fix ensures the platform version is passed when applicable.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2426
Caused by #2205

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
