### PR TITLE
fix: Removed Focused loss triggering button Release

### DIFF
--- a/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/InputSourceWinforms.cs
@@ -47,8 +47,6 @@ namespace Stride.Input
         {
             input = inputManager;
 
-            uiControl.LostFocus += UIControlOnLostFocus;
-
             // Hook window proc
             defaultWndProc = Win32Native.GetWindowLong(uiControl.Handle, Win32Native.WindowLongType.WndProc);
             // This is needed to prevent garbage collection of the delegate.
@@ -92,20 +90,6 @@ namespace Stride.Input
             
                 keysToRelease.Clear();
             }
-        }
-        
-        private void UIControlOnLostFocus(object sender, EventArgs eventArgs)
-        {
-            // Release keys/buttons when control focus is lost (this prevents some keys getting stuck when a focus loss happens when moving the camera)
-            if (keyboard != null)
-            {
-                foreach (var key in keyboard.KeyRepeats.Keys.ToArray())
-                {
-                    keyboard.HandleKeyUp(key);
-                }
-            }
-
-            mouse?.ForceReleaseButtons();
         }
 
         internal void HandleKeyDown(IntPtr wParam, IntPtr lParam)

--- a/sources/engine/Stride.Input/Windows/MouseWinforms.cs
+++ b/sources/engine/Stride.Input/Windows/MouseWinforms.cs
@@ -35,7 +35,6 @@ namespace Stride.Input
             uiControl.MouseWheel += OnMouseWheelEvent;
             uiControl.SizeChanged += OnSizeChanged;
             uiControl.GotFocus += OnGotFocus;
-            uiControl.LostFocus += OnLostFocus;
 
             OnSizeChanged(this, null);
 
@@ -54,7 +53,6 @@ namespace Stride.Input
             uiControl.MouseWheel -= OnMouseWheelEvent;
             uiControl.SizeChanged -= OnSizeChanged;
             uiControl.GotFocus -= OnGotFocus;
-            uiControl.LostFocus -= OnLostFocus;
 
             if (rawInputMouse != null)
             {
@@ -124,14 +122,6 @@ namespace Stride.Input
             }
         }
 
-        internal void ForceReleaseButtons()
-        {
-            foreach (var button in DownButtons.ToArray())
-            {
-                MouseState.HandleButtonUp(button);
-            }
-        }
-
         private void OnGotFocus(object sender, EventArgs e)
         {
             // reapply cursor clip when refocusing
@@ -139,15 +129,6 @@ namespace Stride.Input
             {
                 var rect = new Rect(capturedPosition.X, capturedPosition.Y, capturedPosition.X, capturedPosition.Y);
                 ClipCursor(rect);
-            }
-        }
-
-        private void OnLostFocus(object sender, EventArgs args)
-        {
-            var buttonsToRelease = DownButtons.ToArray();
-            foreach (var button in buttonsToRelease)
-            {
-                MouseState.HandleButtonUp(button);
             }
         }
 


### PR DESCRIPTION
# PR Details

On deselecting Edit Text, via  `myEditTextElement.IsSelectionActive = false;`, focus was lost which triggered two behaviors which both triggered button releases. One mouse and keyboard and the other just the mouse release. This PR affects the following inputs: STRIDE_UI_WINFORMS and STRIDE_UI_WPF.

I have checked the box that this maybe a breaking change due to the following comment in the removed code.
`// Release keys/buttons when control focus is lost (this prevents some keys getting stuck when a focus loss happens when moving the camera)`
I tried to test moving the camera around while typing in an EditText, but was not able to reproduce a key or mouse button press being stuck.

My reasoning for a possibly breaking change is that due to 
- The lack of test coverage or documentation for how to recreate the original issue being fixed by `UIControlOnLostFocus` and `UIControlOnLostFocus`. 
- Having buttons automatically released on focus change can interrupt behaviors like game state changes (managing hotkeys while in menus) and potentially drag and drop functionalities. 
- I cannot think of a use case where we want UI focus to release user/player Input controls. 
- I also checked the SDL and did not see this, button release on focus loss, functionality there. 

If more knowledge on the original goals of the functions `UIControlOnLostFocus` and `UIControlOnLostFocus` are known, I will revised this PR to address it. 

## Related Issue
https://github.com/stride3d/stride/issues/2084

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

## Test Script
Here is the script I used to test if the "Mouse Button Released" was happening on Mouse Press or Release.
```
using Stride.Engine;
using Stride.UI;
using Stride.UI.Controls;
using System.Diagnostics;
using Stride.Input;
using Stride.Core.Mathematics;
using System;

public class Script : SyncScript
{
    public UIComponent page;
    EditText editText;

    public override void Start()
    {
        editText = page.Page.RootElement.FindVisualChildOfType<EditText>("EditText");
    }

    public override void Update()
    {
        if (Input.IsMouseButtonPressed(MouseButton.Left))
        {
            editText.IsSelectionActive = false;
        }
        else if (Input.IsMouseButtonReleased(MouseButton.Left)) 
        {
            Debug.WriteLine("Mouse Button Released");
            DebugText.Print("Mouse Button Released", new Int2(10, 10), null, new TimeSpan(0, 0, 0, 0, 15));
        }
    }
}
```
