### PR TITLE
Introducing Stride Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![All Contributors](https://img.shields.io/github/all-contributors/stride3d/stride?color=ee8449)](#contributors)
 [![Financial sponsors](https://img.shields.io/opencollective/all/stride3d?logo=opencollective)](https://opencollective.com/stride3d)
 [![License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/stride3d/stride/blob/master/LICENSE.md)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Stride%20Guru-006BFF)](https://gurubase.io/g/stride)
 
 Welcome to the Stride source code repository!
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Stride Guru](https://gurubase.io/g/stride) to Gurubase. Stride Guru uses the data from this repo and data from the [docs](https://doc.stride3d.net/latest/en/manual/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Stride Guru", which highlights that Stride now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Stride Guru in Gurubase, just let me know that's totally fine.
