### PR TITLE
fix: Add in gizmos on assembly load

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/StrideDefaultAssetsPlugin.cs
+++ b/sources/editor/Stride.Assets.Presentation/StrideDefaultAssetsPlugin.cs
@@ -150,18 +150,32 @@ namespace Stride.Assets.Presentation
                 category.AddFactory(instance, display.Name, display.Order ?? int.MaxValue / 2);
             }
 
-            // Update display name of scripts to have a decent default value if user didn't set one.
-            var componentTypes = typeof(EntityComponent).GetInheritedInstantiableTypes().Where(x => TypeDescriptorFactory.Default.AttributeRegistry.GetAttribute<DisplayAttribute>(x, false) == null);
-            componentTypes.ForEach(x => TypeDescriptorFactory.Default.AttributeRegistry.Register(x, new DisplayAttribute(x.Name) { Expand = ExpandRule.Once }));
             AssemblyRegistry.AssemblyRegistered += (sender, e) =>
             {
-                var types = e.Assembly.GetTypes().Where(x => typeof(EntityComponent).IsAssignableFrom(x) && TypeDescriptorFactory.Default.AttributeRegistry.GetAttribute<DisplayAttribute>(x, false) == null);
-                types.ForEach(x => TypeDescriptorFactory.Default.AttributeRegistry.Register(x, new DisplayAttribute(x.Name) { Expand = ExpandRule.Once }));
+                var types = e.Assembly.GetTypes();
+                SetTypeExpandRuleFallback(types);
+
+                if (e.Categories.Contains(AssemblyCommonCategories.Assets))
+                {
+                    OnRegisteredAssetAssembly(types);
+                }
+            };
+            
+            AssemblyRegistry.AssemblyUnregistered += (sender, e) =>
+            {
+                if (e.Categories.Contains(AssemblyCommonCategories.Assets))
+                {
+                    OnUnregisteredAssetAssembly(e.Assembly.GetTypes());
+                }
             };
 
+            SetTypeExpandRuleFallback(typeof(EntityComponent).GetInheritedInstantiableTypes().ToArray());
+
+            foreach (var assembly in AssetRegistry.AssetAssemblies)
+                OnRegisteredAssetAssembly(assembly.GetTypes());
+            
             EntityFactoryCategories = entityFactories.Keys.ToList();
-            RegisterGizmoTypes();
-            RegisterAssetHighlighterTypes();
+
             RegisterResourceDictionary(imageDictionary);
             RegisterResourceDictionary(animationPropertyTemplateDictionary);
             RegisterResourceDictionary(entityPropertyTemplateDictionary);
@@ -341,32 +355,53 @@ namespace Stride.Assets.Presentation
             return (ascending ? filtered.OrderBy(t => t.order) : filtered.OrderByDescending(t => t.order)).Select(t => t.type);
         }
 
-        private static void RegisterGizmoTypes()
+        /// <summary>
+        /// Update display name of scripts to have a decent default value if user didn't set one.
+        /// </summary>
+        private static void SetTypeExpandRuleFallback(Type[] types)
         {
-            var allTypes = AssetRegistry.AssetAssemblies.SelectMany(x => x.GetTypes());
-            foreach (var type in allTypes)
+            foreach (var type in types)
             {
-                if (typeof(IGizmo).IsAssignableFrom(type))
+                if (type.IsAssignableTo(typeof(EntityComponent)) && TypeDescriptorFactory.Default.AttributeRegistry.GetAttribute<DisplayAttribute>(type, false) == null)
                 {
-                    var attribute = type.GetCustomAttribute<GizmoComponentAttribute>(true);
-                    if (attribute != null)
-                    {
+                    TypeDescriptorFactory.Default.AttributeRegistry.Register(type, new DisplayAttribute(type.Name) { Expand = ExpandRule.Once });
+                }
+            }
+        }
+
+        private void OnRegisteredAssetAssembly(Type[] types)
+        {
+            foreach (var type in types)
+            {
+                if (type.IsAssignableTo(typeof(IGizmo)))
+                {
+                    if (type.GetCustomAttribute<GizmoComponentAttribute>(true) is {} attribute)
                         GizmoTypes.Add(attribute.ComponentType, type);
+                }
+                if (type.IsAssignableTo(typeof(AssetHighlighter)))
+                {
+                    foreach (var attribute in type.GetCustomAttributes<AssetHighlighterAttribute>(false).NotNull())
+                    {
+                        AssetHighlighterTypes.Add(attribute.AssetType, type);
                     }
                 }
             }
         }
 
-        private static void RegisterAssetHighlighterTypes()
+        private void OnUnregisteredAssetAssembly(Type[] types)
         {
-            var allTypes = AssetRegistry.AssetAssemblies.SelectMany(x => x.GetTypes());
-            foreach (var type in allTypes)
+            foreach (var type in types)
             {
-                if (typeof(AssetHighlighter).IsAssignableFrom(type))
+                if (type.IsAssignableTo(typeof(IGizmo)))
+                {
+                    if (type.GetCustomAttribute<GizmoComponentAttribute>(true) is {} attribute)
+                        GizmoTypes.Remove(attribute.ComponentType);
+                }
+                if (type.IsAssignableTo(typeof(AssetHighlighter)))
                 {
                     foreach (var attribute in type.GetCustomAttributes<AssetHighlighterAttribute>(false).NotNull())
                     {
-                        AssetHighlighterTypes.Add(attribute.AssetType, type);
+                        AssetHighlighterTypes.Remove(attribute.AssetType);
                     }
                 }
             }


### PR DESCRIPTION
# PR Details
User-defined gizmos did not load in when reloading the assembly, whether they were part of the previous version or not.
Same deal for `DisplayAttribute` stuff, also cleaned up registered types when assemblies are unloaded, and replaced the unreadable linq into someting more readable

## Related Issue
None afaict.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
