### PR TITLE
feat: LockFileEx/UnLockFileEx methods shouldn't be called explicitly

### DIFF
--- a/sources/core/Stride.Core.Design/Windows/FileLock.cs
+++ b/sources/core/Stride.Core.Design/Windows/FileLock.cs
@@ -33,7 +33,7 @@ namespace Stride.Core.Windows
         {
             if (lockFile != null)
             {
-                NativeLockFile.UnlockFile(lockFile, 0, uint.MaxValue);
+                NativeLockFile.TryUnlockFile(lockFile, 0, uint.MaxValue);
                 lockFile.Dispose();
 
                 // Try to delete the file
@@ -94,7 +94,7 @@ namespace Stride.Core.Windows
                 if (millisecondsTimeout != 0 && millisecondsTimeout != -1)
                     throw new NotImplementedException("GlobalMutex.Wait() is implemented only for millisecondsTimeout 0 or -1");
 
-                bool hasHandle = NativeLockFile.LockFile(fileLock, 0, uint.MaxValue, true, millisecondsTimeout == 0);
+                bool hasHandle = NativeLockFile.TryLockFile(fileLock, 0, uint.MaxValue, true, millisecondsTimeout == 0);
                 return hasHandle == false ? null : new FileLock(fileLock);
             }
             catch (AbandonedMutexException)

--- a/sources/core/Stride.Core.Design/Windows/FileLock.cs
+++ b/sources/core/Stride.Core.Design/Windows/FileLock.cs
@@ -33,8 +33,7 @@ namespace Stride.Core.Windows
         {
             if (lockFile != null)
             {
-                var overlapped = new NativeOverlapped();
-                NativeLockFile.UnlockFileEx(lockFile.SafeFileHandle, 0, uint.MaxValue, uint.MaxValue, ref overlapped);
+                NativeLockFile.UnlockFile(lockFile, 0, uint.MaxValue);
                 lockFile.Dispose();
 
                 // Try to delete the file
@@ -95,8 +94,7 @@ namespace Stride.Core.Windows
                 if (millisecondsTimeout != 0 && millisecondsTimeout != -1)
                     throw new NotImplementedException("GlobalMutex.Wait() is implemented only for millisecondsTimeout 0 or -1");
 
-                var overlapped = new NativeOverlapped();
-                bool hasHandle = NativeLockFile.LockFileEx(fileLock.SafeFileHandle, NativeLockFile.LOCKFILE_EXCLUSIVE_LOCK | (millisecondsTimeout == 0 ? NativeLockFile.LOCKFILE_FAIL_IMMEDIATELY : 0), 0, uint.MaxValue, uint.MaxValue, ref overlapped);
+                bool hasHandle = NativeLockFile.LockFile(fileLock, 0, uint.MaxValue, true, millisecondsTimeout == 0);
                 return hasHandle == false ? null : new FileLock(fileLock);
             }
             catch (AbandonedMutexException)

--- a/sources/core/Stride.Core.IO/NativeLockFile.cs
+++ b/sources/core/Stride.Core.IO/NativeLockFile.cs
@@ -40,7 +40,7 @@ namespace Stride.Core.IO
                     OffsetHigh = (int)(offset >> 32),
                 };
 
-                return LockFileEx(fileStream.SafeFileHandle, exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0 | failImmediately ? NativeLockFile.LOCKFILE_FAIL_IMMEDIATELY : 0, 0, countLow, countHigh, ref overlapped);
+                return LockFileEx(fileStream.SafeFileHandle, exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0 + failImmediately ? NativeLockFile.LOCKFILE_FAIL_IMMEDIATELY : 0, 0, countLow, countHigh, ref overlapped);
             }
             else
             {

--- a/sources/core/Stride.Core.IO/NativeLockFile.cs
+++ b/sources/core/Stride.Core.IO/NativeLockFile.cs
@@ -40,7 +40,7 @@ namespace Stride.Core.IO
                     OffsetHigh = (int)(offset >> 32),
                 };
 
