### PR TITLE
feat: Add asset support for interface properties

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetPropertyGraph.cs
@@ -983,7 +983,7 @@ namespace Stride.Core.Assets.Quantum
             }
 
             // Content reference (note: they are not treated as reference but as primitive type)
-            if (AssetRegistry.IsContentType(localValue?.GetType()) || AssetRegistry.IsContentType(baseValue?.GetType()))
+            if (AssetRegistry.IsExactContentType(localValue?.GetType()) || AssetRegistry.IsExactContentType(baseValue?.GetType()))
             {
                 var localRef = AttachedReferenceManager.GetAttachedReference(localValue);
                 var baseRef = AttachedReferenceManager.GetAttachedReference(baseValue);
@@ -1037,7 +1037,7 @@ namespace Stride.Core.Assets.Quantum
             }
 
             // Content reference (note: they are not treated as reference but as primitive type)
-            if (AssetRegistry.IsContentType(localValue?.GetType()) || AssetRegistry.IsContentType(baseValue?.GetType()))
+            if (AssetRegistry.IsExactContentType(localValue?.GetType()) || AssetRegistry.IsExactContentType(baseValue?.GetType()))
             {
                 var localRef = AttachedReferenceManager.GetAttachedReference(localValue);
                 var baseRef = AttachedReferenceManager.GetAttachedReference(baseValue);

--- a/sources/assets/Stride.Core.Assets/Analysis/BuildAssetNode.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/BuildAssetNode.cs
@@ -287,7 +287,7 @@ namespace Stride.Core.Assets.Analysis
                     {
                         references.Add(urlRef);
                     }
-                    else if (AssetRegistry.IsContentType(obj.GetType()))
+                    else if (AssetRegistry.IsExactContentType(obj.GetType()))
                     {
                         reference = AttachedReferenceManager.GetAttachedReference(obj);
                         if (reference != null)

--- a/sources/assets/Stride.Core.Assets/Analysis/CollectionItemIdsAnalysis.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/CollectionItemIdsAnalysis.cs
@@ -38,7 +38,7 @@ namespace Stride.Core.Assets.Analysis
 
             protected override bool CanVisit(object obj)
             {
-                return !AssetRegistry.IsContentType(obj?.GetType()) && base.CanVisit(obj);
+                return !AssetRegistry.IsExactContentType(obj?.GetType()) && base.CanVisit(obj);
             }
 
             public override void VisitArray(Array array, ArrayDescriptor descriptor)

--- a/sources/assets/Stride.Core.Assets/AssetRegistry.cs
+++ b/sources/assets/Stride.Core.Assets/AssetRegistry.cs
@@ -457,7 +457,7 @@ namespace Stride.Core.Assets
         }
 
         /// <summary>
-        /// Is this type a concrete content type
+        /// Is this type a concrete content type, or derives from a concrete content type
         /// </summary>
         /// <remarks>
         /// You may want to use <see cref="CanBeAssignedToContentTypes"/> instead if you're checking

--- a/sources/assets/Stride.Core.Assets/CollectionIdGenerator.cs
+++ b/sources/assets/Stride.Core.Assets/CollectionIdGenerator.cs
@@ -20,7 +20,7 @@ namespace Stride.Core.Assets
 
         protected override bool CanVisit(object obj)
         {
-            return !AssetRegistry.IsContentType(obj?.GetType()) && base.CanVisit(obj);
+            return !AssetRegistry.IsExactContentType(obj?.GetType()) && base.CanVisit(obj);
         }
 
         public override void VisitObject(object obj, ObjectDescriptor descriptor, bool visitMembers)

--- a/sources/assets/Stride.Core.Assets/Serializers/ContentReferenceSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/ContentReferenceSerializer.cs
@@ -19,7 +19,7 @@ namespace Stride.Core.Assets.Serializers
 
         public override bool CanVisit(Type type)
         {
-            return AssetRegistry.IsContentType(type);
+            return AssetRegistry.IsExactContentType(type);
         }
 
         public override object ConvertFrom(ref ObjectContext context, Scalar fromScalar)

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/ContentReferenceCollector.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/ContentReferenceCollector.cs
@@ -57,7 +57,7 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
                     Visit(target);
                 }
             }
