### PR TITLE
fix: Slider put in Canvas NaN Exception

### DIFF
--- a/sources/engine/Stride.UI/Controls/Slider.cs
+++ b/sources/engine/Stride.UI/Controls/Slider.cs
@@ -347,7 +347,7 @@ namespace Stride.UI.Controls
             var idealSize = trackBackgroundSprite.SizeInPixels.Y;
             var desiredSize = new Vector3(idealSize, idealSize, 0)
             {
-                [(int)Orientation] = availableSizeWithoutMargins[(int)Orientation]
+                [(int)Orientation] = float.IsInfinity(availableSizeWithoutMargins[(int)Orientation]) ? float.MaxValue : availableSizeWithoutMargins[(int)Orientation]
             };
 
             return desiredSize;


### PR DESCRIPTION
# PR Details
Handled `Slider` UIElement measurement when `availableSizeWithoutMargins` is infinity. This was done by setting it to max value. The UI math after this cannot handle infinity values. Also other UI Elements provide real numbers for desired size.

I have considered multiple values to put in as the default. But when the the UI Editor Slider Layout section is first opened the visual width is set to a high number, maybe max float. Due to canvas not having a limited size the Slider lacks the support to handle what to do in this situation. When the Layout is open the `availableSizeWithoutMargins.X` value becomes a high number, meaning that value is originally from the parent, this is is why I chose `float.Max`. 

It also worth noting that there is still a bug behind the original bug. The first slider put into a canvas wont resize on width change until it is re-selected. I think most UI elements measure override to smallest desired size, while the slider appears to use the `availableSizeWithoutMargins` which is infinity for this issue configuration. 

I plan on leaving the issue like this. Unless someone has a better default, please test this solution before suggesting.

## Related Issue
https://github.com/stride3d/stride/issues/2236

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
