### PR TITLE
feat: [Math] - Exponential damping

### DIFF
--- a/sources/core/Stride.Core.Mathematics/MathUtil.cs
+++ b/sources/core/Stride.Core.Mathematics/MathUtil.cs
@@ -662,5 +662,21 @@ namespace Stride.Core.Mathematics
         {
             return ((value % divisor) + divisor) % divisor;
         }
+
+        /// <summary>
+        /// Exponential damping. 
+        /// Alternative to 
+        /// <code>a = lerp(a, b, damping * dt)</code>
+        /// using the exponential function flipped around the Y axis: e^(-t)
+        /// </summary>
+        /// <param name="a">Initial value</param>
+        /// <param name="b">Plateau value</param>
+        /// <param name="lambda">Damping</param>
+        /// <param name="dt">Discrete time unit, delta time.</param>
+        /// <returns>A value interpolated from a to b depending on lambda and dt.</returns>
+        public static float ExpDecay(float a, float b, float lambda, float dt)
+        {
+            return b + (a - b) * MathF.Exp(-lambda * dt);
+        }
     }
 }

--- a/sources/core/Stride.Core.Mathematics/MathUtil.cs
+++ b/sources/core/Stride.Core.Mathematics/MathUtil.cs
@@ -678,5 +678,21 @@ namespace Stride.Core.Mathematics
         {
             return b + (a - b) * MathF.Exp(-lambda * dt);
         }
+
+        /// <summary>
+        /// Exponential damping. 
+        /// Alternative to 
+        /// <code>a = lerp(a, b, damping * dt)</code>
+        /// using the exponential function flipped around the Y axis: e^(-t)
+        /// </summary>
+        /// <param name="a">Initial value</param>
+        /// <param name="b">Plateau value</param>
+        /// <param name="lambda">Damping</param>
+        /// <param name="dt">Discrete time unit, delta time.</param>
+        /// <returns>A value interpolated from a to b depending on lambda and dt.</returns>
+        public static double ExpDecay(double a, double b, double lambda, double dt)
+        {
+            return b + (a - b) * Math.Exp(-lambda * dt);
+        }
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/Utils/Math.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Utils/Math.sdsl
@@ -114,4 +114,10 @@ shader Math
         vecProjected.xyz /= vecProjected.w;
         return vecProjected;
     }
+
+    //Exponential damping
+    float ExpDecay(float a, float b, float lambda, float dt)
+    {
+        return a + (b - a) * exp(-lambda * dt);
+    }
 };

--- a/sources/engine/Stride.Rendering/Rendering/Utils/Math.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Utils/Math.sdsl
@@ -118,6 +118,6 @@ shader Math
     //Exponential damping
     float ExpDecay(float a, float b, float lambda, float dt)
     {
-        return a + (b - a) * exp(-lambda * dt);
+        return b + (a - b) * exp(-lambda * dt);
     }
 };


### PR DESCRIPTION
# PR Details

Add `ExpDecay` to both `MathUtil` and SDSL as an alternative to damping using linear interpolation.

## Related Issue

Closes #2301 .

## Types of changes
- [N/A] Docs change / refactoring / dependency upgrade
- [N/A] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [N/A] My change requires a change to the documentation.
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
