### PR TITLE
fix: Restore Nuget Resolver UI

### DIFF
--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -16,7 +16,7 @@
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>
     <StrideLocalized>true</StrideLocalized>
-    <StrideNuGetResolverUI>false</StrideNuGetResolverUI>
+    <StrideNuGetResolverUI>true</StrideNuGetResolverUI>
     <StrideSTAThreadOnMain>true</StrideSTAThreadOnMain>
     <UseWPF>true</UseWPF>
     <EnableDefaultPageItems>false</EnableDefaultPageItems>

--- a/sources/shared/Stride.NuGetResolver.Targets/NuGetResolverModuleInitializer.cs
+++ b/sources/shared/Stride.NuGetResolver.Targets/NuGetResolverModuleInitializer.cs
@@ -15,6 +15,9 @@ class NuGetResolverModuleInitializer
             || Assembly.GetEntryAssembly() == Assembly.GetCallingAssembly())) // .NET Core: check against calling assembly (note: if using Stride.NuGetLoader, it will be skipped as well which is what we want)
             return;
 
+#if STRIDE_NUGET_RESOLVER_UI
+        NuGetAssemblyResolver.AvaloniaVersion = STRIDE_NUGET_RESOLVER_UI_AVALONIA_VERSION;
+#endif
         NuGetAssemblyResolver.SetupNuGet(STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK, STRIDE_NUGET_RESOLVER_PACKAGE_NAME, STRIDE_NUGET_RESOLVER_PACKAGE_VERSION);
     }
 }

