### PR TITLE
fix: Optimize assembly reloading

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssemblyReloading/GameStudioAssemblyReloader.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssemblyReloading/GameStudioAssemblyReloader.cs
@@ -58,7 +58,7 @@ namespace Stride.Assets.Presentation.AssemblyReloading
                     throw;
                 }
 
-                var reloadOperation = new ReloadAssembliesOperation(assemblyContainer, modifiedAssemblies, Enumerable.Empty<IDirtiable>());
+                var reloadOperation = new ReloadAssembliesOperation(assemblyContainer, modifiedAssemblies, []);
                 session.UndoRedoService.SetName(reloadOperation, "Reload assemblies");
 
                 // Reload assemblies
@@ -66,15 +66,14 @@ namespace Stride.Assets.Presentation.AssemblyReloading
                 session.UndoRedoService.PushOperation(reloadOperation);
 
                 postReloadAction();
-                var postReloadOperation = new AnonymousDirtyingOperation(Enumerable.Empty<IDirtiable>(), postReloadAction, postReloadAction);
+                var postReloadOperation = new AnonymousDirtyingOperation([], postReloadAction, postReloadAction);
                 session.UndoRedoService.PushOperation(postReloadOperation);
                 session.UndoRedoService.SetName(postReloadOperation, "Post reload action");
 
                 // Restore deserialized objects (or IUnloadable if it didn't work)
-                var reloadingVisitor = new ReloadingVisitor(log, loadedAssembliesSet);
                 try
                 {
-                    PostAssemblyReloading(session.UndoRedoService, session.AssetNodeContainer, reloadingVisitor, log, assetItemsToReload);
+                    PostAssemblyReloading(session.UndoRedoService, session.AssetNodeContainer, log, assetItemsToReload);
                 }
                 catch (Exception e)
                 {
@@ -132,7 +131,7 @@ namespace Stride.Assets.Presentation.AssemblyReloading
             return assetItemsToReload;
         }
 
-        private static void PostAssemblyReloading(IUndoRedoService actionService, SessionNodeContainer nodeContainer, ReloadingVisitor reloaderVisitor, ILogger log, Dictionary<AssetViewModel, List<ItemToReload>> assetItemsToReload)
+        private static void PostAssemblyReloading(IUndoRedoService actionService, SessionNodeContainer nodeContainer, ILogger log, Dictionary<AssetViewModel, List<ItemToReload>> assetItemsToReload)
         {
             log?.Info("Updating components with newly loaded assemblies");
 
@@ -140,7 +139,43 @@ namespace Stride.Assets.Presentation.AssemblyReloading
             foreach (var asset in assetItemsToReload)
             {
                 // Deserialize objects with reloaded types from Yaml
-                reloaderVisitor.Run(asset.Key.Asset, asset.Value);
+                var objectReferences = new YamlAssetMetadata<Guid>();
+                foreach (var itemToReload in asset.Value)
+                {
+                    var expectedPath = itemToReload.Path.Decompose().LastOrDefault()?.GetIndex() != null ? itemToReload.ParentPath : itemToReload.Path;
+                    if (expectedPath.TryGetValue(asset.Key.Asset, out _) == false)
+                        continue;
+
+                    var eventReader = new EventReader(new MemoryParser(itemToReload.ParsingEvents));
+                    var settings = log != null ? new SerializerContextSettings { Logger = log } : null;
+                    PropertyContainer properties;
+                    itemToReload.UpdatedObject = AssetYamlSerializer.Default.Deserialize(eventReader, null, itemToReload.ExpectedType, out properties, settings);
+
+                    // We will have broken references here because we are deserializing objects individually, so we don't pass any logger to discard warnings
+                    var metadata = YamlAssetSerializer.CreateAndProcessMetadata(properties, itemToReload.UpdatedObject, false);
+
+                    itemToReload.Overrides = metadata.RetrieveMetadata(AssetObjectSerializerBackend.OverrideDictionaryKey);
+
+                    var references = metadata.RetrieveMetadata(AssetObjectSerializerBackend.ObjectReferencesKey);
+                    if (references != null)
+                    {
+                        var basePath = YamlAssetPath.FromMemberPath(expectedPath, asset.Key.Asset);
+                        foreach (var reference in references)
+                        {
+                            var basePathWithIndex = basePath.Clone();
+                            if (itemToReload.GraphPathIndex != NodeIndex.Empty)
+                            {
+                                if (itemToReload.ItemId == ItemId.Empty)
+                                    basePathWithIndex.PushIndex(itemToReload.GraphPathIndex.Value);
+                                else
+                                    basePathWithIndex.PushItemId(itemToReload.ItemId);
+                            }
+
+                            var actualPath = basePathWithIndex.Append(reference.Key);
+                            objectReferences.Set(actualPath, reference.Value);
+                        }
+                    }
+                }
 
                 // Set new values
                 var overrides = new YamlAssetMetadata<OverrideType>();
@@ -164,7 +199,7 @@ namespace Stride.Assets.Presentation.AssemblyReloading
                     }
                 }
 
