### PR TITLE
feat: Enable to build WPF projects outside windows

### DIFF
--- a/sources/targets/Stride.Core.TargetFrameworks.Editor.props
+++ b/sources/targets/Stride.Core.TargetFrameworks.Editor.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <StrideEditorTargetFramework>net8.0-windows</StrideEditorTargetFramework>
     <StrideXplatEditorTargetFramework>net8.0</StrideXplatEditorTargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# PR Details

Small and temp feature that enables to build WPF projects that are the part of Stride solution. 
Once we migrate to Avalonia this feature will no longer be needed, just for sake of convenience.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
