### PR TITLE
feat: Get LocalAppData path from Environment.SpecialFolder enum

### DIFF
--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -1,14 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -18,7 +13,7 @@ namespace Stride.Core.Assets
 {
     public class NuGetAssemblyResolver
     {
-        public const string DevSource = @"%LocalAppData%\Stride\NugetDev";
+        public const string DevSource = @"Stride\NugetDev";
 
         static bool assembliesResolved;
         static readonly object assembliesLock = new object();
@@ -39,16 +34,16 @@ namespace Stride.Core.Assets
         {
             // Make sure our nuget local store is added to nuget config
             var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string strideFolder = null;
+            var devSourcePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), DevSource);
+
             while (folder != null)
             {
                 if (File.Exists(Path.Combine(folder, @"build\Stride.sln")))
                 {
-                    strideFolder = folder;
                     var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null);
 
-                    Directory.CreateDirectory(Environment.ExpandEnvironmentVariables(DevSource));
-                    CheckPackageSource(settings, "Stride Dev", NuGet.Configuration.Settings.ApplyEnvironmentTransform(DevSource));
+                    Directory.CreateDirectory(devSourcePath);
+                    CheckPackageSource(settings, "Stride Dev", devSourcePath);
 
                     settings.SaveToDisk();
                     break;


### PR DESCRIPTION
# PR Details

Getting LocalAppData path shouldn't be hardcoded if we want more universal code for all platforms. It should be received from Environment.GetFolderPath with Environment.SpecialFolder enum which contains common paths for OS folders.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
