### PR TITLE
feat: added outline support for TextBlock

### DIFF
--- a/sources/engine/Stride.UI/Controls/TextBlock.cs
+++ b/sources/engine/Stride.UI/Controls/TextBlock.cs
@@ -35,6 +35,8 @@ namespace Stride.UI.Controls
         /// <seealso cref="SpriteFont.Size"/>
         public float ActualTextSize => !float.IsNaN(TextSize) ? TextSize : Font?.Size ?? 0;
 
+       
+
         /// <summary>
         /// Returns the text to display during the draw call.
         /// </summary>
@@ -107,6 +109,22 @@ namespace Stride.UI.Controls
         [DataMember]
         [Display(category: AppearanceCategory)]
         public Color TextColor { get; set; } = Color.FromAbgr(0xF0F0F0FF);
+
+        /// <summary>
+        /// Gets or sets the Text outline color.
+        /// </summary>
+        /// <userdoc>The outline color of the text.</userdoc>
+        [DataMember]
+        [Display(category: AppearanceCategory)]
+        public Color OutlineColor { get; set; } = Color.Black;
+
+        /// <summary>
+        /// Gets or sets the Text outline thickness.
+        /// </summary>
+        /// <userdoc>The outline thickness of the text.</userdoc>
+        [DataMember]
+        [Display(category: AppearanceCategory)]
+        public float OutlineThickness { get; set; } = 0.0f;
 
         /// <summary>
         /// Gets or sets the alignment of the text to display.

--- a/sources/engine/Stride.UI/Controls/TextBlock.cs
+++ b/sources/engine/Stride.UI/Controls/TextBlock.cs
@@ -35,8 +35,6 @@ namespace Stride.UI.Controls
         /// <seealso cref="SpriteFont.Size"/>
         public float ActualTextSize => !float.IsNaN(TextSize) ? TextSize : Font?.Size ?? 0;
 
-       
-
         /// <summary>
         /// Returns the text to display during the draw call.
         /// </summary>

--- a/sources/engine/Stride.UI/Renderers/DefaultTextBlockRenderer.cs
+++ b/sources/engine/Stride.UI/Renderers/DefaultTextBlockRenderer.cs
@@ -54,26 +54,22 @@ namespace Stride.UI.Renderers
                 var borderThickness = textBlock.OutlineThickness;
                 var borderColor = textBlock.RenderOpacity * textBlock.OutlineColor;
 
-                
-                Vector2[] offsets =
-                {
-                    new Vector2(-borderThickness, 0),
-                    new Vector2(borderThickness, 0),
-                    new Vector2(0, -borderThickness),
-                    new Vector2(0, borderThickness),
-                    new Vector2(-borderThickness, -borderThickness),
-                    new Vector2(-borderThickness, borderThickness),
-                    new Vector2(borderThickness, -borderThickness),
-                    new Vector2(borderThickness, borderThickness)
-                };
 
-                foreach (var offset in offsets)
+                for (int x = -1; x <= 1; x++)
                 {
-                    var borderDrawCommand = drawCommand;
-                    borderDrawCommand.Color = borderColor;
-                    borderDrawCommand.Matrix = drawCommand.Matrix * Matrix.Translation(offset.X, offset.Y, 0);
+                    for (int y = -1; y <= 1; y++)
+                    {
+                        if (x == 0 && y == 0) continue;
 
-                    Batch.DrawString(textBlock.Font, textBlock.TextToDisplay, ref borderDrawCommand); ;
+                        var offsetX = x * borderThickness;
+                        var offsetY = y * borderThickness;
+
+                        var borderDrawCommand = drawCommand;
+                        borderDrawCommand.Color = borderColor;
+                        borderDrawCommand.Matrix = drawCommand.Matrix * Matrix.Translation(offsetX, offsetY, 0);
+
+                        Batch.DrawString(textBlock.Font, textBlock.TextToDisplay, ref borderDrawCommand);
+                    }
                 }
             }
 

