### PR TITLE
make default x64 and fix .dd imported files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
    - **Desktop development with C++** with:
      - **Windows 11 SDK (10.0.22621.0)** or a later version (should be enabled by default)
      - **MSVC v143 - VS2022 C++ x64/x86 build tools (Latest)** (should be enabled by default)
-     - **MSVC v143 - VS2022 C++ ARM64 build tools (Latest)**
+     - **MSVC v143 - VS2022 C++ ARM64 build tools (Latest)** *(not enabled by default)*
      - **C++/CLI support for v143 build tools (Latest)** *(not enabled by default)*
    - *Optional* (to target iOS/Android): **.NET Multi-platform App UI development** and the **Android SDK setup** individual component (enabled by default). Then, in Visual Studio, go to `Tools > Android > Android SDK Manager` and install **NDK** (version 20.1+) from the `Tools` tab.
    - *Optional* (to build the VSIX package): **Visual Studio extension development**
+   - *Optional* (to enable windows arm64 builds) [toggle setting to true](https://github.com/stride3d/stride/blob/1925a7bdb9e5627428fab43de36a911f69fcdf7c/sources/native/Stride.Native.targets#L30)
 
 > [!NOTE]
 > The installation of Visual Studio with the required components may require up to **14 GB of disk space**, depending on your system and selected components.

--- a/sources/native/Stride.Native.targets
+++ b/sources/native/Stride.Native.targets
@@ -27,7 +27,7 @@
     <!--<StrideNativeOutputPath>$([MSBuild]::MakeRelative('$(OutputPath)', '$(StridePackageStridePlatformBin)\'))</StrideNativeOutputPath>-->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.so; .a; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
   
-    <StrideNativeWindowsArm64Enabled Condition="'$(StrideNativeWindowsArm64Enabled)' == ''">true</StrideNativeWindowsArm64Enabled>
+    <StrideNativeWindowsArm64Enabled Condition="'$(StrideNativeWindowsArm64Enabled)' == ''">false</StrideNativeWindowsArm64Enabled>
   </PropertyGroup>
 
   <Choose>

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
@@ -507,18 +507,26 @@ namespace Stride.TextureConverter.DxtWrapper
         }
     }
 
+
     /// <summary>
     /// Utility class binding DirectXTex utility methods
     /// </summary>
     internal class Utilities
     {
+
+#if StrideNativeWindowsArm64Enabled
+        private const CharSet _defaultCharSet = CharSet.Ansi;
+#else
+        private const CharSet _defaultCharSet = CharSet.Auto;
+#endif
+
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static void dxtComputePitch(DXGI_FORMAT fmt, int width, int height, out int rowPitch, out int slicePitch, CP_FLAGS flags);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = _defaultCharSet), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtLoadDDSFile(string filePath, DDS_FLAGS flags, out TexMetadata metadata, IntPtr image);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = _defaultCharSet), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtLoadTGAFile(string filePath, out TexMetadata metadata, IntPtr image);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
@@ -545,10 +553,10 @@ namespace Stride.TextureConverter.DxtWrapper
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtDecompressArray(DxtImage[] cImages, int nimages, ref TexMetadata metadata, DXGI_FORMAT format, IntPtr images);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = _defaultCharSet), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtSaveToDDSFile(ref DxtImage dxtImage, DDS_FLAGS flags, string szFile);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = _defaultCharSet), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtSaveToDDSFileArray(DxtImage[] dxtImages, int nimages, ref TexMetadata metadata, DDS_FLAGS flags, string szFile);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
@@ -515,10 +515,10 @@ namespace Stride.TextureConverter.DxtWrapper
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static void dxtComputePitch(DXGI_FORMAT fmt, int width, int height, out int rowPitch, out int slicePitch, CP_FLAGS flags);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtLoadDDSFile(string filePath, DDS_FLAGS flags, out TexMetadata metadata, IntPtr image);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtLoadTGAFile(string filePath, out TexMetadata metadata, IntPtr image);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
@@ -545,10 +545,10 @@ namespace Stride.TextureConverter.DxtWrapper
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtDecompressArray(DxtImage[] cImages, int nimages, ref TexMetadata metadata, DXGI_FORMAT format, IntPtr images);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtSaveToDDSFile(ref DxtImage dxtImage, DDS_FLAGS flags, string szFile);
 
-        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
+        [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto), SuppressUnmanagedCodeSecurity]
         private extern static uint dxtSaveToDDSFileArray(DxtImage[] dxtImages, int nimages, ref TexMetadata metadata, DDS_FLAGS flags, string szFile);
 
         [DllImport("DxtWrapper", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]


### PR DESCRIPTION
# PR Details

Changes the default build setting changed by https://github.com/stride3d/stride/pull/2644
Also removes a change in the DXTWrapper 

## Related Issue

None, found in master.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