-                return LockFileEx(fileStream.SafeFileHandle, exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0 + failImmediately ? NativeLockFile.LOCKFILE_FAIL_IMMEDIATELY : 0, 0, countLow, countHigh, ref overlapped);
+                return LockFileEx(fileStream.SafeFileHandle, (exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0) + (failImmediately ? NativeLockFile.LOCKFILE_FAIL_IMMEDIATELY : 0), 0, countLow, countHigh, ref overlapped);
             }
             else
             {

--- a/sources/core/Stride.Core.IO/NativeLockFile.cs
+++ b/sources/core/Stride.Core.IO/NativeLockFile.cs
@@ -11,15 +11,15 @@ namespace Stride.Core.IO
     public static class NativeLockFile
     {
         [DllImport("Kernel32.dll", SetLastError = true)]
-        internal static extern bool LockFileEx(Microsoft.Win32.SafeHandles.SafeFileHandle handle, uint flags, uint reserved, uint countLow, uint countHigh, ref System.Threading.NativeOverlapped overlapped);
+        private static extern bool LockFileEx(Microsoft.Win32.SafeHandles.SafeFileHandle handle, uint flags, uint reserved, uint countLow, uint countHigh, ref System.Threading.NativeOverlapped overlapped);
 
         [DllImport("Kernel32.dll", SetLastError = true)]
-        internal static extern bool UnlockFileEx(Microsoft.Win32.SafeHandles.SafeFileHandle handle, uint reserved, uint countLow, uint countHigh, ref System.Threading.NativeOverlapped overlapped);
+        private static extern bool UnlockFileEx(Microsoft.Win32.SafeHandles.SafeFileHandle handle, uint reserved, uint countLow, uint countHigh, ref System.Threading.NativeOverlapped overlapped);
 
         internal const uint LOCKFILE_FAIL_IMMEDIATELY = 0x00000001;
         internal const uint LOCKFILE_EXCLUSIVE_LOCK = 0x00000002;
 
-        public static void LockFile(FileStream fileStream, long offset, long count, bool exclusive)
+        public static bool LockFile(FileStream fileStream, long offset, long count, bool exclusive, bool failImmediately  = false)
         {
             if (Platform.Type == PlatformType.Android)
             {
@@ -36,17 +36,11 @@ namespace Stride.Core.IO
 
                 var overlapped = new NativeOverlapped()
                 {
-                    InternalLow = IntPtr.Zero,
-                    InternalHigh = IntPtr.Zero,
-                    OffsetLow = (int)(offset & 0x00000000FFFFFFFF),
+                    OffsetLow = (int)(offset & uint.MaxValue),
                     OffsetHigh = (int)(offset >> 32),
-                    EventHandle = IntPtr.Zero,
                 };
 
-                if (!LockFileEx(fileStream.SafeFileHandle, exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0, 0, countLow, countHigh, ref overlapped))
-                {
-                    throw new IOException("Couldn't lock file.");
-                }
+                return LockFileEx(fileStream.SafeFileHandle, exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0 | failImmediately ? NativeLockFile.LOCKFILE_FAIL_IMMEDIATELY : 0, 0, countLow, countHigh, ref overlapped);
             }
             else
             {
@@ -57,6 +51,7 @@ namespace Stride.Core.IO
                     try
                     {
                         fileStream.Lock(offset, count);
+                        return true;
                     }
                     catch (IOException)
                     {
@@ -64,6 +59,7 @@ namespace Stride.Core.IO
                     }
                 } while (tryAgain);
             }
+            return false;
         }
 
         public static void UnlockFile(FileStream fileStream, long offset, long count)
@@ -81,11 +77,8 @@ namespace Stride.Core.IO
 
                 var overlapped = new NativeOverlapped()
                 {
-                    InternalLow = IntPtr.Zero,
-                    InternalHigh = IntPtr.Zero,
-                    OffsetLow = (int)(offset & 0x00000000FFFFFFFF),
+                    OffsetLow = (int)(offset & uint.MaxValue),
                     OffsetHigh = (int)(offset >> 32),
-                    EventHandle = IntPtr.Zero,
                 };
 
                 if (!UnlockFileEx(fileStream.SafeFileHandle, 0, countLow, countHigh, ref overlapped))

--- a/sources/core/Stride.Core.IO/NativeLockFile.cs
+++ b/sources/core/Stride.Core.IO/NativeLockFile.cs
@@ -19,7 +19,7 @@ namespace Stride.Core.IO
         internal const uint LOCKFILE_FAIL_IMMEDIATELY = 0x00000001;
         internal const uint LOCKFILE_EXCLUSIVE_LOCK = 0x00000002;
 
-        public static bool LockFile(FileStream fileStream, long offset, long count, bool exclusive, bool failImmediately  = false)
+        public static bool TryLockFile(FileStream fileStream, long offset, long count, bool exclusive, bool failImmediately  = false)
         {
             if (Platform.Type == PlatformType.Android)
             {
@@ -62,7 +62,7 @@ namespace Stride.Core.IO
             return false;
         }
 
-        public static void UnlockFile(FileStream fileStream, long offset, long count)
+        public static void TryUnlockFile(FileStream fileStream, long offset, long count)
         {
             if (Platform.Type == PlatformType.Android)
             {

--- a/sources/core/Stride.Core.Serialization/IO/Store.cs
+++ b/sources/core/Stride.Core.Serialization/IO/Store.cs
@@ -134,7 +134,11 @@ namespace Stride.Core.IO
                 // Acquire lock on end of file (for appending)
                 // This will prevent another thread from writing at the same time, or reading before it is flushed.
                 if (LockEnabled && stream is FileStream)
-                    NativeLockFile.LockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
+                {
+                    bool failed = !NativeLockFile.LockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
+                    if (failed)
+                        throw new IOException("Couldn't lock file.");
+                }
 
                 try
                 {
@@ -180,7 +184,11 @@ namespace Stride.Core.IO
                 // Acquire lock on end of file (for appending)
                 // This will prevent another thread from writing at the same time, or reading before it is flushed.
                 if (LockEnabled && stream is FileStream)
-                    NativeLockFile.LockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
+                {
+                    bool failed = !NativeLockFile.LockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
+                    if (failed)
+                        throw new IOException("Couldn't lock file.");
+                }
 
                 try
                 {
@@ -276,7 +284,11 @@ namespace Stride.Core.IO
                 // Or if the previously described case doesn't happen, maybe no lock at all is required?
                 // Otherwise, last possibility would be deterministic filesize (with size encoded at the beginning of each block).
                 if (LockEnabled && stream is FileStream)
-                    NativeLockFile.LockFile((FileStream)stream, position, long.MaxValue - position, false);
+                {
+                    bool failed = !NativeLockFile.LockFile((FileStream)stream, position, long.MaxValue - position, false);
+                    if (failed)
+                        throw new IOException("Couldn't lock file.");
+                }
 
                 try
                 {

--- a/sources/core/Stride.Core.Serialization/IO/Store.cs
+++ b/sources/core/Stride.Core.Serialization/IO/Store.cs
@@ -135,7 +135,7 @@ namespace Stride.Core.IO
                 // This will prevent another thread from writing at the same time, or reading before it is flushed.
                 if (LockEnabled && stream is FileStream)
                 {
-                    bool failed = !NativeLockFile.LockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
+                    bool failed = !NativeLockFile.TryLockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
                     if (failed)
                         throw new IOException("Couldn't lock file.");
                 }
@@ -167,7 +167,7 @@ namespace Stride.Core.IO
                 finally
                 {
                     if (LockEnabled && stream is FileStream)
-                        NativeLockFile.UnlockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition);
+                        NativeLockFile.TryUnlockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition);
                 }
             }
         }
@@ -185,7 +185,7 @@ namespace Stride.Core.IO
                 // This will prevent another thread from writing at the same time, or reading before it is flushed.
                 if (LockEnabled && stream is FileStream)
                 {
-                    bool failed = !NativeLockFile.LockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
+                    bool failed = !NativeLockFile.TryLockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition, true);
                     if (failed)
                         throw new IOException("Couldn't lock file.");
                 }
@@ -211,7 +211,7 @@ namespace Stride.Core.IO
                 finally
                 {
                     if (LockEnabled && stream is FileStream)
-                        NativeLockFile.UnlockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition);
+                        NativeLockFile.TryUnlockFile((FileStream)stream, indexStreamPosition, long.MaxValue - indexStreamPosition);
                 }
             }
         }
