### PR TITLE
fix: TextBlock enters an infinite loop if the given available space is too small to fit even one character.

### DIFF
--- a/sources/engine/Stride.UI/Controls/TextBlock.cs
+++ b/sources/engine/Stride.UI/Controls/TextBlock.cs
@@ -330,7 +330,7 @@ namespace Stride.UI.Controls
                 }
 
                 // we reached the end of the line.
-                if (currentLine.Length <= 1 || CalculateTextSize(currentLine).X <= 0) // just one or all empty characters... just go one by one.
+                if (currentLine.Length <= 1 || lineCurrentSize <= 0) // just one or all empty characters... just go one by one.
                 {
                     currentLine.Clear();
                     currentLine.Append(currentCharacter);

--- a/sources/engine/Stride.UI/Controls/TextBlock.cs
+++ b/sources/engine/Stride.UI/Controls/TextBlock.cs
@@ -296,6 +296,7 @@ namespace Stride.UI.Controls
                 float lineCurrentSize;
                 var indexNextCharacter = 0;
                 var indexOfLastSpace = -1;
+                char currentCharacter = text[0];
 
                 while (true)
                 {
@@ -304,7 +305,7 @@ namespace Stride.UI.Controls
                     if (lineCurrentSize > availableWidth || indexOfNewLine + indexNextCharacter >= text.Length)
                         break;
 
-                    var currentCharacter = text[indexOfNewLine + indexNextCharacter];
+                    currentCharacter = text[indexOfNewLine + indexNextCharacter];
 
                     if (currentCharacter == '\n')
                     {
@@ -329,7 +330,13 @@ namespace Stride.UI.Controls
                 }
 
                 // we reached the end of the line.
-                if (indexOfLastSpace < 0) // no space in the line
+                if (currentLine.Length <= 1 || CalculateTextSize(currentLine).X <= 0) // just one or all empty characters... just go one by one.
+                {
+                    currentLine.Clear();
+                    currentLine.Append(currentCharacter);
+                    indexOfNewLine += indexNextCharacter;
+                }
+                else if (indexOfLastSpace < 0) // no space in the line
                 {
                     // remove last extra character
                     currentLine.Remove(currentLine.Length - 1, 1);


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

If TextBlock is given an available space that the width is so small to fit in even one character, TextBlock will enter an infinite loop of repeatedly adding and removing the first character, and creating a new line in the wrapped text. This unexpected infinite loop will crash the editor due to a memory leak.

With this PR, the wrapped text will have at least one character (even if the character is zero width) from the original text in each new line.

![Not wrapped](https://github.com/user-attachments/assets/72d64382-245f-416d-884b-7b1c869f9f80)

(Wrap Text option disabled, horizontal overflow)

![Wrapped](https://github.com/user-attachments/assets/3ec6b83d-c24c-46e5-bc8a-7c93ad9c2f11)

(Wrap Text option enabled with the fix, horizontal wrapped with vertical overflow. Without this fix the engine will crash eventually given enough time)

## Related Issue

Fixes #2514

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
