### PR TITLE
fix: Handle initial collection items appropriately, YAML

### DIFF
--- a/sources/assets/Stride.Core.Assets/Yaml/CollectionWithIdsSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/CollectionWithIdsSerializer.cs
@@ -114,6 +114,11 @@ public class CollectionWithIdsSerializer : CollectionWithIdsSerializerBase
             throw new InvalidOperationException("The given container does not match the expected type.");
         var identifier = CollectionItemIdHelper.GetCollectionItemIds(targetCollection);
         identifier.Clear();
+
+        // The collection may contain some initial data from its containing instance's ctor,
+        // let's replace the existing data with the data we have serialized
+        collectionDescriptor.Clear(targetCollection);
+
         var i = 0;
         var enumerator = container.GetEnumerator();
         while (enumerator.MoveNext())

--- a/sources/assets/Stride.Core.Assets/Yaml/CollectionWithIdsSerializerBase.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/CollectionWithIdsSerializerBase.cs
@@ -133,6 +133,10 @@ public abstract class CollectionWithIdsSerializerBase : DictionarySerializer
     {
         var dictionaryDescriptor = (DictionaryDescriptor)objectContext.Descriptor;
 
+        // The collection may contain some initial data from its containing instance's ctor,
+        // let's replace the existing data with the data we have serialized
+        dictionaryDescriptor.Clear(objectContext.Instance);
+
         var deletedItems = new HashSet<ItemId>();
 
         var reader = objectContext.Reader;

--- a/sources/assets/Stride.Core.Assets/Yaml/DictionaryWithIdsSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/DictionaryWithIdsSerializer.cs
@@ -97,6 +97,11 @@ public class DictionaryWithIdsSerializer : CollectionWithIdsSerializerBase
             throw new InvalidOperationException("The given container does not match the expected type.");
         var identifier = CollectionItemIdHelper.GetCollectionItemIds(targetCollection);
         identifier.Clear();
+
+        // The collection may contain some initial data from its containing instance's ctor,
+        // let's replace the existing data with the data we have serialized
+        dictionaryDescriptor.Clear(targetCollection);
+
         var enumerator = container.GetEnumerator();
         while (enumerator.MoveNext())
         {

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
@@ -22,6 +22,7 @@ public class DictionaryDescriptor : ObjectDescriptor
     Func<object, ICollection> getValuesMethod;
     Func<object, object, object?> getValueMethod;
     Func<object, IEnumerable<KeyValuePair<object, object?>>> getEnumeratorMethod;
+    Action<object> clearMethod;
 
     #pragma warning disable CS8618
     // This warning is disabled because the necessary initialization will occur 
@@ -56,6 +57,7 @@ public class DictionaryDescriptor : ObjectDescriptor
         getValueMethod = (dictionary, key) => ((IDictionary<TKey, TValue?>)dictionary)[(TKey)key];
         setValueMethod = (dictionary, key, value) => ((IDictionary<TKey, TValue?>)dictionary)[(TKey)key] = (TValue?)value;
         getEnumeratorMethod = (dictionary) => GetGenericEnumerable((IDictionary<TKey, TValue>)dictionary);
+        clearMethod = (dictionary) => ((IDictionary<TKey, TValue?>)dictionary).Clear();
     }
 
     public override void Initialize(IComparer<object> keyComparer)
@@ -180,6 +182,16 @@ public class DictionaryDescriptor : ObjectDescriptor
     {
         ArgumentNullException.ThrowIfNull(dictionary);
         return getValuesMethod(dictionary);
+    }
+
+    /// <summary>
+    /// Calls clear on the dictionary
+    /// </summary>
+    /// <param name="dictionary">The dictionary</param>
+    public void Clear(object dictionary)
+    {
+        ArgumentNullException.ThrowIfNull(dictionary);
+        clearMethod(dictionary);
     }
 
     /// <summary>

--- a/sources/core/Stride.Core.Yaml/Serialization/Serializers/CollectionSerializer.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/Serializers/CollectionSerializer.cs
@@ -148,6 +148,10 @@ namespace Stride.Core.Yaml.Serialization.Serializers
                 throw new InvalidOperationException($"Cannot deserialize collection to readonly collection type [{thisObject.GetType()}].");
             }
 
+            // The collection may contain some initial data from its containing instance's ctor,
+            // let's replace the existing data with the data we have serialized
+            collectionDescriptor.Clear(thisObject);
+
             var reader = objectContext.Reader;
 
             var elementType = collectionDescriptor.ElementType;

--- a/sources/core/Stride.Core.Yaml/Serialization/Serializers/DictionarySerializer.cs
+++ b/sources/core/Stride.Core.Yaml/Serialization/Serializers/DictionarySerializer.cs
@@ -141,6 +141,8 @@ namespace Stride.Core.Yaml.Serialization.Serializers
         {
             var dictionaryDescriptor = (DictionaryDescriptor)objectContext.Descriptor;
 
+            dictionaryDescriptor.Clear(objectContext.Instance);
+
             var reader = objectContext.Reader;
             while (!reader.Accept<MappingEnd>())
             {


### PR DESCRIPTION
# PR Details
The yaml serializer adds its serialized items on top of those that may already be contained in the list. The following snippet would continuously add one more `0.5` to the collection's serialization data on every save.
```cs
public List<float> Coll { get; } = new List<float>(){ 0.5f };
```
This PR ensures that, if yaml has data about items for a collection, the pre-existing ones are cleared before adding those that are serialized.

Do note that this was already handled on the `AssemblyProcessor` side, see `ListSerializer.PreSerialize()` and other collection serializers.

Pinging @IXLLEGACYIXL to let him know of this rule given the work he is doing for the next yaml serializer.

## Related Issue
None logged afaict

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