--- a/sources/engine/Stride.UI/Renderers/DefaultTextBlockRenderer.cs
+++ b/sources/engine/Stride.UI/Renderers/DefaultTextBlockRenderer.cs
@@ -47,9 +47,7 @@ namespace Stride.UI.Renderers
                 Batch.BeginCustom(context.GraphicsContext, 1);                
             }
 
-            
-
-            if (textBlock.OutlineColor != null && textBlock.OutlineThickness > 0)
+            if (textBlock.OutlineColor.A != 0 && textBlock.OutlineThickness > 0)
             {
                 var borderThickness = textBlock.OutlineThickness;
                 var borderColor = textBlock.RenderOpacity * textBlock.OutlineColor;
@@ -71,9 +69,9 @@ namespace Stride.UI.Renderers
                         Batch.DrawString(textBlock.Font, textBlock.TextToDisplay, ref borderDrawCommand);
                     }
                 }
-            }
 
-            drawCommand.DepthBias += 1;
+                drawCommand.DepthBias += 1;
+            }
 
             Batch.DrawString(textBlock.Font, textBlock.TextToDisplay, ref drawCommand);
 

--- a/sources/engine/Stride.UI/Renderers/DefaultTextBlockRenderer.cs
+++ b/sources/engine/Stride.UI/Renderers/DefaultTextBlockRenderer.cs
@@ -47,6 +47,38 @@ namespace Stride.UI.Renderers
                 Batch.BeginCustom(context.GraphicsContext, 1);                
             }
 
+            
+
+            if (textBlock.OutlineColor != null && textBlock.OutlineThickness > 0)
+            {
+                var borderThickness = textBlock.OutlineThickness;
+                var borderColor = textBlock.RenderOpacity * textBlock.OutlineColor;
+
+                
+                Vector2[] offsets =
+                {
+                    new Vector2(-borderThickness, 0),
+                    new Vector2(borderThickness, 0),
+                    new Vector2(0, -borderThickness),
+                    new Vector2(0, borderThickness),
+                    new Vector2(-borderThickness, -borderThickness),
+                    new Vector2(-borderThickness, borderThickness),
+                    new Vector2(borderThickness, -borderThickness),
+                    new Vector2(borderThickness, borderThickness)
+                };
+
+                foreach (var offset in offsets)
+                {
+                    var borderDrawCommand = drawCommand;
+                    borderDrawCommand.Color = borderColor;
+                    borderDrawCommand.Matrix = drawCommand.Matrix * Matrix.Translation(offset.X, offset.Y, 0);
+
+                    Batch.DrawString(textBlock.Font, textBlock.TextToDisplay, ref borderDrawCommand); ;
+                }
+            }
+
+            drawCommand.DepthBias += 1;
+
             Batch.DrawString(textBlock.Font, textBlock.TextToDisplay, ref drawCommand);
 
             if (textBlock.Font.FontType == SpriteFontType.SDF)


### PR DESCRIPTION
# PR Details

## Summary
Added support for text outlines in `TextBlock` with two new properties:
- `OutlineColor`: (Color) Specifies the color of the outline.
- `OutlineThickness`: (float) Determines the thickness of the outline.

When `OutlineThickness` is set to `0` or `OutlineColor` is `null`, the text will render normally without any outline.

## Related Issue
Fixes #2581

## Changes
- Introduced `OutlineColor` and `OutlineThickness` properties in the `TextBlock` class.
- Updated text rendering logic to apply an outline when these properties are configured.
- added them in the appearance section in TextBlock settings section in the editor

## Types of Changes
- [ ] Docs update/refactoring/dependency upgrade
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (modifies existing functionality)

## Checklist
- [ ] Documentation changes required.
- [ ] Documentation updated.
- [x] Verified all existing tests pass.
- [x] Built and tested in the editor.

## Additional Notes
- This change does not break existing functionality.
- Supports both default and custom font rendering workflows.

![st2](https://github.com/user-attachments/assets/6c6220aa-19bf-4edf-9d23-33f23db5c506)
![st1](https://github.com/user-attachments/assets/677bc8f8-20d5-48f3-b4df-86c468aee5e9)


![trout](https://github.com/user-attachments/assets/9b671c88-6e65-4677-a80c-83b7aff1cdc1)

