### PR TITLE
[Build] Update Silk.NET from 2.20.0 to 2.22.0

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -20,12 +20,12 @@
     <PackageVersion Include="SharpDX.MediaFoundation" Version="4.2.0" />
     <PackageVersion Include="SharpDX.RawInput" Version="4.2.0" />
     <PackageVersion Include="SharpDX.XInput" Version="4.2.0" />
-    <PackageVersion Include="Silk.NET.OpenGL" Version="2.20.0" />
-    <PackageVersion Include="Silk.NET.OpenGLES" Version="2.20.0" />
-    <PackageVersion Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.20.0" />
-    <PackageVersion Include="Silk.NET.OpenXR" Version="2.20.0" />
-    <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.20.0" />
-    <PackageVersion Include="Silk.NET.Sdl" Version="2.20.0" />
+    <PackageVersion Include="Silk.NET.OpenGL" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.OpenGLES" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.OpenXR" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.Sdl" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.19.0" />
     <PackageVersion Include="Stride.SharpFont" Version="1.0.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
@@ -55,7 +55,7 @@
     <PackageVersion Include="NuGet.PackageManagement" Version="6.8.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
     <PackageVersion Include="NuGet.Resolver" Version="6.8.0" />
-    <PackageVersion Include="Silk.NET.Assimp" Version="2.20.0" />
+    <PackageVersion Include="Silk.NET.Assimp" Version="2.22.0" />
     <PackageVersion Include="Stride.GNU.Getopt" Version="2.0.0" />
     <PackageVersion Include="Stride.GNU.Gettext" Version="2.0.0" />
     <PackageVersion Include="Stride.Mono.TextTemplating" Version="2.1.0-preview-0009-g0d0b6db3ca" />


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Update Silk.NET for Android fixes (bluetooth permission & receiver export errors)

Major disclaimer: the bluetooth permission error still appeared in a Stride project for me, however this might just be a local machine issue because it disappeared on a standalone Silk-only project (version 2.22.0). I tried deleting as many places where I thought the older version was somehow being cached by Visual Studio but failed to figure it out.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Should fix Bluetooth issue #2348 (will try again when a proper nuget build is released)
Allow #2351 to proceed.

Building (some?) Android projects will still be blocked due to CompilerApp issue #2520


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
