### PR TITLE
fix: CollisionHelper.RayIntersectsPlane to return the correct hit position

### DIFF
--- a/sources/core/Stride.Core.Mathematics.Tests/TestCollisionHelper.cs
+++ b/sources/core/Stride.Core.Mathematics.Tests/TestCollisionHelper.cs
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Stride.Core.Mathematics.Tests;
+
+public class TestCollisionHelper
+{
+    [Theory, ClassData(typeof(RayPlaneIntersectionTestData))]
+    public void TestRayPlaneIntersections(Ray ray, Plane plane, bool expectedIsHit, Vector3? expectedHitPoint)
+    {
+        bool isHit = CollisionHelper.RayIntersectsPlane(in ray, in plane, out Vector3 hitPoint);
+        Assert.Equal(expectedIsHit, isHit);
+        if (isHit)
+        {
+            Assert.Equal(expectedHitPoint, hitPoint);
+        }
+    }
+
+    private class RayPlaneIntersectionTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            var result = new List<object[]>();
+
+            /* Ray hits */
+            {   // Plane on XZ, Y = 0
+                var rayPosition = new Vector3(1, 1, 1);
+                var rayDirection = Vector3.Normalize(new Vector3(-1, -1, -1));
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitY, 0);
+                bool expectedIsHit = true;
+                var expectedHitPoint = new Vector3(0, 0, 0);
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on XZ, Y = 1, ray points down
+                var rayPosition = new Vector3(0, 2, 0);
+                var rayDirection = -Vector3.UnitY;
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitY, 1);
+                bool expectedIsHit = true;
+                var expectedHitPoint = new Vector3(0, 1, 0);
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on YZ, X = 1
+                var rayPosition = new Vector3(2, 2, 2);
+                var rayDirection = Vector3.Normalize(new Vector3(-1, -1, -1));
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitX, 1);
+                bool expectedIsHit = true;
+                var expectedHitPoint = new Vector3(1, 1, 1);
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on XZ, Y = 1
+                var rayPosition = new Vector3(2, 2, 2);
+                var rayDirection = Vector3.Normalize(new Vector3(-1, -1, -1));
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitY, 1);
+                bool expectedIsHit = true;
+                var expectedHitPoint = new Vector3(1, 1, 1);
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on XY, Z = 1
+                var rayPosition = new Vector3(2, 2, 2);
+                var rayDirection = Vector3.Normalize(new Vector3(-1, -1, -1));
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitZ, 1);
+                bool expectedIsHit = true;
+                var expectedHitPoint = new Vector3(1, 1, 1);
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane direction (1, 1, 0), Y = 1 - Ray down from (1, 1, 0) to (1, 0, 0)
+                var rayPosition = new Vector3(1, 1, 0);
+                var rayDirection = -Vector3.UnitY;
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(point: Vector3.UnitY, normal: Vector3.Normalize(new Vector3(1, 1, 0)));
+                bool expectedIsHit = true;
+                var expectedHitPoint = new Vector3(1, 0, 0);
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            /* Ray misses */
+            {   // Plane on XZ, Y = 0 - Parallel ray
+                var rayPosition = new Vector3(1, 1, 1);
+                var rayDirection = Vector3.UnitY;
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitY, 0);
+                bool expectedIsHit = false;
+                var expectedHitPoint = null as Vector3?;
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on XZ, Y = 0 - Perpendicular ray
+                var rayPosition = new Vector3(1, 1, 1);
+                var rayDirection = Vector3.UnitX;
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitY, 0);
+                bool expectedIsHit = false;
+                var expectedHitPoint = null as Vector3?;
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on XZ, Y = 0 - Parallel ray
+                var rayPosition = new Vector3(1, 1, 1);
+                var rayDirection = Vector3.UnitY;
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitY, 0);
+                bool expectedIsHit = false;
+                var expectedHitPoint = null as Vector3?;
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+            {   // Plane on XY, Z = 0 - Parallel ray
+                var rayPosition = new Vector3(1, 1, 1);
+                var rayDirection = Vector3.UnitZ;
+                var ray = new Ray(rayPosition, rayDirection);
+                var plane = new Plane(Vector3.UnitZ, 0);
+                bool expectedIsHit = false;
+                var expectedHitPoint = null as Vector3?;
+                result.Add([ray, plane, expectedIsHit, expectedHitPoint]);
+            }
+
+            return result.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
+++ b/sources/core/Stride.Core.Mathematics/CollisionHelper.cs
@@ -499,7 +499,7 @@ public static class CollisionHelper
         }
 
         Vector3.Dot(in plane.Normal, in ray.Position, out var position);
-        distance = (-plane.D - position) / direction;
+        distance = (plane.D - position) / direction;
 
         if (distance < 0f)
         {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Fix plane-ray equation which was assuming the plane was `P.N + d = 0` whereas the plane equation in Stride is `P.N = d`
See #2670 for the full explanation of the equation.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2670

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
