### PR TITLE
fix: SpriteBatch rotation logic to original code

### DIFF
--- a/sources/engine/Stride.Graphics/SpriteBatch.cs
+++ b/sources/engine/Stride.Graphics/SpriteBatch.cs
@@ -599,7 +599,7 @@ namespace Stride.Graphics
 
                 if (Math.Abs(drawInfo->Rotation) > float.Epsilon)
                 {
-                    (rotation.X, rotation.Y) = MathF.SinCos(drawInfo->Rotation);
+                    (rotation.Y, rotation.X) = MathF.SinCos(drawInfo->Rotation);
                 }
 
                 Vector2 origin = drawInfo->Origin;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
As per https://github.com/stride3d/stride/blob/fe4aa87cdac41ca7ec45cd26660fd5d8c9632944/sources/engine/Stride.Native/Sprite/SpriteBatchNative.c#L24
the original code assigned SinCos to (Y, X), but the C# code changed to (X, Y)

This changes it back to restore the original behavior.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2456 
Caused by #1896


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
