### PR TITLE
Vulkan concurrency and validation error fixes

### DIFF
--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
@@ -406,9 +406,9 @@ namespace Stride.Graphics
                 resource = nativeUploadBuffer;
                 offset = nativeUploadBufferOffset;
                 nativeUploadBufferOffset += size;
-            }
 
-            return nativeUploadBufferStart + offset;
+                return nativeUploadBufferStart + offset;
+            }
         }
 
         protected unsafe void AllocateMemory(VkMemoryPropertyFlags memoryProperties)

--- a/sources/engine/Stride.Shaders.Compiler/OpenGL/ShaderCompiler.cs
+++ b/sources/engine/Stride.Shaders.Compiler/OpenGL/ShaderCompiler.cs
@@ -296,6 +296,9 @@ namespace Stride.Shaders.Compiler.OpenGL
                     var noSampler = new EffectResourceBindingDescription { KeyInfo = { KeyName = "NoSampler" }, RawName = "NoSampler", Class = EffectParameterClass.Sampler, SlotStart = -1, SlotCount = 1 };
                     reflection.ResourceBindings.Add(noSampler);
 
+                    // Make sure it's a point sampler as some texture formats do not support linear sampling which will result in validation errors.
+                    reflection.SamplerStates.Add(new EffectSamplerStateBinding("NoSampler", new SamplerStateDescription(TextureFilter.Point, TextureAddressMode.Clamp)));
+
                     // Defines the ordering of resource groups in Vulkan. This is mirrored in the PipelineState
                     var resourceGroups = reflection.ResourceBindings.Select(x => x.ResourceGroup ?? "Globals").Distinct().ToList();
 


### PR DESCRIPTION
# PR Details

* Fixed concurrency issues that caused a full driver crash when texture streaming is enabled.
* Fixed a validation error casued by the default `NoSampler` that is used when converting `Texture.Load` to `texelFetch`.

## Related Issue

Found some validation errors when running in debug mode and also full driver crash when texture streaming was enabled.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