-                FixupObjectReferences.RunFixupPass(asset.Key.Asset, reloaderVisitor.ObjectReferences, true, false, log);
+                FixupObjectReferences.RunFixupPass(asset.Key.Asset, objectReferences, true, false, log);
 
                 var rootNode = (IAssetNode)nodeContainer.GetNode(asset.Key.Asset);            
                 AssetPropertyGraph.ApplyOverrides(rootNode, overrides);
@@ -297,13 +332,6 @@ namespace Stride.Assets.Presentation.AssemblyReloading
                 base.VisitArrayItem(array, descriptor, index, item, itemDescriptor);
             }
 
-            public override void VisitObjectMember(object container, ObjectDescriptor containerDescriptor, IMemberDescriptor member, object value)
-            {
-                if (ProcessObject(value, member.TypeDescriptor.Type)) return;
-
-                base.VisitObjectMember(container, containerDescriptor, member, value);
-            }
-
             public override void VisitDictionaryKeyValue(object dictionary, DictionaryDescriptor descriptor, object key, ITypeDescriptor keyDescriptor, object value, ITypeDescriptor valueDescriptor)
             {
                 // TODO: CurrentPath is valid only for value, not key
@@ -397,71 +425,6 @@ namespace Stride.Assets.Presentation.AssemblyReloading
                     }
                 }
                 return metadata;
