### PR TITLE
fix: Correct UIPage icon and update default template icon

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/UI/Page.sdtpl
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/UI/Page.sdtpl
@@ -6,6 +6,6 @@ Scope: Asset
 Description: A user interface page
 Group: UI
 Order: -100
-Icon: .sdtpl\UI.png
+Icon: ..\.sdtpl\UI.png
 DefaultOutputName: Page
 FactoryTypeName: UIPageFactory

--- a/sources/editor/Stride.Core.Assets.Editor/Resources/Images/default-template-icon.png
+++ b/sources/editor/Stride.Core.Assets.Editor/Resources/Images/default-template-icon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f5c028b343afb1efb9c4faba19b7cbeb4a09c60ea212c5ea6b5ccadc21fed03
-size 5484
+oid sha256:5f3d836f16c15a680be1af694b556ea34dc1b1eee758e49be80d8e93f94d91c4
+size 1995


### PR DESCRIPTION
# PR Details

PR fixes incorrect display of UIPage asset icon - previously default template icon was selected.

![image](https://github.com/user-attachments/assets/f2ea84f2-7180-4ca9-905c-f9922d57e92e)

I also modified the default icon for assets

![image](https://github.com/user-attachments/assets/8032ffaf-0dba-4caf-8fb5-74557b7d7b24)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
