### PR TITLE
fix: Resolve crashing issue for OpenGL UIPage (#2189)

### DIFF
--- a/sources/engine/Stride.Graphics/OpenGL/CommandList.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/CommandList.OpenGL.cs
@@ -920,8 +920,7 @@ namespace Stride.Graphics
                 mapMode = MapMode.WriteDiscard;
 
 
-            var buffer = resource as Buffer;
-            if (buffer != null)
+            if (resource is Buffer buffer)
             {
                 if (lengthInBytes == 0)
                     lengthInBytes = buffer.Description.SizeInBytes;
@@ -930,29 +929,21 @@ namespace Stride.Graphics
 
                 GL.BindBuffer(buffer.BufferTarget, buffer.BufferId);
 
-#if !STRIDE_GRAPHICS_API_OPENGLES
-                //if (mapMode != MapMode.WriteDiscard && mapMode != MapMode.WriteNoOverwrite)
-                //    mapResult = GL.MapBuffer(buffer.bufferTarget, mapMode.ToOpenGL());
-                //else
-#endif
+                // Orphan the buffer (let driver knows we don't need it anymore)
+                if (mapMode == MapMode.WriteDiscard)
                 {
-                    // Orphan the buffer (let driver knows we don't need it anymore)
-                    if (mapMode == MapMode.WriteDiscard)
-                    {
-                        doNotWait = true;
-                        GL.BufferData(buffer.BufferTarget, (UIntPtr)buffer.Description.SizeInBytes, IntPtr.Zero, buffer.BufferUsageHint);
-                    }
-
-                    var unsynchronized = doNotWait && mapMode != MapMode.Read && mapMode != MapMode.ReadWrite;
-
-                    mapResult = (IntPtr)GL.MapBufferRange(buffer.BufferTarget, (IntPtr)offsetInBytes, (UIntPtr)lengthInBytes, mapMode.ToOpenGLMask() | (unsynchronized ? MapBufferAccessMask.MapUnsynchronizedBit : 0));
+                    doNotWait = true;
+                    GL.BufferData(buffer.BufferTarget, (uint)buffer.Description.SizeInBytes, null, buffer.BufferUsageHint);
                 }
+
+                var unsynchronized = doNotWait && mapMode != MapMode.Read && mapMode != MapMode.ReadWrite;
+
+                mapResult = (IntPtr)GL.MapBufferRange(buffer.BufferTarget, offsetInBytes, (UIntPtr)lengthInBytes, mapMode.ToOpenGLMask() | (unsynchronized ? MapBufferAccessMask.UnsynchronizedBit : 0));
 
                 return new MappedResource(resource, subResourceIndex, new DataBox { DataPointer = mapResult, SlicePitch = 0, RowPitch = 0 });
             }
 
-            var texture = resource as Texture;
-            if (texture != null)
+            if (resource is Texture texture)
             {
                 if (lengthInBytes == 0)
                     lengthInBytes = texture.ComputeSubresourceSize(subResourceIndex);


### PR DESCRIPTION
# PR Details

This PR fixes incorrect buffer clearing for OpenGL when mapping a resource. It turns out that IntPtr.Zero was treated as some kind of value while this was not the author's intention. I also did a small refactoring

## Related Issue

- https://github.com/stride3d/stride/issues/2189
- https://github.com/stride3d/stride/issues/2079

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
