### PR TITLE
feat: TransformComponent.SetWorld, strict equality and fix misc. typos

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Matrix.cs
+++ b/sources/core/Stride.Core.Mathematics/Matrix.cs
@@ -540,7 +540,7 @@ namespace Stride.Core.Mathematics
         /// so that the first row is the most stable and the last row is the least stable.</para>
         /// <para>This operation is performed on the rows of the matrix rather than the columns.
         /// If you wish for this operation to be performed on the columns, first transpose the
-        /// input and than transpose the output.</para>
+        /// input and then transpose the output.</para>
         /// </remarks>
         public void Orthogonalize()
         {
@@ -561,7 +561,7 @@ namespace Stride.Core.Mathematics
         /// so that the first row is the most stable and the last row is the least stable.</para>
         /// <para>This operation is performed on the rows of the matrix rather than the columns.
         /// If you wish for this operation to be performed on the columns, first transpose the
-        /// input and than transpose the output.</para>
+        /// input and then transpose the output.</para>
         /// </remarks>
         public void Orthonormalize()
         {
@@ -569,7 +569,7 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Decomposes a matrix into an orthonormalized matrix Q and a right traingular matrix R.
+        /// Decomposes a matrix into an orthonormalized matrix Q and a right triangular matrix R.
         /// </summary>
         /// <param name="Q">When the method completes, contains the orthonormalized matrix of the decomposition.</param>
         /// <param name="R">When the method completes, contains the right triangular matrix of the decomposition.</param>
@@ -630,8 +630,8 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// This rotation matrix can be represented by <b>intrinsic</b> rotations in the order <paramref name="yaw"/>, <paramref name="pitch"/>, then <paramref name="roll"/>.
         /// <br/>
-        /// Therefore the <b>extrinsic</b> rotations to achieve this matrix is the reversed order of operations,
-        /// ie. Matrix.RotationZ(roll) * Matrix.RotationX(pitch) * Matrix.RotationY(yaw)
+        /// Therefore, the <b>extrinsic</b> rotations to achieve this matrix is the reversed order of operations,
+        /// i.e. Matrix.RotationZ(roll) * Matrix.RotationX(pitch) * Matrix.RotationY(yaw)
         /// </remarks>
         public void Decompose(out float yaw, out float pitch, out float roll)
         {
@@ -784,7 +784,7 @@ namespace Stride.Core.Mathematics
             scale.Y = MathF.Sqrt((M21 * M21) + (M22 * M22) + (M23 * M23));
             scale.Z = MathF.Sqrt((M31 * M31) + (M32 * M32) + (M33 * M33));
 
-            //If any of the scaling factors are zero, than the rotation matrix can not exist.
+            //If any of the scaling factors are zero, then the rotation matrix can not exist.
             if (MathF.Abs(scale.X) < MathUtil.ZeroTolerance ||
                 MathF.Abs(scale.Y) < MathUtil.ZeroTolerance ||
                 MathF.Abs(scale.Z) < MathUtil.ZeroTolerance)
@@ -793,7 +793,7 @@ namespace Stride.Core.Mathematics
                 return false;
             }
 
-            // Calculate an perfect orthonormal matrix (no reflections)
+            // Calculate a perfect orthonormal matrix (no reflections)
             var at = new Vector3(M31 / scale.Z, M32 / scale.Z, M33 / scale.Z);
             var up = Vector3.Cross(at, new Vector3(M11 / scale.X, M12 / scale.X, M13 / scale.X));
             var right = Vector3.Cross(up, at);

--- a/sources/core/Stride.Core.Mathematics/Quaternion.cs
+++ b/sources/core/Stride.Core.Mathematics/Quaternion.cs
@@ -1343,6 +1343,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for equality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1354,6 +1355,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for inequality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1430,11 +1432,23 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Quaternion"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Quaternion"/> is exactly equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Quaternion"/> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="Quaternion"/> is exactly equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool EqualsStrict(Quaternion other)
+        {
+            return other.X == this.X && other.Y == this.Y && other.Z == this.Z && other.W == this.W;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Quaternion"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="other">The <see cref="Stride.Core.Mathematics.Quaternion"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Quaternion"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Quaternion"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public readonly bool Equals(Quaternion other)
         {
@@ -1445,11 +1459,11 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="object"/> is equal to this instance.
+        /// Determines whether the specified <see cref="object"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="value">The <see cref="object"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="object"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override readonly bool Equals(object value)
         {

--- a/sources/core/Stride.Core.Mathematics/Vector2.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector2.cs
@@ -1038,8 +1038,8 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// A coordinate transform performs the transformation with the assumption that the w component
         /// is one. The four dimensional vector obtained from the transformation operation has each
-        /// component in the vector divided by the w component. This forces the wcomponent to be one and
-        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// component in the vector divided by the w component. This forces the w component to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often preferred when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
         public static void TransformCoordinate(ref readonly Vector2 coordinate, ref readonly Matrix transform, out Vector2 result)
@@ -1062,8 +1062,8 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// A coordinate transform performs the transformation with the assumption that the w component
         /// is one. The four dimensional vector obtained from the transformation operation has each
-        /// component in the vector divided by the w component. This forces the wcomponent to be one and
-        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// component in the vector divided by the w component. This forces the w component to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often preferred when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
         public static Vector2 TransformCoordinate(Vector2 coordinate, Matrix transform)
@@ -1076,7 +1076,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Performs a coordinate transformation on an array of vectors using the given <see cref="Stride.Core.Mathematics.Matrix"/>.
         /// </summary>
-        /// <param name="source">The array of coordinate vectors to trasnform.</param>
+        /// <param name="source">The array of coordinate vectors to transform.</param>
         /// <param name="transform">The transformation <see cref="Stride.Core.Mathematics.Matrix"/>.</param>
         /// <param name="destination">The array for which the transformed vectors are stored.
         /// This array may be the same array as <paramref name="source"/>.</param>
@@ -1085,8 +1085,8 @@ namespace Stride.Core.Mathematics
         /// <remarks>
         /// A coordinate transform performs the transformation with the assumption that the w component
         /// is one. The four dimensional vector obtained from the transformation operation has each
-        /// component in the vector divided by the w component. This forces the wcomponent to be one and
-        /// therefore makes the vector homogeneous. The homogeneous vector is often prefered when working
+        /// component in the vector divided by the w component. This forces the w component to be one and
+        /// therefore makes the vector homogeneous. The homogeneous vector is often preferred when working
         /// with coordinates as the w component can safely be ignored.
         /// </remarks>
         public static void TransformCoordinate(Vector2[] source, ref readonly Matrix transform, Vector2[] destination)
@@ -1112,9 +1112,9 @@ namespace Stride.Core.Mathematics
         /// <param name="result">When the method completes, contains the transformed normal.</param>
         /// <remarks>
         /// A normal transform performs the transformation with the assumption that the w component
-        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// is zero. This causes the fourth row and fourth column of the matrix to be unused. The
         /// end result is a vector that is not translated, but all other transformation properties
-        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// apply. This is often preferred for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
         public static void TransformNormal(ref readonly Vector2 normal, ref readonly Matrix transform, out Vector2 result)
@@ -1132,9 +1132,9 @@ namespace Stride.Core.Mathematics
         /// <returns>The transformed normal.</returns>
         /// <remarks>
         /// A normal transform performs the transformation with the assumption that the w component
-        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// is zero. This causes the fourth row and fourth column of the matrix to be unused. The
         /// end result is a vector that is not translated, but all other transformation properties
-        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// apply. This is often preferred for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
         public static Vector2 TransformNormal(Vector2 normal, Matrix transform)
@@ -1155,9 +1155,9 @@ namespace Stride.Core.Mathematics
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="destination"/> is shorter in length than <paramref name="source"/>.</exception>
         /// <remarks>
         /// A normal transform performs the transformation with the assumption that the w component
-        /// is zero. This causes the fourth row and fourth collumn of the matrix to be unused. The
+        /// is zero. This causes the fourth row and fourth column of the matrix to be unused. The
         /// end result is a vector that is not translated, but all other transformation properties
-        /// apply. This is often prefered for normal vectors as normals purely represent direction
+        /// apply. This is often preferred for normal vectors as normals purely represent direction
         /// rather than location because normal vectors should not be translated.
         /// </remarks>
         public static void TransformNormal(Vector2[] source, ref readonly Matrix transform, Vector2[] destination)
@@ -1190,7 +1190,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Assert a vector (return it unchanged).
         /// </summary>
-        /// <param name="value">The vector to assert (unchange).</param>
+        /// <param name="value">The vector to assert (unchanged).</param>
         /// <returns>The asserted (unchanged) vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 operator +(Vector2 value)
@@ -1296,6 +1296,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for equality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1307,6 +1308,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for inequality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1401,11 +1403,23 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Vector2"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Vector2"/> is exactly equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Vector2"/> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="Vector2"/> is exactly equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool EqualsStrict(Vector2 other)
+        {
+            return other.X == this.X && other.Y == this.Y;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Vector2"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="other">The <see cref="Stride.Core.Mathematics.Vector2"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Vector2"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Vector2"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals(Vector2 other)
         {
@@ -1414,11 +1428,11 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="object"/> is equal to this instance.
+        /// Determines whether the specified <see cref="object"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="value">The <see cref="object"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="object"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object value)
         {

--- a/sources/core/Stride.Core.Mathematics/Vector3.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector3.cs
@@ -1588,6 +1588,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for equality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1599,6 +1600,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for inequality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1719,11 +1721,23 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Vector3"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Vector3"/> is exactly equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Vector3"/> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="Vector3"/> is exactly equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool EqualsStrict(Vector3 other)
+        {
+            return other.X == this.X && other.Y == this.Y && other.Z == this.Z;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Vector3"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="other">The <see cref="Stride.Core.Mathematics.Vector3"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Vector3"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Vector3"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals(Vector3 other)
         {
@@ -1733,11 +1747,11 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="object"/> is equal to this instance.
+        /// Determines whether the specified <see cref="object"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="value">The <see cref="object"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="object"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object value)
         {

--- a/sources/core/Stride.Core.Mathematics/Vector4.cs
+++ b/sources/core/Stride.Core.Mathematics/Vector4.cs
@@ -1246,6 +1246,7 @@ namespace Stride.Core.Mathematics
         /// <summary>
         /// Tests for equality between two objects.
         /// </summary>
+        /// <remarks> Comparison is not strict, a difference of <see cref="MathUtil.ZeroTolerance"/> will return as equal. </remarks>
         /// <param name="left">The first value to compare.</param>
         /// <param name="right">The second value to compare.</param>
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
@@ -1353,11 +1354,23 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Vector4"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Vector4"/> is exactly equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="Vector4"/> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="Vector4"/> is exactly equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public bool EqualsStrict(Vector4 other)
+        {
+            return other.X == this.X && other.Y == this.Y && other.Z == this.Z && other.W == this.W;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Stride.Core.Mathematics.Vector4"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="other">The <see cref="Stride.Core.Mathematics.Vector4"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Vector4"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="Stride.Core.Mathematics.Vector4"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals(Vector4 other)
         {
@@ -1368,11 +1381,11 @@ namespace Stride.Core.Mathematics
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="object"/> is equal to this instance.
+        /// Determines whether the specified <see cref="object"/> is within <see cref="MathUtil.ZeroTolerance"/> for equality to this instance.
         /// </summary>
         /// <param name="value">The <see cref="object"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="object"/> is equal or almost equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object value)
         {

--- a/sources/engine/Stride.Engine.Tests/TestTransformComponent.cs
+++ b/sources/engine/Stride.Engine.Tests/TestTransformComponent.cs
@@ -51,5 +51,32 @@ namespace Stride.Engine.Tests
             Assert.Equal(Quaternion.RotationX(MathF.PI * -0.5f), tR1);
             Assert.Equal(new Vector3(0.5f, 0.5f, 0.5f), tS1);
         }
+
+        [Fact]
+        public void TestSetWorldTransformation()
+        {
+            var scene = new Scene();
+            scene.Offset = Vector3.UnitX;
+            var parent = new Entity{ Scene = scene }.Transform;
+            var child = new Entity{ Transform = { Parent = parent } }.Transform;
+
+            parent.Position = Vector3.UnitX;
+            parent.Rotation = Quaternion.RotationY(MathF.PI * -0.5f);
+            parent.Scale = Vector3.One * 0.5f;
+            child.UpdateWorldMatrix();
+            child.SetWorld(Vector3.Zero, Quaternion.Identity);
+            child.UpdateWorldMatrix();
+
+            // Do note that all equality below are NOT strictly equal,
+            // those transformations, as are all floating point operations, are lossy.
+            // By default, Vector and Quaternion equality allow an epsilon of difference
+            
+            Assert.Equal(Vector3.UnitZ * 4f, child.Position); // Validate our assumptions
+            Assert.Equal(Quaternion.RotationY(MathF.PI * 0.5f), child.Rotation);
+            
+            child.GetWorldTransformation(out var pos, out var rot, out _); // Validate transformations
+            Assert.Equal(Vector3.Zero, pos);
+            Assert.Equal(Quaternion.Identity, rot);
+        }
     }
 }

--- a/sources/engine/Stride.Engine/Engine/EntityTransformExtensions.cs
+++ b/sources/engine/Stride.Engine/Engine/EntityTransformExtensions.cs
@@ -334,8 +334,7 @@ namespace Stride.Engine
                 return;
             }
 
-            Matrix worldMatrix = transformComponent.Parent.WorldMatrix;
-            worldMatrix.Decompose(out _, out Quaternion parentRot, out _);
+            transformComponent.Parent.WorldMatrix.Decompose(out _, out Quaternion parentRot, out _);
             transformComponent.Rotation = Quaternion.Invert(parentRot) * rotation;
         }
     }

--- a/sources/engine/Stride.Engine/Engine/EntityTransformExtensions.cs
+++ b/sources/engine/Stride.Engine/Engine/EntityTransformExtensions.cs
@@ -153,12 +153,12 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Performs tranformation of the given transform in world space to local space.
+        /// Performs transformation of the given transform in world space to local space.
         /// </summary>
         /// <param name="transformComponent">The transform component.</param>
-        /// <param name="position">Input world space position tranformed to local space.</param>
-        /// <param name="rotation">Input world space rotation tranformed to local space.</param>
-        /// <param name="scale">Input world space scale tranformed to local space.</param>
+        /// <param name="position">Input world space position transformed to local space.</param>
+        /// <param name="rotation">Input world space rotation transformed to local space.</param>
+        /// <param name="scale">Input world space scale transformed to local space.</param>
         public static void WorldToLocal(this TransformComponent transformComponent, ref Vector3 position, ref Quaternion rotation, ref Vector3 scale)
         {
             Vector3 worldScale;
@@ -176,7 +176,7 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Performs tranformation of the given point in world space to local space.
+        /// Performs transformation of the given point in world space to local space.
         /// </summary>
         /// <param name="transformComponent">The transform component.</param>
         /// <param name="point">World space point.</param>
@@ -189,7 +189,7 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Performs tranformation of the given point in world space to local space.
+        /// Performs transformation of the given point in world space to local space.
         /// </summary>
         /// <param name="transformComponent">The transform component.</param>
         /// <param name="point">World space point.</param>
@@ -204,12 +204,12 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Performs tranformation of the given transform in local space to world space.
+        /// Performs transformation of the given transform in local space to world space.
         /// </summary>
         /// <param name="transformComponent">The transform component.</param>
-        /// <param name="position">Input local space position tranformed to world space.</param>
-        /// <param name="rotation">Input local space rotation tranformed to world space.</param>
-        /// <param name="scale">Input local space scale tranformed to world space.</param>
+        /// <param name="position">Input local space position transformed to world space.</param>
+        /// <param name="rotation">Input local space rotation transformed to world space.</param>
+        /// <param name="scale">Input local space scale transformed to world space.</param>
         public static void LocalToWorld(this TransformComponent transformComponent, ref Vector3 position, ref Quaternion rotation, ref Vector3 scale)
         {
             Vector3 worldScale;
@@ -223,7 +223,7 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Performs tranformation of the given point in local space to world space.
+        /// Performs transformation of the given point in local space to world space.
         /// </summary>
         /// <param name="transformComponent">The transform component.</param>
         /// <param name="point">Local space point.</param>
@@ -234,7 +234,7 @@ namespace Stride.Engine
         }
 
         /// <summary>
-        /// Performs tranformation of the given point in local space to world space.
+        /// Performs transformation of the given point in local space to world space.
         /// </summary>
         /// <param name="transformComponent">The transform component.</param>
         /// <param name="point">Local space point.</param>
@@ -244,6 +244,99 @@ namespace Stride.Engine
             Vector3 result;
             Vector3.Transform(ref point, ref transformComponent.WorldMatrix, out result);
             return result;
+        }
+
+        /// <summary>
+        /// Set this Transform's world position and rotation based on the given parameters.
+        /// </summary>
+        /// <remarks>
+        /// <para> This conversion is lossy, getting the world position back won't match this input position. </para>
+        /// <para>
+        /// This method relies on this object's matrix which may be out of date if any of its parents moved since the last frame.
+        /// If this is likely, you should call <see cref="TransformComponent.UpdateWorldMatrix"/> before calling this method.
+        /// </para>
+        /// </remarks>
+        /// <param name="transformComponent">The transform component.</param>
+        /// <param name="position">Input world space position.</param>
+        /// <param name="rotation">Input world space rotation.</param>
+        public static void SetWorld(this TransformComponent transformComponent, Vector3 position, Quaternion rotation)
+        {
+            if (transformComponent.Parent == null)
+            {
+                if (transformComponent.Entity.Scene is { } s)
+                    transformComponent.Position = position - s.WorldMatrix.TranslationVector;
+                else
+                    transformComponent.Position = position;
+
+                transformComponent.Rotation = rotation;
+                return;
+            }
+
+            ref Matrix worldMatrix = ref transformComponent.Parent.WorldMatrix;
+            Matrix worldMatrixInv;
+            Matrix.Invert(ref worldMatrix, out worldMatrixInv);
+            Vector3.Transform(ref position, ref worldMatrixInv, out position);
+            
+            worldMatrix.Decompose(out _, out Quaternion parentRot, out _);
+            rotation = Quaternion.Invert(parentRot) * rotation;
+            
+            transformComponent.Position = position;
+            transformComponent.Rotation = rotation;
+        }
+
+        /// <summary>
+        /// Set this Transform's world position and rotation based on the given parameters.
+        /// </summary>
+        /// <remarks>
+        /// <para> This conversion is lossy, getting the world position back won't match this input position. </para>
+        /// <para>
+        /// This method relies on this object's matrix which may be out of date if any of its parents moved since the last frame.
+        /// If this is likely, you should call <see cref="TransformComponent.UpdateWorldMatrix"/> before calling this method.
+        /// </para>
+        /// </remarks>
+        /// <param name="transformComponent">The transform component.</param>
+        /// <param name="position">Input world space position.</param>
+        public static void SetWorld(this TransformComponent transformComponent, Vector3 position)
+        {
+            if (transformComponent.Parent == null)
+            {
+                if (transformComponent.Entity.Scene is { } s)
+                    transformComponent.Position = position - s.WorldMatrix.TranslationVector;
+                else
+                    transformComponent.Position = position;
+                return;
+            }
+
+            Matrix worldMatrixInv;
+            Matrix.Invert(ref transformComponent.Parent.WorldMatrix, out worldMatrixInv);
+            Vector3.Transform(ref position, ref worldMatrixInv, out position);
+            
+            transformComponent.Position = position;
+        }
+
+        /// <summary>
+        /// Set this Transform's world position and rotation based on the given parameters.
+        /// </summary>
+        /// <remarks>
+        /// <para> This conversion is lossy, getting the world position back won't match this input position. </para>
+        /// <para>
+        /// This method relies on this object's matrix which may be out of date if any of its parents moved since the last frame.
+        /// If this is likely, you should call <see cref="TransformComponent.UpdateWorldMatrix"/> before calling this method.
+        /// </para>
+        /// </remarks>
+        /// <param name="transformComponent">The transform component.</param>
+        /// <param name="rotation">Input world space rotation.</param>
+        public static void SetWorld(this TransformComponent transformComponent, Quaternion rotation)
+        {
+            if (transformComponent.Parent == null)
+            {
+                transformComponent.Rotation = rotation;
+                return;
+            }
+
+            Matrix worldMatrix = transformComponent.Parent.WorldMatrix;
+            worldMatrix.Decompose(out _, out Quaternion parentRot, out _);
+            transformComponent.Rotation = Quaternion.Invert(parentRot) * rotation;
         }
     }
 }


### PR DESCRIPTION
# PR Details
Introduce `TransformComponent.SetWorld` to set the position and rotation of a transform component to world space values. We previously could retrieve the world position from them, but we did not have any extensions to set it.
Introduce `EqualsStrict` to compare vector and quaternion for equality using the same rules as floating point numbers.
Fix a couple of types in matrix, vector and quaternion.cs

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
