### PR TITLE
fix: Ensure teleporting bodies notify bepu's data structure

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -212,7 +212,7 @@ public class BodyComponent : CollidableComponent
     }
 
     /// <summary>
-    /// The position of this body in the physics scene, setting it will teleport this object to the positoin provided.
+    /// The position of this body in the physics scene, setting it will teleport this object to the position provided.
     /// </summary>
     /// <remarks>
     /// Using this property to move objects around is not recommended,
@@ -226,12 +226,14 @@ public class BodyComponent : CollidableComponent
         set
         {
             if (BodyReference is { } bodyRef)
+            {
                 bodyRef.Pose.Position = PreviousPose.Position = value.ToNumeric();
+                bodyRef.UpdateBounds();
+            }
 
             Quaternion dummy = default;
             WorldToLocal(ref value, ref dummy);
             Entity.Transform.Position = value;
-
         }
     }
 


### PR DESCRIPTION
# PR Details
We have to explicitly notify bepu when moving a body, even more so when sleeping, otherwise its internal representation inside the physics scene is not updated, leading to misses when doing physics tests

## Related Issue
fix #2649

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
