### PR TITLE
[Graphics] Enable rendering to HDR displays on DirectX/Windows

### DIFF
--- a/sources/engine/Stride.Games/GameWindowRenderer.cs
+++ b/sources/engine/Stride.Games/GameWindowRenderer.cs
@@ -96,7 +96,7 @@ namespace Stride.Games
         }
 
         /// <summary>
-        /// Gets or sets the preferred presenter output color space. Can be used to render to HDR monitors.
+        /// Gets or sets the preferred presenter output color space. Can be used to render to HDR monitors. Currently only supported by the DirectX backend.
         /// See: https://learn.microsoft.com/en-us/windows/win32/direct3darticles/high-dynamic-range
         /// </summary>
         /// <value>The preferred presenter output color space.</value>

--- a/sources/engine/Stride.Games/GameWindowRenderer.cs
+++ b/sources/engine/Stride.Games/GameWindowRenderer.cs
@@ -37,8 +37,9 @@ namespace Stride.Games
         private int preferredBackBufferHeight;
         private int preferredBackBufferWidth;
         private PixelFormat preferredDepthStencilFormat;
-        private PresenterColorSpace preferredPresenterColorSpace;
         private bool isBackBufferToResize;
+        private ColorSpaceType preferredOutputColorSpace;
+        private bool isColorSpaceToChange;
         private GraphicsPresenter savedPresenter;
         private bool beginDrawOk;
         private bool windowUserResized;
@@ -52,7 +53,7 @@ namespace Stride.Games
             : base(registry)
         {
             GameContext = gameContext;
-            preferredPresenterColorSpace = PresenterColorSpace.RgbFullG22NoneP709;
+            preferredOutputColorSpace = ColorSpaceType.RgbFullG22NoneP709;
         }
 
         /// <summary>
@@ -95,23 +96,23 @@ namespace Stride.Games
         }
 
         /// <summary>
-        /// Gets or sets the preferred presenter color space. Can be used to render to HDR monitors.
+        /// Gets or sets the preferred presenter output color space. Can be used to render to HDR monitors.
         /// See: https://learn.microsoft.com/en-us/windows/win32/direct3darticles/high-dynamic-range
         /// </summary>
-        /// <value>The preferred presenter color space.</value>
-        public PresenterColorSpace PreferredPresenterColorSpace
+        /// <value>The preferred presenter output color space.</value>
+        public ColorSpaceType PreferredOutputColorSpace
         {
             get
             {
-                return preferredPresenterColorSpace;
+                return preferredOutputColorSpace;
             }
 
             set
             {
-                if (preferredPresenterColorSpace != value)
+                if (preferredOutputColorSpace != value)
                 {
-                    preferredPresenterColorSpace = value;
-                    isBackBufferToResize = true;
+                    preferredOutputColorSpace = value;
+                    isColorSpaceToChange = true;
                 }
             }
         }
@@ -209,13 +210,13 @@ namespace Stride.Games
 
         protected virtual void CreateOrUpdatePresenter()
         {
-            if (Presenter == null)
+            if (Presenter == null || isColorSpaceToChange)
             {
                 PixelFormat resizeFormat;
                 var size = GetRequestedSize(out resizeFormat);
                 var presentationParameters = new PresentationParameters((int)size.X, (int)size.Y, Window.NativeWindow, resizeFormat) { DepthStencilFormat = PreferredDepthStencilFormat };
                 presentationParameters.PresentationInterval = PresentInterval.Immediate;
-                presentationParameters.PresenterColorSpace = preferredPresenterColorSpace;
+                presentationParameters.OutputColorSpace = preferredOutputColorSpace;
 
 #if STRIDE_GRAPHICS_API_DIRECT3D11 && STRIDE_PLATFORM_UWP
                 if (Game.Context is GameContextUWPCoreWindow context && context.IsWindowsMixedReality)
@@ -229,6 +230,7 @@ namespace Stride.Games
                 }
 
                 isBackBufferToResize = false;
+                isColorSpaceToChange = false;
             }
         }
 

--- a/sources/engine/Stride.Games/GameWindowRenderer.cs
+++ b/sources/engine/Stride.Games/GameWindowRenderer.cs
@@ -37,6 +37,7 @@ namespace Stride.Games
         private int preferredBackBufferHeight;
         private int preferredBackBufferWidth;
         private PixelFormat preferredDepthStencilFormat;
