### PR TITLE
[Build] Update NuGet.* packages to version 6.12.1

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -56,11 +56,11 @@
     <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NuGet.Commands" Version="6.8.0" />
-    <PackageVersion Include="NuGet.Configuration" Version="6.8.0" />
-    <PackageVersion Include="NuGet.PackageManagement" Version="6.8.0" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
-    <PackageVersion Include="NuGet.Resolver" Version="6.8.0" />
+    <PackageVersion Include="NuGet.Commands" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.12.1" />
+    <PackageVersion Include="NuGet.PackageManagement" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Resolver" Version="6.12.1" />
     <PackageVersion Include="Silk.NET.Assimp" Version="2.22.0" />
     <PackageVersion Include="Stride.GNU.Getopt" Version="2.0.0" />
     <PackageVersion Include="Stride.GNU.Gettext" Version="2.0.0" />


### PR DESCRIPTION
# PR Details

Our current NuGet.* packages version 6.8.0 have depedency on vulnerable `NuGet.Protocol` 6.8.0 package.

45 occurences in the Visual Studio Build Output window.

## Related Issue

Warnings when the **Solution.sln** is built.

```
D:\Projects\GitHub\stride\sources\editor\Stride.GameStudio\Stride.GameStudio.csproj : 
warning NU1904: Package 'NuGet.Packaging' 6.8.0 has a known critical severity vulnerability,
https://github.com/advisories/GHSA-68w7-72jg-6qpp
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