-            }
-        }
-
-        private class ReloadingVisitor : ReloaderVisitorBase
-        {
-            private Asset root;
-            public YamlAssetMetadata<Guid> ObjectReferences;
-
-            public ReloadingVisitor(ILogger log, HashSet<Assembly> unloadedAssemblies)
-                : base(log, unloadedAssemblies)
-            {
-            }
-
-            public void Run(Asset asset, List<ItemToReload> itemsToReload)
-            {
-                Reset();
-                ItemsToReload = itemsToReload;
-                root = asset;
-                ObjectReferences = new YamlAssetMetadata<Guid>();
-                Visit(asset);
-                ItemsToReload = null;
-            }
-
-            protected override bool ProcessObject(object obj, Type expectedType)
-            {
-                foreach (var unloadedObject in ItemsToReload)
-                {
-                    // If a collection, stop at parent path level (since index will be already removed, we will never visit the target slot)
-                    // TODO: Check if the fact we didn't enter in an item with index affect visitor states
-                    // Other case, stop on the actual member (since we'll just visit null)
-                    var expectedPath = unloadedObject.Path.Decompose().LastOrDefault()?.GetIndex() != null ? unloadedObject.ParentPath : unloadedObject.Path;
-
-                    if (CurrentPath.Match(expectedPath))
-                    {
-                        var eventReader = new EventReader(new MemoryParser(unloadedObject.ParsingEvents));
-                        var settings = Log != null ? new SerializerContextSettings { Logger = Log } : null;
-                        PropertyContainer properties;
-                        unloadedObject.UpdatedObject = AssetYamlSerializer.Default.Deserialize(eventReader, null, unloadedObject.ExpectedType, out properties, settings);
-                        // We will have broken references here because we are deserializing objects individually, so we don't pass any logger to discard warnings
-                        var metadata = YamlAssetSerializer.CreateAndProcessMetadata(properties, unloadedObject.UpdatedObject, false);
-
-                        var overrides = metadata.RetrieveMetadata(AssetObjectSerializerBackend.OverrideDictionaryKey);
-                        unloadedObject.Overrides = overrides;
-
-                        var references = metadata.RetrieveMetadata(AssetObjectSerializerBackend.ObjectReferencesKey);
-                        if (references != null)
-                        {
-                            var basePath = YamlAssetPath.FromMemberPath(CurrentPath, root);
-                            foreach (var reference in references)
-                            {
-                                var basePathWithIndex = basePath.Clone();
-                                if (unloadedObject.GraphPathIndex != NodeIndex.Empty)
-                                {
-                                    if (unloadedObject.ItemId == ItemId.Empty)
-                                        basePathWithIndex.PushIndex(unloadedObject.GraphPathIndex.Value);
-                                    else
-                                        basePathWithIndex.PushItemId(unloadedObject.ItemId);
-                                }
-                                var actualPath = basePathWithIndex.Append(reference.Key);
-                                ObjectReferences.Set(actualPath, reference.Value);
-                            }
-                        }
-                    }
-                }
-                return false;
             }
         }
 

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs
@@ -168,9 +168,10 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
                     throw new InvalidOperationException("Unable to retrieve the game-side node");
 
                 var index = (e as ItemChangeEventArgs)?.Index ?? NodeIndex.Empty;
-                if (!AssetRegistry.CanBeAssignedToContentTypes(e.Node.Descriptor.GetInnerCollectionType(), checkIsUrlType: false))
+                var innerType = e.Node.Descriptor.GetInnerCollectionType();
+                if (!AssetRegistry.CanBeAssignedToContentTypes(innerType, checkIsUrlType: false))
                 {
-                    if (Editor.NodeContainer.NodeBuilder.PrimitiveTypeFilter.IsPrimitiveType(e.Node.Type))
+                    if (Editor.NodeContainer.NodeBuilder.PrimitiveTypeFilter.IsPrimitiveType(innerType))
                     {
                         // No need to retrieve and/or duplicate the value for value type, we just propagate the change
                         await Editor.Controller.InvokeAsync(() => UpdateGameSideContent(gameSideNode, e.NewValue, e.ChangeType, index));


### PR DESCRIPTION
# PR Details
Replaced the `ReloadingVisitor` - we already have the paths to the items we need to reload, no need to go through every leaf of the tree of the asset.

https://github.com/stride3d/stride/blob/8d3547a7de1d3f3fdbd796a998915c461bbaa1e9/sources/editor/Stride.Assets.Presentation/AssemblyReloading/GameStudioAssemblyReloader.cs#L300-L305
Calls `ProcessObject` twice for the same object/path combination, once right in this scope, another one through `VisitObject` down the base call.

Here I'm not 100% certain:
https://github.com/stride3d/stride/blob/8d3547a7de1d3f3fdbd796a998915c461bbaa1e9/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs#L170-L178
The use of `CanBeAssignedToContentTypes()` with `GetInnerCollectionType()` is to ignore `List<MyCustomAsset>` and `MyCustomAsset`, then it would make sense that both `int` and `List<int>` not just `int` should pass the `IsPrimitiveType` branch.

## Related Issue
Kind of a fix for #2716 - the previous logic processed the objects twice, see the blurb about `ProcessObject` above. The first pass consumes the override tag when reading the yaml events because of the `key.Value = keyName;` there
https://github.com/stride3d/stride/blob/8d3547a7de1d3f3fdbd796a998915c461bbaa1e9/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs#L153-L159
It would remove the override tag, so the next read would be without the override metadata, which in term gets the collection item removed as it is not part of its base asset.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
