### PR TITLE
Fix "Add Asset Pop-Up" height

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/Views/AddItemUserControl.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/TemplateDescriptions/Views/AddItemUserControl.xaml
@@ -9,7 +9,7 @@
              xmlns:view="clr-namespace:Stride.Core.Assets.Editor.Components.TemplateDescriptions.Views"
              xmlns:viewModels="clr-namespace:Stride.Core.Assets.Editor.Components.TemplateDescriptions.ViewModels"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             d:DesignHeight="240" d:DesignWidth="300">
   <UserControl.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -20,7 +20,7 @@
   <sd:FilteringComboBox DataContext="{Binding TemplateCollection, RelativeSource={RelativeSource AncestorType=view:AddItemUserControl}}"
                           Text="{Binding SearchToken, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" WatermarkContent="{sd:Localize Search}"
                           ItemsSource="{Binding Templates}" SortMemberPath="Name" x:Name="FilteringComboBox"
-                          ClearTextAfterValidation="True" ValidateOnLostFocus="False">
+                          ClearTextAfterValidation="True" ValidateOnLostFocus="False" Height="240">
     <sd:FilteringComboBox.Template>
       <ControlTemplate TargetType="{x:Type sd:FilteringComboBox}">
         <Grid>
@@ -123,7 +123,7 @@
     </sd:FilteringComboBox.Template>
     <sd:FilteringComboBox.ItemTemplate>
       <DataTemplate DataType="viewModels:ITemplateDescriptionViewModel">
-        <DockPanel Height="56">
+        <DockPanel Height="52">
           <Image Source="{Binding Icon}" DockPanel.Dock="Left" Width="48" Height="48" Margin="2"/>
           <DockPanel Margin="18,0">
             <TextBlock DockPanel.Dock="Top" FontSize="16" Text="{Binding Name}"/>

--- a/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
@@ -205,7 +205,7 @@
           </i:Interaction.Behaviors>
         </ToggleButton>
         <Popup IsOpen="{Binding IsChecked, ElementName=Toggle, Mode=TwoWay}" StaysOpen="False" AllowsTransparency="True">
-          <Border MinHeight="300" Margin="6" Background="{StaticResource ControlBackgroundBrush}"
+          <Border MinHeight="240" Margin="6" Background="{StaticResource ControlBackgroundBrush}"
                   BorderBrush="{StaticResource NormalBrush}" BorderThickness="1">
             <Border.Effect>
               <DropShadowEffect BlurRadius="5" Opacity="0.4"/>


### PR DESCRIPTION
# PR Details

The "Add Asset Pop-Up" does not have a height limit

Before:

![gOl1S5DjA4](https://github.com/user-attachments/assets/2b7e16b0-e366-4911-8e49-38d471ef8c42)

After:

![qXfpZkc6EN](https://github.com/user-attachments/assets/a106021b-af08-476b-b3b5-b8d01e5196d5)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
