### PR TITLE
feat: Adds native dependencies for win-arm64

### DIFF
--- a/deps/BulletPhysics/checkout.bat
+++ b/deps/BulletPhysics/checkout.bat
@@ -6,5 +6,8 @@ IF NOT ERRORLEVEL 0 (
   ECHO "Could not find git.exe"
   EXIT /B %ERRORLEVEL%
 ) 
-%GIT_CMD% clone git@github.com:Eideren/BulletSharpPInvoke.git ../../externals/BulletSharpPInvoke
+%GIT_CMD% clone https://github.com/stride3d/BulletSharpPInvoke ../../externals/BulletSharpPInvoke
+pushd ..\..\externals\BulletSharpPInvoke
+%GIT_CMD% checkout 0de0f3cd564173474c58d57aad31c8aad82cb99d
+popd
 if NOT ERRORLEVEL 0 pause

--- a/deps/BulletPhysics/dotnet/win-arm64/libbulletc.dll
+++ b/deps/BulletPhysics/dotnet/win-arm64/libbulletc.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e13c24c8b16368ecb8dcf0265425ee8f1c70645f756974feb89872935fa8b940
+size 1626112

--- a/deps/Celt/checkout.bat
+++ b/deps/Celt/checkout.bat
@@ -3,5 +3,5 @@ IF NOT ERRORLEVEL 0 (
   ECHO "Could not find git.exe"
   EXIT /B %ERRORLEVEL%
 ) 
-%GIT_CMD% clone https://git.xiph.org/opus.git -b v1.1.3 ..\..\externals\Celt
+%GIT_CMD% clone https://github.com/xiph/opus.git -b v1.1.3 ..\..\externals\Celt
 if NOT ERRORLEVEL 0 pause

--- a/deps/FFmpeg/dotnet/build.sh
+++ b/deps/FFmpeg/dotnet/build.sh
@@ -44,6 +44,24 @@ configure_windows_x64_shared() {
     --prefix="${BASEDIR}/build/windows/x64"
 }
 