--- a/sources/shared/Stride.NuGetResolver.Targets/NuGetResolverModuleInitializer.cs
+++ b/sources/shared/Stride.NuGetResolver.Targets/NuGetResolverModuleInitializer.cs
@@ -3,19 +3,18 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 
-namespace Stride.Core.Assets
-{
-    class NuGetResolverModuleInitializer
-    {
-        [ModuleInitializer(-100000)]
-        internal static void __Initialize__()
-        {
-            // Only perform this for entry assembly
-            if (!(Assembly.GetEntryAssembly() == null // .NET FW: null during module .ctor
-                || Assembly.GetEntryAssembly() == Assembly.GetCallingAssembly())) // .NET Core: check against calling assembly (note: if using Stride.NuGetLoader, it will be skipped as well which is what we want)
-                return;
+namespace Stride.Core.Assets;
 
-            NuGetAssemblyResolver.SetupNuGet(STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK, STRIDE_NUGET_RESOLVER_PACKAGE_NAME, STRIDE_NUGET_RESOLVER_PACKAGE_VERSION);
-        }
+class NuGetResolverModuleInitializer
+{
+    [ModuleInitializer(-100000)]
+    internal static void __Initialize__()
+    {
+        // Only perform this for entry assembly
+        if (!(Assembly.GetEntryAssembly() == null // .NET FW: null during module .ctor
+            || Assembly.GetEntryAssembly() == Assembly.GetCallingAssembly())) // .NET Core: check against calling assembly (note: if using Stride.NuGetLoader, it will be skipped as well which is what we want)
+            return;
+
+        NuGetAssemblyResolver.SetupNuGet(STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK, STRIDE_NUGET_RESOLVER_PACKAGE_NAME, STRIDE_NUGET_RESOLVER_PACKAGE_VERSION);
     }
 }

--- a/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
+++ b/sources/shared/Stride.NuGetResolver.Targets/Stride.NuGetResolver.Targets.projitems
@@ -16,15 +16,15 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>_StrideIncludeNuGetResolver;$(TargetsForTfmSpecificBuildOutput)</TargetsForTfmSpecificBuildOutput>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config;.exe</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <UseWPF Condition="'$(StrideNuGetResolverUI)' == 'true'">true</UseWPF>
   </PropertyGroup>
   <Target Name="NuGetResolverModuleInitializerGenerate" BeforeTargets="BeforeCompile;CoreCompile" DependsOnTargets="PrepareForBuild">
     <PropertyGroup>
       <NuGetResolverModuleInitializerFile>$(IntermediateOutputPath)$(MSBuildProjectName).NuGetResolverEntryPoint$(DefaultLanguageSourceExtension)</NuGetResolverModuleInitializerFile>
       <NuGetResolverTargetFramework>$(TargetFramework)</NuGetResolverTargetFramework>
       <NuGetResolverTargetFramework Condition="'$(TargetPlatformVersion)' != '' and !$(TargetFramework.EndsWith(TargetPlatformVersion))">$(TargetFramework)$(TargetPlatformVersion)</NuGetResolverTargetFramework>
+	  <DefineConstants Condition="'$(StrideNuGetResolverUI)' == 'true'">STRIDE_NUGET_RESOLVER_UI;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
-    <WriteLinesToFile File="$(NuGetResolverModuleInitializerFile)" Overwrite="true" Lines="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)NuGetResolverModuleInitializer.cs')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK','&quot;$(NuGetResolverTargetFramework)&quot;')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_PACKAGE_NAME','&quot;$(PackageId)&quot;')&#xD;&#xA;                              .Replace('STRIDE_NUGET_RESOLVER_PACKAGE_VERSION','&quot;$(PackageVersion)&quot;'))" />
+    <WriteLinesToFile File="$(NuGetResolverModuleInitializerFile)" Overwrite="true" Lines="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)NuGetResolverModuleInitializer.cs').Replace('STRIDE_NUGET_RESOLVER_TARGET_FRAMEWORK','&quot;$(NuGetResolverTargetFramework)&quot;').Replace('STRIDE_NUGET_RESOLVER_PACKAGE_NAME','&quot;$(PackageId)&quot;').Replace('STRIDE_NUGET_RESOLVER_PACKAGE_VERSION','&quot;$(PackageVersion)&quot;').Replace('STRIDE_NUGET_RESOLVER_UI_AVALONIA_VERSION','&quot;$(AvaloniaVersion)&quot;'))" />
     <ItemGroup>
       <FileWrites Include="$(NuGetResolverModuleInitializerFile)" />
       <Compile Include="$(NuGetResolverModuleInitializerFile)" />

--- a/sources/shared/Stride.NuGetResolver.UI/NuGetAssemblyResolver.private.cs
+++ b/sources/shared/Stride.NuGetResolver.UI/NuGetAssemblyResolver.private.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+
+namespace Stride.Core.Assets;
+
+partial class NuGetAssemblyResolver
+{
+    // Use a inner-class so that UI-stuff are lazy loaded (especially after having their dependencies resolved)
+    private static class ResolverUILauncher
+    {
+        public static void Run(TaskCompletionSource dialogNotNeeded, TaskCompletionSource dialogClosed, Logger logger)
+        {
+            NuGetResolver.NugetResolverApp.Run((app, ___) =>
+            {
+                app.Styles.Add(new Avalonia.Themes.Fluent.FluentTheme());
+                var splashScreen = new NuGetResolver.SplashScreenWindow();
+                splashScreen.Show();
+                // Register log
+                logger.SetupLogAction((level, message) => splashScreen.SetupLog(level, message));
+
+                dialogNotNeeded.Task.ContinueWith(__ => splashScreen.CloseApp());
+                splashScreen.Closed += (sender2, e2) => NuGetResolver.SplashScreenWindow.InvokeShutDown();
+
+                app.Run(splashScreen);
+                splashScreen.Close();
+            });
+            dialogClosed.SetResult();
+        }
+    }
+}

--- a/sources/shared/Stride.NuGetResolver.UI/SplashScreenWindow.axaml.cs
+++ b/sources/shared/Stride.NuGetResolver.UI/SplashScreenWindow.axaml.cs
@@ -1,68 +1,65 @@
-using System.Reflection.Emit;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
 using Avalonia.Media;
-using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using NuGet.Common;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
-namespace Stride.NuGetResolver
+namespace Stride.NuGetResolver;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class SplashScreenWindow : Window
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class SplashScreenWindow : Window
+    private int lineCounter;
+
+    public SplashScreenWindow()
     {
-        private int lineCounter;
-
-        public SplashScreenWindow()
-        {
-            this.InitializeComponent();
-        }
-
-        public void AppendMessage(LogLevel level, string message)
-        {
-            if (level == LogLevel.Error)
-            {
-                CloseButton.IsVisible = true;
-                Message.Text = "Error restoring NuGet packages!";
-                Message.Foreground = new SolidColorBrush(Colors.Red);
-            }
-            Log.Text += ($"[{level}] {message}{Environment.NewLine}");
-            Log.ScrollToLine(++lineCounter);
-        }
-
-        public void CloseCommand(object sender, RoutedEventArgs e)
-        {
-            this.Close();
-        }
-
-        public void SetupLog(LogLevel level, string message)
-        {
-            Dispatcher.UIThread.InvokeAsync(() => AppendMessage(level, message));
-        }
-        
-        public void CloseApp()
-        {
-            Dispatcher.UIThread.InvokeAsync(() => Close());
-        }
-        public void InvokeShutDown()
-        {
-            Dispatcher.UIThread.InvokeShutdown();
-        }
+        InitializeComponent();
     }
 
-    public class NugetResolverApp
+    public void AppendMessage(LogLevel level, string message)
     {
-        public static void Run(AppBuilder.AppMainDelegate AppMain)
+        if (level == LogLevel.Error)
         {
-            AppBuilder.Configure<Application>()
-                .UsePlatformDetect()
-                .Start(AppMain, []);
+            CloseButton.IsVisible = true;
+            Message.Text = "Error restoring NuGet packages!";
+            Message.Foreground = new SolidColorBrush(Colors.Red);
         }
+        Log.Text += $"[{level}] {message}{Environment.NewLine}";
+        Log.ScrollToLine(++lineCounter);
+    }
+
+    public void CloseCommand(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    public void SetupLog(LogLevel level, string message)
+    {
+        Dispatcher.UIThread.InvokeAsync(() => AppendMessage(level, message));
+    }
+
+    public void CloseApp()
+    {
+        Dispatcher.UIThread.InvokeAsync(() => Close());
+    }
+
+    public static void InvokeShutDown()
+    {
+        Dispatcher.UIThread.InvokeShutdown();
+    }
+}
+
+public static class NugetResolverApp
+{
+    public static void Run(AppBuilder.AppMainDelegate AppMain)
+    {
+        AppBuilder.Configure<Application>()
+            .UsePlatformDetect()
+            .Start(AppMain, []);
     }
 }

--- a/sources/shared/Stride.NuGetResolver.UI/Stride.NuGetResolver.UI.csproj
+++ b/sources/shared/Stride.NuGetResolver.UI/Stride.NuGetResolver.UI.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="NuGet.PackageManagement" />
     <PackageReference Include="NuGet.Resolver" />
     <PackageReference Include="NuGet.Commands" />
-    <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Desktop" PrivateAssets="all" />
+    <PackageReference Include="Avalonia.Themes.Fluent" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/sources/shared/Stride.NuGetResolver.UI/Stride.NuGetResolver.UI.csproj
+++ b/sources/shared/Stride.NuGetResolver.UI/Stride.NuGetResolver.UI.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="NuGet.PackageManagement" />
     <PackageReference Include="NuGet.Resolver" />
     <PackageReference Include="NuGet.Commands" />
-    <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
   </ItemGroup>

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -287,8 +287,8 @@ public static partial class NuGetAssemblyResolver
             lock (logLock)
             {
                 this.action = action;
-                foreach (var (level, Message) in Logs)
-                    action.Invoke(level, Message);
+                foreach (var (Level, Message) in Logs)
+                    action.Invoke(Level, Message);
             }
         }
 

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using NuGet.Common;
@@ -13,149 +13,145 @@ using NuGet.Versioning;
 using Avalonia.Controls;
 #endif
 
-namespace Stride.Core.Assets
+namespace Stride.Core.Assets;
+
+public static class NuGetAssemblyResolver
 {
-    public class NuGetAssemblyResolver
+    public const string DevSource = @"Stride\NugetDev";
+
+    static bool assembliesResolved;
+    static readonly object assembliesLock = new();
+    static Dictionary<string, string>? assemblyNameToPath;
+
+    public static void DisableAssemblyResolve()
     {
-        public const string DevSource = @"Stride\NugetDev";
+        assembliesResolved = true;
+    }
 
-        static bool assembliesResolved;
-        static readonly object assembliesLock = new object();
-        static Dictionary<string, string> assemblyNameToPath;
+    /// <summary>
+    /// Set up an Assembly resolver which on first missing Assembly runs Nuget resolver over <paramref name="packageName"/>.
+    /// </summary>
+    /// <param name="packageName">Name of the root package for NuGet resolution.</param>
+    /// <param name="packageVersion">Package version.</param>
+    public static void SetupNuGet(string targetFramework, string packageName, string packageVersion)
+    {
+        // Make sure our nuget local store is added to nuget config
+        var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        var devSourcePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), DevSource);
 
-        public static void DisableAssemblyResolve()
+        while (folder != null)
         {
-            assembliesResolved = true;
+            if (File.Exists(Path.Combine(folder, @"build\Stride.sln")))
+            {
+                var settings = Settings.LoadDefaultSettings(null);
+
+                Directory.CreateDirectory(devSourcePath);
+                CheckPackageSource(settings, "Stride Dev", devSourcePath);
+
+                settings.SaveToDisk();
+                break;
+            }
+            folder = Path.GetDirectoryName(folder);
         }
 
-        /// <summary>
-        /// Set up an Assembly resolver which on first missing Assembly runs Nuget resolver over <paramref name="packageName"/>.
-        /// </summary>
-        /// <param name="packageName">Name of the root package for NuGet resolution.</param>
-        /// <param name="packageVersion">Package version.</param>
-        /// <param name="metadataAssembly">Assembly for getting target framrwork and platform.</param>
-        public static void SetupNuGet(string targetFramework, string packageName, string packageVersion)
+        // Note: we perform nuget restore inside the assembly resolver rather than top level module ctor (otherwise it freezes)
+        AppDomain.CurrentDomain.AssemblyResolve += (_, eventArgs) =>
         {
-            // Make sure our nuget local store is added to nuget config
-            var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var devSourcePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), DevSource);
-
-            while (folder != null)
+            if (!assembliesResolved)
             {
-                if (File.Exists(Path.Combine(folder, @"build\Stride.sln")))
+                lock (assembliesLock)
                 {
-                    var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null);
+                    // Note: using NuGet will try to recursively resolve NuGet.*.resources.dll, so set assembliesResolved right away so that it bypasses everything
+                    assembliesResolved = true;
 
-                    Directory.CreateDirectory(devSourcePath);
-                    CheckPackageSource(settings, "Stride Dev", devSourcePath);
-
-                    settings.SaveToDisk();
-                    break;
-                }
-                folder = Path.GetDirectoryName(folder);
-            }
-
-            // Note: we perform nuget restore inside the assembly resolver rather than top level module ctor (otherwise it freezes)
-            AppDomain.CurrentDomain.AssemblyResolve += (sender, eventArgs) =>
-            {
-                if (!assembliesResolved)
-                {
-                    lock (assembliesLock)
-                    {
-                        // Note: using NuGet will try to recursively resolve NuGet.*.resources.dll, so set assembliesResolved right away so that it bypasses everything
-                        assembliesResolved = true;
-
-                        var logger = new Logger();
+                    var logger = new Logger();
 
 #if STRIDE_NUGET_RESOLVER_UI
-                        var dialogNotNeeded = new TaskCompletionSource<bool>();
-                        var dialogClosed = new TaskCompletionSource<bool>();
+                    var dialogNotNeeded = new TaskCompletionSource<bool>();
+                    var dialogClosed = new TaskCompletionSource<bool>();
 
                         // Display splash screen after a 500 msec (when NuGet takes some time to restore)
-                        var newWindowThread = new Thread(() =>
+                    var newWindowThread = new Thread(() =>
+                    {
+                        Thread.Sleep(500);
+                        if (!dialogNotNeeded.Task.IsCompleted)
                         {
-                            Thread.Sleep(500);
-                            if (!dialogNotNeeded.Task.IsCompleted)
+                            NuGetResolver.NugetResolverApp.Run((app, ___) =>
                             {
-                                Stride.NuGetResolver.NugetResolverApp.Run((app, args) =>
-                                {
-                                    app.Styles.Add(new Avalonia.Themes.Fluent.FluentTheme());
-                                    var splashScreen = new Stride.NuGetResolver.SplashScreenWindow();
-                                    splashScreen.Show();
-                                    // Register log
-                                    logger.SetupLogAction((level, message) =>
-                                    {
-                                        splashScreen.SetupLog(level, message);
-                                    });
+                                app.Styles.Add(new Avalonia.Themes.Fluent.FluentTheme());
+                                var splashScreen = new NuGetResolver.SplashScreenWindow();
+                                splashScreen.Show();
+                                // Register log
+                                logger.SetupLogAction((level, message) => splashScreen.SetupLog(level, message));
 
-                                    dialogNotNeeded.Task.ContinueWith(t =>
-                                    {
-                                        splashScreen.CloseApp();
-                                    });
-                                    splashScreen.Closed += (sender2, e2) => { splashScreen.InvokeShutDown();};
+                                dialogNotNeeded.Task.ContinueWith(__ => splashScreen.CloseApp());
+                                splashScreen.Closed += (sender2, e2) => splashScreen.InvokeShutDown();
 
-                                    app.Run(splashScreen);
-                                    splashScreen.Close();
-                                });
-                            }
-                            dialogClosed.SetResult(true);
-                        });
+                                app.Run(splashScreen);
+                                splashScreen.Close();
+                            });
+                        }
+                        dialogClosed.SetResult(true);
+                    });
+                    if (OperatingSystem.IsWindows())
+                    {
                         newWindowThread.SetApartmentState(ApartmentState.STA);
-                        newWindowThread.IsBackground = true;
-                        newWindowThread.Start();
+                    }
+                    newWindowThread.IsBackground = true;
+                    newWindowThread.Start();
 #endif
 
-                        var previousSynchronizationContext = SynchronizationContext.Current;
-                        try
+                    var previousSynchronizationContext = SynchronizationContext.Current;
+                    try
+                    {
+                        // Since we execute restore synchronously, we don't want any surprise concerning synchronization context (i.e. Avalonia one doesn't work with this)
+                        SynchronizationContext.SetSynchronizationContext(null);
+
+                        // Parse current TFM
+                        var nugetFramework = NuGetFramework.Parse(targetFramework);
+
+                        // Only allow this specific version
+                        var versionRange = new VersionRange(new NuGetVersion(packageVersion), true, new NuGetVersion(packageVersion), true);
+                        var (request, result) = RestoreHelper.Restore(logger, nugetFramework, RuntimeInformation.RuntimeIdentifier, packageName, versionRange);
+                        if (!result.Success)
                         {
-                            // Since we execute restore synchronously, we don't want any surprise concerning synchronization context (i.e. Avalonia one doesn't work with this)
-                            SynchronizationContext.SetSynchronizationContext(null);
-
-                            // Parse current TFM
-                            var nugetFramework = NuGetFramework.Parse(targetFramework);
-
-                            // Only allow this specific version
-                            var versionRange = new VersionRange(new NuGetVersion(packageVersion), true, new NuGetVersion(packageVersion), true);
-                            var (request, result) = RestoreHelper.Restore(logger, nugetFramework, RuntimeInformation.RuntimeIdentifier, packageName, versionRange);
-                            if (!result.Success)
-                            {
-                                throw new InvalidOperationException($"Could not restore NuGet packages");
-                            }
-
-                            // Build list of assemblies
-                            var assemblies = RestoreHelper.ListAssemblies(result.LockFile);
-
-                            // Create a dictionary by assembly name
-                            // note: we ignore case as filename might not be properly matching assembly name casing
-                            assemblyNameToPath = new(StringComparer.OrdinalIgnoreCase);
-                            foreach (var assembly in assemblies)
-                            {
-                                var extension = Path.GetExtension(assembly).ToLowerInvariant();
-                                if (extension != ".dll")
-                                    continue;
-                                var assemblyName = Path.GetFileNameWithoutExtension(assembly);
-                                // Ignore duplicates (however, make sure it's the same version otherwise display a warning)
-                                if (assemblyNameToPath.TryGetValue(assemblyName, out var otherAssembly))
-                                {
-                                    if (!FileContentIsSame(new FileInfo(otherAssembly), new FileInfo(assembly)))
-                                        logger.LogWarning($"Assembly {assemblyName} found in two locations with different content: {assembly} and {otherAssembly}");
-                                    continue;
-                                }
-                                assemblyNameToPath.Add(assemblyName, assembly);
-                            }
-
-                            // Register the native libraries
-                            var nativeLibs = RestoreHelper.ListNativeLibs(result.LockFile);
-                            RegisterNativeDependencies(assemblyNameToPath, nativeLibs);
+                            throw new InvalidOperationException("Could not restore NuGet packages");
                         }
-                        catch (Exception e)
+
+                        // Build list of assemblies
+                        var assemblies = RestoreHelper.ListAssemblies(result.LockFile);
+
+                        // Create a dictionary by assembly name
+                        // note: we ignore case as filename might not be properly matching assembly name casing
+                        assemblyNameToPath = new(StringComparer.OrdinalIgnoreCase);
+                        foreach (var assembly in assemblies)
                         {
+                            var extension = Path.GetExtension(assembly).ToLowerInvariant();
+                            if (extension != ".dll")
+                                continue;
+                            var assemblyName = Path.GetFileNameWithoutExtension(assembly);
+                            // Ignore duplicates (however, make sure it's the same version otherwise display a warning)
+                            if (assemblyNameToPath.TryGetValue(assemblyName, out var otherAssembly))
+                            {
+                                if (!FileContentIsSame(new FileInfo(otherAssembly), new FileInfo(assembly)))
+                                    logger.LogWarning($"Assembly {assemblyName} found in two locations with different content: {assembly} and {otherAssembly}");
+                                continue;
+                            }
+                            assemblyNameToPath.Add(assemblyName, assembly);
+                        }
+
+                        // Register the native libraries
+                        var nativeLibs = RestoreHelper.ListNativeLibs(result.LockFile);
+                        RegisterNativeDependencies(assemblyNameToPath, nativeLibs);
+                    }
+                    catch (Exception e)
+                    {
 #if STRIDE_NUGET_RESOLVER_UI
-                            logger.LogError($@"Error restoring NuGet packages: {e}");
-                            dialogClosed.Task.Wait();
+                        logger.LogError($"Error restoring NuGet packages: {e}");
+                        dialogClosed.Task.Wait();
 #else
-                            // Display log in console
-                            var logText = $@"Error restoring NuGet packages!
+                        // Display log in console
+                        var logText = $@"Error restoring NuGet packages!
 
 ==== Exception details ====
 
@@ -165,180 +161,171 @@ namespace Stride.Core.Assets
 
 {string.Join(Environment.NewLine, logger.Logs.Select(x => $"[{x.Level}] {x.Message}"))}
 ";
-                            Console.WriteLine(logText);
+                        Console.WriteLine(logText);
 #endif
-                            Environment.Exit(1);
-                        }
-                        finally
-                        {
+                        Environment.Exit(1);
+                    }
+                    finally
+                    {
 #if STRIDE_NUGET_RESOLVER_UI
-                            dialogNotNeeded.TrySetResult(true);
+                        dialogNotNeeded.TrySetResult(true);
 #endif
-                            SynchronizationContext.SetSynchronizationContext(previousSynchronizationContext);
-                        }
+                        SynchronizationContext.SetSynchronizationContext(previousSynchronizationContext);
                     }
