### PR TITLE
feat: undo/redo & action history panel

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum/IAssetObjectNode.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/IAssetObjectNode.cs
@@ -20,11 +20,11 @@ public interface IAssetObjectNode : IAssetNode, IObjectNode
 
     bool IsItemDeleted(ItemId itemId);
 
-    void Restore(object restoredItem, ItemId id);
+    void Restore(object? restoredItem, ItemId id);
 
-    void Restore(object restoredItem, NodeIndex index, ItemId id);
+    void Restore(object? restoredItem, NodeIndex index, ItemId id);
 
-    void RemoveAndDiscard(object item, NodeIndex itemIndex, ItemId id);
+    void RemoveAndDiscard(object? item, NodeIndex itemIndex, ItemId id);
 
     bool IsItemInherited(NodeIndex index);
 

--- a/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetBoxedNode.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetBoxedNode.cs
@@ -43,11 +43,11 @@ internal class AssetBoxedNode : BoxedNode, IAssetObjectNodeInternal
 
     public bool IsItemDeleted(ItemId itemId) => ex.IsItemDeleted(itemId);
 
-    public void Restore(object restoredItem, ItemId id) => ex.Restore(restoredItem, id);
+    public void Restore(object? restoredItem, ItemId id) => ex.Restore(restoredItem, id);
 
-    public void Restore(object restoredItem, NodeIndex index, ItemId id) => ex.Restore(restoredItem, index, id);
+    public void Restore(object? restoredItem, NodeIndex index, ItemId id) => ex.Restore(restoredItem, index, id);
 
-    public void RemoveAndDiscard(object item, NodeIndex itemIndex, ItemId id) => ex.RemoveAndDiscard(item, itemIndex, id);
+    public void RemoveAndDiscard(object? item, NodeIndex itemIndex, ItemId id) => ex.RemoveAndDiscard(item, itemIndex, id);
 
     public OverrideType GetItemOverride(NodeIndex index) => ex.GetItemOverride(index);
 

--- a/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetObjectNode.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetObjectNode.cs
@@ -44,11 +44,11 @@ internal class AssetObjectNode : ObjectNode, IAssetObjectNodeInternal
 
     public bool IsItemDeleted(ItemId itemId) => ex.IsItemDeleted(itemId);
 
-    public void Restore(object restoredItem, ItemId id) => ex.Restore(restoredItem, id);
+    public void Restore(object? restoredItem, ItemId id) => ex.Restore(restoredItem, id);
 
-    public void Restore(object restoredItem, NodeIndex index, ItemId id) => ex.Restore(restoredItem, index, id);
+    public void Restore(object? restoredItem, NodeIndex index, ItemId id) => ex.Restore(restoredItem, index, id);
 
-    public void RemoveAndDiscard(object item, NodeIndex itemIndex, ItemId id) => ex.RemoveAndDiscard(item, itemIndex, id);
+    public void RemoveAndDiscard(object? item, NodeIndex itemIndex, ItemId id) => ex.RemoveAndDiscard(item, itemIndex, id);
 
     public OverrideType GetItemOverride(NodeIndex index) => ex.GetItemOverride(index);
 

--- a/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetObjectNodeExtended.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/Internal/AssetObjectNodeExtended.cs
@@ -120,7 +120,7 @@ internal struct AssetObjectNodeExtended
         return result;
     }
 
-    public void Restore(object restoredItem, ItemId id)
+    public void Restore(object? restoredItem, ItemId id)
     {
         if (TryGetCollectionItemIds(node.Retrieve(), out var ids))
         {
@@ -131,7 +131,7 @@ internal struct AssetObjectNodeExtended
         node.Add(restoredItem);
     }
 
-    public void Restore(object restoredItem, NodeIndex index, ItemId id)
+    public void Restore(object? restoredItem, NodeIndex index, ItemId id)
     {
         restoringId = id;
         node.Add(restoredItem, index);
@@ -143,7 +143,7 @@ internal struct AssetObjectNodeExtended
         }
     }
 
-    public void RemoveAndDiscard(object item, NodeIndex itemIndex, ItemId id)
+    public void RemoveAndDiscard(object? item, NodeIndex itemIndex, ItemId id)
     {
         node.Remove(item, itemIndex);
         if (TryGetCollectionItemIds(node.Retrieve(), out var ids))

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/ArrayDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/ArrayDescriptor.cs
@@ -51,7 +51,7 @@ public class ArrayDescriptor : ObjectDescriptor
         return ((Array)array).GetValue(index);
     }
 
-    public void SetValue(object array, int index, object value)
+    public void SetValue(object array, int index, object? value)
     {
         ((Array)array).SetValue(value, index);
     }

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/ImageResources.axaml
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/ImageResources.axaml
@@ -2,6 +2,20 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <!-- TODO have different values per theme variant -->
 
+  <!--  Generic action-related icons  -->
+  <DrawingImage x:Key="ImageSave">
+    <DrawingImage.Drawing>
+      <DrawingGroup>
+        <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+        <GeometryDrawing Brush="#FFF6F6F6"
+                         Geometry="F1M16,2L16,16 2.586,16 0,13.414 0,2C0,0.897,0.897,0,2,0L14,0C15.103,0,16,0.897,16,2" />
+        <GeometryDrawing Brush="#FFEFEFF0" Geometry="F1M4,10L4,15 6,15 6,12 8,12 8,15 12,15 12,10z M13,7L3,7 3,3 13,3z" />
+        <GeometryDrawing Brush="#FF00529C"
+                         Geometry="F1M13,3L3,3 3,7 13,7z M15,2L15,15 12,15 12,10 4,10 4,15 3,15 1,13 1,2C1,1.448,1.448,1,2,1L14,1C14.553,1,15,1.448,15,2 M6,12L8,12 8,15 6,15z" />
+      </DrawingGroup>
+    </DrawingImage.Drawing>
+  </DrawingImage>
+
   <!--  Property edition icons  -->
   <DrawingImage x:Key="ImageAdd">
     <DrawingImage.Drawing>
@@ -15,6 +29,7 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+
   <DrawingImage x:Key="ImageClear">
     <DrawingImage.Drawing>
       <DrawingGroup>
@@ -30,6 +45,7 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+
   <DrawingImage x:Key="ImageCreateInstance">
     <DrawingImage.Drawing>
       <DrawingGroup>
@@ -62,6 +78,7 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+
   <DrawingImage x:Key="ImageDropDown">
     <DrawingImage.Drawing>
       <DrawingGroup>
@@ -75,6 +92,7 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+
   <DrawingImage x:Key="ImageFetchAsset">
     <DrawingImage.Drawing>
       <DrawingGroup>
@@ -105,6 +123,7 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+
   <DrawingImage x:Key="ImagePickup">
     <DrawingImage.Drawing>
       <DrawingGroup>
