### PR TITLE
fix: Avoid race condition in parallelized contact event collection

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
@@ -292,7 +292,7 @@ public sealed class BepuSimulation : IDisposable
         #warning Consider wrapping stride's threadpool/dispatcher into an IThreadDispatcher and passing that over to bepu instead of using their dispatcher
         _threadDispatcher = new ThreadDispatcher(targetThreadCount);
         BufferPool = new BufferPool();
-        ContactEvents = new ContactEventsManager(BufferPool, this);
+        ContactEvents = new ContactEventsManager(BufferPool, this, targetThreadCount);
 
         var strideNarrowPhaseCallbacks = new StrideNarrowPhaseCallbacks(this, ContactEvents, CollidableMaterials);
         var stridePoseIntegratorCallbacks = new StridePoseIntegratorCallbacks(CollidableMaterials);


### PR DESCRIPTION
# PR Details
Events should have been collected and passed to the user through the main thread instead of using the worker thread, this caused an issue reported in #2703 as some other part of the event management logic did not expect concurrent access.

## Related Issue
Fix: #2703

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
