### PR TITLE
fix: Replace Xenko logo with Stride logo in MaterialModel.fbx

### DIFF
--- a/samples/Templates/Packs/MaterialPackage/Resources/Models/MaterialModel.fbx
+++ b/samples/Templates/Packs/MaterialPackage/Resources/Models/MaterialModel.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ead3d818f028691baa315b091e72f4dcf5a4cc9b66541bb4e7631c1313f18b68
-size 184960
+oid sha256:ee3f98afd5d5a873a6e10e4cdf67ce9eae49214128cd5c8082a10d060e930c6a
+size 177660


### PR DESCRIPTION
# PR Details

**MaterialModel.fbx** in **Material Package** still had the Xenko logo. I replaced the file for @CodingSea 's slightly changed model that has Stride's logo.

Simple change, but it helps with the engine cohesion. 

![StrideMaterialModel](https://github.com/user-attachments/assets/ec455686-b347-4f23-9e40-33628a05bc87)

## Related Issue

#1505

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
