### PR TITLE
[Graphics] Fixes memory leak when creating D3D11 texture with shared options

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/Texture.Direct3D.cs
@@ -182,14 +182,14 @@ namespace Stride.Graphics
 #if STRIDE_GRAPHICS_API_DIRECT3D11
             else if ((textureDescription.Options & TextureOptions.SharedNthandle) != 0)
             {
-                var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
+                using var sharedResource1 = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource1>();
                 var uniqueName = "Stride:" + Guid.NewGuid().ToString();
                 SharedHandle = sharedResource1.CreateSharedHandle(uniqueName, SharpDX.DXGI.SharedResourceFlags.Write);
                 SharedNtHandleName = uniqueName;
             }
 #endif
             else if ((textureDescription.Options & TextureOptions.Shared) != 0) {
-                var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
+                using var sharedResource = NativeDeviceChild.QueryInterface<SharpDX.DXGI.Resource>();
                 SharedHandle = sharedResource.SharedHandle;
             }
             else


### PR DESCRIPTION
# PR Details

`QueryInterface` increases the reference count and must be paired with a call to `Release`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