-                }
-
-                if (assemblyNameToPath != null)
-                {
-                    var aname = new AssemblyName(eventArgs.Name);
-                    if (aname.Name.StartsWith("Microsoft.Build", StringComparison.Ordinal) && aname.Name != "Microsoft.Build.Locator")
-                        return null;
-                    if (assemblyNameToPath.TryGetValue(aname.Name, out var assemblyPath))
-                    {
-                        return Assembly.LoadFrom(assemblyPath);
-                    }
-                }
-                return null;
-            };
-        }
-
-        static bool FileContentIsSame(FileInfo file1, FileInfo file2)
-        {
-            if (file1.Length != file2.Length)
-                return false;
-
-            // Assume same size and same modified time means it's the same file
-            if (file1.LastWriteTimeUtc == file2.LastWriteTimeUtc)
-                return true;
-
-            // Otherwise, full file compare
-            using (var fs1 = file1.OpenRead())
-            using (var fs2 = file2.OpenRead())
-            {
-                for (int i = 0; i < file1.Length; i++)
-                {
-                    if (fs1.ReadByte() != fs2.ReadByte())
-                        return false;
                 }
             }
+
+            if (assemblyNameToPath != null)
+            {
+                var aname = new AssemblyName(eventArgs.Name);
+                if (aname.Name!.StartsWith("Microsoft.Build", StringComparison.Ordinal) && aname.Name != "Microsoft.Build.Locator")
+                    return null;
+                if (assemblyNameToPath.TryGetValue(aname.Name, out var assemblyPath))
+                {
+                    return Assembly.LoadFrom(assemblyPath);
+                }
+            }
+            return null;
+        };
+    }
+
+    static bool FileContentIsSame(FileInfo file1, FileInfo file2)
+    {
+        if (file1.Length != file2.Length)
+            return false;
+
+        // Assume same size and same modified time means it's the same file
+        if (file1.LastWriteTimeUtc == file2.LastWriteTimeUtc)
             return true;
-        }
 
