### PR TITLE
Fix PhysicsComponent reattach logic crashing the editor

### DIFF
--- a/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
+++ b/sources/engine/Stride.Physics/Elements/RigidbodyComponent.cs
@@ -119,7 +119,7 @@ namespace Stride.Physics
 
                 if (InternalRigidBody == null)
                 {
-                    if (!attachInProgress)
+                    if (Data != null && !attachInProgress)
                     {
                         //When setting ColliderShape, setup could have been previously skipped (eg when PhysicsComponent is created using GetOrCreate)
                         ReAttach();

--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -698,6 +698,10 @@ namespace Stride.Engine
         /// </summary>
         internal void ReAttach()
         {
+            if (Data == null)
+            {
+                throw new InvalidOperationException("PhysicsComponent has not been attached yet.");
+            }
             //TODO: Could consider fully detaching and then rebuilding, but ideally this would cause null refs on Rigidbody OnDetach calls
             //Shouldnt call detach, because at this point the user has added new components and this runs as a check to rebuild as needed.
             //Entire wipes to rebuild causes loss in the data that the user has just added (and is slower)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Ignore reattach call if the component hasn't been attached yet.
This situation occurs when the editor gizmo wants to show the physics shape.

Not sure if null checking in both places is overkill or not, this shouldn't be a frequent call so any performance hit should be minimal. Maybe change to `Debug.Assert` in `ReAttach()`?

I've tested this opening the editor and at run-time and did not encounter any issue, however I did not test whatever the original implementation was for.
Also I couldn't build/run the tests (for an unrelated issue), so someone do a quick run to check this didn't break an existing test.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2464
Caused by #2422 and #2439

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