@@ -118,6 +137,7 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+  
   <DrawingImage x:Key="ImageRemove">
     <DrawingImage.Drawing>
       <DrawingGroup>

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestArchetypesBasicUndoRedo.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestArchetypesBasicUndoRedo.cs
@@ -2,7 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Linq;
-using Stride.Core.Assets.Editor.Quantum;
+using Stride.Core.Assets.Presentation.Quantum;
 using Stride.Core.Assets.Quantum;
 using Stride.Core.Assets.Quantum.Tests;
 using Stride.Core.Presentation.Dirtiables;

--- a/sources/editor/Stride.Core.Assets.Editor/Components/Properties/SessionObjectPropertiesViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/Properties/SessionObjectPropertiesViewModel.cs
@@ -142,19 +142,19 @@ public class SessionObjectPropertiesViewModel : PropertiesViewModel
     {
         base.OnPropertyChanged(propertyNames);
         // Do this only when the property has changed from the UI thread
-        if (Dispatcher.CheckAccess())
+        if (!Dispatcher.CheckAccess())
+            return;
+
+        if (!contextLock && propertyNames.Any(x => x is nameof(ViewModel) or nameof(CanDisplayProperties) or nameof(FallbackMessage)))
         {
-            if (!contextLock && propertyNames.Any(x => x is nameof(ViewModel) or nameof(CanDisplayProperties) or nameof(FallbackMessage)))
+            contextLock = true;
+            if (Session.ActiveProperties != this)
             {
-                contextLock = true;
-                if (Session.ActiveProperties != this)
-                {
-                    // FIXME xplat-editor
-                    //Session.ActiveProperties.ClearSelection();
-                }
-                Session.ActiveProperties = this;
-                contextLock = false;
+                // FIXME xplat-editor
+                //Session.ActiveProperties.ClearSelection();
             }
+            Session.ActiveProperties = this;
+            contextLock = false;
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Components/Transactions/ActionHistoryViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/Transactions/ActionHistoryViewModel.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Assets.Editor.ViewModels;
+using Stride.Core.Assets.Presentation.ViewModels;
+using Stride.Core.Extensions;
+using Stride.Core.Presentation.Collections;
+using Stride.Core.Presentation.Commands;
+using Stride.Core.Presentation.Dirtiables;
+using Stride.Core.Presentation.Services;
+using Stride.Core.Presentation.ViewModels;
+using Stride.Core.Transactions;
+
+namespace Stride.Core.Assets.Editor.Components.Transactions;
+
+public sealed class ActionHistoryViewModel : DispatcherViewModel
+{
+    private readonly IUndoRedoService service;
+    private readonly SessionViewModel session;
+    private readonly ObservableList<TransactionViewModel> transactions = [];
+
+    public ActionHistoryViewModel(SessionViewModel session)
+        : base(session.SafeArgument().ServiceProvider)
+    {
+        this.session = session;
+        service = ServiceProvider.Get<IUndoRedoService>();
+        transactions.CollectionChanged += (_, _) => RefreshUndoRedoStatus();
+        UndoCommand = new AnonymousCommand(ServiceProvider, () => { service.Undo(); /*session.CheckConsistency();*/ RefreshUndoRedoStatus(); });
+        RedoCommand = new AnonymousCommand(ServiceProvider, () => { service.Redo(); /*session.CheckConsistency();*/ RefreshUndoRedoStatus(); });
+        RefreshUndoRedoStatus();
+    }
+
+    /// <summary>
+    /// Gets whether it is currently possible to perform an undo operation.
+    /// </summary>
+    public bool CanUndo => Transactions.Count > 0 && Transactions.First().IsDone;
+
+    /// <summary>
+    /// Gets whether it is currently possible to perform a redo operation.
+    /// </summary>
+    public bool CanRedo => Transactions.Count > 0 && !Transactions.Last().IsDone;
+
+    /// <summary>
+    /// Collection of action view models currently contained in this view model.
+    /// </summary>
+    public IReadOnlyObservableCollection<TransactionViewModel> Transactions => transactions;
+
+    /// <summary>
+    /// Command that will perform an undo operation.
+    /// </summary>
+    public ICommandBase UndoCommand { get; }
+
+    /// <summary>
+    /// Command that will perform an redo operation.
+    /// </summary>
+    public ICommandBase RedoCommand { get; }
+
+    /// <summary>
+    /// Initializes this <see cref="ActionHistoryViewModel"/> and starts to listen to <see cref="IUndoRedoService"/> events.
+    /// </summary>
+    public void Initialize()
+    {
+        service.Done += TransactionDone;
+        service.Undone += TransactionUndoneOrRedone;
+        service.Redone += TransactionUndoneOrRedone;
+        service.TransactionDiscarded += TransactionDiscarded;
+        service.Cleared += Cleared;
+    }
+
+    /// <inheritdoc/>
+    public override void Destroy()
+    {
+        service.Done -= TransactionDone;
+        service.Undone -= TransactionUndoneOrRedone;
+        service.Redone -= TransactionUndoneOrRedone;
+        service.TransactionDiscarded -= TransactionDiscarded;
+        service.Cleared -= Cleared;
+        base.Destroy();
+    }
+
+    /// <summary>
+    /// Notify that everything has been saved and create a save point in the action stack.
+    /// </summary>
+    internal void NotifySave()
+    {
+        service.NotifySave();
+        transactions.ForEach(x => x.NotifySave());
+        transactions.ForEach(x => x.IsSavePoint = false);
+        var savePoint = transactions.LastOrDefault(x => x.IsSaved);
+        if (savePoint != null)
+            savePoint.IsSavePoint = true;
+    }
+    
+    private void Cleared(object? sender, EventArgs e)
+    {
+        Dispatcher.Invoke(() => transactions.Clear());
+    }
+    
+    private void TransactionDiscarded(object? sender, TransactionsDiscardedEventArgs e)
+    {
+        Dispatcher.Invoke(() => transactions.RemoveWhere(x => e.Transactions.Any(y => x.Id == y.Id)));
+    }
+
+    private async void TransactionDone(object? sender, TransactionEventArgs e)
+    {
+        if (e.Transaction.Operations.Count == 0)
+            return;
+
+        var dirtying = e.Transaction.Operations.SelectMany(DirtiableManager.GetDirtyingOperations);
+        var dirtiables = new HashSet<AssetViewModel>(dirtying.SelectMany(x => x.Dirtiables.OfType<AssetViewModel>()));
+        if (dirtiables.Count > 0)
+        {
+            await session.NotifyAssetPropertiesChangedAsync(dirtiables);
+        }
+        await Dispatcher.InvokeAsync(() => transactions.Add(new TransactionViewModel(ServiceProvider, e.Transaction)));
+    }
+
+    private async void TransactionUndoneOrRedone(object? sender, TransactionEventArgs e)
+    {
+        var dirtying = e.Transaction.Operations.SelectMany(DirtiableManager.GetDirtyingOperations);
+        var dirtiables = new HashSet<AssetViewModel>(dirtying.SelectMany(x => x.Dirtiables.OfType<AssetViewModel>()));
+        if (dirtiables.Count > 0)
+        {
+            await session.NotifyAssetPropertiesChangedAsync(dirtiables);
+        }
+
+        await Dispatcher.InvokeAsync(() => transactions.ForEach(x => x.Refresh()));
+    }
+
+    private void RefreshUndoRedoStatus()
+    {
+        UndoCommand.IsEnabled = CanUndo;
+        RedoCommand.IsEnabled = CanRedo;
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/Components/Transactions/TransactionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/Transactions/TransactionViewModel.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Presentation.Dirtiables;
+using Stride.Core.Presentation.Services;
+using Stride.Core.Presentation.ViewModels;
+using Stride.Core.Transactions;
+
+namespace Stride.Core.Assets.Editor.Components.Transactions;
+
+public sealed class TransactionViewModel : DispatcherViewModel
+{
+    private readonly IReadOnlyTransaction transaction;
+    private bool isDone = true;
+    private bool isSaved;
+    private bool isSavePoint;
+
+    public TransactionViewModel(IViewModelServiceProvider serviceProvider, IReadOnlyTransaction transaction)
+        : base(serviceProvider)
+    {
+        this.transaction = transaction;
+        Name = ServiceProvider.Get<IUndoRedoService>().GetName(transaction) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Name of this transaction.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets whether this transaction is currently done.
+    /// </summary>
+    public bool IsDone { get { return isDone; } private set { SetValue(ref isDone, value); } }
+
+    /// <summary>
+    /// Gets whether this transaction is currently saved.
+    /// </summary>
+    public bool IsSaved { get { return isSaved; } private set { SetValue(ref isSaved, value); } }
+
+    /// <summary>
+    /// Get whether this transaction is the current save point.
+    /// </summary>
+    public bool IsSavePoint { get { return isSavePoint; } internal set { SetValue(ref isSavePoint, value); } }
+
+    /// <summary>
+    /// Gets the unique identifier of this transaction.
+    /// </summary>
+    public Guid Id => transaction.Id;
+
+    /// <summary>
+    /// Refresh the <see cref="IsDone"/> property of this view model.
+    /// </summary>
+    internal void Refresh()
+    {
+        var dirtying = transaction.Operations.SelectMany(DirtiableManager.GetDirtyingOperations);
+        IsDone = dirtying.All(x => x.IsDone);
+    }
+
+    /// <summary>
+    /// Notifies that this transaction has been saved and update <see cref="IsSaved"/> accordingly.
+    /// </summary>
+    internal void NotifySave()
+    {
+        IsSaved = IsDone;
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModels/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModels/SessionViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Specialized;
 using Stride.Core.Assets.Analysis;
 using Stride.Core.Assets.Editor.Components.Properties;
+using Stride.Core.Assets.Editor.Components.Transactions;
 using Stride.Core.Assets.Editor.Services;
 using Stride.Core.Assets.Presentation.ViewModels;
 using Stride.Core.Assets.Quantum;
@@ -62,6 +63,7 @@ public sealed partial class SessionViewModel : DispatcherViewModel, ISessionView
         if (ActionService is { } actionService)
         {
             undoRedoStackPage = debugService.CreateUndoRedoDebugPage(actionService, "Undo/redo stack");
+            ActionHistory = new ActionHistoryViewModel(this);
         }
 
         ActiveProperties = AssetCollection.AssetViewProperties;
@@ -127,6 +129,10 @@ public sealed partial class SessionViewModel : DispatcherViewModel, ISessionView
         }
     }
 
+    public ActionHistoryViewModel? ActionHistory { get; }
+
+    public IUndoRedoService? ActionService => ServiceProvider.TryGet<IUndoRedoService>();
+
     public IEnumerable<AssetViewModel> AllAssets => AllPackages.SelectMany(x => x.Assets);
 
     public IEnumerable<PackageViewModel> AllPackages => PackageCategories.Values.SelectMany(x => x.Content);
@@ -181,8 +187,6 @@ public sealed partial class SessionViewModel : DispatcherViewModel, ISessionView
 
     public ICommandBase PreviousSelectionCommand { get; }
 
-    internal IUndoRedoService? ActionService => ServiceProvider.TryGet<IUndoRedoService>();
-
     internal PackageSession PackageSession => session;
 
     internal IAssetsPluginService PluginService => ServiceProvider.Get<IAssetsPluginService>();
@@ -211,6 +215,7 @@ public sealed partial class SessionViewModel : DispatcherViewModel, ISessionView
     {
         EnsureNotDestroyed(nameof(SessionViewModel));
 
+        ActionHistory?.Destroy();
         AssetLog.Destroy();
         Thumbnails.Destroy();
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModels/SessionViewModel.static.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModels/SessionViewModel.static.cs
@@ -97,6 +97,9 @@ partial class SessionViewModel
         // Now resize the undo stack to the correct size.
         actionService.Resize(200);
 
+        // And initialize the actions view model
+        sessionViewModel.ActionHistory?.Initialize();
+
         // Copy the result of the asset loading to the log panel.
         sessionViewModel?.AssetLog.AddLogger(LogKey.Get("Session"), sessionResult);
 

--- a/sources/editor/Stride.Core.Assets.Presentation/Quantum/AssetContentValueChangeOperation.cs
+++ b/sources/editor/Stride.Core.Assets.Presentation/Quantum/AssetContentValueChangeOperation.cs
@@ -3,12 +3,12 @@
 
 using System.Text;
 using Stride.Core.Assets.Quantum;
-using Stride.Core.Reflection;
-using Stride.Core.Transactions;
 using Stride.Core.Presentation.Dirtiables;
 using Stride.Core.Quantum;
+using Stride.Core.Reflection;
+using Stride.Core.Transactions;
 
-namespace Stride.Core.Assets.Editor.Quantum;
+namespace Stride.Core.Assets.Presentation.Quantum;
 
 public class AssetContentValueChangeOperation : ContentValueChangeOperation
 {
@@ -16,7 +16,7 @@ public class AssetContentValueChangeOperation : ContentValueChangeOperation
     private readonly OverrideType previousOverride;
     private readonly ItemId itemId;
 
-    public AssetContentValueChangeOperation(IAssetNode node, ContentChangeType changeType, NodeIndex index, object oldValue, object newValue, OverrideType previousOverride, OverrideType newOverride, ItemId itemId, IEnumerable<IDirtiable> dirtiables)
+    public AssetContentValueChangeOperation(IAssetNode node, ContentChangeType changeType, NodeIndex index, object? oldValue, object? newValue, OverrideType previousOverride, OverrideType newOverride, ItemId itemId, IEnumerable<IDirtiable> dirtiables)
         : base(node, changeType, index, oldValue, newValue, dirtiables)
     {
         this.previousOverride = previousOverride;
@@ -91,7 +91,7 @@ public class AssetContentValueChangeOperation : ContentValueChangeOperation
         }
         base.Undo();
         // If this undo restored inheritance from the base, we have extra-work to do to cancel the override information.
-        if (!previousOverride.HasFlag(OverrideType.New) && Node.BaseNode != null)
+        if (!previousOverride.HasFlag(OverrideType.New) && Node.BaseNode is not null)
         {
             if (ChangeType != ContentChangeType.CollectionAdd)
             {
@@ -119,7 +119,7 @@ public class AssetContentValueChangeOperation : ContentValueChangeOperation
     protected override void Redo()
     {
         base.Redo();
-        if (!newOverride.HasFlag(OverrideType.New) && Node.BaseNode != null)
+        if (!newOverride.HasFlag(OverrideType.New) && Node.BaseNode is not null)
         {
             if (Index != NodeIndex.Empty)
                 ((IAssetObjectNode)Node).ResetOverrideRecursively(Index);
@@ -128,7 +128,7 @@ public class AssetContentValueChangeOperation : ContentValueChangeOperation
         }
     }
 
-    protected override void ApplyUndo(object oldValue, object newValue, ContentChangeType type, bool isUndo)
+    protected override void ApplyUndo(object? oldValue, object? newValue, ContentChangeType type, bool isUndo)
     {
         var memberNode = Node as IAssetMemberNode;
         var objectNode = Node as IAssetObjectNode;

--- a/sources/editor/Stride.Core.Assets.Presentation/Quantum/ViewModels/AssetNodeViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Presentation/Quantum/ViewModels/AssetNodeViewModel.cs
@@ -13,7 +13,7 @@ public class AssetNodeViewModel : NodeViewModel, IInternalAssetNodeViewModel
 {
     private bool overrideChanging;
 
-    public AssetNodeViewModel(GraphViewModel ownerViewModel, NodeViewModel parent, string baseName, Type nodeType, List<INodePresenter> nodePresenters)
+    public AssetNodeViewModel(GraphViewModel ownerViewModel, NodeViewModel? parent, string baseName, Type nodeType, List<INodePresenter> nodePresenters)
         : base(ownerViewModel, parent, baseName, nodeType, nodePresenters)
     {
         foreach (var nodePresenter in NodePresenters)
@@ -47,25 +47,21 @@ public class AssetNodeViewModel : NodeViewModel, IInternalAssetNodeViewModel
 
     protected override void SetNodeValue(object? newValue)
     {
-        using (var transaction = ServiceProvider.TryGet<IUndoRedoService>()?.CreateTransaction())
-        {
-            base.SetNodeValue(newValue);
-            if (transaction != null)
-            {
-                ServiceProvider.TryGet<IUndoRedoService>()?.SetName(transaction, $"Update property {DisplayPath}");
-            }
-        }
+        var actionService = ServiceProvider.TryGet<IUndoRedoService>();
+        using var transaction = actionService?.CreateTransaction();
+        base.SetNodeValue(newValue);
+        actionService?.SetName(transaction!, $"Update property {DisplayPath}");
     }
 
     /// <inheritdoc/>
-    protected override bool AreValueEqual(object value1, object value2)
+    protected override bool AreValueEqual(object? value1, object? value2)
     {
         // If we are comparing content references, check if they are equal (ie. match the same target asset), otherwise fallback to default behavior.
         return AreContentReferenceEqual(value1, value2) || base.AreValueEqual(value1, value2);
     }
 
     /// <inheritdoc/>
-    protected override bool AreValueEquivalent(object value1, object value2)
+    protected override bool AreValueEquivalent(object? value1, object? value2)
     {
         // If we are comparing object references, check if they are equal (ie. match the same object), otherwise fallback to default behavior.
         return NodePresenters.First().IsObjectReference(value1) && ReferenceEquals(value1, value2) || base.AreValueEquivalent(value1, value2);
@@ -76,16 +72,16 @@ public class AssetNodeViewModel : NodeViewModel, IInternalAssetNodeViewModel
         return new AssetNodePresenterCommandWrapper(ServiceProvider, base.NodePresenters, command);
     }
 
-    private static bool AreContentReferenceEqual(object reference1, object reference2)
+    private static bool AreContentReferenceEqual(object? reference1, object? reference2)
     {
-        if (reference1 != null && reference2 != null)
+        if (reference1 is not null && reference2 is not null)
         {
             var type = reference1.GetType();
             if (type == reference2.GetType() && AssetRegistry.IsExactContentType(type))
             {
                 var target1 = AttachedReferenceManager.GetAttachedReference(reference1);
                 var target2 = AttachedReferenceManager.GetAttachedReference(reference2);
-                if (target1.Id == target2.Id && target1.Url == target2.Url)
+                if (target1?.Id == target2?.Id && target1?.Url == target2?.Url)
                 {
                     return true;
                 }

--- a/sources/editor/Stride.Core.Assets.Presentation/Quantum/ViewModels/AssetNodeViewModelFactory.cs
+++ b/sources/editor/Stride.Core.Assets.Presentation/Quantum/ViewModels/AssetNodeViewModelFactory.cs
@@ -8,7 +8,7 @@ namespace Stride.Core.Assets.Presentation.Quantum.ViewModels;
 
 public class AssetNodeViewModelFactory : NodeViewModelFactory
 {
-    protected override NodeViewModel CreateNodeViewModel(GraphViewModel owner, NodeViewModel parent, Type nodeType, List<INodePresenter> nodePresenters, bool isRootNode = false)
+    protected override NodeViewModel CreateNodeViewModel(GraphViewModel owner, NodeViewModel? parent, Type nodeType, List<INodePresenter> nodePresenters, bool isRootNode = false)
     {
         // TODO: properly compute the name
         var viewModel = new AssetNodeViewModel(owner, parent, nodePresenters.First().Name, nodeType, nodePresenters);

--- a/sources/editor/Stride.Core.Assets.Presentation/ViewModels/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Presentation/ViewModels/AssetViewModel.cs
@@ -120,9 +120,6 @@ public abstract class AssetViewModel : SessionObjectViewModel, IAssetPropertyPro
 
     protected Package Package => Directory.Package.Package;
 
-    // FIXME xplat-editor
-    protected internal IUndoRedoService? UndoRedoService => ServiceProvider.TryGet<IUndoRedoService>();
-
     /// <summary>
     /// Initializes this asset. This method is guaranteed to be called once every other assets are loaded in the session.
     /// </summary>

--- a/sources/editor/Stride.Core.Assets.Presentation/ViewModels/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Presentation/ViewModels/AssetViewModel.cs
@@ -3,9 +3,10 @@
 
 using System.Reflection;
 using Stride.Core.Assets.Presentation.Components.Properties;
+using Stride.Core.Assets.Presentation.Quantum;
 using Stride.Core.Assets.Quantum;
+using Stride.Core.Presentation.Dirtiables;
 using Stride.Core.Presentation.Quantum;
-using Stride.Core.Presentation.Services;
 using Stride.Core.Quantum;
 
 namespace Stride.Core.Assets.Presentation.ViewModels;
@@ -50,6 +51,12 @@ public abstract class AssetViewModel : SessionObjectViewModel, IAssetPropertyPro
 
         name = Path.GetFileName(assetItem.Location);
         PropertyGraph = Session.GraphContainer.TryGetGraph(assetItem.Id);
+        if (PropertyGraph is not null)
+        {
+            PropertyGraph.BaseContentChanged += BaseContentChanged;
+            PropertyGraph.Changed += AssetPropertyChanged;
+            PropertyGraph.ItemChanged += AssetPropertyChanged;
+        }
         Initializing = false;
     }
 
@@ -184,6 +191,45 @@ public abstract class AssetViewModel : SessionObjectViewModel, IAssetPropertyPro
     {
         var result = new HashSet<AssetViewModel>(assets.SelectMany(x => x.Dependencies.RecursiveReferencedAssets));
         return result;
+    }
+    
+    private void BaseContentChanged(INodeChangeEventArgs e, IGraphNode node)
+    {
+        // FIXME xplat-editor
+        // Ignore base change if we are fixing up assets.
+        //if (Session.IsInFixupAssetContext)
+        //    return;
+
+        if (!UndoRedoService.UndoRedoInProgress)
+        {
+            // Ensure this asset will be marked as dirty
+            UndoRedoService.PushOperation(new EmptyDirtyingOperation(Dirtiables));
+        }
+    }
+
+    private void AssetPropertyChanged(object? sender, INodeChangeEventArgs e)
+    {
+        // FIXME xplat-editor
+        // Ignore asset property change if we are fixing up assets.
+        //if (Session.IsInFixupAssetContext)
+        //    return;
+
+        var index = (e as ItemChangeEventArgs)?.Index ?? NodeIndex.Empty;
+        var assetNodeChange = (IAssetNodeChangeEventArgs)e;
+        var node = (IAssetNode)e.Node;
+        if (UndoRedoService?.UndoRedoInProgress == false)
+        {
+            // Don't create action items if the change comes from the Base
+            if (!PropertyGraph!.UpdatingPropertyFromBase)
+            {
+                var overrideChange = new AssetContentValueChangeOperation(node, e.ChangeType, index, e.OldValue, e.NewValue, assetNodeChange.PreviousOverride, assetNodeChange.NewOverride, assetNodeChange.ItemId, Dirtiables);
+                UndoRedoService.PushOperation(overrideChange);
+            }
+        }
+
+        // FIXME xplat-editor this method was marked as obsolete
+        //var memberName = (node as IMemberNode)?.Name;
+        //OnAssetPropertyChanged(memberName, node, index, e.OldValue, e.NewValue);
     }
 
     AssetViewModel IAssetPropertyProviderViewModel.RelatedAsset => this;

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
              xmlns:caec="using:Stride.Core.Assets.Editor.Avalonia.Controls"
+             xmlns:caect="using:Stride.Core.Assets.Editor.Components.Transactions"
              xmlns:cpc="using:Stride.Core.Presentation.Commands"
              xmlns:gh="using:Stride.GameStudio.Avalonia.Helpers"
              xmlns:gvm="using:Stride.GameStudio.Avalonia.ViewModels"
@@ -16,6 +17,13 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
     <gvm:MainViewModel/>
   </Design.DataContext>
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://Stride.Core.Assets.Editor.Avalonia/Views/ImageResources.axaml"/>
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
 
   <Grid RowDefinitions="Auto, *, 25"
         Background="Transparent">
@@ -126,7 +134,21 @@
                                  Padding="2"/>
           </TabItem>
           <TabItem Header="Edit history">
-
+            <ListBox ItemsSource="{Binding Session.ActionHistory.Transactions, FallbackValue={x:Null}}"
+                     HorizontalAlignment="Stretch">
+              <ListBox.ItemTemplate>
+                <DataTemplate DataType="caect:TransactionViewModel">
+                  <DockPanel>
+                    <TextBlock DockPanel.Dock="Left" x:Name="Text"
+                               Text="{Binding Name}"/>
+                    <Image DockPanel.Dock="Right" x:Name="Image"
+                           HorizontalAlignment="Right"
+                           IsVisible="{Binding IsSavePoint, Mode=OneWay}"
+                           Source="{StaticResource ImageSave}"/>
+                  </DockPanel>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
           </TabItem>
           <TabItem Header="References">
 

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
@@ -3,58 +3,63 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
-             xmlns:ctrl="using:Stride.Core.Assets.Editor.Avalonia.Controls"
-             xmlns:vm="using:Stride.GameStudio.Avalonia.ViewModels"
-             xmlns:vw="using:Stride.GameStudio.Avalonia.Views"
+             xmlns:caec="using:Stride.Core.Assets.Editor.Avalonia.Controls"
+             xmlns:cpc="using:Stride.Core.Presentation.Commands"
              xmlns:gh="using:Stride.GameStudio.Avalonia.Helpers"
+             xmlns:gvm="using:Stride.GameStudio.Avalonia.ViewModels"
+             xmlns:gvw="using:Stride.GameStudio.Avalonia.Views"
              mc:Ignorable="d" d:DesignWidth="1024" d:DesignHeight="768"
              x:Class="Stride.GameStudio.Avalonia.Views.MainView"
-             x:DataType="vm:MainViewModel">
+             x:DataType="gvm:MainViewModel">
   <Design.DataContext>
     <!-- This only sets the DataContext for the previewer in an IDE,
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-    <vm:MainViewModel />
+    <gvm:MainViewModel/>
   </Design.DataContext>
 
   <Grid RowDefinitions="Auto, *, 25"
         Background="Transparent">
     <Menu Grid.Row="0" Grid.Column="0"
           VerticalAlignment="Top">
+      <!-- File menu -->
       <MenuItem Header="{sd:LocalizeString _File, Context=Menu}">
         <MenuItem Header="{sd:LocalizeString _Open..., Context=Menu}"
-                  Command="{Binding OpenCommand}" />
+                  Command="{Binding OpenCommand}"
+                  HotKey="Ctrl+O" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
         <MenuItem Header="{sd:LocalizeString _Close, Context=Menu}"
                   Command="{Binding CloseCommand}"
                   IsEnabled="{Binding Session, Mode=OneWay, Converter={sd:ObjectToBool}}"/>
-        <Separator />
+        <Separator/>
         <MenuItem Header="{sd:LocalizeString E_xit, Context=Menu}"
-                  Command="{Binding ExitCommand}" />
+                  Command="{Binding ExitCommand}"
+                  HotKey="Alt+F4" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
       </MenuItem>
+      <!-- Help menu -->
       <MenuItem Header="{sd:LocalizeString _Help, Context=Menu}">
-        <MenuItem Header="{sd:LocalizeString Online documentation, Context=Menu}" 
-            Command="{Binding OpenWebPageCommand}" 
+        <MenuItem Header="{sd:LocalizeString Online documentation, Context=Menu}"
+            Command="{Binding OpenWebPageCommand}"
             CommandParameter="{x:Static gh:StrideGameStudio.DocumentationUrl}"/>
         <Separator/>
-        <MenuItem Header="{sd:LocalizeString Questions and answers, Context=Menu}" 
-                  Command="{Binding OpenWebPageCommand}" 
+        <MenuItem Header="{sd:LocalizeString Questions and answers, Context=Menu}"
+                  Command="{Binding OpenWebPageCommand}"
                   CommandParameter="{x:Static gh:StrideGameStudio.AnswersUrl}"/>
-        <MenuItem Header="{sd:LocalizeString Report an issue..., Context=Menu}" 
-                  Command="{Binding OpenWebPageCommand}" 
+        <MenuItem Header="{sd:LocalizeString Report an issue..., Context=Menu}"
+                  Command="{Binding OpenWebPageCommand}"
                   CommandParameter="{x:Static gh:StrideGameStudio.ReportIssueUrl}"/>
-        <MenuItem Header="{sd:LocalizeString Discord forum, Context=Menu}" 
-                  Command="{Binding OpenWebPageCommand}" 
+        <MenuItem Header="{sd:LocalizeString Discord forum, Context=Menu}"
+                  Command="{Binding OpenWebPageCommand}"
                   CommandParameter="{x:Static gh:StrideGameStudio.ForumsUrl}"/>
         <Separator/>
-        <MenuItem Header="{sd:LocalizeString Show debug window, Context=Menu}" 
-                  Command="{Binding OpenDebugWindowCommand}" />
+        <MenuItem Header="{sd:LocalizeString Show debug window, Context=Menu}"
+                  Command="{Binding OpenDebugWindowCommand}"/>
         <Separator/>
         <MenuItem Header="{sd:LocalizeString _About..., Context=Menu}"
-                  Command="{Binding AboutCommand}" />
+                  Command="{Binding AboutCommand}"/>
       </MenuItem>
       <MenuItem Header="Debug"
                 IsVisible="{Binding CrashCommand.IsEnabled, Mode=OneWay}">
         <MenuItem Header="Simulate a crash"
-                  Command="{Binding CrashCommand}" />
+                  Command="{Binding CrashCommand}"/>
       </MenuItem>
     </Menu>
     <Grid Grid.Row="1"
@@ -62,61 +67,63 @@
       <Grid Grid.Row="0"
             ColumnDefinitions="2*, 2, *">
         <!-- Editors -->
-        <vw:EditorCollectionView Grid.Column="0"
+        <gvw:EditorCollectionView Grid.Column="0"
                                  BorderThickness="2"
                                  BorderBrush="Red"
                                  Padding="2"
-                                 DataContext="{Binding Session.EditorCollection}" />
-        <GridSplitter Grid.Column="1" ResizeDirection="Auto" />
+                                 DataContext="{Binding Session.EditorCollection}"/>
+        <GridSplitter Grid.Column="1" ResizeDirection="Auto"/>
         <Grid Grid.Column="2"
               RowDefinitions="Auto, *">
           <StackPanel Grid.Row="0"
                       Orientation="Horizontal">
-            <Button Content="Previous"
-                    Command="{Binding Session.PreviousSelectionCommand}" />
-            <Button Content="Next"
-                    Command="{Binding Session.NextSelectionCommand}" />
+            <Button Content="{sd:LocalizeString Previous, Context=Button}"
+                    Command="{Binding Session.PreviousSelectionCommand, FallbackValue={x:Static cpc:DisabledCommand.Instance}}"
+                    HotKey="Alt+Left" ToolTip.Tip="{Binding $self.HotKey, Mode=OneTime}"/>
+            <Button Content="{sd:LocalizeString Next, Context=Button}"
+                    Command="{Binding Session.NextSelectionCommand, FallbackValue={x:Static cpc:DisabledCommand.Instance}}"
+                    HotKey="Alt+Right" ToolTip.Tip="{Binding $self.HotKey, Mode=OneTime}"/>
           </StackPanel>
           <!-- Property Grid -->
-          <vw:PropertyGridView Grid.Row="1"
+          <gvw:PropertyGridView Grid.Row="1"
                                BorderThickness="2"
                                BorderBrush="Orange"
                                Padding="2"
-                               DataContext="{Binding Session.ActiveProperties}" />
+                               DataContext="{Binding Session.ActiveProperties, FallbackValue={x:Null}}"/>
         </Grid>
       </Grid>
-      <GridSplitter Grid.Row="1" ResizeDirection="Auto" />
+      <GridSplitter Grid.Row="1" ResizeDirection="Auto"/>
       <Grid Grid.Row="2"
             ColumnDefinitions="*, 2, 2*, 2, *">
         <!-- Solution Explorer -->
-        <vw:SolutionExplorerView Grid.Column="0"
+        <gvw:SolutionExplorerView Grid.Column="0"
                                  BorderThickness="2"
                                  BorderBrush="Black"
                                  Padding="2"
-                                 DataContext="{Binding Session}" />
-        <GridSplitter Grid.Column="1" ResizeDirection="Auto" />
+                                 DataContext="{Binding Session}"/>
+        <GridSplitter Grid.Column="1" ResizeDirection="Auto"/>
         <!-- Asset view and logs -->
         <TabControl Grid.Column="2">
           <TabItem Header="Asset view">
-            <vw:AssetExplorerView BorderThickness="2"
+            <gvw:AssetExplorerView BorderThickness="2"
                                   BorderBrush="Blue"
                                   Padding="2"
-                                  DataContext="{Binding Session.AssetCollection}"/>
+                                  DataContext="{Binding Session.AssetCollection, FallbackValue={x:Null}}"/>
           </TabItem>
           <TabItem Header="Asset errors">
-            <ctrl:TextLogViewer LogMessages="{Binding Session.AssetLog.FilteredMessages}" />
+            <caec:TextLogViewer LogMessages="{Binding Session.AssetLog.FilteredMessages, FallbackValue={x:Null}}"/>
           </TabItem>
           <TabItem Header="Output">
 
           </TabItem>
         </TabControl>
-        <GridSplitter Grid.Column="3" ResizeDirection="Auto" />
+        <GridSplitter Grid.Column="3" ResizeDirection="Auto"/>
         <!-- Asset preview, history and references -->
         <TabControl Grid.Column="4">
           <TabItem Header="Asset preview">
-            <vw:AssetPreviewView BorderThickness="2"
+            <gvw:AssetPreviewView BorderThickness="2"
                                  BorderBrush="Cyan"
-                                 Padding="2" />
+                                 Padding="2"/>
           </TabItem>
           <TabItem Header="Edit history">
 
@@ -136,34 +143,34 @@
       <TextBlock Grid.Column="0"
                  Margin="8,0"
                  VerticalAlignment="Center"
-                 Text="{Binding Status.CurrentStatus}" />
+                 Text="{Binding Status.CurrentStatus}"/>
       <Border Grid.Column="1"
               Margin="2"
               BorderThickness="1"
-              BorderBrush="Gray" />
+              BorderBrush="Gray"/>
       <TextBlock Grid.Column="2"
                  Margin="8,0"
                  VerticalAlignment="Center">
-        <Run Text="{Binding Session.AssetCollection.SelectedContent.Count, Mode=OneWay, Converter={sd:Localize Text={}{0} item, Plural={}{0} items, IsStringFormat=True, Context=StatusBar}}" />
-        <Run Text="{Binding Session.AssetCollection.SelectedContent.Count, Mode=OneWay, Converter={sd:Localize Text=({0} selected), Plural=({0} selected), IsStringFormat=True, Context=StatusBar}}" />
+        <Run Text="{Binding Session.AssetCollection.SelectedContent.Count, Mode=OneWay, Converter={sd:Localize Text={}{0} item, Plural={}{0} items, IsStringFormat=True, Context=StatusBar}, FallbackValue={x:Null}}"/>
+        <Run Text="{Binding Session.AssetCollection.SelectedContent.Count, Mode=OneWay, Converter={sd:Localize Text=({0} selected), Plural=({0} selected), IsStringFormat=True, Context=StatusBar}, FallbackValue={x:Null}}"/>
       </TextBlock>
       <Border Grid.Column="3"
               Margin="2"
               BorderThickness="1"
-              BorderBrush="Gray" />
+              BorderBrush="Gray"/>
       <TextBlock Grid.Column="4"
                  Margin="8,0"
                  HorizontalAlignment="Right"
                  VerticalAlignment="Center"
-                 Text="{Binding Status.CurrentJob.Message}" />
+                 Text="{Binding Status.CurrentJob.Message, FallbackValue={x:Null}}"/>
       <ProgressBar Grid.Column="5"
                    IsVisible="{Binding Status.CurrentJob, Converter={sd:ObjectToBool}}"
                    Margin="0,2"
                    VerticalAlignment="Stretch"
                    HorizontalAlignment="Left"
-                   IsIndeterminate="{Binding Status.CurrentJob.IsIndeterminate}"
-                   Maximum="{Binding Status.CurrentJob.Total}"
-                   Value="{Binding Status.CurrentJob.Current}" />
+                   IsIndeterminate="{Binding Status.CurrentJob.IsIndeterminate, FallbackValue={x:Null}}"
+                   Maximum="{Binding Status.CurrentJob.Total, FallbackValue={x:Null}}"
+                   Value="{Binding Status.CurrentJob.Current, FallbackValue={x:Null}}"/>
     </Grid>
   </Grid>
 

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
@@ -42,6 +42,15 @@
                   Command="{Binding ExitCommand}"
                   HotKey="Alt+F4" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
       </MenuItem>
+      <!-- Edit menu -->
+      <MenuItem Header="{sd:LocalizeString Edit, Context=Menu}">
+        <MenuItem Header="{sd:LocalizeString Undo, Context=Menu}"
+                  Command="{Binding Session.ActionHistory.UndoCommand, FallbackValue={x:Static cpc:DisabledCommand.Instance}}"
+                  HotKey="{x:Static gvw:MainView.UndoGesture}" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
+        <MenuItem Header="{sd:LocalizeString Redo, Context=Menu}"
+                  Command="{Binding Session.ActionHistory.RedoCommand, FallbackValue={x:Static cpc:DisabledCommand.Instance}}"
+                  HotKey="{x:Static gvw:MainView.RedoGesture}" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
+      </MenuItem>
       <!-- Help menu -->
       <MenuItem Header="{sd:LocalizeString _Help, Context=Menu}">
         <MenuItem Header="{sd:LocalizeString Online documentation, Context=Menu}"

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 
 namespace Stride.GameStudio.Avalonia.Views;
 
@@ -11,4 +13,14 @@ public partial class MainView : UserControl
     {
         InitializeComponent();
     }
+
+    /// <summary>
+    /// Gets a platform-specific <see cref="KeyGesture"/> for the Redo action
+    /// </summary>
+    public static KeyGesture? RedoGesture => Application.Current?.PlatformSettings?.HotkeyConfiguration.Redo.FirstOrDefault();
+
+    /// <summary>
+    /// Gets a platform-specific <see cref="KeyGesture"/> for the Undo action
+    /// </summary>
+    public static KeyGesture? UndoGesture => Application.Current?.PlatformSettings?.HotkeyConfiguration.Undo.FirstOrDefault();
 }

--- a/sources/presentation/Stride.Core.Presentation/ViewModels/EditableViewModel.cs
+++ b/sources/presentation/Stride.Core.Presentation/ViewModels/EditableViewModel.cs
@@ -25,7 +25,7 @@ public abstract class EditableViewModel : DispatcherViewModel
     protected EditableViewModel(IViewModelServiceProvider serviceProvider)
         : base(serviceProvider)
     {
-        if (serviceProvider.TryGet<IUndoRedoService>() == null)
+        if (serviceProvider.TryGet<IUndoRedoService>() is null)
             throw new ArgumentException($"The given {nameof(IViewModelServiceProvider)} instance does not contain an service implementing {nameof(IUndoRedoService)}.");
     }
 
@@ -34,7 +34,7 @@ public abstract class EditableViewModel : DispatcherViewModel
     /// <summary>
     /// Gets the undo/redo service used by this view model.
     /// </summary>
-    public IUndoRedoService UndoRedoService => ServiceProvider.Get<IUndoRedoService>();
+    public IUndoRedoService? UndoRedoService => ServiceProvider.TryGet<IUndoRedoService>();
 
     protected void RegisterMemberCollectionForActionStack(string name, INotifyCollectionChanged collection)
     {
@@ -161,7 +161,7 @@ public abstract class EditableViewModel : DispatcherViewModel
         foreach (string propertyName in propertyNames.Where(x => x != "IsDirty" && !uncancellableChanges.Contains(x)))
         {
             var propertyInfo = GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
-            if (propertyInfo?.GetSetMethod() != null && propertyInfo.GetSetMethod().IsPublic)
+            if (propertyInfo?.GetSetMethod() is not null && propertyInfo.GetSetMethod().IsPublic)
             {
                 preEditValues.Add(propertyName, propertyInfo.GetValue(this));
             }
@@ -182,7 +182,7 @@ public abstract class EditableViewModel : DispatcherViewModel
             {
                 var propertyInfo = GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
                 var postEditValue = propertyInfo?.GetValue(this);
-                if (!UndoRedoService.UndoRedoInProgress && !Equals(preEditValue, postEditValue))
+                if (UndoRedoService?.UndoRedoInProgress == false && !Equals(preEditValue, postEditValue))
                 {
                     var operation = CreatePropertyChangeOperation(displayName, propertyName, preEditValue);
                     UndoRedoService.PushOperation(operation);
@@ -195,14 +195,14 @@ public abstract class EditableViewModel : DispatcherViewModel
     protected virtual Operation CreatePropertyChangeOperation(string displayName, string propertyName, object? preEditValue)
     {
         var operation = new PropertyChangeOperation(propertyName, this, preEditValue, Dirtiables);
-        UndoRedoService.SetName(operation, displayName);
+        UndoRedoService!.SetName(operation, displayName);
         return operation;
     }
 
     protected virtual Operation CreateCollectionChangeOperation(string displayName, IList list, NotifyCollectionChangedEventArgs args)
     {
         var operation = new CollectionChangeOperation(list, args, Dirtiables);
-        UndoRedoService.SetName(operation, displayName);
+        UndoRedoService!.SetName(operation, displayName);
         return operation;
     }
 
@@ -228,7 +228,7 @@ public abstract class EditableViewModel : DispatcherViewModel
             {
                 if (!UndoRedoService.UndoRedoInProgress && createTransaction)
                 {
-                    if (transaction == null)
+                    if (transaction is null)
                         throw new InvalidOperationException("A transaction failed to be created.");
                     transaction.Complete();
                 }
@@ -242,7 +242,7 @@ public abstract class EditableViewModel : DispatcherViewModel
         if (propertyNames.Length == 0)
             throw new ArgumentOutOfRangeException(nameof(propertyNames), "This method must be invoked with at least one property name.");
 
-        if (hasChangedFunction == null || hasChangedFunction())
+        if (hasChangedFunction is null || hasChangedFunction())
         {
             ITransaction? transaction = null;
             if (!UndoRedoService.UndoRedoInProgress && createTransaction)
@@ -259,7 +259,7 @@ public abstract class EditableViewModel : DispatcherViewModel
             {
                 if (!UndoRedoService.UndoRedoInProgress && createTransaction)
                 {
-                    if (transaction == null)
+                    if (transaction is null)
                         throw new InvalidOperationException("A transaction failed to be created.");
                     transaction.Complete();
                 }
@@ -272,13 +272,13 @@ public abstract class EditableViewModel : DispatcherViewModel
     {
         string displayName = $"Update collection '{collectionName}' ({e.Action})";
         var list = sender as IList;
-        if (list == null)
+        if (list is null)
         {
             var toIListMethod = sender?.GetType().GetMethod("ToIList");
-            if (toIListMethod != null)
+            if (toIListMethod is not null)
                 list = (IList?)toIListMethod.Invoke(sender, []);
         }
-        if (!UndoRedoService.UndoRedoInProgress && !suspendedCollections.Contains(collectionName))
+        if (UndoRedoService?.UndoRedoInProgress == false && !suspendedCollections.Contains(collectionName))
         {
             using (UndoRedoService.CreateTransaction())
             {

--- a/sources/presentation/Stride.Core.Quantum/IObjectNode.cs
+++ b/sources/presentation/Stride.Core.Quantum/IObjectNode.cs
@@ -57,19 +57,19 @@ public interface IObjectNode : IGraphNode, INotifyNodeItemChange
     /// Adds a new item to this content, assuming the content is a collection.
     /// </summary>
     /// <param name="newItem">The new item to add to the collection.</param>
-    void Add(object newItem);
+    void Add(object? newItem);
 
     /// <summary>
     /// Adds a new item at the given index to this content, assuming the content is a collection.
     /// </summary>
     /// <param name="newItem">The new item to add to the collection.</param>
     /// <param name="itemIndex">The index at which the new item must be added.</param>
-    void Add(object newItem, NodeIndex itemIndex);
+    void Add(object? newItem, NodeIndex itemIndex);
 
     /// <summary>
     /// Removes an item from this content, assuming the content is a collection.
     /// </summary>
     /// <param name="item">The item to remove.</param>
     /// <param name="itemIndex">The index from which the item must be removed.</param>
-    void Remove(object item, NodeIndex itemIndex);
+    void Remove(object? item, NodeIndex itemIndex);
 }

--- a/sources/presentation/Stride.Core.Quantum/ObjectNode.cs
+++ b/sources/presentation/Stride.Core.Quantum/ObjectNode.cs
@@ -84,7 +84,7 @@ public class ObjectNode : GraphNodeBase, IInitializingObjectNode, IGraphNodeInte
     }
 
     /// <inheritdoc/>
-    public void Add(object newItem)
+    public void Add(object? newItem)
     {
         if (Descriptor is CollectionDescriptor collectionDescriptor)
         {
@@ -111,7 +111,7 @@ public class ObjectNode : GraphNodeBase, IInitializingObjectNode, IGraphNodeInte
     }
 
     /// <inheritdoc/>
-    public void Add(object newItem, NodeIndex itemIndex)
+    public void Add(object? newItem, NodeIndex itemIndex)
     {
         if (Descriptor is CollectionDescriptor collectionDescriptor)
         {
@@ -146,7 +146,7 @@ public class ObjectNode : GraphNodeBase, IInitializingObjectNode, IGraphNodeInte
     }
 
     /// <inheritdoc/>
-    public void Remove(object item, NodeIndex itemIndex)
+    public void Remove(object? item, NodeIndex itemIndex)
     {
         if (!itemIndex.TryGetValue(out var itemIndexValue))
             throw new ArgumentException("index cannot be empty.", nameof(itemIndex));


### PR DESCRIPTION
# PR Details

Displays the transaction history into the dedicated panel. Binds key gestures `CTRL+Z` and `CTRL+Y` to the Undo and Redo action.

## Related Issue

#2758

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
