### PR TITLE
fix: yaml, rollback trimming of the override tag when parsing collection index to ensure inputs can be re-used

### DIFF
--- a/sources/assets/Stride.Core.Assets.Tests/TestAssetInheritance.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestAssetInheritance.cs
@@ -1,10 +1,28 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Stride.Core.Assets.Serializers;
+using Stride.Core.Reflection;
+using Stride.Core.Yaml;
+using Stride.Core.Yaml.Events;
+
 namespace Stride.Core.Assets.Tests;
 
 public class TestAssetInheritance
 {
+    private const string ObjectWithStringsDerivedYaml =
+        """
+        MyStrings:
+            0a0000000a0000000a0000000a000000*: MyDerivedString
+            14000000140000001400000014000000: MyBaseString
+        """;
+
+    [DataContract]
+    public class ObjectWithStrings
+    {
+        public List<string> MyStrings { get; set; } = [];
+    }
+
     [Fact]
     public void TestWithParts()
     {
@@ -45,5 +63,31 @@ public class TestAssetInheritance
             Assert.Equal(instanceId, part.Base.InstanceId);
             ++i;
         }
+    }
+
+    [Fact]
+    public void TestParsingEventReuse()
+    {
+        // This test checks if a List<ParsingEvent> can be read multiple times without loosing its overrides
+        // Built as part of a GameStudio reloading issue raised in #2718
+        
+        var reader = new EventReader(new Parser(new StringReader(ObjectWithStringsDerivedYaml)));
+        var parsingEvents = new List<ParsingEvent>();
+        reader.ReadCurrent(parsingEvents);
+
+        var eventReader = new EventReader(new MemoryParser(parsingEvents));
+        PropertyContainer properties;
+        var obj = AssetYamlSerializer.Default.Deserialize(eventReader, null, typeof(ObjectWithStrings), out properties);
+        
+        eventReader = new EventReader(new MemoryParser(parsingEvents));
+        obj = AssetYamlSerializer.Default.Deserialize(eventReader, null, typeof(ObjectWithStrings), out properties);
+
+        var metadata = YamlAssetSerializer.CreateAndProcessMetadata(properties, obj, false);
+
+        var overrides = metadata.RetrieveMetadata(AssetObjectSerializerBackend.OverrideDictionaryKey);
+        Assert.NotNull(overrides);
+        Assert.Equal(1, overrides.Count);
+        Assert.Equal("(object).MyStrings{0a0000000a0000000a0000000a000000}", overrides.First().Key.ToString());
+        Assert.Equal(OverrideType.New, overrides.First().Value);
     }
 }

--- a/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
@@ -154,9 +154,19 @@ public class AssetObjectSerializerBackend : DefaultObjectSerializerBackend
     {
         var key = objectContext.Reader.Peek<Scalar>();
         var keyName = TrimAndParseOverride(key.Value, out var overrideTypes);
+        var previousKeyValue = key.Value;
+
         key.Value = keyName;
 
-        var keyValue = base.ReadDictionaryKey(ref objectContext, keyType);
+        object? keyValue;
+        try
+        {
+            keyValue = base.ReadDictionaryKey(ref objectContext, keyType);
+        }
+        finally
+        {
+            key.Value = previousKeyValue; // rollback the change to ensure this can be re-used
+        }
 
         if (overrideTypes[0] != OverrideType.Base)
         {


### PR DESCRIPTION
# PR Details
The parsing events, which are effectively tokens that the deserializer reads to create the final object, are mutated when deserializing. If you were to re-use those parsing events a second time, it would generate the same object, but the metadata would be partially lost.

A reader-like object should not be writing to the stream it is reading from.

The spot where it is called twice with the same parsing events is located here:
https://github.com/stride3d/stride/blob/8d3547a7de1d3f3fdbd796a998915c461bbaa1e9/sources/editor/Stride.Assets.Presentation/AssemblyReloading/GameStudioAssemblyReloader.cs#L423-L466

And it is because
https://github.com/stride3d/stride/blob/8d3547a7de1d3f3fdbd796a998915c461bbaa1e9/sources/editor/Stride.Assets.Presentation/AssemblyReloading/GameStudioAssemblyReloader.cs#L300-L305
Calls `ProcessObject` twice for the same object/path combination, once right in this scope, another one through `VisitObject` down the base call.
I have another PR covering that scope.

## Related Issue
Fix: #2716 
The previous logic processed the objects twice, see the blurb about `ProcessObject` above. The first pass consumes the override tag when reading the yaml events because of the `key.Value = keyName;` there
https://github.com/stride3d/stride/blob/8d3547a7de1d3f3fdbd796a998915c461bbaa1e9/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs#L153-L159
It would remove the override tag, so the next read would be without the override metadata, which in term gets the collection item removed as it is not part of its base asset.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
