### PR TITLE
fix: compile.bat error when computing duration (#2733)

### DIFF
--- a/build/compile.bat
+++ b/build/compile.bat
@@ -2,7 +2,7 @@
 
 setlocal
 
-set STARTTIME=%TIME%
+set STARTTIME=%TIME: =0%
 set __SkipTestBuild=true
 set __BuildType=Debug
 set __BuildVerbosity=n
@@ -115,7 +115,7 @@ goto :eof
 
 :exit
 
-set ENDTIME=%TIME%
+set ENDTIME=%TIME: =0%
 
 echo.
 echo Starting time was: %STARTTIME%
@@ -130,7 +130,7 @@ rem calculating the duration is easy
 set /A DURATION=%ENDTIME%-%STARTTIME%
 
 rem we might have measured the time inbetween days
-if %ENDTIME% LSS %STARTTIME% set set /A DURATION=%STARTTIME%-%ENDTIME%
+if %ENDTIME% LSS %STARTTIME% set /A DURATION=%STARTTIME%-%ENDTIME%
 
 set /A DURATION=%DURATION%/1000
 


### PR DESCRIPTION
# PR Details

Fixes the error reported in #2733 in a (hopefully) minimally invasive way. 

I also tried another approach to fix this [here](https://github.com/hoelzl/stride/tree/fix-build-de). But that is probably too much code for such a simple task, although it seems slightly more robust. 

I know very little about writing CMD scripts, however, so both approaches might be flawed.

## Related Issue

#2733 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

