### PR TITLE
fix: bepu, removal of collidables while running a contact event leaves contact tracking in an unexpected state

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Tests/Stride.BepuPhysics.Tests.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Tests/Stride.BepuPhysics.Tests.csproj
@@ -10,6 +10,7 @@
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <!-- Force msbuild to check to rebuild this assembly instead of letting VS IDE guess -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>xunit.runner.stride.Program</StartupObject>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
@@ -292,7 +292,7 @@ public sealed class BepuSimulation : IDisposable
         #warning Consider wrapping stride's threadpool/dispatcher into an IThreadDispatcher and passing that over to bepu instead of using their dispatcher
         _threadDispatcher = new ThreadDispatcher(targetThreadCount);
         BufferPool = new BufferPool();
-        ContactEvents = new ContactEventsManager(_threadDispatcher, BufferPool);
+        ContactEvents = new ContactEventsManager(BufferPool, this);
 
         var strideNarrowPhaseCallbacks = new StrideNarrowPhaseCallbacks(this, ContactEvents, CollidableMaterials);
         var stridePoseIntegratorCallbacks = new StridePoseIntegratorCallbacks(CollidableMaterials);
@@ -303,7 +303,7 @@ public sealed class BepuSimulation : IDisposable
         Simulation.Solver.SubstepCount = 1;
 
         CollidableMaterials.Initialize(Simulation);
-        ContactEvents.Initialize(this);
+        ContactEvents.Initialize();
         //CollisionBatcher = new CollisionBatcher<BatcherCallbacks>(BufferPool, Simulation.Shapes, Simulation.NarrowPhase.CollisionTaskRegistry, 0, DefaultBatcherCallbacks);
     }
 

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -303,6 +303,16 @@ public class BodyComponent : CollidableComponent
     /// </summary>
     public IReadOnlyList<ConstraintComponentBase> Constraints => BoundConstraints ?? (IReadOnlyList<ConstraintComponentBase>)Array.Empty<ConstraintComponentBase>();
 
+    protected internal override CollidableReference? CollidableReference
+    {
+        get
+        {
+            if (BodyReference is { } bRef)
+                return bRef.CollidableReference;
+            return null;
+        }
+    }
+
     /// <summary>
     /// Applies an explosive force at a specific offset off of this body which will affect both its angular and linear velocity
     /// </summary>
@@ -416,25 +426,6 @@ public class BodyComponent : CollidableComponent
             return bRef.Handle.Value;
 
         throw new InvalidOperationException();
-    }
-
-    protected override void RegisterContactHandler()
-    {
-        if (ContactEventHandler is not null && Simulation is not null && BodyReference is { } bRef)
-            Simulation.ContactEvents.Register(bRef.Handle);
-    }
-
-    protected override void UnregisterContactHandler()
-    {
-        if (Simulation is not null && BodyReference is { } bRef)
-            Simulation.ContactEvents.Unregister(bRef.Handle);
-    }
-
-    protected override bool IsContactHandlerRegistered()
-    {
-        if (Simulation is not null && BodyReference is { } bRef)
-            return Simulation.ContactEvents.IsRegistered(bRef.Handle);
-        return false;
     }
 
     /// <summary>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -94,7 +94,7 @@ public class BodyComponent : CollidableComponent
     }
 
     /// <summary>
-    /// Whether the object's path or only its destination is checked for collision when moving, prevents objects from passing through each other at higher speed 
+    /// Whether the object's path or only its destination is checked for collision when moving, prevents objects from passing through each other at higher speed
     /// </summary>
     /// <remarks>
     /// This property is a shortcut to the <see cref="ContinuousDetection"/>.<see cref="ContinuousDetection.Mode"/> property
@@ -139,7 +139,7 @@ public class BodyComponent : CollidableComponent
             }
         }
     }
-    
+
     /// <summary>
     /// The number of time steps that the body must be under the sleep threshold before the body becomes a sleeping candidate.
     /// Note that the body is not guaranteed to go to sleep immediately after meeting this minimum.
@@ -164,7 +164,7 @@ public class BodyComponent : CollidableComponent
     }
 
     /// <summary>
-    /// Whether the body is being actively simulated. 
+    /// Whether the body is being actively simulated.
     /// Setting this to true will attempt to wake the body; setting it to false will force the body and any constraint-connected bodies asleep.
     /// </summary>
     [DataMemberIgnore]
@@ -196,8 +196,8 @@ public class BodyComponent : CollidableComponent
     /// The rotation velocity in unit per second
     /// </summary>
     /// <remarks>
-    /// The rotation format is in axis-angle, 
-    /// meaning that AngularVelocity.Normalized is the axis of rotation, 
+    /// The rotation format is in axis-angle,
+    /// meaning that AngularVelocity.Normalized is the axis of rotation,
     /// while AngularVelocity.Length is the amount of rotation around that axis in radians per second
     /// </remarks>
     [DataMemberIgnore]
@@ -421,7 +421,7 @@ public class BodyComponent : CollidableComponent
     protected override void RegisterContactHandler()
     {
         if (ContactEventHandler is not null && Simulation is not null && BodyReference is { } bRef)
-            Simulation.ContactEvents.Register(bRef.Handle, ContactEventHandler);
+            Simulation.ContactEvents.Register(bRef.Handle);
     }
 
     protected override void UnregisterContactHandler()