+        private PresenterColorSpace preferredPresenterColorSpace;
         private bool isBackBufferToResize;
         private GraphicsPresenter savedPresenter;
         private bool beginDrawOk;
@@ -51,6 +52,7 @@ namespace Stride.Games
             : base(registry)
         {
             GameContext = gameContext;
+            preferredPresenterColorSpace = PresenterColorSpace.RgbFullG22NoneP709;
         }
 
         /// <summary>
@@ -87,6 +89,28 @@ namespace Stride.Games
                 if (preferredBackBufferFormat != value)
                 {
                     preferredBackBufferFormat = value;
+                    isBackBufferToResize = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the preferred presenter color space. Can be used to render to HDR monitors.
+        /// See: https://learn.microsoft.com/en-us/windows/win32/direct3darticles/high-dynamic-range
+        /// </summary>
+        /// <value>The preferred presenter color space.</value>
+        public PresenterColorSpace PreferredPresenterColorSpace
+        {
+            get
+            {
+                return preferredPresenterColorSpace;
+            }
+
+            set
+            {
+                if (preferredPresenterColorSpace != value)
+                {
+                    preferredPresenterColorSpace = value;
                     isBackBufferToResize = true;
                 }
             }
@@ -191,6 +215,7 @@ namespace Stride.Games
                 var size = GetRequestedSize(out resizeFormat);
                 var presentationParameters = new PresentationParameters((int)size.X, (int)size.Y, Window.NativeWindow, resizeFormat) { DepthStencilFormat = PreferredDepthStencilFormat };
                 presentationParameters.PresentationInterval = PresentInterval.Immediate;
+                presentationParameters.PresenterColorSpace = preferredPresenterColorSpace;
 
 #if STRIDE_GRAPHICS_API_DIRECT3D11 && STRIDE_PLATFORM_UWP
                 if (Game.Context is GameContextUWPCoreWindow context && context.IsWindowsMixedReality)

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -840,6 +840,9 @@ namespace Stride.Games
         {
             switch (format)
             {
+                case PixelFormat.R16G16B16A16_Float:
+                    return 64;
+
                 case PixelFormat.R8G8B8A8_UNorm:
                 case PixelFormat.R8G8B8A8_UNorm_SRgb:
                 case PixelFormat.B8G8R8A8_UNorm:

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -480,7 +480,7 @@ namespace Stride.Graphics
             var swapChain3 = newSwapChain.QueryInterface<SwapChain3>();
             if (swapChain3 != null)
             {
-                swapChain3.ColorSpace1 = (SharpDX.DXGI.ColorSpaceType)Description.PresenterColorSpace;
+                swapChain3.ColorSpace1 = (SharpDX.DXGI.ColorSpaceType)Description.OutputColorSpace;
                 swapChain3.Dispose();
             }
 
@@ -530,7 +530,7 @@ namespace Stride.Graphics
             var nonSRgb = pixelFormat.ToNonSRgb();
             switch (nonSRgb)
             {
-                case PixelFormat.R16G16B16A16_Float: // scRGB HDR, should use PresenterColorSpace.RgbFullG10NoneP709 scRGB, gets converted by windows to display color space
+                case PixelFormat.R16G16B16A16_Float: // scRGB HDR, should use PresenterColorSpace.RgbFullG10NoneP709, gets converted by windows to display color space
                 case PixelFormat.R10G10B10A2_UNorm: // HDR10/BT.2100 HDR, should use PresenterColorSpace.RgbFullG2084NoneP2020, directly sent to display
                 case PixelFormat.B8G8R8A8_UNorm:
                 case PixelFormat.R8G8B8A8_UNorm:

--- a/sources/engine/Stride.Graphics/GraphicsPresenter.cs
+++ b/sources/engine/Stride.Graphics/GraphicsPresenter.cs
@@ -159,6 +159,33 @@ namespace Stride.Graphics
             GraphicsDevice.End();
         }
 
+        /// <summary>
+        /// Sets the output color space of the presenter and the format for the backbuffer.
+        /// Use the following compinations: <br />
+        /// Render to SDR Display with gamma 2.2: <see cref="ColorSpaceType.RgbFullG22NoneP709"/> with <see cref="PixelFormat.R8G8B8A8_UNorm"/>, <see cref="PixelFormat.R8G8B8A8_UNorm_SRgb"/>, <see cref="PixelFormat.B8G8R8A8_UNorm"/>, <see cref="PixelFormat.B8G8R8A8_UNorm"/>. <br />
+        /// Render to HDR Display in scRGB (standard linear), windows DWM will do the color conversion: <see cref="ColorSpaceType.RgbFullG10NoneP709"/> with <see cref="PixelFormat.R16G16B16A16_Float"/> <br />
+        /// Render to HDR Display in HDR10/BT.2100, no windows DWM conversion, rendering needs to be in the Display color space: <see cref="ColorSpaceType.RgbFullG2084NoneP2020"/> with <see cref="PixelFormat.R10G10B10A2_UNorm"/> <br />
+        /// </summary>
+        /// <param name="colorSpace"></param>
+        /// <param name="format"></param>
+        public void SetOutputColorSpace(ColorSpaceType colorSpace, PixelFormat format)
+        {
+            GraphicsDevice.Begin();
+
+            Description.BackBufferFormat = NormalizeBackBufferFormat(format);
+ 
+            // new resources
+            ResizeBackBuffer(Description.BackBufferWidth, Description.BackBufferHeight, format);
+            ResizeDepthStencilBuffer(Description.BackBufferWidth, Description.BackBufferHeight, depthStencilBuffer.ViewFormat);
+
+            // recreate swapchain
+            OnDestroyed();
+            Description.OutputColorSpace = colorSpace;
+            OnRecreated();
+
+            GraphicsDevice.End();
+        }
+
         private PixelFormat NormalizeBackBufferFormat(PixelFormat backBufferFormat)
         {
             // If we are creating a GraphicsPresenter with 

--- a/sources/engine/Stride.Graphics/GraphicsPresenter.cs
+++ b/sources/engine/Stride.Graphics/GraphicsPresenter.cs
@@ -160,7 +160,7 @@ namespace Stride.Graphics
         }
 
         /// <summary>
-        /// Sets the output color space of the presenter and the format for the backbuffer.
+        /// Sets the output color space of the presenter and the format for the backbuffer. Currently only supported by the DirectX backend.
         /// Use the following compinations: <br />
         /// Render to SDR Display with gamma 2.2: <see cref="ColorSpaceType.RgbFullG22NoneP709"/> with <see cref="PixelFormat.R8G8B8A8_UNorm"/>, <see cref="PixelFormat.R8G8B8A8_UNorm_SRgb"/>, <see cref="PixelFormat.B8G8R8A8_UNorm"/>, <see cref="PixelFormat.B8G8R8A8_UNorm"/>. <br />
         /// Render to HDR Display in scRGB (standard linear), windows DWM will do the color conversion: <see cref="ColorSpaceType.RgbFullG10NoneP709"/> with <see cref="PixelFormat.R16G16B16A16_Float"/> <br />

--- a/sources/engine/Stride.Graphics/PresentationParameters.cs
+++ b/sources/engine/Stride.Graphics/PresentationParameters.cs
@@ -77,7 +77,7 @@ namespace Stride.Graphics
         /// <summary>
         /// The colorspace type used for the swapchain output.
         /// </summary>
-        public PresenterColorSpace PresenterColorSpace;
+        public ColorSpaceType OutputColorSpace;
         
 
         #endregion
@@ -98,7 +98,7 @@ namespace Stride.Graphics
             IsFullScreen = false;
             RefreshRate = new Rational(60, 1); // by default
             ColorSpace = ColorSpace.Linear;
-            PresenterColorSpace = PresenterColorSpace.RgbFullG22NoneP709; // default rgb output for monitors with a standard gamma of 2.2
+            OutputColorSpace = ColorSpaceType.RgbFullG22NoneP709; // default rgb output for monitors with a standard gamma of 2.2
         }
 
         /// <summary>

--- a/sources/engine/Stride.Graphics/PresentationParameters.cs
+++ b/sources/engine/Stride.Graphics/PresentationParameters.cs
@@ -70,9 +70,15 @@ namespace Stride.Graphics
         public int PreferredFullScreenOutputIndex;
 
         /// <summary>
-        /// The colorspace used.
+        /// The colorspace of the rendering pipeline.
         /// </summary>
         public ColorSpace ColorSpace;
+
+        /// <summary>
+        /// The colorspace type used for the swapchain output.
+        /// </summary>
+        public PresenterColorSpace PresenterColorSpace;
+        
 
         #endregion
 
@@ -92,6 +98,7 @@ namespace Stride.Graphics
             IsFullScreen = false;
             RefreshRate = new Rational(60, 1); // by default
             ColorSpace = ColorSpace.Linear;
+            PresenterColorSpace = PresenterColorSpace.RgbFullG22NoneP709; // default rgb output for monitors with a standard gamma of 2.2
         }
 
         /// <summary>

--- a/sources/engine/Stride.Graphics/PresentationParameters.cs
+++ b/sources/engine/Stride.Graphics/PresentationParameters.cs
@@ -75,7 +75,7 @@ namespace Stride.Graphics
         public ColorSpace ColorSpace;
 
         /// <summary>
-        /// The colorspace type used for the swapchain output.
+        /// The colorspace type used for the swapchain output. Currently only supported by the DirectX backend.
         /// </summary>
         public ColorSpaceType OutputColorSpace;
         

--- a/sources/engine/Stride/Graphics/ColorSpace.cs
+++ b/sources/engine/Stride/Graphics/ColorSpace.cs
@@ -32,7 +32,7 @@ namespace Stride.Graphics
     /// such as ID2D1DeviceContext2::CreateImageSourceFromDxgi. The following color parameters
     /// are defined:
     /// </remarks>
-    public enum PresenterColorSpace
+    public enum ColorSpaceType
     {
         /// <summary>
         /// ColorspaceRGB Range0-255 Gamma2.2 SitingImage PrimariesBT.709. Use with backbuffer of 8 bit colors, such as PixelFormat.B8G8R8A8_UNorm.

--- a/sources/engine/Stride/Graphics/ColorSpace.cs
+++ b/sources/engine/Stride/Graphics/ColorSpace.cs
@@ -21,4 +21,177 @@ namespace Stride.Graphics
         /// </summary>
         Gamma,
     }
+
+    /// <summary>
+    /// Specifies color space types.
+    /// </summary>
+    /// <remarks>
+    /// This enum is used within DXGI in the CheckColorSpaceSupport, SetColorSpace1 and
+    /// CheckOverlayColorSpaceSupport methods. It is also referenced in D3D11 video methods
+    /// such as ID3D11VideoContext1::VideoProcessorSetOutputColorSpace1, and D2D methods
+    /// such as ID2D1DeviceContext2::CreateImageSourceFromDxgi. The following color parameters
+    /// are defined:
+    /// </remarks>
+    public enum PresenterColorSpace
+    {
+        /// <summary>
+        /// ColorspaceRGB Range0-255 Gamma2.2 SitingImage PrimariesBT.709. Use with backbuffer of 8 bit colors, such as PixelFormat.B8G8R8A8_UNorm.
+        /// This is the standard definition for sRGB. Note that this is often implemented
+        /// with a linear segment, but in that case, the exponent is corrected to stay aligned
+        /// with a gamma 2.2 curve. This is usually used with 8-bit and 10-bit color channels.
+        /// </summary>
+        RgbFullG22NoneP709 = 0,
+
+        /// <summary>
+        /// ColorspaceRGB Range0-255 Gamma1.0 SitingImage PrimariesBT.709. Use with backbuffer of 16 bit colors, PixelFormat.R16G16B16A16_Float.
+        /// This is the standard definition for scRGB, and is usually used with 16-bit integer,
+        /// 16-bit floating point, and 32-bit floating point channels.
+        /// </summary>
+        RgbFullG10NoneP709 = 1,
+
+        /// <summary>
+        /// ColorspaceRGB Range16-235 Gamma2.2 SitingImage PrimariesBT.709.
+        /// This is the standard definition for ITU-R Recommendation BT.709. Note that
+        /// due to the inclusion of a linear segment, the transfer curve looks similar to
+        /// a pure exponential gamma of 1.9. This is usually used with 8-bit and 10-bit color
+        /// channels.
+        /// </summary>
+        RgbStudioG22NoneP709 = 2,
+
+        /// <summary>
+        /// ColorspaceRGB Range16-235 Gamma2.2 SitingImage PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        RgbStudioG22NoneP2020 = 3,
+
+        /// <summary>
+        /// Reserved.
+        /// </summary>
+        Reserved = 4,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range0-255 Gamma2.2 SitingImage PrimariesBT.709 TransferBT.601.
+        /// This definition is commonly used for JPG, and is usually used with 8, 10, 12,
+        /// or 16-bit color channels.
+        /// </summary>
+        YcbcrFullG22NoneP709X601 = 5,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range16-235 Gamma2.2 SitingVideo PrimariesBT.601.
+        /// This definition is commonly used for MPEG2, and is usually used with 8, 10, 12,
+        /// or 16-bit color channels.
+        /// </summary>
+        YcbcrStudioG22LeftP601 = 6,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range0-255 Gamma2.2 SitingVideo PrimariesBT.601.
+        /// This is sometimes used for H.264 camera capture, and is usually used with 8, 10,
+        /// 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrFullG22LeftP601 = 7,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range16-235 Gamma2.2 SitingVideo PrimariesBT.709.
+        /// This definition is commonly used for H.264 and HEVC, and is usually used with
+        /// 8, 10, 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrStudioG22LeftP709 = 8,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range0-255 Gamma2.2 SitingVideo PrimariesBT.709.
+        /// This is sometimes used for H.264 camera capture, and is usually used with 8, 10,
+        /// 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrFullG22LeftP709 = 9,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range16-235 Gamma2.2 SitingVideo PrimariesBT.2020.
+        /// This definition may be used by HEVC, and is usually used with 10, 12, or 16-bit
+        /// color channels.
+        /// </summary>
+        YcbcrStudioG22LeftP2020 = 10,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range0-255 Gamma2.2 SitingVideo PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrFullG22LeftP2020 = 11,
+
+        /// <summary>
+        /// ColorspaceRGB Range0-255 Gamma2084 SitingImage PrimariesBT.2020. Use with backbuffer of 10 bit colors, PixelFormat.R10G10B10A2_UNorm.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        RgbFullG2084NoneP2020 = 12,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range16-235 Gamma2084 SitingVideo PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrStudioG2084LeftP2020 = 13,
+
+        /// <summary>
+        /// ColorspaceRGB Range16-235 Gamma2084 SitingImage PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        RgbStudioG2084NoneP2020 = 14,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range16-235 Gamma2.2 SitingVideo PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrStudioG22TopleftP2020 = 15,
+
+        /// <summary>
+        /// ColorspaceYCbCr Range16-235 Gamma2084 SitingVideo PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        YcbcrStudioG2084TopleftP2020 = 16,
+
+        /// <summary>
+        /// ColorspaceRGB Range0-255 Gamma2.2 SitingImage PrimariesBT.2020.
+        /// This is usually used with 10, 12, or 16-bit color channels.
+        /// </summary>
+        RgbFullG22NoneP2020 = 17,
+
+        /// <summary>
+        /// A custom color definition is used.
+        /// </summary>
+        YcbcrStudioGhlgTopleftP2020 = 18,
+
+        /// <summary>
+        /// No documentation.
+        /// </summary>
+        YcbcrFullGhlgTopleftP2020 = 19,
+
+        /// <summary>
+        /// No documentation.
+        /// </summary>
+        RgbStudioG24NoneP709 = 20,
+
+        /// <summary>
+        /// No documentation.
+        /// </summary>
+        RgbStudioG24NoneP2020 = 21,
+
+        /// <summary>
+        /// No documentation.
+        /// </summary>
+        YcbcrStudioG24LeftP709 = 22,
+
+        /// <summary>
+        /// No documentation.
+        /// </summary>
+        YcbcrStudioG24LeftP2020 = 23,
+
+        /// <summary>
+        /// No documentation.
+        /// </summary>
+        YcbcrStudioG24TopleftP2020 = 24,
+
+        /// <summary>
+        /// A custom color definition is used.
+        /// </summary>
+        Custom = -1
+    }
+
 }


### PR DESCRIPTION
# PR Details

This PR introduces support for rendering to High Dynamic Range (HDR) displays by enabling configuration of the swap chain's output color space and pixel format.

## Key Changes:

1.  **`ColorSpaceType` Enum:** Added a new `Stride.Graphics.ColorSpaceType` enum (in `ColorSpace.cs`) which mirrors the `DXGI_COLOR_SPACE_TYPE` values. 
2.  **`GraphicsPresenter.SetOutputColorSpace` Method:** Added a new public method `GraphicsPresenter.SetOutputColorSpace(ColorSpaceType colorSpace, PixelFormat format)`. This is the primary way for users to configure the desired output. Calling this method will:
    *   Update the presenter's description.
    *   Recreate the underlying swap chain (using `IDXGISwapChain3::SetColorSpace1` on D3D11/12) with the specified color space.
    *   Resize back buffer and depth stencil buffers accordingly.
3.  **Integration:**
    *   `PresentationParameters` now includes an `OutputColorSpace` property.
    *   `GameWindowRenderer` uses this property and allows setting `PreferredOutputColorSpace` to trigger a presenter update.
    *   The Direct3D `SwapChainGraphicsPresenter` applies the `OutputColorSpace` when creating/recreating the swap chain.
    *   Comments added to clarify which `PixelFormat` and `ColorSpaceType` combinations are intended for specific HDR standards (scRGB, HDR10).

## How to Use HDR Output:

To enable HDR rendering, you need to get the `Game.GraphicsDevice.Presenter` and call the new `SetOutputColorSpace` method with the appropriate `ColorSpaceType` and `PixelFormat`. This should typically be done after the game has started and the graphics device is initialized, for example, within a game script's `Start` or `Update` method.

Common combinations include:

*   **HDR10 / BT.2100 PQ:** Use `ColorSpaceType.RgbFullG2084NoneP2020` with `PixelFormat.R10G10B10A2_UNorm`. This requires the rendering pipeline to output colors matching the PQ transfer function and Rec.2020 primaries.
*   **scRGB (Linear):** Use `ColorSpaceType.RgbFullG10NoneP709` with `PixelFormat.R16G16B16A16_Float`. This allows for linear rendering in a wider gamut, relying on the Windows Desktop Window Manager (DWM) for final conversion to the display.
*   **Standard SDR with gamma 2.2:** Use `ColorSpaceType.RgbFullG22NoneP709` with an 8-bit format like `PixelFormat.R8G8B8A8_UNorm_SRgb`.

Example Script:

```csharp
using Stride.Engine;
using Stride.Graphics;
using Stride.Core.Diagnostics;
using System; 

namespace MyGameNamespace;

public class SetHdrOnStart : StartupScript
{
    public override void Start()
    {
        try
        {
            Game.GraphicsDevice.Presenter.SetOutputColorSpace(
                ColorSpaceType.RgbFullG10NoneP709,
                PixelFormat.R16G16B16A16_Float
            );
        }
        catch (Exception ex)
        {
            Log.Error($"Failed to set HDR color space: {ex.Message}", ex);
        }
    }
}
```

**Important Considerations:**

*   **Hardware/OS Support:** HDR output requires a compatible display, GPU, drivers, and OS configuration (e.g., "Use HDR" enabled in Windows display settings). The `SetOutputColorSpace` call may fail if the combination is not supported. Error handling is recommended.
*   **Rendering Pipeline:** When using HDR output (especially HDR10/PQ), the game's rendering pipeline (lighting, tonemapping, color grading) needs to be adjusted to correctly produce colors within the target color space and dynamic range. Using scRGB allows for a more traditional linear rendering workflow, with the OS handling the final tone mapping.
*   **Performance:** Using higher bit-depth formats like `R16G16B16A16_Float` increases memory bandwidth usage compared to standard 8-bit formats.

See also Microsoft's documentation on HDR with DirectX:
*   [Using DirectX with high dynamic range displays and advanced color](https://learn.microsoft.com/en-us/windows/win32/direct3darticles/high-dynamic-range)
*   [DXGI_COLOR_SPACE_TYPE enumeration](https://learn.microsoft.com/en-us/windows/win32/api/dxgicommon/ne-dxgicommon-dxgi_color_space_type)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation. 
- [ ] I have added tests to cover my changes. 
- [ ] All new and existing tests passed.
- [x] I have built and run the editor to try this change out.