### PR TITLE
feat: Process required keyword like MemberRequiredAttribute

### DIFF
--- a/sources/engine/Stride.Assets.Tests/TestMemberRequiredComponentChecks.cs
+++ b/sources/engine/Stride.Assets.Tests/TestMemberRequiredComponentChecks.cs
@@ -35,6 +35,9 @@ namespace Stride.Assets.Tests
             [MemberRequired]
             [DataMember] internal object InternalProp { get; set; }
             public override object VirtualProp { get; set; } = new object();
+            public required object KeywordRequired { get; set; }
+            [MemberRequired(ReportAs = MemberRequiredReportType.Error)] public required object KeywordAndAttributeRequired { get; set; }
+
             public MemberRequiredComponent(object initData, object internalData)
             {
                 InitProp = initData;
@@ -50,6 +53,8 @@ namespace Stride.Assets.Tests
                 InternalField = new object(),
                 PublicProp = new object(),
                 PublicField = new object(),
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = new object()
             };
             var entity = new Entity("test");
             entity.Add(memberRequiredComponent);
@@ -70,9 +75,11 @@ namespace Stride.Assets.Tests
                 InternalField = new object(),
                 PublicProp = new object(),
                 PublicField = null,
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = new object()
             };
             var memberName = nameof(memberRequiredComponent.PublicField);
-            TestSingle(memberRequiredComponent, memberName);
+            TestSingleWarning(memberRequiredComponent, memberName);
         }
 
         [Fact]
@@ -83,9 +90,11 @@ namespace Stride.Assets.Tests
                 InternalField = new object(),
                 PublicProp = null,
                 PublicField = new object(),
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = new object()
             };
             var memberName = nameof(memberRequiredComponent.PublicProp);
-            TestSingle(memberRequiredComponent, memberName);
+            TestSingleWarning(memberRequiredComponent, memberName);
         }
 
         [Fact]
@@ -96,9 +105,11 @@ namespace Stride.Assets.Tests
                 InternalField = new object(),
                 PublicProp = new object(),
                 PublicField = new object(),
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = new object()
             };
             var memberName = nameof(MemberRequiredComponent.InitProp);
-            TestSingle(memberRequiredComponent, memberName);
+            TestSingleWarning(memberRequiredComponent, memberName);
         }
 
         [Fact]
@@ -109,9 +120,41 @@ namespace Stride.Assets.Tests
                 InternalField = new object(),
                 PublicProp = new object(),
                 PublicField = new object(),
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = new object()
             };
             var memberName = nameof(MemberRequiredComponent.InternalProp);
-            TestSingle(memberRequiredComponent, memberName);
+            TestSingleWarning(memberRequiredComponent, memberName);
+        }
+
+        [Fact]
+        void EntityIsMissingRequiredMember_Keyword()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(new object(), new object())
+            {
+                InternalField = new object(),
+                PublicProp = new object(),
+                PublicField = new object(),
+                KeywordRequired = null,
+                KeywordAndAttributeRequired = new object()
+            };
+            var memberName = nameof(MemberRequiredComponent.KeywordRequired);
+            TestSingleWarning(memberRequiredComponent, memberName);
+        }
+
+        [Fact]
+        void EntityIsMissingRequiredMember_KeywordWithAttribute()
+        {
+            var memberRequiredComponent = new MemberRequiredComponent(new object(), new object())
+            {
+                InternalField = new object(),
+                PublicProp = new object(),
+                PublicField = new object(),
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = null
+            };
+            var memberName = nameof(MemberRequiredComponent.KeywordAndAttributeRequired);
+            TestSingleError(memberRequiredComponent, memberName);
         }
 
         [Fact]
@@ -121,6 +164,8 @@ namespace Stride.Assets.Tests
             {
                 PublicProp = null,
                 PublicField = null,
+                KeywordRequired = null,
+                KeywordAndAttributeRequired = null
             };
             var entity = new Entity("test");
             entity.Add(memberRequiredComponent);