@@ -433,7 +433,7 @@ public class BodyComponent : CollidableComponent
     protected override bool IsContactHandlerRegistered()
     {
         if (Simulation is not null && BodyReference is { } bRef)
-            return Simulation.ContactEvents.IsListener(bRef.Handle);
+            return Simulation.ContactEvents.IsRegistered(bRef.Handle);
         return false;
     }
 

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -22,6 +22,7 @@ namespace Stride.BepuPhysics;
 [DefaultEntityComponentProcessor(typeof(CollidableProcessor), ExecutionMode = ExecutionMode.Runtime)]
 public abstract class CollidableComponent : EntityComponent
 {
+    private static uint IdCounter;
     private static uint VersioningCounter;
 
     private float _springFrequency = 30;
@@ -46,6 +47,8 @@ public abstract class CollidableComponent : EntityComponent
 
     [DataMemberIgnore]
     internal uint Versioning { get; private set; }
+
+    internal uint StableId { get; } = Interlocked.Increment(ref IdCounter);
 
     /// <summary>
     /// The simulation this object belongs to, null when it is not part of a simulation.
@@ -84,9 +87,9 @@ public abstract class CollidableComponent : EntityComponent
     /// The bounce frequency in hz
     /// </summary>
     /// <remarks>
-    /// Must be low enough that the simulation can actually represent it. 
-    /// If the contact is trying to make a bounce happen at 240hz, 
-    /// but the integrator timestep is only 60hz, 
+    /// Must be low enough that the simulation can actually represent it.
+    /// If the contact is trying to make a bounce happen at 240hz,
+    /// but the integrator timestep is only 60hz,
     /// the unrepresentable motion will get damped out and the body won't bounce as much.
     /// </remarks>
     public float SpringFrequency
@@ -291,7 +294,7 @@ public abstract class CollidableComponent : EntityComponent
         if (reAttaching == false)
         {
             Simulation.TemporaryDetachedLookup = (getHandleValue, this);
-            Simulation.ContactEvents.Flush(); // Ensure that removing this collidable sends the appropriate contact events to listeners
+            Simulation.ContactEvents.ClearCollisionsOf(this); // Ensure that removing this collidable sends the appropriate contact events to listeners
             Simulation.TemporaryDetachedLookup = (-1, null);
         }
 

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -48,7 +48,7 @@ public abstract class CollidableComponent : EntityComponent
     [DataMemberIgnore]
     internal uint Versioning { get; private set; }
 
-    internal uint StableId { get; } = Interlocked.Increment(ref IdCounter);
+    internal uint InstanceIndex { get; } = Interlocked.Increment(ref IdCounter);
 
     /// <summary>
     /// The simulation this object belongs to, null when it is not part of a simulation.
@@ -219,6 +219,8 @@ public abstract class CollidableComponent : EntityComponent
     [DataMemberIgnore]
     public Vector3 CenterOfMass { get; private set; }
 
+    protected internal abstract CollidableReference? CollidableReference { get; }
+
     public CollidableComponent()
     {
         _collider = new CompoundCollider();
@@ -341,7 +343,21 @@ public abstract class CollidableComponent : EntityComponent
 
     protected abstract int GetHandleValue();
 
-    protected abstract void RegisterContactHandler();
-    protected abstract void UnregisterContactHandler();
-    protected abstract bool IsContactHandlerRegistered();
+
+    protected void RegisterContactHandler()
+    {
+        if (ContactEventHandler is not null && Simulation is not null)
+            Simulation.ContactEvents.Register(this);
+    }
+
+    protected void UnregisterContactHandler()
+    {
+        if (Simulation is not null)
+            Simulation.ContactEvents.Unregister(this);
+    }
+
+    protected bool IsContactHandlerRegistered()
+    {
+        return Simulation is not null && Simulation.ContactEvents.IsRegistered(this);
+    }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Contacts/ContactEventsManager.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Contacts/ContactEventsManager.cs
@@ -18,160 +18,60 @@ namespace Stride.BepuPhysics.Definitions.Contacts;
 /// </summary>
 internal class ContactEventsManager : IDisposable
 {
-    //To know what events to emit, we have to track the previous state of a collision. We don't need to keep around old positions/offets/normals/depths, so it's quite a bit lighter.
-    [StructLayout(LayoutKind.Sequential)]
-    struct PreviousCollision
+    private readonly Dictionary<OrderedPair, LastCollisionState> _trackedCollisions = new();
+    private readonly BufferPool _pool;
+    private readonly BepuSimulation _simulation;
+    private IndexSet _staticListenerFlags;
+    private IndexSet _bodyListenerFlags;
+    private int _flushes;
+
+    public ContactEventsManager(BufferPool pool, BepuSimulation simulation)
     {
-        public CollidableReference Collidable;
-        public bool Fresh;
-        public bool WasTouching;
-        public int ContactCount;
-        //FeatureIds are identifiers encoding what features on the involved shapes contributed to the contact. We store up to 4 feature ids, one for each potential contact.
-        //A "feature" is things like a face, vertex, or edge. There is no single interpretation for what a feature is- the mapping is defined on a per collision pair level.
-        //In this demo, we only care to check whether a given contact in the current frame maps onto a contact from a previous frame.
-        //We can use this to only emit 'contact added' events when a new contact with an unrecognized id is reported.
-        public int FeatureId0;
-        public int FeatureId1;
-        public int FeatureId2;
-        public int FeatureId3;
+        _pool = pool;
+        _simulation = simulation;
     }
 
-    BepuSimulation bepuSimulation;
-    Simulation simulation;
-    IThreadDispatcher? threadDispatcher;
-    BufferPool? pool;
-
-    //We'll use a handle->index mapping in a CollidableProperty to point at our contiguously stored listeners (in the later listeners array).
-    //Note that there's also IndexSets for the statics and bodies; those will be checked first before accessing the listenerIndices.
-    //The CollidableProperty is quite barebones- it doesn't try to stop all invalid accesses, and the backing memory isn't guaranteed to be zero initialized.
-    //IndexSets are tightly bitpacked and are cheap to access, so they're an easy way to check if a collidable can trigger an event before doing any further processing.
-    CollidableProperty<int> listenerIndices;
-    IndexSet staticListenerFlags;
-    IndexSet bodyListenerFlags;
-    int listenerCount;
-
-    //For the purpose of this demo, we'll use some regular ol' interfaces rather than using the struct-implementing-interface for specialization.
-    //This array will be GC tracked as a result, but that should be mostly fine. If you've got hundreds of thousands of event handlers, you may want to consider alternatives.
-    struct Listener
+    public void Initialize()
     {
-        public CollidableReference Source;
-        public IContactEventHandler Handler;
-        public QuickList<PreviousCollision> PreviousCollisions;
-    }
-    Listener[] listeners;
-
-    //The callbacks are invoked from a multithreaded context, and we don't know how many pairs will exist.
-    //Rather than attempting to synchronize all accesses, every worker thread spits out the results into a worker-local list to be processed later by the main thread flush.
-    struct PendingWorkerAdd
-    {
-        public int ListenerIndex;
-        public PreviousCollision Collision;
-    }
-    QuickList<PendingWorkerAdd>[] pendingWorkerAdds;
-
-    /// <summary>
-    /// Creates a new contact events stream.
-    /// </summary>
-    /// <param name="threadDispatcher">Thread dispatcher to pull per-thread buffer pools from, if any.</param>
-    /// <param name="pool">Buffer pool used to manage resources internally. If null, the simulation's pool will be used.</param>
-    /// <param name="initialListenerCapacity">Number of listeners to allocate space for initially.</param>
-#pragma warning disable CS8618 // Unassigned null fields, will be initialized through Initialize() below
-    public ContactEventsManager(IThreadDispatcher? threadDispatcher = null, BufferPool? pool = null, int initialListenerCapacity = 64)
-#pragma warning restore CS8618
-    {
-        this.threadDispatcher = threadDispatcher;
-        this.pool = pool;
-        listeners = new Listener[initialListenerCapacity];
+        //simulation.Simulation.Timestepper.BeforeCollisionDetection += SetFreshnessForCurrentActivityStatus;
     }
 
-    BufferPool? GetPoolForWorker(int workerIndex)
+    public void Dispose()
     {
-        return threadDispatcher == null ? pool : threadDispatcher.WorkerPools[workerIndex];
-    }
-
-    /// <summary>
-    /// Initializes the contact events system with a simulation.
-    /// </summary>
-    /// <param name="simulation">Simulation to use with the contact events demo.</param>
-    /// <remarks>The constructor and initialization are split because of how this class is expected to be used.
-    /// It will be passed into a simulation's constructor as a part of its contact callbacks, so there is no simulation available at the time of construction.</remarks>
-    public void Initialize(BepuSimulation simulation)
-    {
-        this.bepuSimulation = simulation;
-        this.simulation = simulation.Simulation;
-        pool ??= simulation.BufferPool;
-        this.simulation.Timestepper.BeforeCollisionDetection += SetFreshnessForCurrentActivityStatus;
-        listenerIndices = new CollidableProperty<int>(this.simulation, pool);
-        pendingWorkerAdds = new QuickList<PendingWorkerAdd>[threadDispatcher == null ? 1 : threadDispatcher.ThreadCount];
-    }
-
-    /// <summary>
-    /// Begins listening for events related to the given collidable.
-    /// </summary>
-    /// <param name="collidable">Collidable to monitor for events.</param>
-    /// <param name="handler">Handlers to use for the collidable.</param>
-    public void Register(CollidableReference collidable, IContactEventHandler handler)
-    {
-        if (collidable.Mobility == CollidableMobility.Static)
-            staticListenerFlags.Add(collidable.RawHandleValue, pool);
-        else
-            bodyListenerFlags.Add(collidable.RawHandleValue, pool);
-        if (listenerCount >= listeners.Length)
-        {
-            Array.Resize(ref listeners, listeners.Length * 2);
-        }
-        //Note that allocations for the previous collision list are deferred until they actually exist.
-        listeners[listenerCount] = new Listener { Handler = handler, Source = collidable };
-        listenerIndices[collidable] = listenerCount;
-        ++listenerCount;
+        //_simulation.Simulation.Timestepper.BeforeCollisionDetection -= SetFreshnessForCurrentActivityStatus;
+        if (_bodyListenerFlags.Flags.Allocated)
+            _bodyListenerFlags.Dispose(_pool);
+        if (_staticListenerFlags.Flags.Allocated)
+            _staticListenerFlags.Dispose(_pool);
     }
 
     /// <summary>
     /// Begins listening for events related to the given body.
     /// </summary>
     /// <param name="body">Body to monitor for events.</param>
-    /// <param name="handler">Handlers to use for the body.</param>
-    public void Register(BodyHandle body, IContactEventHandler handler)
+    public void Register(BodyHandle body)
     {
-        Register(simulation.Bodies[body].CollidableReference, handler);
+        Register(_simulation.Simulation.Bodies[body].CollidableReference);
     }
 
     /// <summary>
     /// Begins listening for events related to the given static.
     /// </summary>
     /// <param name="staticHandle">Static to monitor for events.</param>
-    /// <param name="handler">Handlers to use for the static.</param>
-    public void Register(StaticHandle staticHandle, IContactEventHandler handler)
+    public void Register(StaticHandle staticHandle)
     {
-        Register(new CollidableReference(staticHandle), handler);
+        Register(new CollidableReference(staticHandle));
     }
 
     /// <summary>
-    /// Stops listening for events related to the given collidable.
+    /// Begins listening for events related to the given collidable.
     /// </summary>
-    /// <param name="collidable">Collidable to stop listening for.</param>
-    public void Unregister(CollidableReference collidable)
+    public void Register(CollidableReference collidable)
     {
         if (collidable.Mobility == CollidableMobility.Static)
-        {
-            staticListenerFlags.Remove(collidable.RawHandleValue);
-        }
+            _staticListenerFlags.Add(collidable.RawHandleValue, _pool);
         else
-        {
-            bodyListenerFlags.Remove(collidable.RawHandleValue);
-        }
-        var index = listenerIndices[collidable];
-        --listenerCount;
-        ref var removedSlot = ref listeners[index];
-        if (removedSlot.PreviousCollisions.Span.Allocated)
-            removedSlot.PreviousCollisions.Dispose(pool);
-        ref var lastSlot = ref listeners[listenerCount];
-        if (index < listenerCount)
-        {
-            listenerIndices[lastSlot.Source] = index;
-            removedSlot = lastSlot;
-        }
-        lastSlot = default;
+            _bodyListenerFlags.Add(collidable.RawHandleValue, _pool);
     }
 
     /// <summary>
@@ -180,7 +80,7 @@ internal class ContactEventsManager : IDisposable
     /// <param name="body">Body to stop listening for.</param>
     public void Unregister(BodyHandle body)
     {
-        Unregister(simulation.Bodies[body].CollidableReference);
+        Unregister(_simulation.Simulation.Bodies[body].CollidableReference);
     }
 
     /// <summary>
@@ -193,40 +93,301 @@ internal class ContactEventsManager : IDisposable
     }
 
     /// <summary>
-    /// Checks if a collidable is registered as a listener.
+    /// Stops listening for events related to the given collidable.
     /// </summary>
-    /// <param name="collidable">Collidable to check.</param>
-    /// <returns>True if the collidable has been registered as a listener, false otherwise.</returns>
-    public bool IsListener(CollidableReference collidable)
+    public void Unregister(CollidableReference collidable)
     {
         if (collidable.Mobility == CollidableMobility.Static)
-        {
-            return staticListenerFlags.Contains(collidable.RawHandleValue);
-        }
+            _staticListenerFlags.Remove(collidable.RawHandleValue);
         else
-        {
-            return bodyListenerFlags.Contains(collidable.RawHandleValue);
-        }
+            _bodyListenerFlags.Remove(collidable.RawHandleValue);
+
+        ClearCollisionsOf(_simulation.GetComponent(collidable));
     }
 
     /// <summary>
     /// Checks if a collidable is registered as a listener.
     /// </summary>
-    public bool IsListener(BodyHandle body)
+    public bool IsRegistered(BodyHandle body)
     {
-        return IsListener(simulation.Bodies[body].CollidableReference);
+        return IsRegistered(_simulation.Simulation.Bodies[body].CollidableReference);
     }
     /// <summary>
     /// Checks if a collidable is registered as a listener.
     /// </summary>
-    public bool IsListener(StaticHandle staticHandle)
+    public bool IsRegistered(StaticHandle staticHandle)
     {
-        return IsListener(simulation.Statics[staticHandle].CollidableReference);
+        return IsRegistered(_simulation.Simulation.Statics[staticHandle].CollidableReference);
     }
+
+    /// <summary>
+    /// Checks if a collidable is registered as a listener.
+    /// </summary>
+    public bool IsRegistered(CollidableReference collidable)
+    {
+        if (collidable.Mobility == CollidableMobility.Static)
+            return _staticListenerFlags.Contains(collidable.RawHandleValue);
+        else
+            return _bodyListenerFlags.Contains(collidable.RawHandleValue);
+    }
+
+    public unsafe void ClearCollisionsOf(CollidableComponent collidable)
+    {
+#error Handle handler exceptions
+        // Really slow, but improving performance has a huge amount of gotchas since user code
+        // may cause this method to be re-entrant through handler calls.
+        // Something to investigate later
+
+        int workerIndex = 0;
+        var manifold = new EmptyManifold();
+        bool flippedManifold = false; // The flipped manifold argument does not make sense in this context given that we pass an empty one
+
+        foreach (var (pair, state) in _trackedCollisions)
+        {
+            if (!ReferenceEquals(pair.A, collidable) && !ReferenceEquals(pair.B, collidable))
+                continue;
+
+#if DEBUG
+            ref var stateRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_trackedCollisions, pair, out _);
+            _trackedCollisions.Remove(pair);
+            System.Diagnostics.Debug.Assert(stateRef.Alive == false); // Notify HandleManifoldInner higher up the call stack that the manifold they are processing is dead
+#else
+            _trackedCollisions.Remove(pair);
+#endif
+
+            for (int i = 0; i < state.ContactCount; i++)
+            {
+                state.HandlerA?.OnContactRemoved(pair.A, pair.B, ref manifold, flippedManifold, state.FeatureId[i], workerIndex, _simulation);
+                state.HandlerB?.OnContactRemoved(pair.B, pair.A, ref manifold, flippedManifold, state.FeatureId[i], workerIndex, _simulation);
+            }
+
+            if (state.Touching)
+            {
+                state.HandlerA?.OnStoppedTouching(pair.A, pair.B, ref manifold, flippedManifold, workerIndex, _simulation);
+                state.HandlerB?.OnStoppedTouching(pair.B, pair.A, ref manifold, flippedManifold, workerIndex, _simulation);
+            }
+
+            state.HandlerA?.OnPairEnded(pair.A, pair.B, _simulation);
+            state.HandlerB?.OnPairEnded(pair.B, pair.A, _simulation);
+        }
+    }
+
+    public void HandleManifold<TManifold>(int workerIndex, CollidablePair pair, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
+    {
+        bool aListener = IsRegistered(pair.A);
+        bool bListener = IsRegistered(pair.B);
+        if (aListener == false && bListener == false)
+            return;
+
+        HandleManifoldInner(workerIndex, _simulation.GetComponent(pair.A), _simulation.GetComponent(pair.A), ref manifold);
+    }
+
+    private unsafe void HandleManifoldInner<TManifold>(int workerIndex, CollidableComponent a, CollidableComponent b, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
+    {
+#error Handle handler exceptions
+        ref var collisionState = ref CollectionsMarshal.GetValueRefOrAddDefault(_trackedCollisions, new OrderedPair(a, b), out bool alreadyExisted);
+
+        var handlerA = a.ContactEventHandler;
+        var handlerB = b.ContactEventHandler;
+
+        if (alreadyExisted)
+        {
+            bool previouslyTouching = collisionState.Touching;
+            for (int contactIndex = 0; contactIndex < manifold.Count; ++contactIndex)
+            {
+                if (manifold.GetDepth(contactIndex) < 0)
+                    continue;
+
+                if (collisionState.Touching == false)
+                {
+                    collisionState.Touching = true;
+                    handlerA?.OnStartedTouching(a, b, ref manifold, false, workerIndex, _simulation);
+                    if (collisionState.Alive == false)
+                        return;
+                    handlerB?.OnStartedTouching(b, a, ref manifold, true, workerIndex, _simulation);
+                    if (collisionState.Alive == false)
+                        return;
+                }
+
+                handlerA?.OnTouching(a, b, ref manifold, false, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+                handlerB?.OnTouching(b, a, ref manifold, true, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+                break;
+            }
+
+            int previousContactsStillExist = 0; // Bitmask to mark contacts that are both inside the previous and current manifold
+            for (int contactIndex = 0; contactIndex < manifold.Count; ++contactIndex)
+            {
+                //We can check if each contact was already present in the previous frame by looking at contact feature ids. See the 'PreviousCollision' type for a little more info on FeatureIds.
+                var featureId = manifold.GetFeatureId(contactIndex);
+                var featureIdWasInPreviousCollision = false;
+                for (int previousContactIndex = 0; previousContactIndex < collisionState.ContactCount; ++previousContactIndex)
+                {
+                    if (featureId == collisionState.FeatureId[previousContactIndex])
+                    {
+                        featureIdWasInPreviousCollision = true;
+                        previousContactsStillExist |= 1 << previousContactIndex;
+                        break;
+                    }
+                }
+
+                if (!featureIdWasInPreviousCollision)
+                {
+                    handlerA?.OnContactAdded(a, b, ref manifold, false, contactIndex, workerIndex, _simulation);
+                    if (collisionState.Alive == false)
+                        return;
+                    handlerB?.OnContactAdded(b, a, ref manifold, true, contactIndex, workerIndex, _simulation);
+                    if (collisionState.Alive == false)
+                        return;
+                }
+            }
+
+            if (previousContactsStillExist != (1 << collisionState.ContactCount) - 1) //At least one contact that used to exist no longer does.
+            {
+                for (int previousContactIndex = 0; previousContactIndex < collisionState.ContactCount; ++previousContactIndex)
+                {
+                    if ((previousContactsStillExist & (1 << previousContactIndex)) != 0)
+                        continue;
+
+                    int id = collisionState.FeatureId[previousContactIndex];
+                    handlerA?.OnContactRemoved(a, b, ref manifold, false, id, workerIndex, _simulation);
+                    if (collisionState.Alive == false)
+                        return;
+                    handlerB?.OnContactRemoved(b, a, ref manifold, true, id, workerIndex, _simulation);
+                    if (collisionState.Alive == false)
+                        return;
+                }
+            }
+
+            if (previouslyTouching && collisionState.Touching == false)
+            {
+                handlerA?.OnStoppedTouching(a, b, ref manifold, false, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+
+                handlerB?.OnStoppedTouching(b, a, ref manifold, true, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+            }
+        }
+        else
+        {
+            collisionState.Alive = true; // This is set as a flag to check for removal events
+            collisionState.HandlerA = handlerA;
+            collisionState.HandlerB = handlerB;
+
+
+            handlerA?.OnPairCreated(a, b, ref manifold, false, workerIndex, _simulation);
+            if (collisionState.Alive == false)
+                return;
+            handlerB?.OnPairCreated(b, a, ref manifold, true, workerIndex, _simulation);
+            if (collisionState.Alive == false)
+                return;
+
+            for (int i = 0; i < manifold.Count; ++i)
+            {
+                if (manifold.GetDepth(i) < 0)
+                    continue;
+
+                collisionState.Touching = true;
+
+                handlerA?.OnStartedTouching(a, b, ref manifold, false, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+                handlerB?.OnStartedTouching(b, a, ref manifold, true, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+
+                handlerA?.OnTouching(a, b, ref manifold, false, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+                handlerB?.OnTouching(b, a, ref manifold, true, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+                break;
+            }
+
+            for (int i = 0; i < manifold.Count; ++i)
+            {
+                handlerA?.OnContactAdded(a, b, ref manifold, false, i, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+                handlerB?.OnContactAdded(b, a, ref manifold, true, i, workerIndex, _simulation);
+                if (collisionState.Alive == false)
+                    return;
+            }
+        }
+
+        handlerA?.OnPairUpdated(a, b, ref manifold, false, workerIndex, _simulation);
+        if (collisionState.Alive == false)
+            return;
+        handlerB?.OnPairUpdated(b, a, ref manifold, true, workerIndex, _simulation);
+        if (collisionState.Alive == false)
+            return;
+
+        System.Diagnostics.Debug.Assert(manifold.Count <= LastCollisionState.FeatureCount, "This was built on the assumption that nonconvex manifolds will have a maximum of 4 contacts, but that might have changed.");
+        //If the above assert gets hit because of a change to nonconvex manifold capacities, the packed feature id representation this uses will need to be updated.
+        //I very much doubt the nonconvex manifold will ever use more than 8 contacts, so addressing this wouldn't require much of a change.
+        for (int j = 0; j < manifold.Count; ++j)
+            collisionState.FeatureId[j] = manifold.GetFeatureId(j);
+
+        collisionState.ContactCount = manifold.Count;
+        collisionState.Flushes = _flushes;
+    }
+
+    public unsafe void Flush()
+    {
+#error Handle handler exceptions
+        return;
+        int workerIndex = 0;
+        var manifold = new EmptyManifold();
+        bool flippedManifold = false; // The flipped manifold argument does not make sense in this context given that we pass an empty one
+
+        //Remove any stale collisions. Stale collisions are those which should have received a new manifold update but did not because the manifold is no longer active.
+        foreach (var (pair, state) in _trackedCollisions)
+        {
+            if (state.Flushes == _flushes)
+                continue;
+
+            if ((state.Flushes & 1) != (_flushes & 1))
+                continue;
+
+            // Two flushes ago, remove the collision
+
+#if DEBUG
+            ref var stateRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_trackedCollisions, pair, out _);
+            _trackedCollisions.Remove(pair);
+            System.Diagnostics.Debug.Assert(stateRef.Alive == false); // Notify HandleManifoldInner higher up the call stack that the manifold they are processing is dead
+#else
+            _trackedCollisions.Remove(pair);
+#endif
+
+            for (int i = 0; i < state.ContactCount; i++)
+            {
+                state.HandlerA?.OnContactRemoved(pair.A, pair.B, ref manifold, flippedManifold, state.FeatureId[i], workerIndex, _simulation);
+                state.HandlerB?.OnContactRemoved(pair.B, pair.A, ref manifold, flippedManifold, state.FeatureId[i], workerIndex, _simulation);
+            }
+
+            if (state.Touching)
+            {
+                state.HandlerA?.OnStoppedTouching(pair.A, pair.B, ref manifold, flippedManifold, workerIndex, _simulation);
+                state.HandlerB?.OnStoppedTouching(pair.B, pair.A, ref manifold, flippedManifold, workerIndex, _simulation);
+            }
+
+            state.HandlerA?.OnPairEnded(pair.A, pair.B, _simulation);
+            state.HandlerB?.OnPairEnded(pair.B, pair.A, _simulation);
+        }
+
+        _flushes++;
+    }
+
     /// <summary>
     /// Callback attached to the simulation's ITimestepper which executes just prior to collision detection to take a snapshot of activity states to determine which pairs we should expect updates in.
     /// </summary>
-    void SetFreshnessForCurrentActivityStatus(float dt, IThreadDispatcher threadDispatcher)
+    /*void SetFreshnessForCurrentActivityStatus(float dt, IThreadDispatcher threadDispatcher)
     {
         //Every single pair tracked by the contact events has a 'freshness' flag. If the final flush sees a pair that is stale, it'll remove it
         //and any necessary events to represent the end of that pair are reported.
@@ -235,11 +396,11 @@ internal class ContactEventsManager : IDisposable
 
         //This could be multithreaded reasonably easily if there are a ton of listeners or collisions, but that would be a pretty high bar.
         //For simplicity, the demo will keep it single threaded.
-        var bodyHandleToLocation = simulation.Bodies.HandleToLocation;
-        for (int listenerIndex = 0; listenerIndex < listenerCount; ++listenerIndex)
+        var bodyHandleToLocation = _simulation.Simulation.Bodies.HandleToLocation;
+        foreach (var trackedCollision in _trackedCollisions)
         {
-            ref var listener = ref listeners[listenerIndex];
-            var source = listener.Source;
+            var source = trackedCollision.Key.A.ContactEventHandler;
+
             //If it's a body, and it's in the active set (index 0), then every pair associated with the listener should expect updates.
             var sourceExpectsUpdates = source.Mobility != CollidableMobility.Static && bodyHandleToLocation[source.BodyHandle.Value].SetIndex == 0;
             if (sourceExpectsUpdates)
@@ -262,226 +423,50 @@ internal class ContactEventsManager : IDisposable
                 }
             }
         }
-    }
+    }*/
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void UpdatePreviousCollision<TManifold>(ref PreviousCollision collision, ref TManifold manifold, bool isTouching) where TManifold : unmanaged, IContactManifold<TManifold>
+    private unsafe struct LastCollisionState
     {
-        //If the above assert gets hit because of a change to nonconvex manifold capacities, the packed feature id representation this uses will need to be updated.
-        //I very much doubt the nonconvex manifold will ever use more than 8 contacts, so addressing this wouldn't require much of a change.
-        for (int j = 0; j < manifold.Count; ++j)
-        {
-            Unsafe.Add(ref collision.FeatureId0, j) = manifold.GetFeatureId(j);
-        }
-        collision.ContactCount = manifold.Count;
-        collision.Fresh = true;
-        collision.WasTouching = isTouching;
+        public const int FeatureCount = 4;
+
+        public IContactEventHandler? HandlerA, HandlerB;
+        public bool Alive;
+        public bool Touching;
+        public int Flushes;
+        public int ContactCount;
+        //FeatureIds are identifiers encoding what features on the involved shapes contributed to the contact. We store up to 4 feature ids, one for each potential contact.
+        //A "feature" is things like a face, vertex, or edge. There is no single interpretation for what a feature is- the mapping is defined on a per collision pair level.
+        //In this demo, we only care to check whether a given contact in the current frame maps onto a contact from a previous frame.
+        //We can use this to only emit 'contact added' events when a new contact with an unrecognized id is reported.
+        public fixed int FeatureId[FeatureCount];
     }
 
-    public void HandleManifold<TManifold>(int workerIndex, CollidablePair pair, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
+    private readonly record struct OrderedPair
     {
-        bool aListener = IsListener(pair.A);
-        bool bListener = IsListener(pair.B);
-        if (aListener == false && bListener == false)
-            return;
-
-        var collidableA = bepuSimulation.GetComponent(pair.A);
-        var collidableB = bepuSimulation.GetComponent(pair.B);
-
-        if (aListener)
-            HandleManifoldInner(workerIndex, pair.A, pair.B, collidableA, collidableB, false, ref manifold);
-        if (bListener)
-            HandleManifoldInner(workerIndex, pair.B, pair.A, collidableB, collidableA, true, ref manifold);
+        public readonly CollidableComponent A, B;
+        public OrderedPair(CollidableComponent a, CollidableComponent b)
+        {
+            (A, B) = a.StableId > b.StableId ? (a, b) : (b, a);
+        }
     }
 
-    void HandleManifoldInner<TManifold>(int workerIndex, CollidableReference source, CollidableReference other, CollidableComponent sourceCollidable, CollidableComponent otherCollidable, bool flippedManifold, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
-    {
-        var listenerIndex = listenerIndices[source];
-        //This collidable is registered. Is the opposing collidable present?
-        ref var listener = ref listeners[listenerIndex];
 
-        int previousCollisionIndex = -1;
-        bool isTouching = false;
-        for (int i = 0; i < listener.PreviousCollisions.Count; ++i)
-        {
-            ref var collision = ref listener.PreviousCollisions[i];
-            //Since the 'Packed' field contains both the handle type (dynamic, kinematic, or static) and the handle index packed into a single bitfield, an equal value guarantees we are dealing with the same collidable.
-            if (collision.Collidable.Packed != other.Packed)
-                continue;
-
-            previousCollisionIndex = i;
-            //This manifold is associated with an existing collision.
-            //For every contact in the old collsion still present (by feature id), set a flag in this bitmask so we can know when a contact is removed.
-            int previousContactsStillExist = 0;
-            for (int contactIndex = 0; contactIndex < manifold.Count; ++contactIndex)
-            {
-                //We can check if each contact was already present in the previous frame by looking at contact feature ids. See the 'PreviousCollision' type for a little more info on FeatureIds.
-                var featureId = manifold.GetFeatureId(contactIndex);
-                var featureIdWasInPreviousCollision = false;
-                for (int previousContactIndex = 0; previousContactIndex < collision.ContactCount; ++previousContactIndex)
-                {
-                    if (featureId == Unsafe.Add(ref collision.FeatureId0, previousContactIndex))
-                    {
-                        featureIdWasInPreviousCollision = true;
-                        previousContactsStillExist |= 1 << previousContactIndex;
-                        break;
-                    }
-                }
-                if (!featureIdWasInPreviousCollision)
-                {
-                    listener.Handler.OnContactAdded(sourceCollidable, otherCollidable, ref manifold, flippedManifold, contactIndex, workerIndex, bepuSimulation);
-                }
-                if (manifold.GetDepth(contactIndex) >= 0)
-                    isTouching = true;
-            }
-            if (previousContactsStillExist != (1 << collision.ContactCount) - 1)
-            {
-                //At least one contact that used to exist no longer does.
-                for (int previousContactIndex = 0; previousContactIndex < collision.ContactCount; ++previousContactIndex)
-                {
-                    if ((previousContactsStillExist & 1 << previousContactIndex) == 0)
-                    {
-                        listener.Handler.OnContactRemoved(sourceCollidable, otherCollidable, ref manifold, flippedManifold, Unsafe.Add(ref collision.FeatureId0, previousContactIndex), workerIndex, bepuSimulation);
-                    }
-                }
-            }
-            if (!collision.WasTouching && isTouching)
-            {
-                listener.Handler.OnStartedTouching(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-            }
-            else if (collision.WasTouching && !isTouching)
-            {
-                listener.Handler.OnStoppedTouching(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-            }
-            if (isTouching)
-            {
-                listener.Handler.OnTouching(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-            }
-            UpdatePreviousCollision(ref collision, ref manifold, isTouching);
-            break;
-        }
-        if (previousCollisionIndex < 0)
-        {
-            //There was no collision previously.
-            ref var addsForWorker = ref pendingWorkerAdds[workerIndex];
-            //EnsureCapacity will create the list if it doesn't already exist.
-            addsForWorker.EnsureCapacity(Math.Max(addsForWorker.Count + 1, 64), GetPoolForWorker(workerIndex));
-            ref var pendingAdd = ref addsForWorker.AllocateUnsafely();
-            pendingAdd.ListenerIndex = listenerIndex;
-            pendingAdd.Collision.Collidable = other;
-            listener.Handler.OnPairCreated(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-            //Dispatch events for all contacts in this new manifold.
-            for (int i = 0; i < manifold.Count; ++i)
-            {
-                listener.Handler.OnContactAdded(sourceCollidable, otherCollidable, ref manifold, flippedManifold, i, workerIndex, bepuSimulation);
-                if (manifold.GetDepth(i) >= 0)
-                    isTouching = true;
-            }
-            if (isTouching)
-            {
-                listener.Handler.OnStartedTouching(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-                listener.Handler.OnTouching(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-            }
-            UpdatePreviousCollision(ref pendingAdd.Collision, ref manifold, isTouching);
-        }
-        listener.Handler.OnPairUpdated(sourceCollidable, otherCollidable, ref manifold, flippedManifold, workerIndex, bepuSimulation);
-    }
-
-    //For final events fired by the flush that still expect a manifold, we'll provide a special empty type.
-    struct EmptyManifold : IContactManifold<EmptyManifold>
+    private struct EmptyManifold : IContactManifold<EmptyManifold>
     {
         public int Count => 0;
         public bool Convex => true;
-        //This type never has any contacts, so there's no need for any property grabbers.
-        public Contact this[int contactIndex] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public static ref ConvexContact GetConvexContactReference(ref EmptyManifold manifold, int contactIndex) => throw new NotImplementedException();
-        public static ref float GetDepthReference(ref EmptyManifold manifold, int contactIndex) => throw new NotImplementedException();
-        public static ref int GetFeatureIdReference(ref EmptyManifold manifold, int contactIndex) => throw new NotImplementedException();
-        public static ref Contact GetNonconvexContactReference(ref EmptyManifold manifold, int contactIndex) => throw new NotImplementedException();
-        public static ref Vector3 GetNormalReference(ref EmptyManifold manifold, int contactIndex) => throw new NotImplementedException();
-        public static ref Vector3 GetOffsetReference(ref EmptyManifold manifold, int contactIndex) => throw new NotImplementedException();
-        public void GetContact(int contactIndex, out Vector3 offset, out Vector3 normal, out float depth, out int featureId) => throw new NotImplementedException();
-        public void GetContact(int contactIndex, out Contact contactData) => throw new NotImplementedException();
-        public float GetDepth(int contactIndex) => throw new NotImplementedException();
-        public int GetFeatureId(int contactIndex) => throw new NotImplementedException();
-        public Vector3 GetNormal(int contactIndex) => throw new NotImplementedException();
-        public Vector3 GetOffset(int contactIndex) => throw new NotImplementedException();
-    }
-
-    public void Flush()
-    {
-        //For simplicity, this is completely sequential. Note that it's technically possible to extract more parallelism, but the complexity cost is high and you would need
-        //very large numbers of events being processed to make it worth it.
-
-        //Remove any stale collisions. Stale collisions are those which should have received a new manifold update but did not because the manifold is no longer active.
-        for (int i = 0; i < listenerCount; ++i)
-        {
-            ref var listener = ref listeners[i];
-            var sourceComponent = bepuSimulation.GetComponent(listener.Source);
-            //Note reverse order. We remove during iteration.
-            for (int j = listener.PreviousCollisions.Count - 1; j >= 0; --j)
-            {
-                ref var collision = ref listener.PreviousCollisions[j];
-                if (collision.Fresh)
-                {
-                    collision.Fresh = false;
-                    continue;
-                }
-
-                var otherComponent = bepuSimulation.GetComponent(collision.Collidable);
-                //Sort the references to be consistent with the direct narrow phase results.
-                CollidablePair pair;
-                NarrowPhase.SortCollidableReferencesForPair(listener.Source, collision.Collidable, out _, out _, out pair.A, out pair.B);
-                if (collision.ContactCount > 0)
-                {
-                    var emptyManifold = new EmptyManifold();
-                    for (int previousContactCount = 0; previousContactCount < collision.ContactCount; ++previousContactCount)
-                    {
-                        listener.Handler.OnContactRemoved(sourceComponent, otherComponent, ref emptyManifold, false, Unsafe.Add(ref collision.FeatureId0, previousContactCount), 0, bepuSimulation);
-                    }
-
-                    if (collision.WasTouching)
-                    {
-                        listener.Handler.OnStoppedTouching(sourceComponent, otherComponent, ref emptyManifold, false, 0, bepuSimulation);
-                    }
-                }
-
-                listener.Handler.OnPairEnded(sourceComponent, otherComponent, bepuSimulation);
-                //This collision was not updated since the last flush despite being active. It should be removed.
-                listener.PreviousCollisions.FastRemoveAt(j);
-                if (listener.PreviousCollisions.Count == 0)
-                {
-                    listener.PreviousCollisions.Dispose(pool);
-                    listener.PreviousCollisions = default;
-                }
-            }
-        }
-
-        for (int i = 0; i < pendingWorkerAdds.Length; ++i)
-        {
-            ref var pendingAdds = ref pendingWorkerAdds[i];
-            for (int j = 0; j < pendingAdds.Count; ++j)
-            {
-                ref var add = ref pendingAdds[j];
-                ref var collisions = ref listeners[add.ListenerIndex].PreviousCollisions;
-                //Ensure capacity will initialize the slot if necessary.
-                collisions.EnsureCapacity(Math.Max(8, collisions.Count + 1), pool);
-                collisions.AllocateUnsafely() = pendingAdds[j].Collision;
-            }
-            if (pendingAdds.Span.Allocated)
-                pendingAdds.Dispose(GetPoolForWorker(i));
-            //We rely on zeroing out the count for lazy initialization.
-            pendingAdds = default;
-        }
-    }
-
-    public void Dispose()
-    {
-        if (bodyListenerFlags.Flags.Allocated)
-            bodyListenerFlags.Dispose(pool);
-        if (staticListenerFlags.Flags.Allocated)
-            staticListenerFlags.Dispose(pool);
-        listenerIndices.Dispose();
-        simulation.Timestepper.BeforeCollisionDetection -= SetFreshnessForCurrentActivityStatus;
+        public Contact this[int contactIndex] { get => throw new IndexOutOfRangeException("This manifold is empty"); set => throw new IndexOutOfRangeException("This manifold is empty"); }
+        public static ref ConvexContact GetConvexContactReference(ref EmptyManifold manifold, int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public static ref float GetDepthReference(ref EmptyManifold manifold, int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public static ref int GetFeatureIdReference(ref EmptyManifold manifold, int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public static ref Contact GetNonconvexContactReference(ref EmptyManifold manifold, int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public static ref Vector3 GetNormalReference(ref EmptyManifold manifold, int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public static ref Vector3 GetOffsetReference(ref EmptyManifold manifold, int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public void GetContact(int contactIndex, out Vector3 offset, out Vector3 normal, out float depth, out int featureId) => throw new IndexOutOfRangeException("This manifold is empty");
+        public void GetContact(int contactIndex, out Contact contactData) => throw new IndexOutOfRangeException("This manifold is empty");
+        public float GetDepth(int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public int GetFeatureId(int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public Vector3 GetNormal(int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
+        public Vector3 GetOffset(int contactIndex) => throw new IndexOutOfRangeException("This manifold is empty");
     }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Contacts/IContactEventHandler.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Contacts/IContactEventHandler.cs
@@ -18,6 +18,10 @@ public interface IContactEventHandler
     /// <summary>
     /// Fires when a contact is added.
     /// </summary>
+    /// <remarks>
+    /// This may be called before <see cref="OnStartedTouching{TManifold}"/>,
+    /// contacts are registered when two collidables are close enough, not necessarily when actually touching.
+    /// </remarks>
     /// <typeparam name="TManifold">Type of the contact manifold detected.</typeparam>
     /// <param name="eventSource">Collidable that the event was attached to.</param>
     /// <param name="other">Other collider <paramref name="eventSource"/> collided with.</param>
@@ -33,6 +37,11 @@ public interface IContactEventHandler
     /// <summary>
     /// Fires when a contact is removed.
     /// </summary>
+    /// <remarks>
+    /// This may be called without a corresponding call to <see cref="OnStoppedTouching{TManifold}"/>,
+    /// contacts are registered when two collidables are close enough, not necessarily when actually touching.
+    /// If the two collidables grazed each other, none of the touching methods will be called.
+    /// </remarks>
     /// <typeparam name="TManifold">Type of the contact manifold detected.</typeparam>
     /// <param name="eventSource">Collidable that the event was attached to.</param>
     /// <param name="other">Other collider <paramref name="eventSource"/> collided with.</param>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
@@ -58,6 +58,16 @@ public class StaticComponent : CollidableComponent
     protected override ref MaterialProperties MaterialProperties => ref Simulation!.CollidableMaterials[StaticReference!.Value.Handle];
     protected internal override NRigidPose? Pose => StaticReference?.Pose;
 
+    protected internal override CollidableReference? CollidableReference
+    {
+        get
+        {
+            if (StaticReference is { } sRef)
+                return sRef.CollidableReference;
+            return null;
+        }
+    }
+
     protected override void AttachInner(NRigidPose pose, BodyInertia shapeInertia, TypedIndex shapeIndex)
     {
         Debug.Assert(Processor is not null);
@@ -103,24 +113,5 @@ public class StaticComponent : CollidableComponent
             return sRef.Handle.Value;
 
         throw new InvalidOperationException();
-    }
-
-    protected override void RegisterContactHandler()
-    {
-        if (ContactEventHandler is not null && Simulation is not null && StaticReference is { } sRef)
-            Simulation.ContactEvents.Register(sRef.Handle);
-    }
-
-    protected override void UnregisterContactHandler()
-    {
-        if (Simulation is not null && StaticReference is { } sRef)
-            Simulation.ContactEvents.Unregister(sRef.Handle);
-    }
-
-    protected override bool IsContactHandlerRegistered()
-    {
-        if (Simulation is not null && StaticReference is { } sRef)
-            return Simulation.ContactEvents.IsRegistered(sRef.Handle);
-        return false;
     }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
@@ -108,7 +108,7 @@ public class StaticComponent : CollidableComponent
     protected override void RegisterContactHandler()
     {
         if (ContactEventHandler is not null && Simulation is not null && StaticReference is { } sRef)
-            Simulation.ContactEvents.Register(sRef.Handle, ContactEventHandler);
+            Simulation.ContactEvents.Register(sRef.Handle);
     }
 
     protected override void UnregisterContactHandler()
@@ -120,7 +120,7 @@ public class StaticComponent : CollidableComponent
     protected override bool IsContactHandlerRegistered()
     {
         if (Simulation is not null && StaticReference is { } sRef)
-            return Simulation.ContactEvents.IsListener(sRef.Handle);
+            return Simulation.ContactEvents.IsRegistered(sRef.Handle);
         return false;
     }
 }


### PR DESCRIPTION
# PR Details
See title, doing this causes some issues in the tracking of contact events, refactoring the logic to avoid this.

## Related Issue
None reported afaict

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
