### PR TITLE
changed AssImp error to warning

### DIFF
--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -529,7 +529,7 @@ namespace Stride.Importer.ThreeD
                     // TODO: Need to resample the animation created by the pivot chain into a single animation, have a look at the file hierarchy in Assimp's viewer to get a better clue
                     // See: 'IMPORT_FBX_PRESERVE_PIVOTS' above and https://github.com/assimp/assimp/discussions/4966
                     if (nodeAnim->MNodeName.AsString.Contains("$AssimpFbx$"))
-                        Logger.Error($"Animation '{animName}' contains a pivot bone ({nodeAnim->MNodeName.AsString}), we currently do not handle these. This animation may not resolve properly.");
+                        Logger.Warning($"Animation '{animName}' contains a pivot bone ({nodeAnim->MNodeName.AsString}), we currently do not handle these. This animation may not resolve properly.");
 
                     if (visitedNodeNames.Add(nodeName))
                     {


### PR DESCRIPTION
# PR Details

Some projects fail to build due to a possible regression in the AssImp importer from FBX. The failure is due to FBX files being given virtual nodes that describe translation, rotation and scale in the form of `$AssimpFbx$` nodes. This changes the error to be a warning ~as it seems to be importing correctly and animating correctly.~

These were 3 previously problematic models that seem to be working fine:
![image](https://github.com/user-attachments/assets/2c4561dc-a464-4340-ab61-53d8ed8a242f)

## Related Issue

https://github.com/stride3d/stride/issues/2459 - technically a fix for the reported issue but not for the actual cause.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
