### PR TITLE
docs: README.md - Update Visual Studio 2022 installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
 1. **Latest [Git](https://git-scm.com/downloads)** with **Large File Support** selected during setup. For convenience, you might also use a Git UI client like [GitExtensions](https://gitextensions.github.io/).
 2. **[.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)**
    - Run `dotnet --info` in a console or PowerShell window to see which versions you have installed.
-3. **[Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)** (the Community edition is free) with the following workloads, which can be installed also through [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) if you would like to use other IDEs:
+3. [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/) (the Community edition is free), with the following workloads. Follow this link if you would rather use [a different IDE or the command line](#build-stride-without-visual-studio).
    - **.NET desktop development** with **.NET Framework 4.7.2 targeting pack** *(should be enabled by default)*
    - **Desktop development with C++** with:
      - **Windows 11 SDK (10.0.22621.0)** or a later version *(should be enabled by default)*

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
 1. **Latest [Git](https://git-scm.com/downloads)** with **Large File Support** selected during setup. For convenience, you might also use a Git UI client like [GitExtensions](https://gitextensions.github.io/).
 2. **[.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)**
    - Run `dotnet --info` in a console or PowerShell window to see which versions you have installed.
-3. [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/) (the Community edition is free), with the following workloads. Follow this link if you would rather use [a different IDE or the command line](#build-stride-without-visual-studio).
+3. **[Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)** (the Community edition is free), with the following workloads. Follow this link if you would rather use [a different IDE or the command line](#build-stride-without-visual-studio).
    - **.NET desktop development** with **.NET Framework 4.7.2 targeting pack** *(should be enabled by default)*
    - **Desktop development with C++** with:
      - **Windows 11 SDK (10.0.22621.0)** or a later version *(should be enabled by default)*

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
 1. **Latest [Git](https://git-scm.com/downloads)** with **Large File Support** selected during setup. For convenience, you might also use a Git UI client like [GitExtensions](https://gitextensions.github.io/).
 2. **[.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)**
    - Run `dotnet --info` in a console or PowerShell window to see which versions you have installed.
-3. **[Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)** (the Community edition is free) with the following workloads:
-   - **.NET desktop development** with **.NET Framework 4.7.2 targeting pack** (should be enabled by default)
+3. **[Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)** (the Community edition is free) with the following workloads, which can be installed also through [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) if you would like to use other IDEs:
+   - **.NET desktop development** with **.NET Framework 4.7.2 targeting pack** *(should be enabled by default)*
    - **Desktop development with C++** with:
-     - **Windows 11 SDK (10.0.22621.0)** or a later version (should be enabled by default)
-     - **MSVC v143 - VS2022 C++ x64/x86 build tools (Latest)** (should be enabled by default)
-     - **MSVC v143 - VS2022 C++ ARM64/ARM64EC build tools (Latest)**
+     - **Windows 11 SDK (10.0.22621.0)** or a later version *(should be enabled by default)*
+     - **MSVC v143 - VS2022 C++ x64/x86 build tools (Latest)** *(should be enabled by default)*
+     - **MSVC v143 - VS2022 C++ ARM64/ARM64EC build tools (Latest)** *(not enabled by default, click Individual components tab to select or search)*
      - **C++/CLI support for v143 build tools (Latest)** *(not enabled by default)*
    - *Optional* (to target iOS/Android): **.NET Multi-platform App UI development** and the **Android SDK setup** individual component (enabled by default). Then, in Visual Studio, go to `Tools > Android > Android SDK Manager` and install **NDK** (version 20.1+) from the `Tools` tab.
    - *Optional* (to build the VSIX package): **Visual Studio extension development**


### PR DESCRIPTION
# PR Details

- Added a note that Visual Studio 2022 workloads can be installed via Visual Studio Build Tools.
- Updated C++ build tools section to clarify default enabled status.
- Emphasized that ARM64/ARM64EC build tools are not enabled by default and provided instructions for enabling them.
- Adjusted formatting for improved clarity.

I did 3 tests of building Stride from source in Windows 11, all in a clean Windows installations:

- Build Stride with Visaul Studio 2022 - **Success**
- Build Stride without Visual Studio - **Success**
- Build Stride without Visual Studio without installing ARM64/ARM64EC - **Build Error** (Expected) because of missing ARM64/ARM64EC

Based on the tests and following current instructions I propose minor adjusments in the instructions (this PR).

-----------------------

# Other Issues

Also, in both successfull tests, the first run of Game Studio, when a small window shows up to accept T&C, crashed after clicking the button "**I accept**".

Any following Game Studio run was ok. It seems that the crash is related only when a button **I accept** is clicked.

Not that much information or errors. These are from the Event Viewer:

**.NET Runtime**
Application: Stride.GameStudio.dll
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: exception code e0434352, exception address 00007FF80B52933A
Stack:

**Application Error**
Faulting application name: Stride.GameStudio.dll, version: 4.2.0.1, time stamp: 0xa72ca3b6
Faulting module name: KERNELBASE.dll, version: 10.0.26100.3775, time stamp: 0x6e2fc3bb
Exception code: 0xe0434352
Fault offset: 0x00000000000c933a
Faulting process id: 0x368
Faulting application start time: 0x1DBB2497194165E
Faulting application path: C:\Projects\GitHub\stride\sources\editor\Stride.GameStudio\bin\Debug\net8.0-windows\Stride.GameStudio.dll
Faulting module path: C:\WINDOWS\System32\KERNELBASE.dll
Report Id: 659587d0-1259-436e-b352-5e7ffa3ee4ed
Faulting package full name: 
Faulting package-relative application ID: 

### Other

For a reference when ARM64/ARM64EC isn't installed, you might get this build error:

 "C:\Projects\GitHub\stride\build\Stride.sln" (default target) (1) ->
       "C:\Projects\GitHub\stride\sources\engine\Stride.Audio\Stride.Audio.csproj" (default target) (26:7) ->
       "C:\Projects\GitHub\stride\sources\engine\Stride.Audio\Stride.Audio.csproj" (Build target) (26:8) ->
       "C:\Projects\GitHub\stride\sources\native\WindowsProjects\WindowsDesktop\WindowsDesktop.vcxproj" (Build target) (111:3) ->
       (PrepareForBuild target) ->
         C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(459,5): error MSB8020: The build tools for v143 (Platform Toolset = 'v143') cannot be found. To build using th
       e v143 build tools, please install v143 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution". [C:\Proje
       cts\GitHub\stride\sources\native\WindowsProjects\WindowsDesktop\WindowsDesktop.vcxproj]

## Related Issue

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
