### PR TITLE
fix: Restore LoadWICFile for Windows due to incomplete cross-platform functionality

### DIFF
--- a/sources/tools/Stride.TextureConverter.Wrappers/DxtWrapper/dxt_wrapper.cpp
+++ b/sources/tools/Stride.TextureConverter.Wrappers/DxtWrapper/dxt_wrapper.cpp
@@ -109,6 +109,11 @@ HRESULT dxtLoadTGAFile( const char* szFile, DirectX::TexMetadata* metadata, Dire
 	return result;
 }
 
+HRESULT dxtLoadWICFile(LPCWSTR szFile, int flags, DirectX::TexMetadata* metadata, DirectX::ScratchImage& image)
+{
+	return DirectX::LoadFromWICFile(szFile, flags, metadata, image);
+}
+
 HRESULT dxtSaveToDDSFile( const DirectX::Image& image, DirectX::DDS_FLAGS flags, const char* szFile )
 {
 	const wchar_t* filePath = narrowToWideString(szFile);

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
@@ -522,6 +522,9 @@ namespace Stride.TextureConverter.DxtWrapper
         private extern static uint dxtLoadTGAFile(string filePath, out TexMetadata metadata, IntPtr image);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
+        private extern static uint dxtLoadWICFile(String filePath, WIC_FLAGS flags, out TexMetadata metadata, IntPtr image);
+
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static bool dxtIsCompressed(DXGI_FORMAT fmt);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
@@ -582,6 +585,11 @@ namespace Stride.TextureConverter.DxtWrapper
         public static HRESULT LoadTGAFile(string filePath, out TexMetadata metadata, ScratchImage image)
         {
             return HandleHRESULT(dxtLoadTGAFile(filePath, out metadata, image.ptr));
+        }
+
+        public static HRESULT LoadWICFile(String filePath, WIC_FLAGS flags, out TexMetadata metadata, ScratchImage image)
+        {
+            return HandleHRESULT(dxtLoadWICFile(filePath, flags, out metadata, image.ptr));
         }
 
         public static HRESULT SaveToDDSFile(ref DxtImage dxtImage, DDS_FLAGS flags, string szFile)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Partial revert of #2314 and #2338 for Windows to allow loading non-32-bit pixel formats.

Note that (as far as I'm aware) DxtWrapper.dll for Windows was not rebuilt with the 'dxtLoadWICFile' function removed, so it also means it does not need to be rebuilt for this revert.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Problem raised in #2376.
Technically it only fixes it for Windows, but the issue will persist for the non-Windows editor (which doesn't exist yet) and will require implementation/alternative solution if the intention is to remove it again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
