### PR TITLE
feat: Added support for per frame logical groups in RootEffectRenderFeature

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
@@ -53,6 +53,7 @@ namespace Stride.Rendering
         private readonly List<NamedSlotDefinition> viewCBufferOffsetSlots = new List<NamedSlotDefinition>();
         private readonly List<NamedSlotDefinition> drawCBufferOffsetSlots = new List<NamedSlotDefinition>();
 
+        private readonly List<NamedSlotDefinition> frameLogicalGroups = new List<NamedSlotDefinition>();
         private readonly List<NamedSlotDefinition> viewLogicalGroups = new List<NamedSlotDefinition>();
         private readonly List<NamedSlotDefinition> drawLogicalGroups = new List<NamedSlotDefinition>();
 
@@ -213,6 +214,33 @@ namespace Stride.Rendering
         public void RemoveViewCBufferOffsetSlot(ConstantBufferOffsetReference cbufferOffsetSlot)
         {
             viewCBufferOffsetSlots[cbufferOffsetSlot.Index] = new NamedSlotDefinition(null);
+        }
+
+        public LogicalGroupReference CreateFrameLogicalGroup(string logicalGroup)
+        {
+            // Check existing slots
+            for (int i = 0; i < frameLogicalGroups.Count; i++)
+            {
+                if (frameLogicalGroups[i].Variable.Equals(logicalGroup))
+                    return new LogicalGroupReference(i);
+            }
+
+            // Need a new slot
+            var slotReference = new LogicalGroupReference(frameLogicalGroups.Count);
+            frameLogicalGroups.Add(new NamedSlotDefinition(logicalGroup));
+
+            foreach (var frameResourceLayoutEntry in frameResourceLayouts)
+            {
+                var resourceGroupLayout = frameResourceLayoutEntry.Value;
+
+                // Ensure there is enough space
+                if (resourceGroupLayout.LogicalGroups == null || resourceGroupLayout.LogicalGroups.Length < frameLogicalGroups.Count)
+                    Array.Resize(ref resourceGroupLayout.LogicalGroups, frameLogicalGroups.Count);
+
+                ResolveLogicalGroup(resourceGroupLayout, slotReference.Index, logicalGroup);
+            }
+
+            return slotReference;
         }
 
         public LogicalGroupReference CreateViewLogicalGroup(string logicalGroup)
@@ -746,7 +774,7 @@ namespace Stride.Rendering
                     {
                         threadContext.ResourceGroupAllocator.PrepareResourceGroup(frameLayout, BufferPoolAllocationType.UsedMultipleTime, frameLayout.Entry.Resources);
 
-                        // Register it in list of view layouts to update for this frame
+                        // Register it in list of frame layouts to update for this frame
                         FrameLayouts.Add(frameLayout);
                     }
 
@@ -928,6 +956,13 @@ namespace Stride.Rendering
                 }
 
                 frameResourceLayouts.Add(hash, result);
+
+                // Resolve logical groups
+                result.LogicalGroups = new LogicalGroup[frameLogicalGroups.Count];
+                for (int index = 0; index < frameLogicalGroups.Count; index++)
+                {
+                    ResolveLogicalGroup(result, index, frameLogicalGroups[index].Variable);
+                }
             }
 
             return result;


### PR DESCRIPTION
# PR Details

Adds support for logical groups to the per frame resource groups, this allows for easy binding of per frame global resources. It's the same implementation as the per view / draw resource groups.

Sample usage:

```csharp
// Setup globally available resource group in sdsl
// It then only have to be bound once no matter how which materials use it.
rgroup PerFrame.Test
{
  stage Texture2D GlobalTexture;
}

// Locate all per frame resource layouts that have the logical grou present.
// This is preferably done in SubRenderFeature.Prepare
var logicalGroupKey = ((RootEffectRenderFeature)RootRenderFeature).CreateFrameLogicalGroup("Test");
foreach (var frameLayout in ((RootEffectRenderFeature)RootRenderFeature).FrameLayouts)
{
  var resourceGroup = frameLayout.Entry.Resources;
  var logicalGroup = frameLayout.GetLogicalGroup(logicalGroupKey);
  if (logicalGroup.Hash == ObjectId.Empty) continue;
  
  resourceGroup.DescriptorSet.SetShaderResourceView(logicalGroup.DescriptorEntryStart + 0, GlobalTexture);
}
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
