### PR TITLE
feat: Generalized per view resource binding

### DIFF
--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -789,23 +789,9 @@ namespace Stride.Rendering.Compositing
 
             foreach (var renderFeature in context.RenderContext.RenderSystem.RenderFeatures)
             {
-                if (!(renderFeature is RootEffectRenderFeature))
-                    continue;
-
-                var depthLogicalKey = ((RootEffectRenderFeature)renderFeature).CreateViewLogicalGroup("Depth");
-                var viewFeature = renderView.Features[renderFeature.Index];
-
-                // Copy ViewProjection to PerFrame cbuffer
-                foreach (var viewLayout in viewFeature.Layouts)
+                if (renderFeature is RootRenderFeature rootRenderFeature)
                 {
-                    var resourceGroup = viewLayout.Entries[renderView.Index].Resources;
-
-                    var depthLogicalGroup = viewLayout.GetLogicalGroup(depthLogicalKey);
-                    if (depthLogicalGroup.Hash == ObjectId.Empty)
-                        continue;
-
-                    // Might want to use ProcessLogicalGroup if more than 1 Recource
-                    resourceGroup.DescriptorSet.SetShaderResourceView(depthLogicalGroup.DescriptorSlotStart, depthStencilSRV);
+                    rootRenderFeature.BindPerViewShaderResource("Depth", renderView, depthStencilSRV);
                 }
             }
 
@@ -838,20 +824,9 @@ namespace Stride.Rendering.Compositing
             var renderView = drawContext.RenderContext.RenderView;
             foreach (var renderFeature in drawContext.RenderContext.RenderSystem.RenderFeatures)
             {
-                if (!(renderFeature is RootEffectRenderFeature))
-                    continue;
-
-                var opaqueLogicalKey = ((RootEffectRenderFeature)renderFeature).CreateViewLogicalGroup("Opaque");
-                var viewFeature = renderView.Features[renderFeature.Index];
-
-                foreach (var viewLayout in viewFeature.Layouts)
+                if (renderFeature is RootRenderFeature rootRenderFeature)
                 {
-                    var opaqueLogicalRenderGroup = viewLayout.GetLogicalGroup(opaqueLogicalKey);
-                    if (opaqueLogicalRenderGroup.Hash == ObjectId.Empty)
-                        continue;
-
-                    var resourceGroup = viewLayout.Entries[renderView.Index].Resources;
-                    resourceGroup.DescriptorSet.SetShaderResourceView(opaqueLogicalRenderGroup.DescriptorSlotStart, renderTargetTexture);
+                    rootRenderFeature.BindPerViewShaderResource("Opaque", renderView, renderTargetTexture);
                 }
             }
 

--- a/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootEffectRenderFeature.cs
@@ -1013,6 +1013,22 @@ namespace Stride.Rendering
             }
         }
 
+        public override void BindPerViewShaderResource(string logicalGroupName, RenderView renderView, GraphicsResource resource)
+        {
+            var depthLogicalKey = CreateViewLogicalGroup(logicalGroupName);
+            var viewFeature = renderView.Features[Index];
+
+            foreach (var viewLayout in viewFeature.Layouts)
+            {
+                var logicalGroup = viewLayout.GetLogicalGroup(depthLogicalKey);
+                if (logicalGroup.Hash == ObjectId.Empty)
+                    continue;
+
+                var resourceGroup = viewLayout.Entries[renderView.Index].Resources;
+                resourceGroup.DescriptorSet.SetShaderResourceView(logicalGroup.DescriptorSlotStart, resource);
+            }
+        }
+
         protected override void Destroy()
         {
             foreach (var effect in InstantiatedEffects)

--- a/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
@@ -13,6 +13,7 @@ using Stride.Core.Collections;
 using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
 using Stride.Core.Threading;
+using Stride.Graphics;
 
 namespace Stride.Rendering
 {
@@ -255,6 +256,16 @@ namespace Stride.Rendering
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        /// <summary>
+        /// Allows the renderer to inject per view resources such as depth buffer and opaque pass output.
+        /// </summary>
+        /// <param name="logicalGroupName">Name of the logical group to bind to.</param>
+        /// <param name="renderView"></param>
+        /// <param name="resource"></param>
+        public virtual void BindPerViewShaderResource(string logicalGroupName, RenderView renderView, GraphicsResource resource)
+        { 
         }
     }
 }


### PR DESCRIPTION
# PR Details

Generalizes the binding of per view resources in the `ForwardRenderer`. This change allows any `RootRenderFeature` to make use of depth and opaque render targets instead of being limited to only `RootEffectRenderFeature` and thus giving advanced users more options in how to implement features without being forced to use `RootEffectRenderFeature`, implement a custom `ForwardRenderer` or use other hacks.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
