### PR TITLE
fix: CharacterComponent can stand on trigger boxes

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CharacterComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CharacterComponent.cs
@@ -148,6 +148,9 @@ public class CharacterComponent : BodyComponent, ISimulationUpdate, IContactEven
 
         foreach (var contact in Contacts)
         {
+            if (contact.Source.ContactEventHandler?.NoContactResponse == true)
+                continue;
+
             var contactNormal = contact.Contact.Normal;
 
             if (NVector3.Dot(groundNormal, contactNormal) >= threshold) // If the body is supported by a contact whose surface is against gravity


### PR DESCRIPTION
# PR Details
Characters could continuously jump inside and stand on top of a `NoContactResponse` `Collidable` - `NoContactResponse` still notifies `IContactEventHandler` of course, which `CharacterController` depends on to figure out whether it should be falling or if it can jump.

## Related Issue
None reported.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
