### PR TITLE
Fixed getting actual bounds and refresh rate of the output (monitor/display) from GraphicsOutput.CurrentDisplayMode when using Direct3D

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/$ProjectName$.csproj.t4
@@ -7,6 +7,7 @@
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>
     <RootNamespace><#= Properties.Namespace #></RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
 
     <OutputPath>..\Bin\<#= Properties.CurrentPlatform #>\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/ProjectExecutable.Windows.ttproj
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/ProjectExecutable.Windows.ttproj
@@ -1,5 +1,6 @@
-﻿!ProjectTemplate
+!ProjectTemplate
 Files:
   - {Source: $ProjectName$.csproj.t4, Target: $ProjectName$.csproj, IsTemplate: true}
   - {Source: $PackageGameNameShort$App.cs.t4, Target: $PackageGameNameShort$App.cs, IsTemplate: true}
   - {Source: Resources\GameIcon.ico, Target: Resources\Icon.ico}
+  - {Source: app.manifest.t4, Target: app.manifest, IsTemplate: true}

--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/app.manifest.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/ProjectExecutable.Windows/app.manifest.t4
@@ -1,0 +1,41 @@
+<#@ template inherits="ProjectTemplateTransformation" language="C#" #>
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- The combination of below two tags have the following effect : 
+           1) Per-Monitor for >= RS1 (Windows 10 Anniversary Update)
+           2) System < RS1
+      -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+</assembly>

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
@@ -236,7 +236,10 @@ namespace Stride.Graphics
             using (SharpDX.Direct3D11.Device device = deviceTemp)
                 output.GetClosestMatchingMode(device, description, out closestDescription);
 
-            return DisplayMode.FromDescription(closestDescription);
+            if (description.Format == format)
+                return DisplayMode.FromDescription(closestDescription);
+            else
+                return null;
         }
     }
 }

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
@@ -83,9 +83,10 @@ namespace Stride.Graphics
 
             ModeDescription closestDescription;
             SharpDX.Direct3D11.Device deviceTemp = null;
+            FeatureLevel[] features = null;
             try
             {
-                var features = new FeatureLevel[targetProfiles.Length];
+                features = new FeatureLevel[targetProfiles.Length];
                 for (int i = 0; i < targetProfiles.Length; i++)
                 {
                     features[i] = (FeatureLevel)targetProfiles[i];
@@ -93,7 +94,10 @@ namespace Stride.Graphics
 
                 deviceTemp = new SharpDX.Direct3D11.Device(adapter.NativeAdapter, SharpDX.Direct3D11.DeviceCreationFlags.None, features);
             }
-            catch (Exception) { }
+            catch (Exception exception)
+            {
+                Log.Error($"Failed to create Direct3D device using {adapter.NativeAdapter.Description} adapter with features: {string.Join(", ", features)}.\nException: {exception}");
+            }
 
             var description = new ModeDescription()
             {
@@ -212,7 +216,10 @@ namespace Stride.Graphics
                 // about the current display/monitor mode and not the supported display mode for the specific graphics profile
                 deviceTemp = new SharpDX.Direct3D11.Device(adapter.NativeAdapter);
             }
-            catch (Exception) { }
+            catch (Exception exception)
+            {
+                Log.Error($"Failed to create Direct3D device using {adapter.NativeAdapter.Description}.\nException: {exception}");
+            }
 
             RawRectangle desktopBounds = outputDescription.DesktopBounds;
             // We don't specify RefreshRate on purpose, it will be automatically

--- a/sources/engine/Stride.Graphics/GraphicsOutput.cs
+++ b/sources/engine/Stride.Graphics/GraphicsOutput.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 
 namespace Stride.Graphics
 {
     public partial class GraphicsOutput : ComponentBase
     {
+        private static readonly Logger Log = GlobalLogger.GetLogger(typeof(GraphicsOutput).FullName);
         private readonly object lockModes = new object();
         private readonly GraphicsAdapter adapter;
         private DisplayMode currentDisplayMode;


### PR DESCRIPTION
# PR Details
Fix for the bug https://github.com/stride3d/stride/issues/2492.

References:
- https://www.gamedev.net/forums/topic/689459-sharpdx-dxgi-trying-to-get-the-current-display-mode/
- https://github.com/MonoGame/MonoGame/pull/5096

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
