### PR TITLE
fix: internal exception being thrown when selecting a EntityComponent type in interface properties + drag and drop support

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Commands/SetComponentReferenceCommand.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Commands/SetComponentReferenceCommand.cs
@@ -29,7 +29,7 @@ namespace Stride.Assets.Presentation.NodePresenters.Commands
         /// <inheritdoc/>
         public override bool CanAttach(INodePresenter nodePresenter)
         {
-            return typeof(EntityComponent).IsAssignableFrom(nodePresenter.Type);
+            return typeof(EntityComponent).IsAssignableFrom(nodePresenter.Type) || nodePresenter.Type.IsInterface && nodePresenter.Type.IsImplementedOnAny<EntityComponent>();
         }
 
         /// <inheritdoc/>

--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/EntityHierarchyAssetNodeUpdater.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/EntityHierarchyAssetNodeUpdater.cs
@@ -78,7 +78,8 @@ namespace Stride.Assets.Presentation.NodePresenters.Updaters
                     componentCount[type] = ++count;
                 }
             }
-            if (typeof(EntityComponent).IsAssignableFrom(node.Type))
+            if (typeof(EntityComponent).IsAssignableFrom(node.Type) 
+                || node.Type.IsInterface && node.Type.IsImplementedOnAny<EntityComponent>())
             {
                 node.AttachedProperties.Add(ReferenceData.Key, new ComponentReferenceViewModel());
             }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
@@ -19,15 +19,34 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
         {
             var type = node.Descriptor.GetInnerCollectionType();
 
-            IEnumerable<AbstractNodeEntry> abstractNodeMatchingEntries = AbstractNodeType.GetInheritedInstantiableTypes(type);
+            var abstractNodeMatchingEntries = AbstractNodeType.GetInheritedInstantiableTypes(type);
+            IEnumerable<AbstractNodeEntry> abstractNodeMatchingEntries2 = [];
+            foreach (var nodeType in abstractNodeMatchingEntries)
+            {
+                AbstractNodeEntry nodeEntry = IsEntityComponent(nodeType.Type) ? new AbstractNodeValue(null, nodeType.Type.Name, 0) : nodeType;
+                abstractNodeMatchingEntries2 = abstractNodeMatchingEntries2.Append(nodeEntry);
+            }
 
-            if (abstractNodeMatchingEntries != null)
+            if (abstractNodeMatchingEntries2 != null)
             {
                 // Prepend the value that will allow to set the value to null, if this command is allowed.
                 if (IsAllowingNull(node))
-                    abstractNodeMatchingEntries = AbstractNodeValue.Null.Yield().Concat(abstractNodeMatchingEntries);
+                    abstractNodeMatchingEntries2 = AbstractNodeValue.Null.Yield().Concat(abstractNodeMatchingEntries2);
             }
-            return abstractNodeMatchingEntries;
+            return abstractNodeMatchingEntries2;
+
+            static bool IsEntityComponent(Type type)
+            {
+                for (var t = type; t != null; t = t.BaseType)
+                {
+                    if (t.Name == "EntityComponent" && t.FullName == "Stride.Engine.EntityComponent")
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AbstractNodeEntryNodeUpdater.cs
@@ -39,6 +39,7 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
             {
                 for (var t = type; t != null; t = t.BaseType)
                 {
+                    // TODO: Workaround for internal engine issue when selecting a component type from the type dropdown generated, see #2719
                     if (t.Name == "EntityComponent" && t.FullName == "Stride.Engine.EntityComponent")
                     {
                         return true;


### PR DESCRIPTION
# PR Details
The exception thrown is because the handler always tries to create a new instance of whichever type is selected while the editor expects `EntityComponent` to live on an entity in a scene.

Drag and drop support for interface properties specifically, other property types already works.
Here's how it looks like *without* this PR:

https://github.com/user-attachments/assets/e04b40b8-4c6d-48fc-b33d-3b6db4b6dc1a

## Related Issue
None reported afaict.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
