### PR TITLE
fix: Add assets cleanup target when calling dotnet clean, clarify ref out of sync issues

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -160,6 +160,10 @@
   </Target>
 
   <!-- Clean assets -->
+  <Target Name="StrideCleanAssetsOnClean" AfterTargets="Clean">
+    <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
+  </Target>
+
   <Target Name="StrideCleanAsset" Condition="'$(StrideIsExecutable)' == 'true' And '$(StrideCompilerSkipBuild)' != 'true'">
     <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
     <RemoveDir Condition="Exists('$(StrideCompileAssetOutputPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetOutputPath)"/>

--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -160,7 +160,7 @@
   </Target>
 
   <!-- Clean assets -->
-  <Target Name="StrideCleanAssetsOnClean" AfterTargets="Clean">
+  <Target Name="StrideCleanAssetsOnClean" AfterTargets="Clean" Condition="'$(StrideSkipAssetsClean)' != 'true'">
     <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
     <RemoveDir Condition="Exists('$(StrideCompileAssetOutputPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetOutputPath)"/>
   </Target>

--- a/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/build/Stride.Core.Assets.CompilerApp.targets
@@ -162,6 +162,7 @@
   <!-- Clean assets -->
   <Target Name="StrideCleanAssetsOnClean" AfterTargets="Clean">
     <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
+    <RemoveDir Condition="Exists('$(StrideCompileAssetOutputPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetOutputPath)"/>
   </Target>
 
   <Target Name="StrideCleanAsset" Condition="'$(StrideIsExecutable)' == 'true' And '$(StrideCompilerSkipBuild)' != 'true'">

--- a/sources/core/Stride.Core/Serialization/ContentRefOutOfSyncException.cs
+++ b/sources/core/Stride.Core/Serialization/ContentRefOutOfSyncException.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+namespace Stride.Core.Serialization;
+
+public class ContentRefOutOfSyncException() 
+    : InvalidOperationException("Serialization contentRef indices are out of sync, assets need to be rebuilt, clean your projects and rebuild");

--- a/sources/core/Stride.Core/Serialization/MemberSerializerCore.ttinclude
+++ b/sources/core/Stride.Core/Serialization/MemberSerializerCore.ttinclude
@@ -233,7 +233,7 @@
                     if (reuseReferences)
                     {
                         if (objectReferences.Count != index)
-                            throw new InvalidOperationException("Serialization contentRef indices are out of sync.");
+                            throw new ContentRefOutOfSyncException();
                         objectReferences.Add(null);
                     }
 <# } #>

--- a/sources/core/Stride.Core/Serialization/MemberSerializerGenerated.cs
+++ b/sources/core/Stride.Core/Serialization/MemberSerializerGenerated.cs
@@ -1053,7 +1053,7 @@ namespace Stride.Core.Serialization
                     if (reuseReferences)
                     {
                         if (objectReferences.Count != index)
-                            throw new InvalidOperationException("Serialization contentRef indices are out of sync.");
+                            throw new ContentRefOutOfSyncException();
                         objectReferences.Add(null);
                     }
                     if (hasTypeInfo)
@@ -1262,7 +1262,7 @@ namespace Stride.Core.Serialization
                     if (reuseReferences)
                     {
                         if (objectReferences.Count != index)
-                            throw new InvalidOperationException("Serialization contentRef indices are out of sync.");
+                            throw new ContentRefOutOfSyncException();
                         objectReferences.Add(null);
                     }
                     if (hasTypeInfo)
@@ -1483,7 +1483,7 @@ namespace Stride.Core.Serialization
                     if (reuseReferences)
                     {
                         if (objectReferences.Count != index)
-                            throw new InvalidOperationException("Serialization contentRef indices are out of sync.");
+                            throw new ContentRefOutOfSyncException();
                         objectReferences.Add(null);
                     }
                     if (hasTypeInfo)
@@ -1703,7 +1703,7 @@ namespace Stride.Core.Serialization
                     if (reuseReferences)
                     {
                         if (objectReferences.Count != index)
-                            throw new InvalidOperationException("Serialization contentRef indices are out of sync.");
+                            throw new ContentRefOutOfSyncException();
                         objectReferences.Add(null);
                     }
                     if (hasTypeInfo)


### PR DESCRIPTION
# PR Details
Content out of sync exception triggers when removing/adding a property to a [custom asset](https://doc.stride3d.net/latest/en/manual/scripts/custom-assets.html), this change ensures users are aware of how to proceed when encountering this issue.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

Kindly pinging @Jklawreszuk to check this one as he is more experienced with the build system than I am