-        private static void RemoveSources(ISettings settings, string prefixName)
+        // Otherwise, full file compare
+        using var fs1 = file1.OpenRead();
+        using var fs2 = file2.OpenRead();
+        for (int i = 0; i < file1.Length; i++)
         {
-            var packageSources = settings.GetSection("packageSources");
-            if (packageSources != null)
+            if (fs1.ReadByte() != fs2.ReadByte())
+                return false;
+        }
+        return true;
+    }
+
+    private static void RemoveSources(ISettings settings, string prefixName)
+    {
+        var packageSources = settings.GetSection("packageSources");
+        if (packageSources != null)
+        {
+            foreach (var packageSource in packageSources.Items.OfType<SourceItem>().ToList())
             {
-                foreach (var packageSource in packageSources.Items.OfType<SourceItem>().ToList())
+                if (packageSource.Key.StartsWith(prefixName, StringComparison.Ordinal))
                 {
-                    if (packageSource.Key.StartsWith(prefixName, StringComparison.Ordinal))
-                    {
-                        // Remove entry from packageSources
-                        settings.Remove("packageSources", packageSource);
-                    }
+                    // Remove entry from packageSources
+                    settings.Remove("packageSources", packageSource);
                 }
             }
         }
+    }
 
-        private static void CheckPackageSource(ISettings settings, string name, string url)
+    private static void CheckPackageSource(ISettings settings, string name, string url)
+    {
+        settings.AddOrUpdate("packageSources", new SourceItem(name, url));
+    }
+
+    /// <summary>
+    /// Registers the listed native libs in Stride.Core.NativeLibraryHelper using reflection to avoid a compile time dependency on Stride.Core
+    /// </summary>
+    private static void RegisterNativeDependencies(Dictionary<string, string> assemblyNameToPath, List<string> nativeLibs)
+    {
+        var strideCoreAssembly = Assembly.LoadFrom(assemblyNameToPath["Stride.Core"])
+            ?? throw new InvalidOperationException("Couldn't find assembly 'Stride.Core' in restored packages");
+        var nativeLibraryHelperType = strideCoreAssembly.GetType("Stride.Core.NativeLibraryHelper")
+            ?? throw new InvalidOperationException($"Couldn't find type 'Stride.Core.NativeLibraryHelper' in {strideCoreAssembly}");
+        var registerDependencyMethod = nativeLibraryHelperType.GetMethod("RegisterDependency")
+            ?? throw new InvalidOperationException($"Couldn't find method 'RegisterDependency' in {nativeLibraryHelperType}");
+        foreach (var lib in nativeLibs)
+            registerDependencyMethod.Invoke(null, [lib]);
+    }
+
+    public class Logger : ILogger
+    {
+        private readonly object logLock = new();
+        private Action<LogLevel, string>? action;
+        public List<(LogLevel Level, string Message)> Logs { get; } = [];
+
+        public void SetupLogAction(Action<LogLevel, string> action)
         {
-            settings.AddOrUpdate("packageSources", new SourceItem(name, url));
+            lock (logLock)
+            {
+                this.action = action;
+                foreach (var (level, Message) in Logs)
+                    action.Invoke(level, Message);
+            }
         }
 
-        /// <summary>
-        /// Registers the listed native libs in Stride.Core.NativeLibraryHelper using reflection to avoid a compile time dependency on Stride.Core
-        /// </summary>
-        private static void RegisterNativeDependencies(Dictionary<string, string> assemblyNameToPath, List<string> nativeLibs)
+        public void LogDebug(string data)
         {
-            var strideCoreAssembly = Assembly.LoadFrom(assemblyNameToPath["Stride.Core"]);
-            if (strideCoreAssembly is null)
-                throw new InvalidOperationException($"Couldn't find assembly 'Stride.Core' in restored packages");
-
-            var nativeLibraryHelperType = strideCoreAssembly.GetType("Stride.Core.NativeLibraryHelper");
-            if (nativeLibraryHelperType is null)
-                throw new InvalidOperationException($"Couldn't find type 'Stride.Core.NativeLibraryHelper' in {strideCoreAssembly}");
-
-            var registerDependencyMethod = nativeLibraryHelperType.GetMethod("RegisterDependency");
-            if (registerDependencyMethod is null)
-                throw new InvalidOperationException($"Couldn't find method 'RegisterDependency' in {nativeLibraryHelperType}");
-
-            foreach (var lib in nativeLibs)
-                registerDependencyMethod.Invoke(null, new[] { lib });
+            Log(LogLevel.Debug, data);
         }
 
-        public class Logger : ILogger
+        public void LogVerbose(string data)
         {
-            private readonly object logLock = new object();
-            private Action<LogLevel, string> action;
-            public List<(LogLevel Level, string Message)> Logs { get; } = new List<(LogLevel, string)>();
+            Log(LogLevel.Verbose, data);
+        }
 
-            public void SetupLogAction(Action<LogLevel, string> action)
-            {
-                lock (logLock)
-                {
-                    this.action = action;
-                    foreach (var log in Logs)
-                        action.Invoke(log.Level, log.Message);
-                }
-            }
+        public void LogInformation(string data)
+        {
+            Log(LogLevel.Information, data);
+        }
 
-            public void LogDebug(string data)
-            {
-                Log(LogLevel.Debug, data);
-            }
+        public void LogMinimal(string data)
+        {
+            Log(LogLevel.Minimal, data);
+        }
 
-            public void LogVerbose(string data)
-            {
-                Log(LogLevel.Verbose, data);
-            }
+        public void LogWarning(string data)
+        {
+            Log(LogLevel.Warning, data);
+        }
 
-            public void LogInformation(string data)
-            {
-                Log(LogLevel.Information, data);
-            }
+        public void LogError(string data)
+        {
+            Log(LogLevel.Error, data);
+        }
 
-            public void LogMinimal(string data)
-            {
-                Log(LogLevel.Minimal, data);
-            }
+        public void LogInformationSummary(string data)
+        {
+            Log(LogLevel.Information, data);
+        }
 
-            public void LogWarning(string data)
-            {
-                Log(LogLevel.Warning, data);
-            }
+        public void LogErrorSummary(string data)
+        {
+            Log(LogLevel.Error, data);
+        }
 
-            public void LogError(string data)
+        public void Log(LogLevel level, string data)
+        {
+            lock (logLock)
             {
-                Log(LogLevel.Error, data);
+                Debug.WriteLine($"[{level}] {data}");
+                Logs.Add((level, data));
+                action?.Invoke(level, data);
             }
+        }
 
-            public void LogInformationSummary(string data)
-            {
-                Log(LogLevel.Information, data);
-            }
+        public Task LogAsync(LogLevel level, string data)
+        {
+            Log(level, data);
+            return Task.CompletedTask;
+        }
 
-            public void LogErrorSummary(string data)
-            {
-                Log(LogLevel.Error, data);
-            }
+        public void Log(ILogMessage message)
+        {
+            Log(message.Level, message.Message);
+        }
 
-            public void Log(LogLevel level, string data)
-            {
-                lock (logLock)
-                {
-                    Debug.WriteLine($"[{level}] {data}");
-                    Logs.Add((level, data));
-                    action?.Invoke(level, data);
-                }
-            }
-
-            public Task LogAsync(LogLevel level, string data)
-            {
-                Log(level, data);
-                return Task.CompletedTask;
-            }
-
-            public void Log(ILogMessage message)
-            {
-                Log(message.Level, message.Message);
-            }
-
-            public Task LogAsync(ILogMessage message)
-            {
-                Log(message);
-                return Task.CompletedTask;
-            }
+        public Task LogAsync(ILogMessage message)
+        {
+            Log(message);
+            return Task.CompletedTask;
         }
     }
 }

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -14,6 +14,9 @@ namespace Stride.Core.Assets;
 public static partial class NuGetAssemblyResolver
 {
     public const string DevSource = @"Stride\NugetDev";
+#if STRIDE_NUGET_RESOLVER_UI
+    public static string AvaloniaVersion = string.Empty;
+#endif
 
     static bool assembliesResolved;
     static readonly object assembliesLock = new();
@@ -76,7 +79,6 @@ public static partial class NuGetAssemblyResolver
 
                     // We need to make sure Avalonia has been restored before we can display the UI.
                     const string AvaloniaPackageName = "Avalonia.Desktop";
-                    const string AvaloniaVersion = "11.0.6"; // FIXME find a way to inject that version number
                     var i = 0;
                     packagesConfigs.Insert(i++, (packagesConfigs[0].targetFramework, "Stride.Core", packagesConfigs[0].packageVersion));
                     packagesConfigs.Insert(i++, (packagesConfigs[0].targetFramework, "Avalonia.Themes.Fluent", AvaloniaVersion));

--- a/sources/shared/Stride.NuGetResolver/Stride.NuGetResolver.csproj
+++ b/sources/shared/Stride.NuGetResolver/Stride.NuGetResolver.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <StrideBuildTags>WindowsTools</StrideBuildTags>
   </PropertyGroup>
 


### PR DESCRIPTION
# PR Details

Following #2651, properly solves the issue with displaying the new Nuget Resolver UI that broke `releases/4.2.0.2371`.

## Description

The new Resolver UI uses Avalonia instead of WPF.

By design (and because of its function) the resolver runs very early in the startup of the GameStudio (or of the ConnectionRouter). Stride packages(and their dependencies) might not have ever been resolved on the user machine and the purpose of the resolver is also to locate such packages so that their paths can be known and their respective assembly resolved. It is also required because the GameStudio is started from its nuget package which doesn't bring all of its dependencies with it (but rather links them as is the usual way).

However, Avalonia itself is also not resolved and the UI cannot be loaded because of that. On top of that, Avalonia has its own dependencies, some of which are native.

To add to the fun, when building and running the GameStudio locally, the issue would not be apparent because the Stride.NugetResolver.UI project was referencing Avalonia as a direct dependency and its dlls would end up in the bin folder of the local build, which .NET is perfectly able to resolve by itself.

We have a mechanism to load native libraries, but this require the `NativeLibraryHelper` which is located in `Stride.Core` which itself is also not resolved/loaded.

In short, the following was needed to make it work :
* First resolve `Stride.Core`
* Then resolve Avalonia packages (`Avalonia.Themes.Fluent` and `Avalonia.Desktop`)
* Then finally resolve `Stride.GameStudio`.
* For all of the above resolve their native dependencies.

## How to test this PR

0. Clean the bin folder in your local Stride clone as well as `%LOCALAPPDATA%\Stride\NugetDev`
1. Build the GameStudio
2. Run it once to make sure it works locally.
3. Close it.
4. Open the launcher
5. Select the dev version (`4.2.0.1`)
6. If it's already "downloaded", remove it.
7. Go to your local nuget packages cache (should be `%USERPROFILE%\.nuget\packages`)
8. Locate and remove all Avalonia packages from the cache
9. Back to the launcher, install the dev version (`4.2.0.1`)
10. Make sure no Avalonia packages appeared in the nuget cache
11. Run the dev version from the launcher
12. It should resolve Avalonia, display the resolver UI and then open the GameStudio
13. Avalonia packages should be visible in the nuget cache

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
