### PR TITLE
fix: Rendering hang when creating object node

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Properties.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Properties.cs
@@ -158,7 +158,7 @@ namespace Stride.Rendering
 
     public partial struct ObjectNodeReference
     {
-        public readonly int Index;
+        public int Index;
 
         /// <summary>
         /// Invalid slot.

--- a/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RootRenderFeature.cs
@@ -142,20 +142,18 @@ namespace Stride.Rendering
         internal unsafe ObjectNodeReference GetOrCreateObjectNode(RenderObject renderObject)
         {
             using var _ = Profiler.Begin(GetOrCreateObjectNodeKey);
-            fixed (ObjectNodeReference* objectNodeRef = &renderObject.ObjectNode)
+
+            var oldValue = Interlocked.CompareExchange(ref renderObject.ObjectNode.Index, -2, -1);
+            if (oldValue == -1)
             {
-                var oldValue = Interlocked.CompareExchange(ref *(int*)objectNodeRef, -2, -1);
-                if (oldValue == -1)
+                var index = objectNodes.Add(new ObjectNode(renderObject));
+                ObjectNodeReferences.Add(renderObject.ObjectNode);
+                renderObject.ObjectNode = new ObjectNodeReference(index);
+            }
+            else if (oldValue == -2) // Wait until whoever is inside the scope above finishes
+            {
+                while (Volatile.Read(ref renderObject.ObjectNode.Index) == -2)
                 {
-                    var index = objectNodes.Add(new ObjectNode(renderObject));
-                    renderObject.ObjectNode = new ObjectNodeReference(index);
-                    ObjectNodeReferences.Add(renderObject.ObjectNode);
-                }
-                else
-                {
-                    while (renderObject.ObjectNode.Index == -2)
-                    {
-                    }
                 }
             }
 


### PR DESCRIPTION
# PR Details
Under net9 this tight loop ended up running indefinitely, added a volatile read to ensure the value is not cached, and removed UB write to a readonly field.

## Related Issue
fixes #2601

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
