### PR TITLE
fix: Bepu, validate Debug.Assert and remove as the logic was mistakenly inverted

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Raycast/RayHitsStackHandler.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Raycast/RayHitsStackHandler.cs
@@ -32,16 +32,14 @@ internal unsafe struct RayHitsStackHandler(HitInfoStack* Ptr, int Length, BepuSi
                 indexOfMax = Head;
             }
 
-            Ptr[Head++] = GenerateHitInfo((ray.Origin + ray.Direction * t), normal, t, collidable, sim, childIndex);
+            Ptr[Head++] = GenerateHitInfo(ray.Origin + ray.Direction * t, normal, t, collidable, sim, childIndex);
 
             if (Head == Length) // Once the array is filled up, ignore all hits that occur further away than the furthest hit in the array
                 maximumT = storedMax;
         }
         else
         {
-            Debug.Assert(t > storedMax, "maximumT should have prevented this hit from being returned, if this is hit it means that we need to change the above into an 'else if (distance < StoredMax)'");
-
-            Ptr[indexOfMax] = GenerateHitInfo((ray.Origin + ray.Direction * t), normal, t, collidable, sim, childIndex);
+            Ptr[indexOfMax] = GenerateHitInfo(ray.Origin + ray.Direction * t, normal, t, collidable, sim, childIndex);
 
             // Re-scan to find the new max now that the last one was replaced
             storedMax = float.NegativeInfinity;
@@ -75,8 +73,6 @@ internal unsafe struct RayHitsStackHandler(HitInfoStack* Ptr, int Length, BepuSi
         }
         else
         {
-            Debug.Assert(t > storedMax, "maximumT should have prevented this hit from being returned, if this is hit it means that we need to change the above into an 'else if (distance < StoredMax)'");
-
             Ptr[indexOfMax] = GenerateHitInfo(hitLocation, normal, t, collidable, sim, -1);
 
             // Re-scan to find the new max now that the last one was replaced


### PR DESCRIPTION
# PR Details
That assert is always hit when the buffer provided to the player is smaller than the amount of hits bepu found.
I wrote this nonsense, `Debug.Assert(t > storedMax, ...` should have been `Debug.Assert(t < storedMax` from the start since `maximumT` ensures subsequent hits have the `t < maximumT` constraint. I was aware of that at the time given the message, I just wrote the comparison the wrong way around.

Removed the assert as I finally had the time to test this proper.

## Related Issue
None reported

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**