### PR TITLE
Update README.md for ARM64 latest version is called ARM64/ARM64EC

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
    - **Desktop development with C++** with:
      - **Windows 11 SDK (10.0.22621.0)** or a later version (should be enabled by default)
      - **MSVC v143 - VS2022 C++ x64/x86 build tools (Latest)** (should be enabled by default)
-     - **MSVC v143 - VS2022 C++ ARM64 build tools (Latest)**
+     - **MSVC v143 - VS2022 C++ ARM64/ARM64EC build tools (Latest)**
      - **C++/CLI support for v143 build tools (Latest)** *(not enabled by default)*
    - *Optional* (to target iOS/Android): **.NET Multi-platform App UI development** and the **Android SDK setup** individual component (enabled by default). Then, in Visual Studio, go to `Tools > Android > Android SDK Manager` and install **NDK** (version 20.1+) from the `Tools` tab.
    - *Optional* (to build the VSIX package): **Visual Studio extension development**


### PR DESCRIPTION
# PR Details

installing the latest arm build tools didn't help building the engine because is needed ARM64 build tools and ARM64 build tools have no latest version but there is one called ARM64/ARM64EC build tools and it has a latest version and after asking on discord @Eideren said that i should install it and when i installed it i had no problem building the engine


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
