### PR TITLE
fix: Prevent editor-inserted filters from persisting across views

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -1150,14 +1150,19 @@ namespace Stride.Core.Assets.Editor.ViewModel
             List<AssetFilterViewModelData> listData = new List<AssetFilterViewModelData>();
 
             // Run through our currentAssetFilters and store out the data
-            for (int i = 0; i < currentAssetFilters.Count; i++)
+            foreach (var filter in currentAssetFilters)
             {
-                AssetFilterViewModelData obj = new AssetFilterViewModelData();
+                if (filter.IsReadOnly)
+                    continue; // Skip engine defined filters
+                
+                AssetFilterViewModelData obj = new AssetFilterViewModelData
+                {
+                    DisplayName = filter.DisplayName, 
+                    Filter = filter.Filter, 
+                    IsActive = filter.IsActive,
+                    category = filter.Category
+                };
 
-                obj.DisplayName = currentAssetFilters[i].DisplayName;
-                obj.Filter = currentAssetFilters[i].Filter;
-                obj.IsActive = currentAssetFilters[i].IsActive;
-                obj.category = currentAssetFilters[i].Category;
                 listData.Add(obj);
             }
             InternalSettings.ViewFilters.SetValue(listData);


### PR DESCRIPTION
# PR Details
Followup to #2320 - filters that are added by the engine, like `UIPage` when opening the picker for field of that type, persisted to new instance of the picker, meaning that new pickers for `Texture` would have a `UIPage` filter added in as well.
This change ensures that we only persist user-defined filters across instances.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