+configure_windows_arm64_shared() {
+  "${BASEDIR}/configure" \
+    --toolchain=msvc \
+    --arch=arm64 \
+    --enable-asm \
+    --enable-shared \
+    --enable-version3 \
+    --enable-w32threads \
+    --enable-yasm \
+    --disable-debug \
+    --disable-doc \
+    --disable-programs \
+    --disable-static \
+    --disable-x86asm \
+    --target-os=win64 \
+    --prefix="${BASEDIR}/build/windows/arm64"
+}
+
 configure_windows_x86_shared() {
   "${BASEDIR}/configure" \
     --toolchain=msvc \
@@ -99,6 +117,26 @@ configure_windows_x64_exe() {
     --prefix="${BASEDIR}/build/windows/x64"
 }
 
+configure_windows_arm64_exe() {
+  "${BASEDIR}/configure" \
+    --toolchain=msvc \
+    --arch=arm64 \
+    --enable-asm \
+    --enable-static \
+    --enable-version3 \
+    --enable-w32threads \
+    --enable-yasm \
+    --disable-debug \
+    --disable-doc \
+    --disable-ffplay \
+    --disable-ffprobe \
+    --disable-ffserver \
+    --disable-shared \
+    --disable-x86asm \
+    --target-os=win64 \
+    --prefix="${BASEDIR}/build/windows/arm64"
+}
+
 install() {
   make -j${NUMBER_OF_CORES} && make install
 }
@@ -110,6 +148,21 @@ build_windows_x64_shared() {
   
   # Configure ffmpeg (can be skipped if already done)
   configure_windows_x64_shared
+  # Make sure any previous build doesn't pollute the current one (can be skipped if configure didn't change since last time)
+  clean
+  # Build FFmpeg and copy binaries+include files into the installation folder (defined by --prefix in the configure command)
+  install
+  
+  popd
+}
+
+build_windows_arm64_shared() {
+  oot="${BASEDIR}/build/windows/arm64/oot/ffmpeg"
+  mkdir -p "$oot"
+  pushd "$oot"
+  
+  # Configure ffmpeg (can be skipped if already done)
+  configure_windows_arm64_shared
   # Make sure any previous build doesn't pollute the current one (can be skipped if configure didn't change since last time)
   clean
   # Build FFmpeg and copy binaries+include files into the installation folder (defined by --prefix in the configure command)
@@ -148,6 +201,21 @@ build_windows_x64_exe() {
   popd
 }
 
+build_windows_arm64_exe() {
+  oot="${BASEDIR}/build/windows/arm64/oot/ffmpeg"
+  mkdir -p "$oot"
+  pushd "$oot"
+  
+  # Configure ffmpeg (can be skipped if already done)
+  configure_windows_arm64_exe
+  # Make sure any previous build doesn't pollute the current one (can be skipped if configure didn't change since last time)
+  clean
+  # Build FFmpeg and copy binaries+include files into the installation folder (defined by --prefix in the configure command)
+  install
+  
+  popd
+}
+
 build_windows_x86_exe() {
   oot="${BASEDIR}/build/windows/x86/oot/ffmpeg"
   mkdir -p "$oot"
@@ -171,3 +239,4 @@ NUMBER_OF_CORES=$(nproc)
 build_windows_x86_shared
 #build_windows_x64_exe
 #build_windows_x86_exe
+#build_windows_arm64_exe

--- a/deps/FFmpeg/dotnet/win-arm64/avcodec-57.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/avcodec-57.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f69cd8022a13a8be34f01506e10b9bbf92f0bb04d6eb71a662267b47c54351d
+size 9722880

--- a/deps/FFmpeg/dotnet/win-arm64/avdevice-57.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/avdevice-57.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e8c57dcd4b5e3cb81b035597424c800fb44f52607af295ac487728888f6c040
+size 204800

--- a/deps/FFmpeg/dotnet/win-arm64/avfilter-6.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/avfilter-6.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7f4842a8224747bbaff9a5e0d5b2e191f4c7d2085099cd6d5b56ace545ad7ea
+size 1856512

--- a/deps/FFmpeg/dotnet/win-arm64/avformat-57.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/avformat-57.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3725c5ed89c43e6cf1060a413773644eaf78a5c2efacf7e8f9413f994c62e33d
+size 2210816

--- a/deps/FFmpeg/dotnet/win-arm64/avutil-55.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/avutil-55.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b434850920c56ed34c9047f0f904d7dc8673ba580de40bc601f7df28b88b1255
+size 623616

--- a/deps/FFmpeg/dotnet/win-arm64/swresample-2.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/swresample-2.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcf2ea93ba2a06818955cf2cd7880c5771f147f885a10b64aa72410e98b58525
+size 186880

--- a/deps/FFmpeg/dotnet/win-arm64/swscale-4.dll
+++ b/deps/FFmpeg/dotnet/win-arm64/swscale-4.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eefb4dc92d198b7bd7013f3a68afc3f1a3b131327db7bbdd2148ca59305a13e1
+size 452608

--- a/deps/FFmpeg/notes-win-arm64.txt
+++ b/deps/FFmpeg/notes-win-arm64.txt
@@ -1,0 +1,1 @@
+For win-arm64: Use https://github.com/azeno/FFmpeg/tree/win-arm64, it's based on release/3.4

--- a/deps/FreeImage/Release/win-arm64/FreeImage.dll
+++ b/deps/FreeImage/Release/win-arm64/FreeImage.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:283ad091f5fde12450a7ed0c51b93c1531d804ab58e8c485d1248de0b1479f97
+size 3449856

--- a/deps/FreeImage/build-fix.patch
+++ b/deps/FreeImage/build-fix.patch
@@ -1,0 +1,144 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5c302b2..aa06919 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,5 @@
++cmake_minimum_required(VERSION 3.30)
++
+ project(FreeImage)
+ 
+ set(FreeImage_SOURCES
+@@ -30,9 +32,17 @@ include_directories(Source/LibJXR/common/include)
+ include_directories(Source/LibJXR/image/sys)
+ include_directories(Source/LibJXR/jxrgluelib)
+ 
+-add_definitions(-DOPJ_STATIC -DNO_WINDOWS -DNO_LCMS -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -DLIBRAW_NODLL -DLIBRAW_LIBRARY_BUILD -DFREEIMAGE_LIB -DNO_LCMS)
+-add_library(FreeImage STATIC ${FreeImage_SOURCES})
+-install_dep(FreeImage include Source/FreeImage.h)
++add_definitions(-DOPJ_STATIC -DNO_WINDOWS -DNO_LCMS -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -DLIBRAW_NODLL -DLIBRAW_LIBRARY_BUILD -DNO_LCMS)
++add_library(FreeImage SHARED ${FreeImage_SOURCES})
++# install_dep(FreeImage include Source/FreeImage.h)
++
++# Set C++ standard
++if (DEFINED C_STANDARD)
++    set(CMAKE_C_STANDARD ${C_STANDARD})
++endif()
++if (DEFINED CPP_STANDARD)
++    set(CMAKE_CXX_STANDARD ${CPP_STANDARD})
++endif()
+ 
+ if (APPLE)
+  set_target_properties(FreeImage PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH "NO")
+@@ -42,6 +52,11 @@ if (APPLE)
+  endif()
+ endif()
+ 
++# Enable Multi-core compilation in MSVC
++if (MSVC)
++    target_compile_options(${PROJECT_NAME} PRIVATE /MP)
++endif()
++
+ set(FreeImage_INCLUDE_DIR "${FreeImage_SOURCE_DIR}/Source" CACHE PATH "" FORCE)
+ set(FreeImage_LIBRARY_DBG FreeImage CACHE STRING "" FORCE)
+ set(FreeImage_LIBRARY_REL FreeImage CACHE STRING "" FORCE)
+diff --git a/Source/DeprecationManager/DeprecationMgr.h b/Source/DeprecationManager/DeprecationMgr.h
+index 9141f23..c3926cc 100644
+--- a/Source/DeprecationManager/DeprecationMgr.h
++++ b/Source/DeprecationManager/DeprecationMgr.h
+@@ -30,7 +30,7 @@
+ 
+ // ==========================================================
+ 
+-#if !defined(_M_X64) && defined(_MSC_VER)
++#if !(defined(_M_X64) || defined(_M_ARM64)) && defined(_MSC_VER)
+ 	#define DEPRECATE(a,b) \
+ 	{ \
+ 		void *fptr;	\
+diff --git a/Source/LibJXR/image/sys/ansi.h b/Source/LibJXR/image/sys/ansi.h
+index 2927b05..334d196 100644
+--- a/Source/LibJXR/image/sys/ansi.h
++++ b/Source/LibJXR/image/sys/ansi.h
+@@ -1,14 +1,14 @@
+ //*@@@+++@@@@******************************************************************
+ //
+-// Copyright © Microsoft Corp.
++// Copyright Â© Microsoft Corp.
+ // All rights reserved.
+ // 
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are met:
+ // 
+-// • Redistributions of source code must retain the above copyright notice,
++// â€¢ Redistributions of source code must retain the above copyright notice,
+ //   this list of conditions and the following disclaimer.
+-// • Redistributions in binary form must reproduce the above copyright notice,
++// â€¢ Redistributions in binary form must reproduce the above copyright notice,
+ //   this list of conditions and the following disclaimer in the documentation
+ //   and/or other materials provided with the distribution.
+ // 
+@@ -44,7 +44,7 @@
+ //================================
+ #define FORCE_INLINE
+ #define CDECL
+-#if __LP64__
++#if defined(__LP64__) || defined(_WIN64)
+ #define UINTPTR_T unsigned long long
+ #define INTPTR_T long long
+ #else
+diff --git a/Source/LibJXR/image/sys/strcodec.h b/Source/LibJXR/image/sys/strcodec.h
+index ba3df4e..f727d4e 100644
+--- a/Source/LibJXR/image/sys/strcodec.h
++++ b/Source/LibJXR/image/sys/strcodec.h
+@@ -1,14 +1,14 @@
+ //*@@@+++@@@@******************************************************************
+ //
+-// Copyright © Microsoft Corp.
++// Copyright Â© Microsoft Corp.
+ // All rights reserved.
+ // 
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are met:
+ // 
+-// • Redistributions of source code must retain the above copyright notice,
++// â€¢ Redistributions of source code must retain the above copyright notice,
+ //   this list of conditions and the following disclaimer.
+-// • Redistributions in binary form must reproduce the above copyright notice,
++// â€¢ Redistributions in binary form must reproduce the above copyright notice,
+ //   this list of conditions and the following disclaimer in the documentation
+ //   and/or other materials provided with the distribution.
+ // 
+diff --git a/Source/LibTIFF4/tif_config.h b/Source/LibTIFF4/tif_config.h
+index 64391b8..3027b83 100644
+--- a/Source/LibTIFF4/tif_config.h
++++ b/Source/LibTIFF4/tif_config.h
+@@ -81,7 +81,10 @@ If your big endian system isn't being detected, add an OS specific check
+ #endif // BYTE_ORDER
+ 
+ #ifdef _WIN32
++/* Visual Studio 2015 / VC 14 / MSVC 19.00 finally has snprintf() */
++#if defined(_MSC_VER) && (_MSC_VER < 1900)
+ #define snprintf _snprintf
++#endif // _MSC_VER
+ #define lfind _lfind
+ #endif // _WIN32
+ 
+diff --git a/Source/OpenEXR/IlmImf/ImfAttribute.cpp b/Source/OpenEXR/IlmImf/ImfAttribute.cpp
+index feb5f83..3d601fc 100644
+--- a/Source/OpenEXR/IlmImf/ImfAttribute.cpp
++++ b/Source/OpenEXR/IlmImf/ImfAttribute.cpp
+@@ -61,12 +61,11 @@ Attribute::~Attribute () {}
+ 
+ namespace {
+ 
+-struct NameCompare: std::binary_function <const char *, const char *, bool>
++struct NameCompare
+ {
+-    bool
+-    operator () (const char *x, const char *y) const
++    bool operator () (const char *x, const char *y) const
+     {
+-	return strcmp (x, y) < 0;
++        return strcmp(x, y) < 0;
+     }
+ };
+ 

--- a/deps/FreeImage/checkout.bat
+++ b/deps/FreeImage/checkout.bat
@@ -1,0 +1,14 @@
+@echo OFF
+setlocal
+set HOME=%USERPROFILE%
+CALL ..\find_git.cmd
+IF NOT ERRORLEVEL 0 (
+  ECHO "Could not find git.exe"
+  EXIT /B %ERRORLEVEL%
+) 
+%GIT_CMD% clone https://github.com/danoli3/FreeImage.git %~dp0..\..\externals\FreeImage
+pushd %~dp0..\..\externals\FreeImage
+%GIT_CMD% checkout 3.16.0
+%GIT_CMD% apply ..\..\deps\freeimage\build-fix.patch
+popd
+if NOT ERRORLEVEL 0 pause

--- a/deps/NativePath/checkout.bat
+++ b/deps/NativePath/checkout.bat
@@ -5,4 +5,8 @@ IF NOT ERRORLEVEL 0 (
 ) 
 %GIT_CMD% clone https://github.com/stride3d/NativePath ../../externals/NativePath
 IF NOT ERRORLEVEL 0 PAUSE
+pushd ..\..\externals\NativePath
+%GIT_CMD% checkout e615840e57ea80ce30b9e9f29f5fd84ca9b4b253
+popd
+IF NOT ERRORLEVEL 0 PAUSE
 

--- a/deps/NativePath/dotnet/win-arm64/Detour.lib
+++ b/deps/NativePath/dotnet/win-arm64/Detour.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e78bf20c78faf7945b80e84663d1d1c6df654f23b14f6054e2030a1f43fabad
+size 494618

--- a/deps/NativePath/dotnet/win-arm64/Recast.lib
+++ b/deps/NativePath/dotnet/win-arm64/Recast.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1552179e9a2b22e0cf178f57ad99a5200c168b8d39f99e9fe8fdd1d20a31791f
+size 734800

--- a/deps/NativePath/dotnet/win-arm64/libCelt.lib
+++ b/deps/NativePath/dotnet/win-arm64/libCelt.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66decfaf25162b91365bfcf3feb817079abee7653f7ce2a8661fdab68176baef
+size 175554

--- a/deps/NativePath/dotnet/win-arm64/libNativePath.lib
+++ b/deps/NativePath/dotnet/win-arm64/libNativePath.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f906931d6a7ffaa8a9d6b763d5266429c6a098a54bb3fc69a48ebf4e20425f88
+size 530896

--- a/deps/NativePath/dotnet/win-x64/libCompilerRt.lib
+++ b/deps/NativePath/dotnet/win-x64/libCompilerRt.lib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9ac4e34096cb64b0c2af25b86e9789c824ac8b4051e9b349f04614a2738e4c7
-size 118144

--- a/deps/NativePath/dotnet/win-x86/libCompilerRt.lib
+++ b/deps/NativePath/dotnet/win-x86/libCompilerRt.lib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:563c64651e98ad1f13220be65f2d0b6787881b351924b3504073a428b84dbd84
-size 109040

--- a/deps/Recast/Detour.vcxproj
+++ b/deps/Recast/Detour.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -8,6 +12,10 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -23,28 +31,40 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Detour</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
@@ -76,8 +96,20 @@
     <TargetName>Detour</TargetName>
     <TargetExt>.lib</TargetExt>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>lib\arm64\</OutDir>
+    <IntDir>obj\$(Configuration)\Detour\</IntDir>
+    <TargetName>Detour</TargetName>
+    <TargetExt>.lib</TargetExt>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>lib\x64\</OutDir>
+    <IntDir>obj\$(Configuration)\Detour\</IntDir>
+    <TargetName>Detour</TargetName>
+    <TargetExt>.lib</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <OutDir>lib\arm64\</OutDir>
     <IntDir>obj\$(Configuration)\Detour\</IntDir>
     <TargetName>Detour</TargetName>
     <TargetExt>.lib</TargetExt>
@@ -127,7 +159,17 @@
       <AdditionalIncludeDirectories>Detour\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>Detour\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>Detour\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
       <AdditionalIncludeDirectories>Detour\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/deps/Recast/Recast.vcxproj
+++ b/deps/Recast/Recast.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -8,6 +12,10 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -23,28 +31,39 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Recast</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
@@ -76,11 +95,23 @@
     <TargetExt>.lib</TargetExt>
     <IntDir>obj\$(Platform)\Recast\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>lib\arm64\</OutDir>
+    <IntDir>obj\$(Platform)\Recast\</IntDir>
+    <TargetName>Recast</TargetName>
+    <TargetExt>.lib</TargetExt>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>lib\x64\</OutDir>
     <TargetName>Recast</TargetName>
     <TargetExt>.lib</TargetExt>
     <IntDir>obj\$(Platform)\Recast\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <OutDir>lib\arm64\</OutDir>
+    <IntDir>obj\$(Platform)\Recast\</IntDir>
+    <TargetName>Recast</TargetName>
+    <TargetExt>.lib</TargetExt>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -127,7 +158,17 @@
       <AdditionalIncludeDirectories>Recast\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>Recast\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>Recast\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
       <AdditionalIncludeDirectories>Recast\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/deps/Recast/build.bat
+++ b/deps/Recast/build.bat
@@ -1,22 +1,29 @@
 @echo OFF
 set recast_source=%~dp0..\..\externals\recast
 set output=%~dp0
+set vcvarsall="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat"
 
 REM copy project files
 copy /Y Detour.vcxproj "%recast_source%\Detour.vcxproj"
 copy /Y Recast.vcxproj "%recast_source%\Recast.vcxproj"
 
 REM build x64 projects
-call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\vc\vcvarsall.bat" x64
+call %vcvarsall% x64
 cd "%output%"
 msbuild "%recast_source%\Detour.vcxproj" /p:Platform="x64";Configuration="Release"
 msbuild "%recast_source%\Recast.vcxproj" /p:Platform="x64";Configuration="Release"
 
 REM build x86 projects
-call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\vc\vcvarsall.bat" x86
+call %vcvarsall% x86
 cd "%output%"
 msbuild "%recast_source%\Detour.vcxproj" /p:Platform="x86";Configuration="Release"
 msbuild "%recast_source%\Recast.vcxproj" /p:Platform="x86";Configuration="Release"
+
+REM build ARM64 projects
+call %vcvarsall% arm64
+cd "%output%"
+msbuild "%recast_source%\Detour.vcxproj" /p:Platform="ARM64";Configuration="Release"
+msbuild "%recast_source%\Recast.vcxproj" /p:Platform="ARM64";Configuration="Release"
 
 REM copy include files (some additional include files are needed for post-processing)
 rmdir /Q /S "%output%include"

--- a/deps/Recast/checkout.bat
+++ b/deps/Recast/checkout.bat
@@ -7,4 +7,7 @@ IF NOT ERRORLEVEL 0 (
   EXIT /B %ERRORLEVEL%
 ) 
 %GIT_CMD% clone https://github.com/recastnavigation/recastnavigation.git %~dp0..\..\externals\recast
+pushd %~dp0..\..\externals\recast
+%GIT_CMD% checkout d11c1bdbac8dc0cc0e96613d515f9c1ae3457d58
+popd
 if NOT ERRORLEVEL 0 pause

--- a/deps/TextureWrappers/Release/win-arm64/DxtWrapper.dll
+++ b/deps/TextureWrappers/Release/win-arm64/DxtWrapper.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82a27cf8390f63d7ab4d000e8576f8ad2b3beea03889e0e9a48d515a6e4d0381
+size 230912

--- a/deps/VHACD/build.bat
+++ b/deps/VHACD/build.bat
@@ -3,15 +3,18 @@ pushd ..\..\externals\BulletSharpPInvoke\src\VHACD_Lib\VHACD
 REM Compile vhacd
 msbuild VHACD.vcxproj /p:Configuration=Release;Platform=x64
 msbuild VHACD.vcxproj /p:Configuration=Release;Platform=Win32
+msbuild VHACD.vcxproj /p:Configuration=Release;Platform=ARM64
 if %ERRORLEVEL% neq 0 GOTO :error_popd
 popd
 
 REM Create folders
 mkdir win-x86
 mkdir win-x64
+mkdir win-arm64
 
 copy ..\..\externals\BulletSharpPInvoke\src\VHACD_Lib\VHACD\Release\*.dll win-x86
 copy ..\..\externals\BulletSharpPInvoke\src\VHACD_Lib\VHACD\x64\Release\*.dll win-x64
+copy ..\..\externals\BulletSharpPInvoke\src\VHACD_Lib\VHACD\ARM64\Release\*.dll win-arm64
 
 GOTO :end
 :error_popd

--- a/deps/VHACD/win-arm64/VHACD.dll
+++ b/deps/VHACD/win-arm64/VHACD.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5cccfda95271d2508de3333697827ce9ac53dca7e368ce0e5cae9ee39eaae1f
+size 141312

--- a/deps/freetype/build.bat
+++ b/deps/freetype/build.bat
@@ -1,6 +1,7 @@
 call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\vc\vcvarsall.bat" x86
 msbuild ..\..\externals\freetype\builds\windows\vc2013\freetype.vcxproj /Property:Configuration=Release;StridePlatform=Windows;Platform=Win32
 msbuild ..\..\externals\freetype\builds\windows\vc2013\freetype.vcxproj /Property:Configuration=Release;StridePlatform=Windows;Platform=x64
+msbuild ..\..\externals\freetype\builds\windows\vc2013\freetype.vcxproj /Property:Configuration=Release;StridePlatform=Windows;Platform=ARM64
 
 xcopy /Y /S ..\..\externals\freetype\builds\windows\vc2013\bin\Windows\Release\*.dll Windows\
 xcopy /Y /S ..\..\externals\freetype\builds\windows\vc2013\bin\Windows\Release\*.pdb Windows\

--- a/deps/freetype/checkout.bat
+++ b/deps/freetype/checkout.bat
@@ -6,7 +6,10 @@ IF NOT ERRORLEVEL 0 (
 %GIT_CMD% clone https://github.com/stride3d/freetype.git -b 2.6.3 ../../externals/freetype
 if NOT ERRORLEVEL 0 pause
 pushd ..\..\externals\freetype
-%GIT_CMD% remote add upstream http://git.sv.nongnu.org/r/freetype/freetype2.git
-%GIT_CMD% fetch --all
+%GIT_CMD% checkout 84631a11ab76240581f621287b260a6936a9014c
 popd
 if NOT ERRORLEVEL 0 pause
+
+:: Upstream repo can be added via
+:: %GIT_CMD% remote add upstream http://git.sv.nongnu.org/r/freetype/freetype2.git
+:: %GIT_CMD% fetch --all

--- a/deps/freetype/dotnet/win-arm64/freetype.dll
+++ b/deps/freetype/dotnet/win-arm64/freetype.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:762e5879ac53c6eebe25888b3e34a09065a5010c36a06742253783f65852c330
+size 783872

--- a/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
+++ b/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
@@ -53,6 +53,7 @@ public static class NativeLibraryHelper
                 Architecture.X86 => "x86",
                 Architecture.X64 => "x64",
                 Architecture.Arm => "ARM",
+                Architecture.Arm64 => "arm64",
                 _ => throw new PlatformNotSupportedException(),
             };
 

--- a/sources/core/Stride.Core/build/Stride.Core.targets
+++ b/sources/core/Stride.Core/build/Stride.Core.targets
@@ -1,7 +1,11 @@
 <Project InitialTargets="_StrideCheckVisualCRuntime2019" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Check if Visual C++ Runtime 2019 is properly installed -->
   <Target Name="_StrideCheckVisualCRuntime2019" Condition="'$(MSBuildRuntimeType)' == 'Full'">
-    <ItemGroup>
+    <PropertyGroup>
+      <IsWindowsARM64 Condition="$([MSBuild]::IsOsPlatform('Windows')) And $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == ARM64">true</IsWindowsARM64>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(IsWindowsARM64)' == 'false'">
       <_StrideVisualCRuntime2019 Include="Visual C++ Redistributable for Visual Studio 2019 x86">
         <Version>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\VC\Servicing\14.0\RuntimeMinimum', 'Version', null, RegistryView.Registry32))</Version>
         <ExpectedVersion>14.22.27821</ExpectedVersion>
@@ -12,7 +16,17 @@
         <ExpectedVersion>14.22.27821</ExpectedVersion>
         <DownloadUrl>https://download.visualstudio.microsoft.com/download/pr/cc0046d4-e7b4-45a1-bd46-b1c079191224/9c4042a4c2e6d1f661f4c58cf4d129e9/vc_redist.x64.exe</DownloadUrl>
       </_StrideVisualCRuntime2019>
+    </ItemGroup>
 
+    <ItemGroup Condition="'$(IsWindowsARM64)' == 'true'">
+      <_StrideVisualCRuntime2019 Include="Visual C++ Redistributable for Visual Studio 2019 ARM64">
+        <Version>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\VC\Servicing\14.0\Runtime_arm64', 'Version', null, RegistryView.Registry64))</Version>
+        <ExpectedVersion>14.42.34433</ExpectedVersion>
+        <DownloadUrl>https://download.visualstudio.microsoft.com/download/pr/285b28c7-3cf9-47fb-9be8-01cf5323a8df/8A81A52B7FF6B194CB88E1BB48D597B6588D2B840552909359F286FB1699235C/VC_redist.arm64.exe</DownloadUrl>
+      </_StrideVisualCRuntime2019>      
+    </ItemGroup>
+
+    <ItemGroup>
       <_StrideVisualCRuntime2019NotInstalled Include="@(_StrideVisualCRuntime2019)" Condition="'%(_StrideVisualCRuntime2019.Version)' == '' Or $([System.Version]::Parse('%(Version)').CompareTo($([System.Version]::Parse('%(_StrideVisualCRuntime2019.ExpectedVersion)')))) &lt; 0" />
     </ItemGroup>
 

--- a/sources/engine/Stride.Audio/Stride.Native.Libs.targets
+++ b/sources/engine/Stride.Audio/Stride.Native.Libs.targets
@@ -1,13 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <StrideNativePathLibsWindows>libCompilerRt.lib libCelt.lib</StrideNativePathLibsWindows>
-    <StrideNativePathLibsUWP>libCompilerRt.lib libCelt.lib Xaudio2.lib</StrideNativePathLibsUWP>
+    <StrideNativePathLibsWindows>libCelt.lib</StrideNativePathLibsWindows>
+    <StrideNativePathLibsUWP>libCelt.lib Xaudio2.lib</StrideNativePathLibsUWP>
   </PropertyGroup>
 
   <ItemGroup>
     <StrideNativePathLibsiOS Include="$(MSBuildThisFileDirectory)..\..\..\deps\NativePath\iOS\libCelt.a" />
     <StrideNativePathLibsmacOS Include="$(MSBuildThisFileDirectory)..\..\..\deps\NativePath\iOS\libCelt.a" />
-    <StrideNativePathLibsLinux Include="libCelt.a;libCompilerRt.a" />
-    <StrideNativePathLibsAndroid Include="libCelt.a;libCompilerRt.a" />
+    <StrideNativePathLibsLinux Include="libCelt.a" />
+    <StrideNativePathLibsAndroid Include="libCelt.a" />
   </ItemGroup>
 </Project>

--- a/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
+++ b/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
@@ -3,6 +3,7 @@
     <StrideRuntime>true</StrideRuntime>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideNativeOutputName>libstridevr</StrideNativeOutputName>
+    <StrideNativeWindowsArm64Enabled>false</StrideNativeWindowsArm64Enabled>
   </PropertyGroup>
   <Import Project="..\..\targets\Stride.props" />
   <PropertyGroup>

--- a/sources/native/Stride.Native.targets
+++ b/sources/native/Stride.Native.targets
@@ -26,6 +26,8 @@
   
     <!--<StrideNativeOutputPath>$([MSBuild]::MakeRelative('$(OutputPath)', '$(StridePackageStridePlatformBin)\'))</StrideNativeOutputPath>-->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.so; .a; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  
+    <StrideNativeWindowsArm64Enabled Condition="'$(StrideNativeWindowsArm64Enabled)' == ''">true</StrideNativeWindowsArm64Enabled>
   </PropertyGroup>
 
   <Choose>
@@ -46,7 +48,7 @@
   <!-- Define default CPU architectures -->
   <!-- TODO: Some targets are not crossplatform, so they are restricted to Windows OS -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(StrideFramework)'">
-    <StrideNativeCPU Condition="$([MSBuild]::IsOSPlatform('Windows'))" Include="win-x64;win-x86" LibraryExtension=".dll" LibraryRuntime="win" />
+    <StrideNativeCPU Condition="$([MSBuild]::IsOSPlatform('Windows'))" Include="win-x64;win-x86;win-arm64" LibraryExtension=".dll" LibraryRuntime="win" />
     <StrideNativeCPU Include="linux-x64"  LibraryExtension=".so" LibraryRuntime="linux" />
     <StrideNativeCPU Condition="$([MSBuild]::IsOSPlatform('Windows'))" Include="osx-x64"  LibraryExtension=".dylib" LibraryRuntime="osx" />
   </ItemGroup>
@@ -58,13 +60,17 @@
   </ItemGroup>
   <!-- Can be deleted -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(StrideFrameworkUWP)'">
-    <StrideNativeCPU Include="x86;x64;ARM" LibraryExtension=".dll" />
+    <StrideNativeCPU Include="x86;x64;ARM;ARM64" LibraryExtension=".dll" />
   </ItemGroup>
   <!-- Use runtimes/*/native folder -->
   <ItemGroup>
     <StrideNativeCPU Update="@(StrideNativeCPU)">
       <LibraryOutputDirectory>runtimes\%(Identity)\native\</LibraryOutputDirectory>
     </StrideNativeCPU>
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(StrideNativeWindowsArm64Enabled) == 'false'">
+    <StrideNativeCPU Remove="win-arm64" />
   </ItemGroup>
   
   <ItemGroup>
@@ -137,6 +143,11 @@
     <Exec Condition="'%(StrideNativeCFile.Extension)' != '.cpp'" Command="&quot;$(StrideNativeClangCommand)&quot; -gcodeview -fno-ms-extensions -nobuiltininc -nostdinc++ $(StrideNativeClang) -DNEED_DLL_EXPORT -o &quot;$(OutputObjectPath)\win-x64\%(StrideNativeCFile.Filename).obj&quot; -c &quot;%(StrideNativeCFile.FullPath)&quot; -fms-extensions -DWINDOWS_DESKTOP -target x86_64-pc-windows-msvc" />
     <Exec Condition="'%(StrideNativeCFile.Extension)' == '.cpp'" Command="&quot;$(StrideNativeClangCommand)&quot; -gcodeview -fno-ms-extensions -nobuiltininc -nostdinc++ $(StrideNativeClangCPP) $(StrideNativeClang) -DNEED_DLL_EXPORT -o &quot;$(OutputObjectPath)\win-x64\%(StrideNativeCFile.Filename).obj&quot; -c &quot;%(StrideNativeCFile.FullPath)&quot;  -fms-extensions -DWINDOWS_DESKTOP -target x86_64-pc-windows-msvc" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)WindowsProjects\WindowsDesktop\WindowsDesktop.vcxproj" Targets="Build" Properties="StrideNativeOutputName=$(StrideNativeOutputName);StrideNativeOutputDir=$(StrideNativeOutputPath)\runtimes\win-x64\native;StrideDependenciesDir=$(MSBuildThisFileDirectory)..\..\deps\;StrideNativePathLibs=libNativePath.lib $(StrideNativePathLibsWindows);StrideNativeProjectFolder=$(ProjectDir);StrideNativeProjectObjFolder=$(OutputObjectPath)\win-x64;Configuration=$(Configuration);Platform=x64" StopOnFirstFailure="true" />
+
+    <MakeDir Directories="$(OutputObjectPath)\win-arm64" Condition="'$(StrideNativeWindowsArm64Enabled)' == 'true'"/>
+    <Exec Condition="'%(StrideNativeCFile.Extension)' != '.cpp' AND '$(StrideNativeWindowsArm64Enabled)' == 'true'" Command="&quot;$(StrideNativeClangCommand)&quot; -gcodeview -fno-ms-extensions -nobuiltininc -nostdinc++ $(StrideNativeClang) -DNEED_DLL_EXPORT -o &quot;$(OutputObjectPath)\win-arm64\%(StrideNativeCFile.Filename).obj&quot; -c &quot;%(StrideNativeCFile.FullPath)&quot; -fms-extensions -DWINDOWS_DESKTOP -target aarch64-pc-windows-msvc" />
+    <Exec Condition="'%(StrideNativeCFile.Extension)' == '.cpp' AND '$(StrideNativeWindowsArm64Enabled)' == 'true'" Command="&quot;$(StrideNativeClangCommand)&quot; -gcodeview -fno-ms-extensions -nobuiltininc -nostdinc++ $(StrideNativeClangCPP) $(StrideNativeClang) -DNEED_DLL_EXPORT -o &quot;$(OutputObjectPath)\win-arm64\%(StrideNativeCFile.Filename).obj&quot; -c &quot;%(StrideNativeCFile.FullPath)&quot;  -fms-extensions -DWINDOWS_DESKTOP -target aarch64-pc-windows-msvc" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)WindowsProjects\WindowsDesktop\WindowsDesktop.vcxproj" Targets="Build" Properties="StrideNativeOutputName=$(StrideNativeOutputName);StrideNativeOutputDir=$(StrideNativeOutputPath)\runtimes\win-arm64\native;StrideDependenciesDir=$(MSBuildThisFileDirectory)..\..\deps\;StrideNativePathLibs=libNativePath.lib $(StrideNativePathLibsWindows);StrideNativeProjectFolder=$(ProjectDir);StrideNativeProjectObjFolder=$(OutputObjectPath)\win-arm64;Configuration=$(Configuration);Platform=arm64" StopOnFirstFailure="true" Condition="'$(StrideNativeWindowsArm64Enabled)' == 'true'" />
 
     <!-- Workaround: forcing C# rebuild so that timestamp are up to date (ideally we should have separate input/output groups for C# and Native) -->
     <Delete Files="@(IntermediateAssembly)"/>

--- a/sources/native/Stride.Native.targets
+++ b/sources/native/Stride.Native.targets
@@ -60,7 +60,7 @@
   </ItemGroup>
   <!-- Can be deleted -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(StrideFrameworkUWP)'">
-    <StrideNativeCPU Include="x86;x64;ARM;ARM64" LibraryExtension=".dll" />
+    <StrideNativeCPU Include="x86;x64;ARM" LibraryExtension=".dll" />
   </ItemGroup>
   <!-- Use runtimes/*/native folder -->
   <ItemGroup>

--- a/sources/native/WindowsProjects/WindowsDesktop/WindowsDesktop.vcxproj
+++ b/sources/native/WindowsProjects/WindowsDesktop/WindowsDesktop.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{75C5F896-0E36-4348-9E80-5E9EFE494D94}</ProjectGuid>
@@ -51,6 +59,19 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -66,6 +87,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -121,6 +148,26 @@
       <AdditionalOptions>$(StrideNativePathLibs) %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;WINDOWSDESKTOP_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(StrideDependenciesDir)\NativePath\dotnet\win-arm64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>$(StrideNativePathLibs) %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -170,6 +217,32 @@
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;WINDOWSDESKTOP_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(StrideDependenciesDir)\NativePath\dotnet\win-arm64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>$(StrideNativePathLibs) %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
@@ -178,11 +251,17 @@
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
       </PrecompiledHeader>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</CompileAsManaged>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+      </PrecompiledHeader>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
       </PrecompiledHeader>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </PrecompiledHeader>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</CompileAsManaged>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
       </PrecompiledHeader>
     </ClCompile>
   </ItemGroup>

--- a/sources/tools/Stride.TextureConverter.Wrappers/DirectXTex/DirectXTex_Desktop_2017.vcxproj
+++ b/sources/tools/Stride.TextureConverter.Wrappers/DirectXTex/DirectXTex_Desktop_2017.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -9,6 +13,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Profile|ARM64">
+      <Configuration>Profile</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Profile|Win32">
       <Configuration>Profile</Configuration>
       <Platform>Win32</Platform>
@@ -16,6 +24,10 @@
     <ProjectConfiguration Include="Profile|x64">
       <Configuration>Profile</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -44,6 +56,11 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
@@ -54,12 +71,22 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|X64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
@@ -78,10 +105,19 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Profile|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Profile|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -93,6 +129,13 @@
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
+    <OutDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>DirectXTex</TargetName>
+    <LinkIncremental>true</LinkIncremental>
+    <GenerateManifest>true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <OutDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTex</TargetName>
@@ -113,6 +156,13 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <OutDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>DirectXTex</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+    <GenerateManifest>true</GenerateManifest>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'">
     <OutDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</IntDir>
@@ -121,6 +171,13 @@
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|X64'">
+    <OutDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>DirectXTex</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+    <GenerateManifest>true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|ARM64'">
     <OutDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>Bin\Desktop_2017\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTex</TargetName>
@@ -196,6 +253,46 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <TargetMachine>MachineX64</TargetMachine>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+      <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>false</EnableDPIAwareness>
+    </Manifest>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <OpenMPSupport>true</OpenMPSupport>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <AdditionalOptions> /permissive- /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;WIN32;_DEBUG;_LIB;_WIN7_PLATFORM_UPDATE;_WIN32_WINNT=0x0600;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>DirectXTexP.h</PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <LargeAddressAware>true</LargeAddressAware>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
@@ -298,6 +395,48 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <OpenMPSupport>true</OpenMPSupport>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <AdditionalOptions> /permissive- /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;WIN32;NDEBUG;_LIB;_WIN7_PLATFORM_UPDATE;_WIN32_WINNT=0x0600;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>DirectXTexP.h</PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LargeAddressAware>true</LargeAddressAware>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+      <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>false</EnableDPIAwareness>
+    </Manifest>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
@@ -385,6 +524,48 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Profile|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <OpenMPSupport>true</OpenMPSupport>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <AdditionalOptions> /permissive- /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;WIN32;NDEBUG;PROFILE;_LIB;_WIN7_PLATFORM_UPDATE;_WIN32_WINNT=0x0600;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>DirectXTexP.h</PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LargeAddressAware>true</LargeAddressAware>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+      <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>false</EnableDPIAwareness>
+    </Manifest>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <CLInclude Include="BC.h" />
     <ClCompile Include="BC.cpp" />
@@ -417,8 +598,11 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="DirectXTexWIC.cpp" />
   </ItemGroup>

--- a/sources/tools/Stride.TextureConverter.Wrappers/DxtWrapper/DxtWrapper.vcxproj
+++ b/sources/tools/Stride.TextureConverter.Wrappers/DxtWrapper/DxtWrapper.vcxproj
@@ -1,6 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -8,6 +12,10 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -36,6 +44,12 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -44,6 +58,13 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
@@ -59,10 +80,16 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -76,12 +103,22 @@
     <OutDir>$(MSBuildThisFileDirectory)..\..\..\..\build\$(Configuration)\$(Platform)</OutDir>
     <IntDir>$(Configuration)\$(Platform)</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <TargetName>$(ProjectName)</TargetName>
+    <OutDir>$(MSBuildThisFileDirectory)..\..\..\..\build\$(Configuration)\$(Platform)</OutDir>
+    <IntDir>$(Configuration)\$(Platform)</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>$(ProjectName)</TargetName>
     <OutDir>$(MSBuildThisFileDirectory)..\..\..\..\build\$(Configuration)\$(Platform)</OutDir>
     <IntDir>$(Configuration)\$(Platform)</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>$(ProjectName)</TargetName>
+    <OutDir>$(MSBuildThisFileDirectory)..\..\..\..\build\$(Configuration)\$(Platform)</OutDir>
+    <IntDir>$(Configuration)\$(Platform)</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <TargetName>$(ProjectName)</TargetName>
     <OutDir>$(MSBuildThisFileDirectory)..\..\..\..\build\$(Configuration)\$(Platform)</OutDir>
     <IntDir>$(Configuration)\$(Platform)</IntDir>
@@ -118,6 +155,23 @@
     </Link>
     <PostBuildEvent>
       <Command>xcopy /y $(OutDir)$(TargetName).dll $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\x64\ &amp; xcopy /y $(OutDir)$(TargetName).pdb $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\x64\</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\DirectXTex</AdditionalIncludeDirectories>
+      <FloatingPointModel>Strict</FloatingPointModel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\DirectXTex\Bin\Desktop_2017\arm64\$(Configuration);</AdditionalLibraryDirectories>
+      <AdditionalDependencies>DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y $(OutDir)$(TargetName).dll $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\arm64\ &amp; xcopy /y $(OutDir)$(TargetName).pdb $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\arm64\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -160,6 +214,27 @@
     </Link>
     <PostBuildEvent>
       <Command>xcopy /y $(OutDir)$(TargetName).dll $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\x64\ &amp; xcopy /y $(OutDir)$(TargetName).pdb $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\x64\</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\DirectXTex</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FloatingPointModel>Strict</FloatingPointModel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\DirectXTex\Bin\Desktop_2017\arm64\$(Configuration);</AdditionalLibraryDirectories>
+      <AdditionalDependencies>DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y $(OutDir)$(TargetName).dll $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\arm64\ &amp; xcopy /y $(OutDir)$(TargetName).pdb $(ProjectDir)..\..\..\..\deps\TextureWrappers\$(Configuration)\arm64\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/sources/tools/Stride.TextureConverter.Wrappers/DxtWrapper/dxt_wrapper.h
+++ b/sources/tools/Stride.TextureConverter.Wrappers/DxtWrapper/dxt_wrapper.h
@@ -38,6 +38,7 @@ extern "C" {
 	// I/O functions
 	DXT_API HRESULT dxtLoadTGAFile(const char* szFile, DirectX::TexMetadata* metadata, DirectX::ScratchImage& image);
 	DXT_API HRESULT dxtLoadDDSFile(const char* szFile, DirectX::DDS_FLAGS flags, DirectX::TexMetadata* metadata, DirectX::ScratchImage& image);
+	DXT_API HRESULT dxtLoadWICFile(LPCWSTR szFile, int flags, DirectX::TexMetadata* metadata, DirectX::ScratchImage& image);
 	DXT_API HRESULT dxtSaveToDDSFile( const DirectX::Image& image, DirectX::DDS_FLAGS flags, const char* szFile );
     DXT_API HRESULT dxtSaveToDDSFileArray( const DirectX::Image* images, int nimages, const DirectX::TexMetadata& metadata, DirectX::DDS_FLAGS flags, const char* szFile );
 

--- a/sources/tools/Stride.TextureConverter.Wrappers/Stride.TextureConverter.Wrappers.sln
+++ b/sources/tools/Stride.TextureConverter.Wrappers/Stride.TextureConverter.Wrappers.sln
@@ -1,30 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29326.143
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35806.99 d17.13
 MinimumVisualStudioVersion = 15.0.26228.4
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DxtWrapper", "DxtWrapper\DxtWrapper.vcxproj", "{29F41E6E-532D-440E-941B-0CD13EE96B6F}"
 	ProjectSection(ProjectDependencies) = postProject
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77} = {371B9FA9-4C90-4AC6-A123-ACED756D6C77}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FreeImage.NET", "FreeImage.Net\FreeImage.NET.csproj", "{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTex", "DirectXTex\DirectXTex_Desktop_2017.vcxproj", "{371B9FA9-4C90-4AC6-A123-ACED756D6C77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM64 = Debug|ARM64
 		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Profile|Any CPU = Profile|Any CPU
+		Profile|ARM64 = Profile|ARM64
 		Profile|Mixed Platforms = Profile|Mixed Platforms
 		Profile|Win32 = Profile|Win32
 		Profile|x64 = Profile|x64
 		Profile|x86 = Profile|x86
 		Release|Any CPU = Release|Any CPU
+		Release|ARM64 = Release|ARM64
 		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
@@ -32,6 +33,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|ARM64.Build.0 = Debug|ARM64
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|Win32.ActiveCfg = Debug|Win32
@@ -41,6 +44,8 @@ Global
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|x86.ActiveCfg = Debug|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Debug|x86.Build.0 = Debug|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|Any CPU.ActiveCfg = Release|Win32
+		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|ARM64.ActiveCfg = Release|ARM64
+		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|ARM64.Build.0 = Release|ARM64
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|Mixed Platforms.ActiveCfg = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|Mixed Platforms.Build.0 = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|Win32.ActiveCfg = Release|Win32
@@ -49,6 +54,8 @@ Global
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|x86.ActiveCfg = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Profile|x86.Build.0 = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|Any CPU.ActiveCfg = Release|Win32
+		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|ARM64.ActiveCfg = Release|ARM64
+		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|ARM64.Build.0 = Release|ARM64
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|Mixed Platforms.ActiveCfg = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|Win32.ActiveCfg = Release|Win32
@@ -57,37 +64,9 @@ Global
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|x64.Build.0 = Release|x64
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|x86.ActiveCfg = Release|Win32
 		{29F41E6E-532D-440E-941B-0CD13EE96B6F}.Release|x86.Build.0 = Release|Win32
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|Win32.ActiveCfg = Debug|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|Win32.Build.0 = Debug|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|x64.ActiveCfg = Debug|x64
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|x64.Build.0 = Debug|x64
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|x86.ActiveCfg = Debug|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Debug|x86.Build.0 = Debug|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|Any CPU.ActiveCfg = Release|Any CPU
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|Any CPU.Build.0 = Release|Any CPU
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|Mixed Platforms.ActiveCfg = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|Mixed Platforms.Build.0 = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|Win32.ActiveCfg = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|Win32.Build.0 = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|x64.ActiveCfg = Release|x64
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|x64.Build.0 = Release|x64
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|x86.ActiveCfg = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Profile|x86.Build.0 = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|Mixed Platforms.Build.0 = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|Win32.ActiveCfg = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|Win32.Build.0 = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|x64.ActiveCfg = Release|x64
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|x64.Build.0 = Release|x64
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|x86.ActiveCfg = Release|x86
-		{6598A7CD-8F27-4D3F-A675-5AE63113A7C3}.Release|x86.Build.0 = Release|x86
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|ARM64.Build.0 = Debug|ARM64
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|Win32.ActiveCfg = Debug|Win32
@@ -97,6 +76,8 @@ Global
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|x86.ActiveCfg = Debug|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|x86.Build.0 = Debug|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|Any CPU.ActiveCfg = Profile|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|ARM64.ActiveCfg = Profile|ARM64
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|ARM64.Build.0 = Profile|ARM64
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|Mixed Platforms.ActiveCfg = Profile|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|Mixed Platforms.Build.0 = Profile|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|Win32.ActiveCfg = Profile|Win32
@@ -106,6 +87,8 @@ Global
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|x86.ActiveCfg = Profile|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Profile|x86.Build.0 = Profile|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|Any CPU.ActiveCfg = Release|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|ARM64.ActiveCfg = Release|ARM64
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|ARM64.Build.0 = Release|ARM64
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|Mixed Platforms.ActiveCfg = Release|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|Win32.ActiveCfg = Release|Win32

--- a/sources/tools/Stride.TextureConverter.Wrappers/build-deps.bat
+++ b/sources/tools/Stride.TextureConverter.Wrappers/build-deps.bat
@@ -2,3 +2,5 @@ msbuild Stride.TextureConverter.Wrappers.sln /Property:Configuration=Debug;Platf
 msbuild Stride.TextureConverter.Wrappers.sln /Property:Configuration=Release;Platform="Win32"
 msbuild Stride.TextureConverter.Wrappers.sln /Property:Configuration=Debug;Platform="x64"
 msbuild Stride.TextureConverter.Wrappers.sln /Property:Configuration=Release;Platform="x64"
+msbuild Stride.TextureConverter.Wrappers.sln /Property:Configuration=Debug;Platform="ARM64"
+msbuild Stride.TextureConverter.Wrappers.sln /Property:Configuration=Release;Platform="ARM64"

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
@@ -515,10 +515,10 @@ namespace Stride.TextureConverter.DxtWrapper
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static void dxtComputePitch(DXGI_FORMAT fmt, int width, int height, out int rowPitch, out int slicePitch, CP_FLAGS flags);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtLoadDDSFile(string filePath, DDS_FLAGS flags, out TexMetadata metadata, IntPtr image);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtLoadTGAFile(string filePath, out TexMetadata metadata, IntPtr image);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
@@ -545,10 +545,10 @@ namespace Stride.TextureConverter.DxtWrapper
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtDecompressArray(DxtImage[] cImages, int nimages, ref TexMetadata metadata, DXGI_FORMAT format, IntPtr images);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtSaveToDDSFile(ref DxtImage dxtImage, DDS_FLAGS flags, string szFile);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtSaveToDDSFileArray(DxtImage[] dxtImages, int nimages, ref TexMetadata metadata, DDS_FLAGS flags, string szFile);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]

--- a/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
@@ -12,6 +12,7 @@ using Stride.TextureConverter.Requests;
 using Stride.TextureConverter.TexLibraries;
 using System.Runtime.CompilerServices;
 using Stride.TextureConverter.Backend.Requests;
+using System.Runtime.InteropServices;
 
 namespace Stride.TextureConverter
 {
@@ -38,11 +39,16 @@ namespace Stride.TextureConverter
         {
             var type = typeof(TextureTool);
             NativeLibraryHelper.PreloadLibrary("DxtWrapper", type);
-            NativeLibraryHelper.PreloadLibrary("PVRTexLib", type);
+            if (IsPVRTexLibAvailable())
+                NativeLibraryHelper.PreloadLibrary("PVRTexLib", type);
             NativeLibraryHelper.PreloadLibrary("freeimage", type);
-            //TODO: needs to explain why FreeImageNET is loaded as a dll instead of directly referencing the C# project (this does not affect the compilation process on Linux).
-            if (OperatingSystem.IsWindows())
-                NativeLibraryHelper.PreloadLibrary("FreeImageNET", type); 
+
+            static bool IsPVRTexLibAvailable()
+            {
+                if (OperatingSystem.IsWindows())
+                    return RuntimeInformation.ProcessArchitecture != Architecture.Arm64;
+                return true;
+            }
         }
 
         /// <summary>

--- a/sources/tools/Stride.VisualStudio.Package.Tests/Stride.VisualStudio.Package.Tests.csproj
+++ b/sources/tools/Stride.VisualStudio.Package.Tests/Stride.VisualStudio.Package.Tests.csproj
@@ -76,7 +76,7 @@
   <Import Project="$(StrideSdkTargets)" />
   <Target Name="LocateDevenv" AfterTargets="PrepareForBuild">
     <!-- Compute and save VisualStudio path to a file so that it can be used when running the test. Note: ideally we should use a Task, but Visual Studio lock the files -->
-    <Exec Command="&quot;..\..\core\Stride.Core.Tasks\bin\$(Configuration)\$(StrideEditorTargetFramework)\Stride.Core.Tasks.exe&quot; locate-devenv &quot;$(MSBuildBinPath)&quot;" ConsoleToMsBuild="true">
+    <Exec Command="&quot;..\..\core\Stride.Core.Tasks\bin\$(Configuration)\$(StrideXplatEditorTargetFramework)\Stride.Core.Tasks.exe&quot; locate-devenv &quot;$(MSBuildBinPath)&quot;" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="DevenvPath" />
     </Exec>
     <WriteLinesToFile File="$(OutputPath)\devenvpath.txt" Lines="$(DevenvPath)" Overwrite="true" />


### PR DESCRIPTION
# PR Details

Allows to develop and also run games on `win-arm64`.

Needs MSVC v143 - VS2022 C++ ARM64 build tools (Latest) 

- The used versions of those dependencies are often rather dated and didn't build out of the box on win-arm64 / Visual Studio 2022, minimal patches had to be applied. Need to push/document those separately.
- As far as I understood PVRTexLib is delivered as binary only and there's no win-arm64 - therefor added a check to not load it at all. In the end it's only needed by the asset compiler, which in turn is platform neutral. However when invoking it on a arm64 machine, the `dotnet path/to/asset/compiler` will launch it in arm64. If there would be some option to launch it in x64 we wouldn't have any issues with asset compiling. Still the editor might have issues, since its running in process?
- Removed the FreeImageNET load - it's not used anywhere in code
- Fixes some PInvoke signatures in DxtWrapper

The game studio also runs on arm64, but one must set the runtime identifiers in Stride.GameStudio/Editor/Assets.Presentation accordingly. Would be nice to add an arm64 version to the installer, but different topic I'd say.

## FFmepg
checkout.bat says to use n3.3.3 tag however I didn't manage to get it to build. Was therefor using release/3.4 as a base.
Basically had to cherry-pick two commits from main branch in regards to arm64.
A quick test with importing a video asset and playing it later in the game worked. 
https://github.com/azeno/FFmpeg/tree/win-arm64

## FreeImage
- Added a checkout.bat file which will also apply the needed fixes

## Recast
Guessed the commit by comparing the checked in header files to those in the original repo.  Added the used commit-id to checkout.bat file.

## Needed PRs in other repos
- https://github.com/stride3d/BulletSharpPInvoke/pull/5
- https://github.com/stride3d/NativePath/pull/2
- https://github.com/stride3d/freetype/pull/1

## Related Issue
#2397 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
