### PR TITLE
fix: Legacy DynamicNavigationMeshSystem bugs and memory leak

### DIFF
--- a/sources/engine/Stride.Navigation/NavigationMeshBuilder.cs
+++ b/sources/engine/Stride.Navigation/NavigationMeshBuilder.cs
@@ -273,8 +273,7 @@ namespace Stride.Navigation
                         if (p.Item2 == null)
                         {
                             // Remove a tile
-                            if (layer.TilesInternal.ContainsKey(p.Item1))
-                                layer.TilesInternal.Remove(p.Item1);
+                            layer.TilesInternal.Remove(p.Item1);
                         }
                         else
                         {
@@ -415,8 +414,8 @@ namespace Stride.Navigation
                             }
                         }
 
-                        Navigation.DestroyBuilder(builder);
                     }
+                    Navigation.DestroyBuilder(builder);
                 }
             }
 

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -41,6 +41,7 @@ namespace Stride.Navigation.Processors
                 throw new Exception("NavigationProcessor can not access the game systems collection");
 
             gameSystemCollection.CollectionChanged += GameSystemsOnCollectionChanged;
+            TryRegisterDynamicNavigationMeshSystem();
         }
 
         /// <inheritdoc />
@@ -89,10 +90,9 @@ namespace Stride.Navigation.Processors
 
         private void DynamicNavigationMeshSystemOnNavigationMeshUpdatedUpdated(object sender, NavigationMeshUpdatedEventArgs eventArgs)
         {
-            var newNavigationMesh = eventArgs.BuildResult.NavigationMesh;
-            NavigationMeshData data;
-            if (eventArgs.OldNavigationMesh != null && loadedNavigationMeshes.TryGetValue(eventArgs.OldNavigationMesh, out data))
+            if (eventArgs?.OldNavigationMesh is not null && loadedNavigationMeshes.TryGetValue(eventArgs.OldNavigationMesh, out var data))
             {
+                var newNavigationMesh = eventArgs.BuildResult.NavigationMesh;
                 // Move to new navigation mesh
                 loadedNavigationMeshes.Remove(eventArgs.OldNavigationMesh);
                 loadedNavigationMeshes.Add(newNavigationMesh, data);
@@ -181,6 +181,11 @@ namespace Stride.Navigation.Processors
         }
 
         private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        {
+            TryRegisterDynamicNavigationMeshSystem();
+        }
+
+        private void TryRegisterDynamicNavigationMeshSystem()
         {
             // Detect addition of dynamic navigation mesh system
             if (dynamicNavigationMeshSystem == null)

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -262,6 +262,7 @@ namespace Stride.Navigation.Processors
                 {
                     loadedNavigationMeshes.Remove(data.NavigationMesh);
                 }
+                group.RecastNavigationMesh.Dispose();
             }
         }
 

--- a/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
@@ -62,7 +62,7 @@ namespace Stride.Physics
             if (sharedData.Key == null)
             {
                 // Not actually shared, dispose and move on
-                sharedData.BulletMesh.Dispose();
+                sharedData.Dispose();
                 return;
             }
 
@@ -72,7 +72,7 @@ namespace Stride.Physics
                 if (sharedData.RefCount == 0)
                 {
                     MeshSharingCache.Remove(sharedData.Key);
-                    sharedData.BulletMesh.Dispose();
+                    sharedData.Dispose();
                 }
             }
         }
@@ -295,11 +295,17 @@ namespace Stride.Physics
             return null;
         }
 
-        private record SharedMeshData
+        private record SharedMeshData : IDisposable
         {
             public BulletSharp.TriangleIndexVertexArray BulletMesh;
             public int RefCount;
             public string Key;
+
+            public void Dispose()
+            {
+                BulletMesh.IndexedMeshArray.Clear();
+                BulletMesh.Dispose();
+            }
         }
         
         private class StrideToBulletWrapper : ICollection<BulletSharp.Math.Vector3>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
1. Ensure NavigationProcessor looks for DynamicNavigationMeshSystem when added, in case DynamicNavigationMeshSystem exists before itself.
2. Guard against null `eventArgs` which occurs when DynamicNavigationMeshSystem.Enabled = false
3. Ensure `Navigation.DestroyBuilder(builder)` is always called otherwise memory is never released on failed cases.
4. Call dispose on BulletMesh & RecastNavigationMesh to ensure memory released.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2630

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