@@ -285,7 +285,7 @@ namespace Stride.Core.IO
                 // Otherwise, last possibility would be deterministic filesize (with size encoded at the beginning of each block).
                 if (LockEnabled && stream is FileStream)
                 {
-                    bool failed = !NativeLockFile.LockFile((FileStream)stream, position, long.MaxValue - position, false);
+                    bool failed = !NativeLockFile.TryLockFile((FileStream)stream, position, long.MaxValue - position, false);
                     if (failed)
                         throw new IOException("Couldn't lock file.");
                 }
@@ -300,7 +300,7 @@ namespace Stride.Core.IO
                 {
                     // Release the lock
                     if (LockEnabled && stream is FileStream)
-                        NativeLockFile.UnlockFile((FileStream)stream, position, long.MaxValue - position);
+                        NativeLockFile.TryUnlockFile((FileStream)stream, position, long.MaxValue - position);
                 }
 
                 return true;


### PR DESCRIPTION
# PR Details

Stride should avoid direct references to any OS if possible. This PR Hides Lock/UnLockEx methods under already made Lock/Unlock methods that wrap them.

## Related Issue

None, but this relates to Stride.Launcher which is using `FileLock.Wait` method, so this provides cross-platform experience

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change - kind of, but only changes return type from void --> bool

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
