### PR TITLE
fix: Interpolation discontinuities after teleporting a body component

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
@@ -744,8 +744,10 @@ public sealed class BepuSimulation : IDisposable
             foreach (var body in _interpolatedBodies)
             {
                 body.PreviousPose = body.CurrentPose;
-                if (body.BodyReference is {} bRef)
-                    body.CurrentPose = bRef.Pose;
+
+                Debug.Assert(body.BodyReference.HasValue);
+
+                body.CurrentPose = body.BodyReference.Value.Pose;
             }
         }
 
@@ -861,11 +863,9 @@ public sealed class BepuSimulation : IDisposable
     {
         _interpolatedBodies.Add(body);
 
-        body.Entity.Transform.UpdateWorldMatrix();
-        body.Entity.Transform.WorldMatrix.Decompose(out _, out Quaternion collidableWorldRotation, out Vector3 collidableWorldTranslation);
-        body.CurrentPose.Position = (collidableWorldTranslation + body.CenterOfMass).ToNumeric();
-        body.CurrentPose.Orientation = collidableWorldRotation.ToNumeric();
-        body.PreviousPose = body.CurrentPose;
+        Debug.Assert(body.BodyReference.HasValue);
+
+        body.PreviousPose = body.CurrentPose = body.BodyReference.Value.Pose;
     }
 
     internal void UnregisterInterpolated(BodyComponent body)

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -31,8 +31,11 @@ public class BodyComponent : CollidableComponent
     [DataMemberIgnore]
     internal BodyComponent? Parent;
 
+    /// <summary>
+    /// Data used in conjunction with <see cref="InterpolationMode"/> set for this object, see <see cref="BepuSimulation.InterpolateTransforms"/>
+    /// </summary>
     [DataMemberIgnore]
-    internal NRigidPose PreviousPose, CurrentPose; //Sets by AfterSimulationUpdate()
+    internal NRigidPose PreviousPose, CurrentPose;
 
     /// <summary>
     /// Constraints that currently references this body, may not be attached if they are not in a valid state
@@ -360,6 +363,7 @@ public class BodyComponent : CollidableComponent
             bodyRef.Pose.Orientation = PreviousPose.Orientation = orientation.ToNumeric();
             bodyRef.Pose.Position = PreviousPose.Position = position.ToNumeric();
             bodyRef.UpdateBounds();
+            CurrentPose = bodyRef.Pose; // Update interpolation data as well
         }
 
         WorldToLocal(ref position, ref orientation);


### PR DESCRIPTION
# PR Details
Basically, bodies set to interpolate would interpolate with outdated data if the user happened to teleport the body between two physics tick. Also removed a couple of unnecessary operations around those areas.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
