### PR TITLE
Revert "feat: Crossplatform font loading"

### DIFF
--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/CharacterRegionTypeConverter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/CharacterRegionTypeConverter.cs
@@ -112,12 +112,19 @@ namespace Stride.Assets.SpriteFont.Compiler
                 split[i] = ConvertCharacter(splitStr[i]);
             }
 
-            return split.Length switch
+            switch (split.Length)
             {
-                1 => new CharacterRegion(split[0], split[0]), // Only a single character (eg. "a").
-                2 => new CharacterRegion(split[0], split[1]), // Range of characters (eg. "a-z").
-                _ => throw new ArgumentException()
-            };
+                case 1:
+                    // Only a single character (eg. "a").
+                    return new CharacterRegion(split[0], split[0]);
+
+                case 2:
+                    // Range of characters (eg. "a-z").
+                    return new CharacterRegion(split[0], split[1]);
+             
+                default:
+                    throw new ArgumentException();
+            }
         }
 
 
@@ -128,9 +135,11 @@ namespace Stride.Assets.SpriteFont.Compiler
                 // Single character directly specifies a codepoint.
                 return value[0];
             }
-
-            // Otherwise it must be an integer (eg. "32" or "0x20").
-            return (char)(int)intConverter.ConvertFromInvariantString(value);
+            else
+            {
+                // Otherwise it must be an integer (eg. "32" or "0x20").
+                return (char)(int)intConverter.ConvertFromInvariantString(value);
+            }
         }
 
 

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/FontNotFoundException.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/FontNotFoundException.cs
@@ -6,7 +6,7 @@ namespace Stride.Assets.SpriteFont.Compiler
 {
     internal class FontNotFoundException : Exception
     {
-        public FontNotFoundException(string fontName) : base($"Font with name [{fontName}] not found on this machine")
+        public FontNotFoundException(string fontName) : base(string.Format("Font with name [{0}] not found on this machine", fontName))
         {
             FontName = fontName;
         }

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/Glyph.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/Glyph.cs
@@ -76,7 +76,6 @@
 //--------------------------------------------------------------------
 
 using System.Drawing;
-using FreeImageAPI;
 
 namespace Stride.Assets.SpriteFont.Compiler
 {
@@ -84,11 +83,11 @@ namespace Stride.Assets.SpriteFont.Compiler
     internal class Glyph
     {
         // Constructor.
-        public Glyph(char character, FreeImageBitmap bitmap, Rectangle? subrect = null)
+        public Glyph(char character, Bitmap bitmap, Rectangle? subrect = null)
         {
-            Character = character;
-            Bitmap = bitmap;
-            Subrect = subrect.GetValueOrDefault(new Rectangle(0, 0, bitmap.Width, bitmap.Height));
+            this.Character = character;
+            this.Bitmap = bitmap;
+            this.Subrect = subrect.GetValueOrDefault(new Rectangle(0, 0, bitmap.Width, bitmap.Height));
         }
 
 
@@ -97,7 +96,7 @@ namespace Stride.Assets.SpriteFont.Compiler
 
 
         // Glyph image data (may only use a portion of a larger bitmap).
-        public FreeImageBitmap Bitmap;
+        public Bitmap Bitmap;
         public Rectangle Subrect;
         
 

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/GlyphCropper.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/GlyphCropper.cs
@@ -85,7 +85,7 @@ namespace Stride.Assets.SpriteFont.Compiler
         public static void Crop(Glyph glyph)
         {
             // Crop the top.
-            while ((glyph.Subrect.Height > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, glyph.Subrect with { Height = 1 }))
+            while ((glyph.Subrect.Height > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, new Rectangle(glyph.Subrect.X, glyph.Subrect.Y, glyph.Subrect.Width, 1)))
             {
                 glyph.Subrect.Y++;
                 glyph.Subrect.Height--;
@@ -94,13 +94,13 @@ namespace Stride.Assets.SpriteFont.Compiler
             }
 
             // Crop the bottom.
-            while ((glyph.Subrect.Height > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, glyph.Subrect with { Y = glyph.Subrect.Bottom - 1, Height = 1 }))
+            while ((glyph.Subrect.Height > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, new Rectangle(glyph.Subrect.X, glyph.Subrect.Bottom - 1, glyph.Subrect.Width, 1)))
             {
                 glyph.Subrect.Height--;
             }
 
             // Crop the left.
-            while ((glyph.Subrect.Width > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, glyph.Subrect with { Width = 1 }))
+            while ((glyph.Subrect.Width > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, new Rectangle(glyph.Subrect.X, glyph.Subrect.Y, 1, glyph.Subrect.Height)))
             {
                 glyph.Subrect.X++;
                 glyph.Subrect.Width--;
@@ -109,7 +109,7 @@ namespace Stride.Assets.SpriteFont.Compiler
             }
 
             // Crop the right.
-            while ((glyph.Subrect.Width > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, glyph.Subrect with { X = glyph.Subrect.Right - 1, Width = 1 }))
+            while ((glyph.Subrect.Width > 1) && BitmapUtils.IsAlphaEntirely(0, glyph.Bitmap, new Rectangle(glyph.Subrect.Right - 1, glyph.Subrect.Y, 1, glyph.Subrect.Height)))
             {
                 glyph.Subrect.Width--;
             }

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/GlyphPacker.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/GlyphPacker.cs
@@ -79,17 +79,16 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-using FreeImageAPI;
 
 namespace Stride.Assets.SpriteFont.Compiler
 {
     // Helper for arranging many small bitmaps onto a single larger surface.
     internal static class GlyphPacker
     {
-        public static FreeImageBitmap ArrangeGlyphs(Glyph[] sourceGlyphs)
+        public static Bitmap ArrangeGlyphs(Glyph[] sourceGlyphs)
         {
             // Build up a list of all the glyphs needing to be arranged.
-            List<ArrangedGlyph> glyphs = [];
+            List<ArrangedGlyph> glyphs = new List<ArrangedGlyph>();
 
             for (int i = 0; i < sourceGlyphs.Length; i++)
             {
@@ -127,9 +126,9 @@ namespace Stride.Assets.SpriteFont.Compiler
 
 
         // Once arranging is complete, copies each glyph to its chosen position in the single larger output bitmap.
-        static FreeImageBitmap CopyGlyphsToOutput(List<ArrangedGlyph> glyphs, int width, int height)
+        static Bitmap CopyGlyphsToOutput(List<ArrangedGlyph> glyphs, int width, int height)
         {
-            FreeImageBitmap output = new FreeImageBitmap(width, height, FreeImageAPI.PixelFormat.Format32bppArgb);
+            Bitmap output = new Bitmap(width, height, PixelFormat.Format32bppArgb);
 
             foreach (ArrangedGlyph glyph in glyphs)
             {
@@ -231,7 +230,8 @@ namespace Stride.Assets.SpriteFont.Compiler
 
             if (aSize != bSize)
                 return bSize.CompareTo(aSize);
-            return a.Source.Character.CompareTo(b.Source.Character);
+            else
+                return a.Source.Character.CompareTo(b.Source.Character);
         }
 
 
@@ -269,9 +269,11 @@ namespace Stride.Assets.SpriteFont.Compiler
 
                 return powerOfTwo;
             }
-
-            // Round up to the specified block size.
-            return (value + blockSize - 1) & ~(blockSize - 1);
+            else
+            {
+                // Round up to the specified block size.
+                return (value + blockSize - 1) & ~(blockSize - 1);
+            }
         }
     }
 }

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/OfflineRasterizedSpriteFontWriter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/OfflineRasterizedSpriteFontWriter.cs
@@ -77,8 +77,8 @@
 
 using System;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using FreeImageAPI;
 using Stride.Core.Mathematics;
 using Stride.Graphics.Font;
 
@@ -87,7 +87,7 @@ namespace Stride.Assets.SpriteFont.Compiler
     // Writes the output sprite font binary file.
     internal static class OfflineRasterizedSpriteFontWriter
     {
-        public static Graphics.SpriteFont CreateSpriteFontData(IFontFactory fontFactory, SpriteFontAsset options, Glyph[] glyphs, float lineSpacing, float baseLine, FreeImageBitmap bitmap, bool srgb)
+        public static Graphics.SpriteFont CreateSpriteFontData(IFontFactory fontFactory, SpriteFontAsset options, Glyph[] glyphs, float lineSpacing, float baseLine, Bitmap bitmap, bool srgb)
         {
             var fontGlyphs = ConvertGlyphs(glyphs);
             var images = new[] { GetImage(options, bitmap, srgb) };
@@ -100,7 +100,7 @@ namespace Stride.Assets.SpriteFont.Compiler
         {
             var fontGlyphs = new Graphics.Font.Glyph[glyphs.Length];
 
-            for (int i=0; i<glyphs.Length; ++i)
+            for  (var i=0; i<glyphs.Length; ++i)
             {
                 var glyph = glyphs[i];
                 fontGlyphs[i] = new Graphics.Font.Glyph
@@ -115,7 +115,7 @@ namespace Stride.Assets.SpriteFont.Compiler
             return fontGlyphs;
         }
 
-        static Graphics.Image GetImage(SpriteFontAsset options, FreeImageBitmap bitmap, bool srgb)
+        static Graphics.Image GetImage(SpriteFontAsset options, Bitmap bitmap, bool srgb)
         {
             // TODO Currently we only support Rgba32 as an option. Grayscale might be added later
             return GetImageRgba32(bitmap, srgb);
@@ -123,21 +123,146 @@ namespace Stride.Assets.SpriteFont.Compiler
 
 
         // Writes an uncompressed 32 bit font texture.
-        static Graphics.Image GetImageRgba32(FreeImageBitmap bitmap, bool srgb)
+        static Graphics.Image GetImageRgba32(Bitmap bitmap, bool srgb)
         {
             var image = Graphics.Image.New2D(bitmap.Width, bitmap.Height, 1, srgb ? Graphics.PixelFormat.R8G8B8A8_UNorm_SRgb : Graphics.PixelFormat.R8G8B8A8_UNorm);
             var pixelBuffer = image.PixelBuffer[0];
-            var bitmapData = new BitmapUtils.PixelAccessor(bitmap);
-
-            for (int y = 0; y < bitmap.Height; y++)
+            using (var bitmapData = new BitmapUtils.PixelAccessor(bitmap, ImageLockMode.ReadOnly))
             {
-                for (int x = 0; x < bitmap.Width; x++)
+                for (int y = 0; y < bitmap.Height; y++)
                 {
-                    var color = bitmapData[x, y];
-                    pixelBuffer.SetPixel(x, y, new Core.Mathematics.Color(color.R, color.G, color.B, color.A));
+                    for (int x = 0; x < bitmap.Width; x++)
+                    {
+                        var color = bitmapData[x, y];
+                        pixelBuffer.SetPixel(x, y, new Core.Mathematics.Color(color.R, color.G, color.B, color.A));
+                    }
                 }
             }
             return image;
+        }
+
+        // Writes a block compressed monochromatic font texture.
+        static unsafe Graphics.Image GetCompressedMono(Bitmap bitmap, SpriteFontAsset options)
+        {
+            if ((bitmap.Width & 3) != 0 ||
+                (bitmap.Height & 3) != 0)
+            {
+                throw new ArgumentException("Block compression requires texture size to be a multiple of 4.");
+            }
+
+            var image = Graphics.Image.New2D(bitmap.Width, bitmap.Height, 1, Graphics.PixelFormat.BC2_UNorm);
+            var pixelBuffer = (BC2Pixel*)image.PixelBuffer[0].DataPointer;
+            using (var bitmapData = new BitmapUtils.PixelAccessor(bitmap, ImageLockMode.ReadOnly))
+            {
+                for (int y = 0; y < bitmap.Height; y += 4)
+                {
+                    for (int x = 0; x < bitmap.Width; x += 4)
+                    {
+                        BC2Pixel bc2Pixel;
+                        CompressBlock( bitmapData, x, y, options, out bc2Pixel);
+                        *pixelBuffer = bc2Pixel;
+                        pixelBuffer++;
+                    }
+                }
+            }
+            return image;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        struct BC2Pixel
+        {
+            public long AlphaBits;
+            public uint EndPoint;
+            public int RgbBits;
+        }
+
+
+        // We want to compress our font textures, because, like, smaller is better, 
+        // right? But a standard DXT compressor doesn't do a great job with fonts that 
+        // are in premultiplied alpha format. Our font data is greyscale, so all of the 
+        // RGBA channels have the same value. If one channel is compressed differently 
+        // to another, this causes an ugly variation in brightness of the rendered text. 
+        // Also, fonts are mostly either black or white, with grey values only used for 
+        // antialiasing along their edges. It is very important that the black and white 
+        // areas be accurately represented, while the precise value of grey is less 
+        // important.
+        //
+        // Trouble is, your average DXT compressor knows nothing about these 
+        // requirements. It will optimize to minimize a generic error metric such as 
+        // RMS, but this will often sacrifice crisp black and white in exchange for 
+        // needless accuracy of the antialiasing pixels, or encode RGB differently to 
+        // alpha. UGLY!
+        //
+        // Fortunately, encoding monochrome fonts turns out to be trivial. Using DXT3, 
+        // we can fix the end colors as black and white, which gives guaranteed exact 
+        // encoding of the font inside and outside, plus two fractional values for edge 
+        // antialiasing. Also, these RGB values (0, 1/3, 2/3, 1) map exactly to four of 
+        // the possible 16 alpha values available in DXT3, so we can ensure the RGB and 
+        // alpha channels always exactly match.
+
+        static void CompressBlock(BitmapUtils.PixelAccessor bitmapData, int blockX, int blockY, SpriteFontAsset options, out BC2Pixel bc2Pixel)
+        {
+            long alphaBits = 0;
+            int rgbBits = 0;
+
+            int pixelCount = 0;
+
+            for (int y = 0; y < 4; y++)
+            {
+                for (int x = 0; x < 4; x++)
+                {
+                    long alpha;
+                    int rgb;
+
+                    int value = bitmapData[blockX + x, blockY + y].A;
+
+                    if (!options.FontType.IsPremultiplied)
+                    {
+                        // If we are not pre-multiplied, RGB is always white and we have 4 bit alpha.
+                        alpha = value >> 4;
+                        rgb = 0;
+                    }
+                    else
+                    {
+                        // For pre-multiplied encoding, quantize the source value to 2 bit precision.
+                        if (value < 256 / 6)
+                        {
+                            alpha = 0;
+                            rgb = 1;
+                        }
+                        else if (value < 256 / 2)
+                        {
+                            alpha = 5;
+                            rgb = 3;
+                        }
+                        else if (value < 256 * 5 / 6)
+                        {
+                            alpha = 10;
+                            rgb = 2;
+                        }
+                        else
+                        {
+                            alpha = 15;
+                            rgb = 0;
+                        }
+                    }
+
+                    // Add this pixel to the alpha and RGB bit masks.
+                    alphaBits |= alpha << (pixelCount * 4);
+                    rgbBits |= rgb << (pixelCount * 2);
+
+                    pixelCount++;
+                }
+            }
+
+            // Output the alpha bit mask.
+            bc2Pixel.AlphaBits = alphaBits;
+
+            // Output the two endpoint colors (black and white in 5.6.5 format).
+            bc2Pixel.EndPoint = 0x0000FFFF;
+
+            // Output the RGB bit mask.
+            bc2Pixel.RgbBits = rgbBits;
         }
     }
 }

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontCompiler.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontCompiler.cs
@@ -85,7 +85,6 @@ using Stride.Graphics.Font;
 
 using System.Linq;
 using Stride.Graphics;
-using FreeImageAPI;
 
 namespace Stride.Assets.SpriteFont.Compiler
 {
@@ -102,12 +101,16 @@ namespace Stride.Assets.SpriteFont.Compiler
         /// <returns>A SpriteFontData object.</returns>
         public static Graphics.SpriteFont Compile(IFontFactory fontFactory, SpriteFontAsset fontAsset)
         {
-            if (fontAsset.FontType is not SignedDistanceFieldSpriteFontType)
+            var fontTypeSDF = fontAsset.FontType as SignedDistanceFieldSpriteFontType;
+            if (fontTypeSDF == null)
                 throw new ArgumentException("Tried to compile a dynamic sprite font with compiler for signed distance field fonts");
 
-            var glyphs = ImportFont(fontAsset, out var lineSpacing, out var baseLine);
+            float lineSpacing;
+            float baseLine;
 
-            FreeImageBitmap bitmap = GlyphPacker.ArrangeGlyphs(glyphs);
+            var glyphs = ImportFont(fontAsset, out lineSpacing, out baseLine);
+
+            Bitmap bitmap = GlyphPacker.ArrangeGlyphs(glyphs);
 
             return SignedDistanceFieldFontWriter.CreateSpriteFontData(fontFactory, fontAsset, glyphs, lineSpacing, baseLine, bitmap);
         }
@@ -175,7 +178,8 @@ namespace Stride.Assets.SpriteFont.Compiler
         {
             var characters = new List<char>();
 
-            if (asset.FontType is not SignedDistanceFieldSpriteFontType fontTypeSDF)
+            var fontTypeSDF = asset.FontType as SignedDistanceFieldSpriteFontType;
+            if (fontTypeSDF == null)
                 throw new ArgumentException("Tried to compile a dynamic sprite font with compiler for signed distance field fonts");
             
             // extract the list from the provided file if it exits

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontImporter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontImporter.cs
@@ -11,9 +11,7 @@ namespace Stride.Assets.SpriteFont.Compiler
 {
     using System.Drawing;
     using System.Drawing.Imaging;
-    using FreeImageAPI;
     using SharpDX.DirectWrite;
-    using SharpFont;
     using Factory = SharpDX.DirectWrite.Factory;
 
     // This code was originally taken from DirectXTk but rewritten with DirectWrite
@@ -44,7 +42,7 @@ namespace Stride.Assets.SpriteFont.Compiler
         /// <param name="scaleX">Scale factor to convert from 'shape unit' to 'pixel unit' on x-axis</param>
         /// <param name="scaleY">Scale factor to convert from 'shape unit' to 'pixel unit' on y-axis</param>
         /// <returns></returns>
-        private FreeImageBitmap LoadSDFBitmap(char c, int width, int height, float offsetX, float offsetY, float scaleX, float scaleY)
+        private Bitmap LoadSDFBitmap(char c, int width, int height, float offsetX, float offsetY, float scaleX, float scaleY)
         {
             try
             {
@@ -77,7 +75,7 @@ namespace Stride.Assets.SpriteFont.Compiler
 
                 if (File.Exists(outputFilePath))
                 {
-                    var bitmap = FreeImageBitmap.FromFile(outputFilePath);
+                    var bitmap = (Bitmap)Image.FromFile(outputFilePath);
 
                     Normalize(bitmap);
 
@@ -90,7 +88,7 @@ namespace Stride.Assets.SpriteFont.Compiler
             }
 
             // If font generation failed for any reason, ignore it and return an empty glyph
-            return new FreeImageBitmap(1, 1, FreeImageAPI.PixelFormat.Format32bppArgb);
+            return new Bitmap(1, 1, PixelFormat.Format32bppArgb);
         }
 
         /// <summary>
@@ -99,7 +97,7 @@ namespace Stride.Assets.SpriteFont.Compiler
         /// Because we use offset we can easily detect if the corner pixel has negative (correct) or positive distance (incorrect)
         /// </summary>
         /// <param name="bitmap"></param>
-        private void Normalize(FreeImageBitmap bitmap)
+        private void Normalize(Bitmap bitmap)
         {
             // Case 1 - corner pixel is negative (outside), do not invert
             var firstPixel = bitmap.GetPixel(0, 0);
@@ -137,10 +135,15 @@ namespace Stride.Assets.SpriteFont.Compiler
 
             msdfgenExe = msdfgen.FullPath;
 #if DEBUG
-            tempDir = Path.Combine(Path.GetTempPath(), "StrideGlyphs");
+            tempDir = $"{Environment.GetEnvironmentVariable("TEMP")}\\StrideGlyphs\\";
             Directory.CreateDirectory(tempDir);
 #endif
-            Face face = options.FontSource.GetFont();
+
+            var factory = new Factory();
+
+            FontFace fontFace = options.FontSource.GetFontFace();
+
+            var fontMetrics = fontFace.Metrics;
 
             // Create a bunch of GDI+ objects.
             var fontSize = options.FontType.Size;
@@ -157,22 +160,24 @@ namespace Stride.Assets.SpriteFont.Compiler
             //
             // So we are first applying a factor to the line gap:
             //     NewLineGap = LineGap * LineGapFactor
-            var lineGap = (face.Height - face.Ascender + face.Descender) * options.LineGapFactor;
+            var lineGap = fontMetrics.LineGap * options.LineGapFactor;
 
-            float pixelPerDesignUnit = fontSize / face.UnitsPerEM;
+            float pixelPerDesignUnit = fontSize / fontMetrics.DesignUnitsPerEm;
             // Store the font height.
-            LineSpacing = (lineGap + face.Ascender + Math.Abs(face.Descender)) * pixelPerDesignUnit;
+            LineSpacing = (lineGap + fontMetrics.Ascent + fontMetrics.Descent) * pixelPerDesignUnit;
 
             // And then the baseline is also changed in order to allow the linegap to be distributed between the top and the
             // bottom of the font:
             //     BaseLine = NewLineGap * LineGapBaseLineFactor
-            BaseLine = (lineGap * options.LineGapBaseLineFactor + face.Ascender) * pixelPerDesignUnit;
+            BaseLine = (lineGap * options.LineGapBaseLineFactor + fontMetrics.Ascent) * pixelPerDesignUnit;
 
             // Generate SDF bitmaps for each character in turn.
             foreach (var character in characters)
-                glyphList.Add(ImportGlyph(face, character, fontSize));
+                glyphList.Add(ImportGlyph(fontFace, character, fontMetrics, fontSize));
 
             Glyphs = glyphList;
+
+            factory.Dispose();
         }
 
         /// <summary>
@@ -183,24 +188,23 @@ namespace Stride.Assets.SpriteFont.Compiler
         /// <param name="fontMetrics">Font metrics, used to obtain design units scale</param>
         /// <param name="fontSize">Requested font size. The bigger, the more precise the SDF image is going to be</param>
         /// <returns></returns>
-        private Glyph ImportGlyph(Face face, char character, float fontSize)
+        private Glyph ImportGlyph(FontFace fontFace, char character, FontMetrics fontMetrics, float fontSize)
         {
-            var index = face.GetCharIndex(character);
-            face.SetPixelSizes(0, (uint)fontSize);
-            face.LoadGlyph(index, LoadFlags.NoScale, LoadTarget.Normal);
-            
-            //------------------------------------
-            float pixelPerDesignUnit = fontSize / face.UnitsPerEM;
-            
-            float fontWidthPx = face.Glyph.Metrics.Width.Value * pixelPerDesignUnit;
-            float fontHeightPx = face.Glyph.Metrics.Height.Value * pixelPerDesignUnit;
+            var indices = fontFace.GetGlyphIndices(new int[] { character });
 
-            float fontOffsetXPx = face.Glyph.Metrics.HorizontalBearingX.Value * pixelPerDesignUnit;
-            float fontOffsetYPx = -face.Glyph.Metrics.HorizontalBearingY.Value * pixelPerDesignUnit;
+            var metrics = fontFace.GetDesignGlyphMetrics(indices, isSideways: false);
+            var metric = metrics[0];
 
-            float advanceWidthPx = face.Glyph.Metrics.HorizontalAdvance.Value * pixelPerDesignUnit;
-            
-            //---------------------------------------------------
+            float pixelPerDesignUnit = fontSize / fontMetrics.DesignUnitsPerEm;
+            float fontWidthPx = (metric.AdvanceWidth - metric.LeftSideBearing - metric.RightSideBearing) * pixelPerDesignUnit;
+            float fontHeightPx = (metric.AdvanceHeight - metric.TopSideBearing - metric.BottomSideBearing) * pixelPerDesignUnit;
+
+            float fontOffsetXPx = metric.LeftSideBearing * pixelPerDesignUnit;
+            float fontOffsetYPx = (metric.TopSideBearing - metric.VerticalOriginY) * pixelPerDesignUnit;
+
+            float advanceWidthPx = metric.AdvanceWidth * pixelPerDesignUnit;
+            //var advanceHeight = metric.AdvanceHeight * pixelPerDesignUnit;
+
             const int MarginPx = 2;     // Buffer zone for the sdf image to avoid clipping
             int bitmapWidthPx = (int)Math.Ceiling(fontWidthPx) + (2 * MarginPx);
             int bitmapHeightPx = (int)Math.Ceiling(fontHeightPx) + (2 * MarginPx);
@@ -208,23 +212,23 @@ namespace Stride.Assets.SpriteFont.Compiler
             float bitmapOffsetXPx = fontOffsetXPx - MarginPx;
             float bitmapOffsetYPx = fontOffsetYPx - MarginPx;
 
-            FreeImageBitmap bitmap;
+            Bitmap bitmap;
             if (char.IsWhiteSpace(character))
             {
-                bitmap = new FreeImageBitmap(1, 1, FreeImageAPI.PixelFormat.Format32bppArgb);
+                bitmap = new Bitmap(1, 1, PixelFormat.Format32bppArgb);
             }
             else
             {
                 // sdfPixelPerDesignUnit is hardcoded from the import in this code
                 // https://github.com/stride3d/msdfgen/blob/1af188c77822e447fe8e412420fe0fe05b782b38/ext/import-font.cpp#L126-L150
                 const float sdfPixelPerDesignUnit = 1 / 64f;      // msdf default coordinate scale
-                float boundLeft = face.Glyph.Metrics.HorizontalBearingX.Value * sdfPixelPerDesignUnit;
+                float boundLeft = metric.LeftSideBearing * sdfPixelPerDesignUnit;
                 //float boundRight = (metric.AdvanceWidth - metric.RightSideBearing) * sdfPixelPerDesignUnit;
                 //float boundTop = (metric.VerticalOriginY - metric.TopSideBearing) * sdfPixelPerDesignUnit;
-                float boundBottom = (face.Glyph.Metrics.HorizontalBearingY.Value - face.Glyph.Metrics.Height.Value) * sdfPixelPerDesignUnit;
+                float boundBottom = (metric.VerticalOriginY  - (metric.AdvanceHeight - metric.BottomSideBearing)) * sdfPixelPerDesignUnit;
 
-                float glyphWidthPx = face.Glyph.Metrics.Width.Value * sdfPixelPerDesignUnit;
-                float glyphHeightPx = face.Glyph.Metrics.Height.Value * sdfPixelPerDesignUnit;
+                float glyphWidthPx = (metric.AdvanceWidth - metric.LeftSideBearing - metric.RightSideBearing) * sdfPixelPerDesignUnit;
+                float glyphHeightPx = (metric.AdvanceHeight - metric.TopSideBearing - metric.BottomSideBearing) * sdfPixelPerDesignUnit;
 
                 // Need to scale from msdfgen's 'shape unit' into the final bitmap's space
                 float scaleX = fontWidthPx / glyphWidthPx;

--- a/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontWriter.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/Compiler/SignedDistanceFieldFontWriter.cs
@@ -77,8 +77,8 @@
 
 using System;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using FreeImageAPI;
 using Stride.Core.Mathematics;
 using Stride.Graphics.Font;
 
@@ -87,7 +87,7 @@ namespace Stride.Assets.SpriteFont.Compiler
     // Writes the output sprite font binary file.
     internal static class SignedDistanceFieldFontWriter
     {
-        public static Graphics.SpriteFont CreateSpriteFontData(IFontFactory fontFactory, SpriteFontAsset options, Glyph[] glyphs, float lineSpacing, float baseLine, FreeImageBitmap bitmap)
+        public static Graphics.SpriteFont CreateSpriteFontData(IFontFactory fontFactory, SpriteFontAsset options, Glyph[] glyphs, float lineSpacing, float baseLine, Bitmap bitmap)
         {
             var fontGlyphs = ConvertGlyphs(glyphs);
             var images = new[] { GetImage(options, bitmap) };
@@ -115,7 +115,7 @@ namespace Stride.Assets.SpriteFont.Compiler
             return fontGlyphs;
         }
 
-        static Graphics.Image GetImage(SpriteFontAsset options, FreeImageBitmap bitmap)
+        static Graphics.Image GetImage(SpriteFontAsset options, Bitmap bitmap)
         {
             // TODO Currently we only support Rgba32 as an option. Grayscale might be added later
             return GetImageRgba32(bitmap);
@@ -123,22 +123,31 @@ namespace Stride.Assets.SpriteFont.Compiler
 
         // Writes an uncompressed 32 bit font texture.
         // We have distance values encoded so we want uncompressed texture
-        static Graphics.Image GetImageRgba32(FreeImageBitmap bitmap)
+        static Graphics.Image GetImageRgba32(Bitmap bitmap)
         {
             // TODO Maybe switch to 3-channel texture
             var image = Graphics.Image.New2D(bitmap.Width, bitmap.Height, 1, Graphics.PixelFormat.R8G8B8A8_UNorm);
             var pixelBuffer = image.PixelBuffer[0];
-            using var bitmapData = new BitmapUtils.PixelAccessor(bitmap);
-
-            for (int y = 0; y < bitmap.Height; y++)
+            using (var bitmapData = new BitmapUtils.PixelAccessor(bitmap, ImageLockMode.ReadOnly))
             {
-                for (int x = 0; x < bitmap.Width; x++)
+                for (int y = 0; y < bitmap.Height; y++)
                 {
-                    var color = bitmapData[x, y];
-                    pixelBuffer.SetPixel(x, y, new Core.Mathematics.Color(color.R, color.G, color.B, color.A));
+                    for (int x = 0; x < bitmap.Width; x++)
+                    {
+                        var color = bitmapData[x, y];
+                        pixelBuffer.SetPixel(x, y, new Core.Mathematics.Color(color.R, color.G, color.B, color.A));
+                    }
                 }
             }
             return image;
-        }      
+        }
+   
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        struct BC2Pixel
+        {
+            public long AlphaBits;
+            public uint EndPoint;
+            public int RgbBits;
+        }        
     }
 }

--- a/sources/engine/Stride.Assets/SpriteFont/FileFontProvider.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/FileFontProvider.cs
@@ -10,7 +10,6 @@ using Stride.Core;
 using Stride.Core.IO;
 using Stride.Assets.SpriteFont.Compiler;
 using Stride.Graphics.Font;
-using SharpFont;
 
 namespace Stride.Assets.SpriteFont
 {
@@ -58,20 +57,15 @@ namespace Stride.Assets.SpriteFont
                         throw new ArgumentOutOfRangeException();
                 }
 
+                RawBool isSupported;
+                FontFileType fontType;
+                FontFaceType faceType;
+                int numberFaces;
 
-                fontFile.Analyze(out var isSupported, out var fontType, out var faceType, out var numberFaces);
+                fontFile.Analyze(out isSupported, out fontType, out faceType, out numberFaces);
 
                 return new FontFace(factory, faceType, new[] { fontFile }, 0, fontSimulations);
             }
-        }
-
-        /// <inheritdoc/>
-        public override Face GetFont()
-        {
-            var library = new SharpFont.Library();
-
-            var face = new SharpFont.Face(library, Source);
-            return face;
         }
 
         /// <inheritdoc/>

--- a/sources/engine/Stride.Assets/SpriteFont/FontProviderBase.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/FontProviderBase.cs
@@ -4,8 +4,6 @@
 using SharpDX.DirectWrite;
 using Stride.Core.Assets.Compiler;
 using Stride.Core;
-using SharpFont;
-using System;
 
 namespace Stride.Assets.SpriteFont
 {
@@ -15,18 +13,11 @@ namespace Stride.Assets.SpriteFont
         [DataMemberIgnore]
         public virtual Graphics.Font.FontStyle Style { get; set; } = Graphics.Font.FontStyle.Regular;
 
-        [Obsolete("Use GetFont method instead")]
         /// <summary>
         /// Gets the associated <see cref="FontFace"/>
         /// </summary>
         /// <returns><see cref="FontFace"/> from the specified source or <c>null</c> if not found</returns>
         public abstract FontFace GetFontFace();
-
-        /// <summary>
-        /// Gets the associated font <see cref="Face"/>
-        /// </summary>
-        /// <returns><see cref="Face"/> from the specified source or <c>null</c> if not found</returns>
-        public abstract Face GetFont();
 
         /// <summary>
         /// Gets the actual file path to the font file

--- a/sources/engine/Stride.Assets/SpriteFont/SystemFontProvider.cs
+++ b/sources/engine/Stride.Assets/SpriteFont/SystemFontProvider.cs
@@ -71,15 +71,6 @@ namespace Stride.Assets.SpriteFont
             return new FontFace(font);
         }
 
-        /// <inheritdoc/>
-        public override Face GetFont()
-        {
-            var library = new SharpFont.Library();
-
-            var face = new SharpFont.Face(library, GetFontPath());
-            return face;
-        }
-
         public override string GetFontPath(AssetCompilerResult result = null)
         {
             if (OperatingSystem.IsWindows())

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/FreeImageBitmap.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/FreeImageBitmap.cs
@@ -1488,8 +1488,8 @@ namespace FreeImageAPI
 			return new RectangleF(
 					0f,
 					0f,
-					FreeImage.GetWidth(dib),
-					FreeImage.GetHeight(dib));
+                    FreeImage.GetWidth(dib),
+                    FreeImage.GetHeight(dib));
 		}
 
 		/// <summary>
@@ -2413,6 +2413,36 @@ namespace FreeImageAPI
 			EnsureNotDisposed();
 			FreeImage.SetResolutionX(dib, (uint)xDpi);
 			FreeImage.SetResolutionY(dib, (uint)yDpi);
+		}
+
+		/// <summary>
+		/// This function is not yet implemented.
+		/// </summary>
+		/// <exception cref="NotImplementedException">
+		/// This method is not implemented.</exception>
+		public BitmapData LockBits(Rectangle rect, ImageLockMode flags, PixelFormat format)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// This function is not yet implemented.
+		/// </summary>
+		/// <exception cref="NotImplementedException">
+		/// This method is not implemented.</exception>
+		public BitmapData LockBits(Rectangle rect, ImageLockMode flags, PixelFormat format, BitmapData bitmapData)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// This function is not yet implemented.
+		/// </summary>
+		/// <exception cref="NotImplementedException">
+		/// This method is not implemented.</exception>
+		public void UnlockBits(BitmapData bitmapdata)
+		{
+			throw new NotImplementedException();
 		}
 
 		/// <summary>
@@ -4039,11 +4069,6 @@ namespace FreeImageAPI
 			}
 			memory.Capacity = (int)memory.Length;
 			info.AddValue("Bitmap Data", memory.GetBuffer());
-		}
-
-		public FreeImageBitmap ConvertTo32Bits()
-		{
-			return new FreeImageBitmap(FreeImage.ConvertTo32Bits(dib));
 		}
 
 		#endregion


### PR DESCRIPTION
We'll revert stride3d/stride#2530 for now as that PR introduced an issue on windows with fonts of specific sizes, for example Calibri with a size of 17 threw an exception. #2636 fixes that issue but there is still some issues with some font rendering in an incorrect glitchy way.