### PR TITLE
fix: Wayland crash workaround

### DIFF
--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -24,6 +24,11 @@ namespace Stride.Graphics.SDL
         {
             SDL = Silk.NET.SDL.Sdl.GetApi();
 
+            // jklawreszuk: Workaround for wayland (see #2487 for more details)  
+            // Perhabs there is more elegant solution?
+            if (OperatingSystem.IsLinux())
+                SDL.SetHint("SDL_VIDEODRIVER", "x11");
+
             SDL.Init(Sdl.InitEverything);
 
             // Pass first mouse event when user clicked on window 
@@ -85,6 +90,7 @@ namespace Stride.Graphics.SDL
                 // Create the SDL window and then extract the native handle.
                 sdlHandle = SDL.CreateWindow(title, Sdl.WindowposUndefined, Sdl.WindowposUndefined, 640, 480, (uint)flags);
             }
+            
 
 #if STRIDE_PLATFORM_ANDROID || STRIDE_PLATFORM_IOS
             GraphicsAdapter.DefaultWindow = sdlHandle;

--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -25,7 +25,7 @@ namespace Stride.Graphics.SDL
             SDL = Silk.NET.SDL.Sdl.GetApi();
 
             // jklawreszuk: Workaround for wayland (see #2487 for more details)  
-            // Perhabs there is more elegant solution? (FIXME ?)
+            // Wayland SDL_EGL_MakeCurrent does not cover multi-context scenario (https://github.com/libsdl-org/SDL/issues/9072)
             if (OperatingSystem.IsLinux())
                 SDL.SetHint("SDL_VIDEODRIVER", "x11");
 

--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -25,7 +25,7 @@ namespace Stride.Graphics.SDL
             SDL = Silk.NET.SDL.Sdl.GetApi();
 
             // jklawreszuk: Workaround for wayland (see #2487 for more details)  
-            // Wayland SDL_EGL_MakeCurrent does not cover multi-context scenario (https://github.com/libsdl-org/SDL/issues/9072)
+            // TODO: Wayland SDL_EGL_MakeCurrent does not cover multi-context scenario (https://github.com/libsdl-org/SDL/issues/9072)
             if (OperatingSystem.IsLinux())
                 SDL.SetHint("SDL_VIDEODRIVER", "x11");
 

--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -25,7 +25,7 @@ namespace Stride.Graphics.SDL
             SDL = Silk.NET.SDL.Sdl.GetApi();
 
             // jklawreszuk: Workaround for wayland (see #2487 for more details)  
-            // Perhabs there is more elegant solution?
+            // Perhabs there is more elegant solution? (FIXME ?)
             if (OperatingSystem.IsLinux())
                 SDL.SetHint("SDL_VIDEODRIVER", "x11");
 


### PR DESCRIPTION
# PR Details

This PR fixes an issue for Wayland based DE like Gnome that causes a crash. Issue was fixed by setting driver to X11. 

## Related Issue

https://github.com/stride3d/stride/issues/2487

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
