### PR TITLE
fix: Cecil serialization inheritance cutoff with complex base types

### DIFF
--- a/sources/core/Stride.Core.AssemblyProcessor/SerializationProcessor.cs
+++ b/sources/core/Stride.Core.AssemblyProcessor/SerializationProcessor.cs
@@ -82,9 +82,9 @@ namespace Stride.Core.AssemblyProcessor
 
                 TypeReference parentType = null;
                 FieldDefinition parentSerializerField = null;
-                if (complexType.Value.ComplexSerializerProcessParentType)
+                if (complexType.Value.ComplexSerializerProcessParentType != null)
                 {
-                    parentType = ResolveGenericsVisitor.Process(serializerType, type.BaseType);
+                    parentType = complexType.Value.ComplexSerializerProcessParentType;
                     serializerType.Fields.Add(parentSerializerField = new FieldDefinition("parentSerializer", Mono.Cecil.FieldAttributes.Private, dataSerializerTypeRef.MakeGenericType(parentType)));
 
                     hash.Write("parent");
@@ -134,7 +134,7 @@ namespace Stride.Core.AssemblyProcessor
                 // Add Initialize method
                 var initialize = new MethodDefinition("Initialize", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Virtual, assembly.MainModule.TypeSystem.Void);
                 initialize.Parameters.Add(new ParameterDefinition("serializerSelector", ParameterAttributes.None, serializerSelectorTypeRef));
-                if (complexType.Value.ComplexSerializerProcessParentType)
+                if (complexType.Value.ComplexSerializerProcessParentType != null)
                 {
                     initialize.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
                     initialize.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
@@ -162,7 +162,7 @@ namespace Stride.Core.AssemblyProcessor
                     serialize.Parameters.Add(new ParameterDefinition(parentParameter.Name, ParameterAttributes.None, assembly.MainModule.ImportReference(parentParameter.ParameterType)));
                 }
 
-                if (complexType.Value.ComplexSerializerProcessParentType)
+                if (complexType.Value.ComplexSerializerProcessParentType != null)
                 {
                     serialize.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
                     serialize.Body.Instructions.Add(Instruction.Create(OpCodes.Ldfld, parentSerializerField.MakeGeneric(genericParameters)));

--- a/sources/core/Stride.Core.AssemblyProcessor/Serializers/CecilSerializerContext.cs
+++ b/sources/core/Stride.Core.AssemblyProcessor/Serializers/CecilSerializerContext.cs
@@ -194,11 +194,12 @@ namespace Stride.Core.AssemblyProcessor.Serializers
         private void ProcessComplexSerializerMembers(TypeReference type, SerializableTypeInfo serializableTypeInfo, string profile = "Default")
         {
             // Process base type (for complex serializers)
-            // If it's a closed type and there is a serializer, we'll serialize parent
+            // Check if we have any serializable closed base type and collect it to pass it over to GenerateSerializerCode later,
+            // who'll ensure the generated serializer for this type calls into its base types' serializer
             for (var baseType = type; (baseType = ResolveGenericsVisitor.Process(baseType, baseType.Resolve().BaseType)) != null;)
             {
                 if (baseType.ContainsGenericParameter())
-                    continue;
+                    continue; // ResolveGenericsVisitor failed, the type it returned is not closed, we can't serialize it
 
                 var parentSerializableTypeInfo = GenerateSerializer(baseType, false, profile);
                 if (parentSerializableTypeInfo?.SerializerType != null)

--- a/sources/core/Stride.Core.AssemblyProcessor/Serializers/CecilSerializerContext.cs
+++ b/sources/core/Stride.Core.AssemblyProcessor/Serializers/CecilSerializerContext.cs
@@ -195,12 +195,17 @@ namespace Stride.Core.AssemblyProcessor.Serializers
         {
             // Process base type (for complex serializers)
             // If it's a closed type and there is a serializer, we'll serialize parent
-            SerializableTypeInfo parentSerializableTypeInfo;
-            var parentType = ResolveGenericsVisitor.Process(type, type.Resolve().BaseType);
-            if (!parentType.ContainsGenericParameter() && (parentSerializableTypeInfo = GenerateSerializer(parentType, false, profile)) != null &&
-                parentSerializableTypeInfo.SerializerType != null)
+            for (var baseType = type; (baseType = ResolveGenericsVisitor.Process(baseType, baseType.Resolve().BaseType)) != null;)
             {
-                serializableTypeInfo.ComplexSerializerProcessParentType = true;
+                if (baseType.ContainsGenericParameter())
+                    continue;
+
+                var parentSerializableTypeInfo = GenerateSerializer(baseType, false, profile);
+                if (parentSerializableTypeInfo?.SerializerType != null)
+                {
+                    serializableTypeInfo.ComplexSerializerProcessParentType = baseType;
+                    break;
+                }
             }
 
             // Process members
@@ -580,9 +585,9 @@ namespace Stride.Core.AssemblyProcessor.Serializers
             public bool ComplexSerializer;
 
             /// <summary>
-            /// True if it's a complex serializer and its base class should be serialized too.
+            /// Not null if it's a complex serializer and its base class should be serialized too.
             /// </summary>
-            public bool ComplexSerializerProcessParentType;
+            public TypeReference ComplexSerializerProcessParentType;
 
             public SerializableTypeInfo(TypeReference serializerType, bool local, DataSerializerGenericMode mode = DataSerializerGenericMode.None)
             {


### PR DESCRIPTION
# PR Details
The binary serializer can lose serialized data when round-tripped with a specific inheritance setup;
```cs
[DataContract]
public class D : C<AnyType>{ public bool bill; }

public class C<T> : B<T>{}
public class B<T> : A{}

[DataContract(Inherited = true)]
public class A : EntityComponent{}
```

The following logic fails to capture `B<T>`
https://github.com/stride3d/stride/blob/37bbf0c85262711f56786319effab2621479bab9/sources/core/Stride.Core.AssemblyProcessor/Serializers/CecilSerializerContext.cs#L198-L204
Which in turn means that all serialized data contained in its base types would be discarded, most obvious with the component Id inherited from `EntityComponent`, which right now shows up as a new Id on every save caused by the asset collision Id de-duplication using binary serialization through the `Clone` function:
https://github.com/stride3d/stride/blob/37bbf0c85262711f56786319effab2621479bab9/sources/assets/Stride.Core.Assets/Analysis/AssetCollision.cs#L33-L48

## Related Issue
Kind of hard to tell

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
