### PR TITLE
Make Forward Renderer more flexible

### DIFF
--- a/build/Stride.sln
+++ b/build/Stride.sln
@@ -338,7 +338,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stride.BepuPhysics.Debug", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stride.Importer.3D", "..\sources\tools\Stride.Importer.3D\Stride.Importer.3D.csproj", "{66EFFDE4-24F0-4E57-9618-0F5577E20A1E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stride.BepuPhysics.Tests", "..\sources\engine\Stride.BepuPhysics\Stride.BepuPhysics.Tests\Stride.BepuPhysics.Tests.csproj", "{7B70C783-4085-4702-B3C6-6570FD85CB8F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stride.BepuPhysics.Tests", "..\sources\engine\Stride.BepuPhysics\Stride.BepuPhysics.Tests\Stride.BepuPhysics.Tests.csproj", "{7B70C783-4085-4702-B3C6-6570FD85CB8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1515,12 +1515,16 @@ Global
 		{66EFFDE4-24F0-4E57-9618-0F5577E20A1E}.Release|Win32.Build.0 = Release|Any CPU
 		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Debug|Win32.Build.0 = Debug|Any CPU
+		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Win32.ActiveCfg = Release|Any CPU
+		{7B70C783-4085-4702-B3C6-6570FD85CB8F}.Release|Win32.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EntityHierarchyEditorGame.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EntityHierarchyEditorGame.cs
@@ -370,7 +370,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             {
                 Child = new ForwardRenderer
                 {
-                    Clear = null, // Don't clear (we want to keep reusing same render target and depth buffer)
+                    SceneRenderer = null, // Don't clear (we want to keep reusing same render target and depth buffer)
                     OpaqueRenderStage = EditorSceneSystem.GraphicsCompositor.RenderStages.FirstOrDefault(x => x.Name == "Opaque"),
                     TransparentRenderStage = EditorSceneSystem.GraphicsCompositor.RenderStages.FirstOrDefault(x => x.Name == "Transparent"),
                 },

--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -51,7 +51,7 @@ namespace Stride.Rendering.Compositing
 
         protected int ViewIndex { get; private set; }
 
-        public ClearRenderer Clear { get; set; } = new ClearRenderer();
+        public SceneRendererBase SceneRenderer { get; set; } = new ClearRenderer();
 
         /// <summary>
         /// Enable Light Probe.
@@ -703,7 +703,7 @@ namespace Stride.Rendering.Compositing
                                 {
                                     // Clear render target and depth stencil
                                     if (hasPostEffects || i == 0) // need to clear for each eye in the case we have two different render targets
-                                        Clear?.Draw(drawContext);
+                                        SceneRenderer?.Draw(drawContext);
 
                                     ViewIndex = i;
 
@@ -749,7 +749,7 @@ namespace Stride.Rendering.Compositing
                         drawContext.CommandList.SetRenderTargets(currentDepthStencil, currentRenderTargets.Count, currentRenderTargets.Items);
 
                         // Clear render target and depth stencil
-                        Clear?.Draw(drawContext);
+                        SceneRenderer?.Draw(drawContext);
 
                         DrawView(context, drawContext, 0, 1);
                     }

--- a/sources/engine/Stride.Engine/Rendering/Compositing/GraphicsCompositorHelper.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/GraphicsCompositorHelper.cs
@@ -50,7 +50,6 @@ namespace Stride.Rendering.Compositing
 
             var singleView = new ForwardRenderer
             {
-                Clear = { Color = clearColor ?? Color.CornflowerBlue },
                 OpaqueRenderStage = opaqueRenderStage,
                 TransparentRenderStage = transparentRenderStage,
                 ShadowMapRenderStages = { shadowCasterRenderStage, shadowCasterParaboloidRenderStage, shadowCasterCubeMapRenderStage },

--- a/sources/engine/Stride.Rendering/Rendering/Compositing/ClearRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Compositing/ClearRenderer.cs
@@ -42,7 +42,7 @@ namespace Stride.Rendering.Compositing
         /// <userdoc>The color value to use when clearing the render targets</userdoc>
         [DataMember(20)]
         [Display("Color")]
-        public Color4 Color { get; set; }
+        public Color4 Color { get; set; } = Core.Mathematics.Color.CornflowerBlue;
 
         /// <summary>
         /// Gets or sets the depth value used to clear the depth stencil buffer.

--- a/sources/engine/Stride.UI.Tests/Regression/ModalElementTest.cs
+++ b/sources/engine/Stride.UI.Tests/Regression/ModalElementTest.cs
@@ -49,7 +49,8 @@ namespace Stride.UI.Tests.Regression
             // TODO: Use a custom compositor as soon as we have visual scripting?
             var topChildRenderer = ((SceneCameraRenderer)SceneSystem.GraphicsCompositor.Game).Child;
             var forwardRenderer = (topChildRenderer as SceneRendererCollection)?.Children.OfType<ForwardRenderer>().FirstOrDefault() ?? (ForwardRenderer)topChildRenderer;
-            forwardRenderer.Clear = new ClearAndDrawTextureRenderer { Color = forwardRenderer.Clear.Color, Texture = sprites["GameScreen"].Texture };
+            var clearRenderer = (ClearRenderer)forwardRenderer.SceneRenderer;
+            forwardRenderer.SceneRenderer = new ClearAndDrawTextureRenderer { Color = clearRenderer.Color, Texture = sprites["GameScreen"].Texture };
 
             var lifeBar = new ImageElement { Source = SpriteFromSheet.Create(sprites, "Logo"), HorizontalAlignment = HorizontalAlignment.Center };
             lifeBar.DependencyProperties.Set(GridBase.ColumnSpanPropertyKey, 3);


### PR DESCRIPTION
# PR Details

This change allows users to add a more generic scene renderer as an alternative to only the clear renderer.

## Related Issue

none. I just want to use the default forward renderer but needed to use an alternative to the default clear option.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