@@ -130,7 +175,7 @@ namespace Stride.Assets.Tests
 
             Assert.True(check.AppliesTo(memberRequiredComponent.GetType()));
             check.Check(memberRequiredComponent, entity, null, "", result);
-            Assert.Equal(5, result.Messages.Count);
+            Assert.Equal(7, result.Messages.Count);
         }
 
         [Fact]
@@ -142,12 +187,24 @@ namespace Stride.Assets.Tests
                 PublicProp = new object(),
                 PublicField = new object(),
                 VirtualProp = null,
+                KeywordRequired = new object(),
+                KeywordAndAttributeRequired = new object()
             };
             var memberName = nameof(memberRequiredComponent.VirtualProp);
-            TestSingle(memberRequiredComponent, memberName);
+            TestSingleWarning(memberRequiredComponent, memberName);
         }
 
-        private static void TestSingle(MemberRequiredComponent memberRequiredComponent, string memberName)
+        private static void TestSingleError(MemberRequiredComponent memberRequiredComponent, string memberName)
+        {
+            TestSingle(memberRequiredComponent, memberName, Core.Diagnostics.LogMessageType.Error);
+        }
+
+        private static void TestSingleWarning(MemberRequiredComponent memberRequiredComponent, string memberName)
+        {
+            TestSingle(memberRequiredComponent, memberName, Core.Diagnostics.LogMessageType.Warning);
+        }
+
+        private static void TestSingle(MemberRequiredComponent memberRequiredComponent, string memberName, Core.Diagnostics.LogMessageType messageType)
         {
             var entity = new Entity("Test");
             entity.Add(memberRequiredComponent);
@@ -159,7 +216,7 @@ namespace Stride.Assets.Tests
             check.Check(memberRequiredComponent, entity, null, "", result);
             Assert.Collection(result.Messages, (msg) =>
             {
-                Assert.Equal(Core.Diagnostics.LogMessageType.Warning, msg.Type);
+                Assert.Equal(messageType, msg.Type);
                 Assert.Contains(memberName, msg.Text);
             });
         }

--- a/sources/engine/Stride.Assets/Entities/ComponentChecks/RequiredMembersCheck.cs
+++ b/sources/engine/Stride.Assets/Entities/ComponentChecks/RequiredMembersCheck.cs
@@ -33,12 +33,16 @@ namespace Stride.Assets.Entities.ComponentChecks
                 if (member.Type.IsValueType)
                     continue; // value types cannot be null, and must always have a proper default value
 
-                MemberRequiredAttribute memberRequired;
-                if ((memberRequired = member.GetCustomAttributes<MemberRequiredAttribute>(true).FirstOrDefault()) != null)
-                {
-                    if (member.Get(component) == null)
-                        WriteResult(result, componentName, targetUrlInStorage, entity.Name, member.Name, memberRequired.ReportAs);
-                }
+                MemberRequiredReportType reportType;
+                if (member.GetCustomAttributes<MemberRequiredAttribute>(true).FirstOrDefault() is {} strideAttribute)
+                    reportType = strideAttribute.ReportAs;
+                else if (member.GetCustomAttributes<System.Runtime.CompilerServices.RequiredMemberAttribute>(true).Any())
+                    reportType = MemberRequiredReportType.Warning;
+                else 
+                    continue;
+
+                if (member.Get(component) == null)
+                    WriteResult(result, componentName, targetUrlInStorage, entity.Name, member.Name, reportType);
             }
         }
 


### PR DESCRIPTION
# PR Details
Now that `required` is an actual keyword, we can use it to notify users when some of their components have missing references, just like our `MemberRequiredAttribute`.

`required` is an essential part of projects using the nullable reference feature, using it in stride to benefit from null-state analysis from both the compiler and our asset builder requires writing a fairly redundant property definition:
```cs
[MemberRequired] public required MyRef myRef { get; set; }
```
When the intent of the attribute is already made clear through the use of the `required` keyword.
```cs
public required MyRef myRef { get; set; }
```

## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

Hopefully you have some time to get back to me about this one @manio143 , would like to hear your thoughts given that this is your feature.