-            else if (AssetRegistry.IsContentType(node.Descriptor.GetInnerCollectionType()))
+            else if (AssetRegistry.CanBeAssignedToContentTypes(node.Descriptor.GetInnerCollectionType(), checkIsUrlType: false))
             {
                 // We have an index, and our collection is directly a collection of content type. Let's just collect the corresponding item.
                 var gameContent = node.GetContent("Game");
@@ -73,19 +73,18 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
             var gameContent = assetNode.GetContent("Game");
             if (gameContent != null)
             {
-                var memberContent = node as IMemberNode;
-                if (memberContent != null)
+                if (node is IMemberNode memberContent)
                 {
-                    if (AssetRegistry.IsContentType(memberContent.Type))
+                    if (AssetRegistry.CanBeAssignedToContentTypes(memberContent.Type, checkIsUrlType: false))
                     {
                         var id = AttachedReferenceManager.GetAttachedReference(memberContent.Retrieve())?.Id ?? AssetId.Empty;
                         CollectContentReference(id, gameContent, NodeIndex.Empty);
                     }
                 }
-                var objectNode = node as IObjectNode;
-                if (objectNode != null && objectNode.Indices != null)
+
+                if (node is IObjectNode objectNode && objectNode.Indices != null)
                 {
-                    if (AssetRegistry.IsContentType(objectNode.Descriptor.GetInnerCollectionType()))
+                    if (AssetRegistry.CanBeAssignedToContentTypes(objectNode.Descriptor.GetInnerCollectionType(), checkIsUrlType: false))
                     {
                         foreach (var index in objectNode.Indices)
                         {

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs
@@ -166,7 +166,7 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
                     throw new InvalidOperationException("Unable to retrieve the game-side node");
 
                 var index = (e as ItemChangeEventArgs)?.Index ?? NodeIndex.Empty;
-                if (!AssetRegistry.IsContentType(e.Node.Descriptor.GetInnerCollectionType()))
+                if (!AssetRegistry.CanBeAssignedToContentTypes(e.Node.Descriptor.GetInnerCollectionType(), checkIsUrlType: false))
                 {
                     if (e.Node.Type.IsValueType)
                     {
@@ -276,7 +276,7 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
         {
             if (editor == null) throw new ArgumentNullException(nameof(editor));
 
-            if (!AssetRegistry.IsContentType(gameSideNode.Descriptor.GetInnerCollectionType()))
+            if (!AssetRegistry.CanBeAssignedToContentTypes(gameSideNode.Descriptor.GetInnerCollectionType(), checkIsUrlType: false))
                 return;
 
             // Grab the old referenced object if it's not null

--- a/sources/editor/Stride.Core.Assets.Editor/Components/FixAssetReferences/AssetReferenceReplacementViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/FixAssetReferences/AssetReferenceReplacementViewModel.cs
@@ -14,7 +14,7 @@ namespace Stride.Core.Assets.Editor.Components.FixAssetReferences
         private readonly NodeIndex index;
 
         public AssetReferenceReplacementViewModel(FixAssetReferencesViewModel fixReferences, AssetViewModel objectToFix, AssetViewModel referencer, object referencedMember, IGraphNode node, NodeIndex index)
-            : base(fixReferences, objectToFix, referencer, referencedMember)
+            : base(fixReferences, objectToFix, referencer, node.Descriptor.GetInnerCollectionType())
         {
             this.node = node;
             this.index = index;

--- a/sources/editor/Stride.Core.Assets.Editor/Components/FixAssetReferences/FixAssetReferencesViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/FixAssetReferences/FixAssetReferencesViewModel.cs
@@ -87,7 +87,7 @@ namespace Stride.Core.Assets.Editor.Components.FixAssetReferences
             return result;
         }
 
-        public override async Task<AssetViewModel> PickupObject(AssetViewModel objectToFix, object referencedMember)
+        public override async Task<AssetViewModel> PickupObject(AssetViewModel objectToFix, Type propertyType)
         {
             var assetPicker = ServiceProvider.Get<IEditorDialogService>().CreateAssetPickerDialog(objectToFix.Session);
             assetPicker.Message = "Select an asset to replace the deleted asset";
@@ -95,10 +95,9 @@ namespace Stride.Core.Assets.Editor.Components.FixAssetReferences
             assetPicker.InitialLocation = objectToFix.Directory;
             assetPicker.AllowMultiSelection = false;
             Type assetType = objectToFix.AssetType;
-            var contentType = AssetRegistry.GetContentType(objectToFix.AssetType);
-            if (contentType != null)
+
+            if (AssetRegistry.CanPropertyHandleAssets(propertyType, out var assetTypes))
             {
-                var assetTypes = AssetRegistry.GetAssetTypes(contentType);
                 assetPicker.AcceptedTypes.AddRange(assetTypes);
             }
             else

--- a/sources/editor/Stride.Core.Assets.Editor/Components/FixReferences/FixReferencesViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/FixReferences/FixReferencesViewModel.cs
@@ -179,9 +179,9 @@ namespace Stride.Core.Assets.Editor.Components.FixReferences
         /// Picks up an object to replace a reference to a deleted object in the given object to fix.
         /// </summary>
         /// <param name="objectToFix">The object for which a new object must be pick up to replace a reference.</param>
-        /// <param name="referencedMember">The member of the object to fix that was actually referenced, in case it is not tje object itself.</param>
+        /// <param name="propertyType">The type of the property or field in case it is more abstract than the object itself</param>
         /// <returns>A replacement object, or <c>null</c> if the user cancelled.</returns>
-        public abstract Task<T> PickupObject(T objectToFix, object referencedMember);
+        public abstract Task<T> PickupObject(T objectToFix, Type propertyType);
         
         /// <summary>
         /// Builds the lists of objects that reference the given deleted object. The return value of this method is an enumeration of key-value pairs,
@@ -244,7 +244,8 @@ namespace Stride.Core.Assets.Editor.Components.FixReferences
         private async Task PickupSingleReplacementObject()
         {
             var current = currentObjectToReplaceEnumerator.Current.Key;
-            var selectedObject = await PickupObject(current.ReferencedObject, current.ReferencedMember);
+            var propType = current.ReferencedObject.GetType(); // We could find the type that is the most abstract and can be assigned to every replacement as well ...
+            var selectedObject = await PickupObject(current.ReferencedObject, propType);
             if (selectedObject != null)
             {
                 SingleReplacementObject = selectedObject;

--- a/sources/editor/Stride.Core.Assets.Editor/Components/FixReferences/ReferenceReplacementViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/FixReferences/ReferenceReplacementViewModel.cs
@@ -11,15 +11,15 @@ namespace Stride.Core.Assets.Editor.Components.FixReferences
     public abstract class ReferenceReplacementViewModel<T> : DispatcherViewModel where T : ViewModelBase
     {
         private readonly FixReferencesViewModel<T> fixReferences;
-        private readonly object referencedMember;
+        private readonly Type propertyType;
         private T replacementObject;
         private bool dontFixReference;
 
-        protected ReferenceReplacementViewModel(FixReferencesViewModel<T> fixReferences, T objectToFix, T referencer, object referencedMember)
+        protected ReferenceReplacementViewModel(FixReferencesViewModel<T> fixReferences, T objectToFix, T referencer, Type propertyType)
             : base(fixReferences.SafeArgument(nameof(fixReferences)).ServiceProvider)
         {
             this.fixReferences = fixReferences;
-            this.referencedMember = referencedMember;
+            this.propertyType = propertyType;
             Referencer = referencer;
             ObjectToFix = objectToFix;
             PickupReplacementObjectCommand = new AnonymousTaskCommand(fixReferences.ServiceProvider, PickupReplacementObject);
@@ -56,7 +56,7 @@ namespace Stride.Core.Assets.Editor.Components.FixReferences
 
         protected async Task PickupReplacementObject()
         {
-            var replacement = await fixReferences.PickupObject(ObjectToFix, referencedMember);
+            var replacement = await fixReferences.PickupObject(ObjectToFix, propertyType);
             if (replacement != null)
             {
                 ReplacementObject = replacement;

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddNewItemCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AddNewItemCommand.cs
@@ -80,6 +80,6 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
 
         public static bool CanConstruct(Type elementType) => !elementType.IsClass || elementType.GetConstructor(Type.EmptyTypes) != null || elementType == typeof(string);
 
-        public static bool IsReferenceType(Type elementType) => AssetRegistry.IsContentType(elementType) || typeof(AssetReference).IsAssignableFrom(elementType) || UrlReferenceBase.IsUrlReferenceType(elementType);
+        public static bool IsReferenceType(Type elementType) => AssetRegistry.IsExactContentType(elementType) || typeof(AssetReference).IsAssignableFrom(elementType) || UrlReferenceBase.IsUrlReferenceType(elementType);
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/FetchAssetCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/FetchAssetCommand.cs
@@ -3,6 +3,7 @@
 using System.Threading.Tasks;
 using Stride.Core.Assets.Editor.Services;
 using Stride.Core.Assets.Editor.ViewModel;
+using Stride.Core.Extensions;
 using Stride.Core.Presentation.Quantum;
 using Stride.Core.Presentation.Quantum.Presenters;
 
@@ -37,7 +38,8 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
         /// <inheritdoc/>
         public override bool CanAttach(INodePresenter nodePresenter)
         {
-            return ContentReferenceHelper.ContainsReferenceType(nodePresenter.Descriptor);
+            var type = nodePresenter.Descriptor.GetInnerCollectionType();
+            return AssetRegistry.CanBeAssignedToContentTypes(type, checkIsUrlType: true);
         }
 
         /// <inheritdoc/>
@@ -59,6 +61,5 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
                 await session.Dispatcher.InvokeAsync(() => session.ActiveAssetView.SelectAssetCommand.Execute(asset));
             }
         }
-
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/PickupAssetCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/PickupAssetCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Stride.Core.Assets.Editor.Services;
 using Stride.Core.Assets.Editor.ViewModel;
+using Stride.Core.Extensions;
 using Stride.Core.Presentation.Quantum;
 using Stride.Core.Presentation.Quantum.Presenters;
 using Stride.Core.Presentation.Services;
@@ -41,7 +42,8 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
         /// <inheritdoc/>
         public override bool CanAttach(INodePresenter nodePresenter)
         {
-            return ContentReferenceHelper.ContainsReferenceType(nodePresenter.Descriptor);
+            var type = nodePresenter.Descriptor.GetInnerCollectionType();
+            return AssetRegistry.CanBeAssignedToContentTypes(type, checkIsUrlType: true);
         }
 
         /// <inheritdoc/>
@@ -96,7 +98,9 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
 
         protected virtual IEnumerable<Type> GetAssetTypes(Type contentType)
         {
-            return AssetRegistry.GetAssetTypes(contentType);
+            if (AssetRegistry.CanPropertyHandleAssets(contentType, out var types))
+                return types;
+            return Array.Empty<Type>();
         }
 
         protected virtual AssetViewModel GetCurrentTarget(object currentValue)

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/SetContentReferenceCommand.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/SetContentReferenceCommand.cs
@@ -3,6 +3,7 @@
 using System;
 using Stride.Core.Assets.Editor.Services;
 using Stride.Core.Assets.Editor.ViewModel;
+using Stride.Core.Extensions;
 using Stride.Core.Presentation.Quantum;
 using Stride.Core.Presentation.Quantum.Presenters;
 
@@ -39,7 +40,8 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
         /// <inheritdoc />
         public override bool CanAttach(INodePresenter nodePresenter)
         {
-            return ContentReferenceHelper.ContainsReferenceType(nodePresenter.Descriptor);
+            var type = nodePresenter.Descriptor.GetInnerCollectionType();
+            return AssetRegistry.CanBeAssignedToContentTypes(type, checkIsUrlType: true);
         }
 
         /// <inheritdoc />

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
@@ -61,15 +61,18 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
         protected override void UpdateNode(IAssetNodePresenter node)
         {
             var type = node.Descriptor.GetInnerCollectionType();
-            if (type.IsAbstract && !IsReferenceType(type) && IsInstantiable(type))
+            if (type.IsAbstract && IsInstantiable(type))
             {
                 var abstractNodeEntries = FillDefaultAbstractNodeEntry(node);
+
+                // Remove content types, the engine expects content types to be serialized as reference, not created inline
+                if (AssetRegistry.CanPropertyHandleContent(type, out var contentTypes))
+                    abstractNodeEntries = abstractNodeEntries.Where(x => x is AbstractNodeType ant == false || contentTypes.Contains(ant.Type) == false);
+
                 node.AttachedProperties.Add(AbstractNodeEntryData.Key, abstractNodeEntries);
             }
         }
 
         private static bool IsInstantiable(Type type) => TypeDescriptorFactory.Default.AttributeRegistry.GetAttribute<NonInstantiableAttribute>(type) == null;
-
-        private static bool IsReferenceType(Type type) => AssetRegistry.IsContentType(type) || typeof(AssetReference).IsAssignableFrom(type) || UrlReferenceBase.IsUrlReferenceType(type);
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/SessionNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/SessionNodeUpdater.cs
@@ -21,7 +21,7 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
 
         protected override void UpdateNode(IAssetNodePresenter node)
         {
-            if (AssetRegistry.IsContentType(node.Type) || typeof(AssetReference).IsAssignableFrom(node.Type) || UrlReferenceBase.IsUrlReferenceType(node.Type))
+            if (AssetRegistry.CanBeAssignedToContentTypes(node.Type, checkIsUrlType: true))
             {
                 node.AttachedProperties.Add(SessionData.SessionKey, session);
                 node.AttachedProperties.Add(ReferenceData.Key, new ContentReferenceViewModel());
@@ -31,9 +31,8 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
             {
                 node.AttachedProperties.Add(SessionData.SessionKey, session);
             }
-            if (AssetRegistry.IsContentType(node.Type))
+            if (AssetRegistry.CanPropertyHandleAssets(node.Type, out var assetTypes))
             {
-                var assetTypes = AssetRegistry.GetAssetTypes(node.Type);
                 var thumbnailService = session.ServiceProvider.Get<IThumbnailService>();
                 node.AttachedProperties.Add(SessionData.DynamicThumbnailKey, !assetTypes.All(thumbnailService.HasStaticThumbnail));
             }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/ViewModels/AssetNodeViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/ViewModels/AssetNodeViewModel.cs
@@ -83,7 +83,7 @@ namespace Stride.Core.Assets.Editor.Quantum.ViewModels
             if (reference1 != null && reference2 != null)
             {
                 var type = reference1.GetType();
-                if (type == reference2.GetType() && AssetRegistry.IsContentType(type))
+                if (type == reference2.GetType() && AssetRegistry.IsExactContentType(type))
                 {
                     var target1 = AttachedReferenceManager.GetAttachedReference(reference1);
                     var target2 = AttachedReferenceManager.GetAttachedReference(reference2);

--- a/sources/editor/Stride.Core.Assets.Editor/View/TemplateProviders/ContentReferenceTemplateProvider.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/TemplateProviders/ContentReferenceTemplateProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using Stride.Core.Presentation.Quantum.ViewModels;
-using Stride.Core.Serialization;
 
 namespace Stride.Core.Assets.Editor.View.TemplateProviders
 {
@@ -13,13 +12,14 @@ namespace Stride.Core.Assets.Editor.View.TemplateProviders
 
         public override bool MatchNode(NodeViewModel node)
         {
-            var isReference = typeof(AssetReference).IsAssignableFrom(node.Type);
-            isReference |= UrlReferenceBase.IsUrlReferenceType(node.Type);
-            isReference |= AssetRegistry.IsContentType(node.Type);
+            if (AssetRegistry.CanBeAssignedToContentTypes(node.Type, checkIsUrlType: true))
+            {
+                object hasDynamic;
+                node.AssociatedData.TryGetValue("DynamicThumbnail", out hasDynamic);
+                return (bool)(hasDynamic ?? false) == DynamicThumbnail;
+            }
 
-            object hasDynamic;
-            node.AssociatedData.TryGetValue("DynamicThumbnail", out hasDynamic);
-            return isReference && (bool)(hasDynamic ?? false) == DynamicThumbnail;
+            return false;
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/ContentReferenceViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/ContentReferenceViewModel.cs
@@ -26,10 +26,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     message = "The selection is not an asset";
                     return false;
                 }
-                if (AssetRegistry.IsContentType(TargetNode.Type) || typeof(AssetReference).IsAssignableFrom(TargetNode.Type) || UrlReferenceBase.IsUrlReferenceType(TargetNode.Type))
+                if (AssetRegistry.CanPropertyHandleAssets(TargetNode.Type, out var resolvedAssetTypes))
                 {
                     var isCompatible = false;
-                    var resolvedAssetTypes = AssetRegistry.GetAssetTypes(TargetNode.Type);
                     foreach (var resolvedAssetType in resolvedAssetTypes)
                     {
                         if (resolvedAssetType.IsAssignableFrom(asset.AssetType))

--- a/sources/editor/Stride.Editor/EditorGame/ContentLoader/LoaderReferenceManager.cs
+++ b/sources/editor/Stride.Editor/EditorGame/ContentLoader/LoaderReferenceManager.cs
@@ -14,7 +14,7 @@ namespace Stride.Editor.EditorGame.ContentLoader
 {
     public class LoaderReferenceManager
     {
-        private struct ReferenceAccessor
+        private readonly record struct ReferenceAccessor
         {
             private readonly IGraphNode contentNode;
             private readonly NodeIndex index;
@@ -72,10 +72,9 @@ namespace Stride.Editor.EditorGame.ContentLoader
             gameDispatcher.EnsureAccess();
             using (await loader.LockDatabaseAsynchronously())
             {
-                if (!references.ContainsKey(referencerId))
+                if (!references.TryGetValue(referencerId, out var referencer))
                     throw new InvalidOperationException("The given referencer is not registered.");
 
-                var referencer = references[referencerId];
                 // Properly clear all reference first
                 foreach (var content in referencer.ToDictionary(x => x.Key, x => x.Value))
                 {
@@ -94,10 +93,9 @@ namespace Stride.Editor.EditorGame.ContentLoader
             gameDispatcher.EnsureAccess();
             using (await loader.LockDatabaseAsynchronously())
             {
-                if (!references.ContainsKey(referencerId))
+                if (!references.TryGetValue(referencerId, out var referencer))
                     throw new InvalidOperationException("The given referencer is not registered.");
 
-                var referencer = references[referencerId];
                 List<ReferenceAccessor> accessors;
                 if (!referencer.TryGetValue(contentId, out accessors))
                 {
@@ -115,8 +113,7 @@ namespace Stride.Editor.EditorGame.ContentLoader
 
                 accessors.Add(accessor);
 
-                object value;
-                if (contents.TryGetValue(contentId, out value))
+                if (contents.TryGetValue(contentId, out var value))
                 {
                     accessor.Update(value);
                 }
@@ -134,14 +131,12 @@ namespace Stride.Editor.EditorGame.ContentLoader
             gameDispatcher.EnsureAccess();
             using (await loader.LockDatabaseAsynchronously())
             {
-                if (!references.ContainsKey(referencerId))
+                if (!references.TryGetValue(referencerId, out var referencer))
                     throw new InvalidOperationException("The given referencer is not registered.");
 
-                var referencer = references[referencerId];
-                if (!referencer.ContainsKey(contentId))
+                if (!referencer.TryGetValue(contentId, out var accessors))
                     throw new InvalidOperationException("The given content is not registered to the given referencer.");
 
-                var accessors = referencer[contentId];
                 var accessor = new ReferenceAccessor(contentNode, index);
                 var accesorIndex = accessors.IndexOf(accessor);
                 if (accesorIndex < 0)

--- a/sources/engine/Stride.Assets/RuntimeTypesCollector.cs
+++ b/sources/engine/Stride.Assets/RuntimeTypesCollector.cs
@@ -26,7 +26,7 @@ namespace Stride.Assets
 
         public override void VisitObject(object obj, ObjectDescriptor descriptor, bool visitMembers)
         {
-            if (AssetRegistry.IsContentType(obj.GetType()))
+            if (AssetRegistry.IsExactContentType(obj.GetType()))
             {
                 // Asset compiler will sort out any dependencies so we dont need to visit any content types
                 runtimeTypes.Add(obj.GetType());

--- a/sources/engine/Stride.Debugger/Debugger/CloneReferenceSerializer.cs
+++ b/sources/engine/Stride.Debugger/Debugger/CloneReferenceSerializer.cs
@@ -44,7 +44,7 @@ namespace Stride.Debugger.Target
         private bool CanVisit(Type type)
         {
             // Also handles Entity, EntityComponent and Script
-            return AssetRegistry.IsContentType(type)
+            return AssetRegistry.IsExactContentType(type)
                    || type == typeof(Entity) || typeof(Entity).IsAssignableFrom(type) || typeof(EntityComponent).IsAssignableFrom(type);
         }
 


### PR DESCRIPTION
# PR Details
Properties of interface types can now be assigned to assets which implement that interface. Similar to the changes done in #1842

## Related Issue
None reported

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**


Excerpt of the idea:
```cs
public class Inventory
{
    public List<IItem> Items { get; set; } = new();
}

public interface IITem;

public class HealthPotion : IItem
{
    public int HealthGained = 10;
}

public class Armor : IItem
{
    public int Value;
}
```
Setup required for the above to work as assets removed, see full example project using this feature [MyGame2.zip](https://github.com/user-attachments/files/18924510/MyGame2.zip)
![image](https://github.com/user-attachments/assets/60350e63-929d-4147-9056-7c33a73e1118)