### PR TITLE
fix: add only new asset folders to the package

### DIFF
--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -1109,7 +1109,7 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
                 }
 
                 var assetFolderAbsolute = UPath.Combine(RootDirectory, asset.SourceFolder);
-                if (!assetFolders.Add(assetFolderAbsolute))
+                if (assetFolders.Add(assetFolderAbsolute))
                 {
                     AssetFolders.Add(new AssetFolder(assetFolderAbsolute));
                     IsDirty = true;


### PR DESCRIPTION
# PR Details

Fixes a bug in the UpdateSourceFolders method of the package class, which updates the root asset folders. The issue was introduced during the modernization refactoring in commit cb520de77b33bfdd8efc3b0de36ddbe9ea0004a4. This fix ensures that only new folders are stored in the asset folder list and avoids duplicated and absolute folders.

## Related Issue

Closes #2667

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
