### PR TITLE
fix: Found and fixed bug pertaining to ReAttach method for PR #2422

### DIFF
--- a/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
+++ b/sources/engine/Stride.Physics.Tests/ColliderShapesTest.cs
@@ -267,6 +267,8 @@ namespace Stride.Physics.Tests
                 
                 var body = cube.GetOrCreate<RigidbodyComponent>();
 
+                await game.Script.NextFrame();
+
                 //verify values not properly set up
                 Assert.Null(body.ColliderShape);
                 Assert.Equal(RigidBodyTypes.Static, body.RigidBodyType);

--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -119,8 +119,12 @@ namespace Stride.Physics
 
                 if (InternalRigidBody == null)
                 {
-                    //When setting ColliderShape, setup could have been previously skipped (eg when PhysicsComponent is created using GetOrCreate)
-                    ReAttach();
+                    if (!attachInProgress)
+                    {
+                        //When setting ColliderShape, setup could have been previously skipped (eg when PhysicsComponent is created using GetOrCreate)
+                        ReAttach();
+                    }
+                    
                     return;
                 }
 

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -368,6 +368,9 @@ namespace Stride.Engine
         protected ColliderShape colliderShape;
 
         [DataMemberIgnore]
+        protected bool attachInProgress = false;
+
+        [DataMemberIgnore]
         public virtual ColliderShape ColliderShape
         {
             get
@@ -644,16 +647,19 @@ namespace Stride.Engine
         internal void Attach(PhysicsProcessor.AssociatedData data)
         {
             Data = data;
+            attachInProgress = true;
 
             if (ColliderShapes.Count == 0 && ColliderShape == null)
             {
                 logger.Error($"Entity {{Entity.Name}} has a PhysicsComponent without any collider shape.");
+                attachInProgress = false;
                 return; //no shape no purpose
             }
 
             //this is mostly required for the game studio gizmos
             if (Simulation.DisableSimulation)
             {
+                attachInProgress = false;
                 return;
             }
 
@@ -666,6 +672,7 @@ namespace Stride.Engine
                 if (ColliderShape == null)
                 {
                     logger.Error($"Entity {Entity.Name}'s PhysicsComponent failed to compose its collider shape.");
+                    attachInProgress = false;
                     return; //no shape no purpose
                 }
             }
@@ -682,6 +689,8 @@ namespace Stride.Engine
                 }
                 ignoreCollisionBuffer = null;
             }
+
+            attachInProgress = false;
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Details

Test cases inside `Stride.Physics.Tests.SendCollisionEndedWhenEntityIsRemovedTest` suite started failing after introduction of PR https://github.com/stride3d/stride/pull/2422. Further investigation showed that while entities are being setup inside `Attach`, the `ReAttach` method could potentially run and cause duplicate entities to be added to simulation, resulting in possible null ref exceptions and in this case, test failures.

Added flag `attachInProgress` that only allows the ReAttach method to run when Entity has fully competed all `Attach` behaviors. Still maintains same behavior that was tested and verified in `Stride.Physics.Tests.ColliderShapesTest.VerifyColliderShapeSetup`.

## Related Issue

Original Issue: https://github.com/stride3d/stride/issues/1504
Merged PR: https://github.com/stride3d/stride/pull/2422

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
