### PR TITLE
fix: Empty GridLogViewer when messages are appended before the element is on screen

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/View/Controls/GridLogViewer.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Controls/GridLogViewer.cs
@@ -158,6 +158,9 @@ namespace Stride.Core.Assets.Editor.View.Controls
                 throw new InvalidOperationException("A part named 'PART_LogGridView' must be present in the ControlTemplate, and must be of type 'DataGridControl'.");
 
             logGridView.MouseDoubleClick += GridMouseDoubleClick;
+
+            // We may have a bunch of messages appended before the logGridView was ready, let's present them now that it is 
+            ApplyFilters();
         }
 
         private void GridMouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
# PR Details
See title, the issue is specifically related to this window, if it hasn't been opened before and an error message is sent to it, opening it would show an empty list even though the tab mentions a non-zero amount of asset errors
![image](https://github.com/user-attachments/assets/36d77098-dedc-47be-a609-77260ef4772f)
This PR makes sure to fill in the message list as soon as the element is created.


## Related Issue
None afaict

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
