### PR TITLE
docs: Add documentation to bepu constraints

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisGearMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisGearMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AngularAxisGearMotorConstraintComponent : TwoBodyConstraintComponent<AngularAxisGearMotor>
+public sealed class AngularAxisGearMotorConstraintComponent : TwoBodyConstraintComponent<AngularAxisGearMotor>, IMotor
 {
     public AngularAxisGearMotorConstraintComponent() => BepuConstraint = new() { Settings = new MotorSettings(1000, 10) };
 
@@ -44,6 +44,7 @@ public sealed class AngularAxisGearMotorConstraintComponent : TwoBodyConstraintC
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -57,6 +58,7 @@ public sealed class AngularAxisGearMotorConstraintComponent : TwoBodyConstraintC
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisGearMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisGearMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AngularAxisMotorConstraintComponent : TwoBodyConstraintComponent<AngularAxisMotor>
+public sealed class AngularAxisMotorConstraintComponent : TwoBodyConstraintComponent<AngularAxisMotor>, IMotor
 {
     public AngularAxisMotorConstraintComponent() => BepuConstraint = new() { Settings = new MotorSettings(1000, 10) };
 
@@ -44,6 +44,7 @@ public sealed class AngularAxisMotorConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -57,6 +58,7 @@ public sealed class AngularAxisMotorConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularAxisMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularHingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularHingeConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AngularHingeConstraintComponent : TwoBodyConstraintComponent<AngularHinge>
+public sealed class AngularHingeConstraintComponent : TwoBodyConstraintComponent<AngularHinge>, ISpring
 {
     public AngularHingeConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -44,6 +44,7 @@ public sealed class AngularHingeConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -57,6 +58,7 @@ public sealed class AngularHingeConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularHingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularHingeConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract("AngularMotorConstraint")]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AngularMotorConstraintComponent : TwoBodyConstraintComponent<AngularMotor>
+public sealed class AngularMotorConstraintComponent : TwoBodyConstraintComponent<AngularMotor>, IMotor
 {
     public AngularMotorConstraintComponent() => BepuConstraint = new() { Settings = new MotorSettings(1000, 10) };
 
@@ -31,6 +31,7 @@ public sealed class AngularMotorConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -44,6 +45,7 @@ public sealed class AngularMotorConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularServoConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract("AngularServoConstraint")]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent<AngularServo>
+public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent<AngularServo>, IServo, ISpring
 {
     public AngularServoConstraintComponent() => BepuConstraint = new()
     {
@@ -35,6 +35,7 @@ public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -48,6 +49,7 @@ public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get
@@ -61,6 +63,7 @@ public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -74,6 +77,7 @@ public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -87,6 +91,7 @@ public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularServoConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularSwivelHingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularSwivelHingeConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularSwivelHingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularSwivelHingeConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AngularSwivelHingeConstraintComponent : TwoBodyConstraintComponent<AngularSwivelHinge>
+public sealed class AngularSwivelHingeConstraintComponent : TwoBodyConstraintComponent<AngularSwivelHinge>, ISpring
 {
     public AngularSwivelHingeConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -44,6 +44,7 @@ public sealed class AngularSwivelHingeConstraintComponent : TwoBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -57,6 +58,7 @@ public sealed class AngularSwivelHingeConstraintComponent : TwoBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AreaConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AreaConstraintComponent.cs
@@ -12,7 +12,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class AreaConstraintComponent : ThreeBodyConstraintComponent<AreaConstraint>
+public sealed class AreaConstraintComponent : ThreeBodyConstraintComponent<AreaConstraint>, ISpring
 {
     public AreaConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -29,6 +29,7 @@ public sealed class AreaConstraintComponent : ThreeBodyConstraintComponent<AreaC
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -42,6 +43,7 @@ public sealed class AreaConstraintComponent : ThreeBodyConstraintComponent<AreaC
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketConstraintComponent.cs
@@ -30,13 +30,11 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class BallSocketConstraintComponent : TwoBodyConstraintComponent<BallSocket>
+public sealed class BallSocketConstraintComponent : TwoBodyConstraintComponent<BallSocket>, ISpring, IWithTwoLocalOffset
 {
     public BallSocketConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
-    /// <summary>
-    /// Offset from the center of body A to its attachment in A's local space.
-    /// </summary>
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -50,9 +48,7 @@ public sealed class BallSocketConstraintComponent : TwoBodyConstraintComponent<B
         }
     }
 
-    /// <summary>
-    /// Offset from the center of body B to its attachment in B's local space.
-    /// </summary>
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -66,10 +62,7 @@ public sealed class BallSocketConstraintComponent : TwoBodyConstraintComponent<B
         }
     }
 
-    /// <summary>
-    /// Gets or sets the target number of undamped oscillations per unit of time.
-    /// Higher frequency values create stiffer connections, while lower values allow more elasticity in the joint.
-    /// </summary>
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -83,10 +76,7 @@ public sealed class BallSocketConstraintComponent : TwoBodyConstraintComponent<B
         }
     }
 
-    /// <summary>
-    /// Gets or sets the ratio of the spring's actual damping to its critical damping. 0 is undamped, 1 is critically damped, and higher values are overdamped.
-    /// Higher damping ratios reduce oscillations and make the connection less elastic.
-    /// </summary>
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class BallSocketMotorConstraintComponent : TwoBodyConstraintComponent<BallSocketMotor>
+public sealed class BallSocketMotorConstraintComponent : TwoBodyConstraintComponent<BallSocketMotor>, IMotor
 {
     public BallSocketMotorConstraintComponent() => BepuConstraint = new()
     {
@@ -47,6 +47,7 @@ public sealed class BallSocketMotorConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -60,6 +61,7 @@ public sealed class BallSocketMotorConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketServoConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintComponent<BallSocketServo>
+public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintComponent<BallSocketServo>, IServo, ISpring, IWithTwoLocalOffset
 {
     public BallSocketServoConstraintComponent() => BepuConstraint = new()
     {
@@ -22,6 +22,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         ServoSettings = new ServoSettings(10, 1, 1000)
     };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -35,6 +36,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -48,6 +50,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -61,6 +64,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get
@@ -74,6 +78,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -87,6 +92,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -100,6 +106,7 @@ public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/BallSocketServoConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/CenterDistanceConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/CenterDistanceConstraintComponent.cs
@@ -23,7 +23,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class CenterDistanceConstraintComponent : TwoBodyConstraintComponent<CenterDistanceConstraint>
+public sealed class CenterDistanceConstraintComponent : TwoBodyConstraintComponent<CenterDistanceConstraint>, ISpring
 {
     public CenterDistanceConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -43,6 +43,7 @@ public sealed class CenterDistanceConstraintComponent : TwoBodyConstraintCompone
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -56,6 +57,7 @@ public sealed class CenterDistanceConstraintComponent : TwoBodyConstraintCompone
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/CenterDistanceLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/CenterDistanceLimitConstraintComponent.cs
@@ -22,7 +22,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class CenterDistanceLimitConstraintComponent : TwoBodyConstraintComponent<CenterDistanceLimit>
+public sealed class CenterDistanceLimitConstraintComponent : TwoBodyConstraintComponent<CenterDistanceLimit>, ISpring
 {
     public CenterDistanceLimitConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -52,6 +52,7 @@ public sealed class CenterDistanceLimitConstraintComponent : TwoBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -65,6 +66,7 @@ public sealed class CenterDistanceLimitConstraintComponent : TwoBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/DistanceLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/DistanceLimitConstraintComponent.cs
@@ -24,13 +24,11 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class DistanceLimitConstraintComponent : TwoBodyConstraintComponent<DistanceLimit>
+public sealed class DistanceLimitConstraintComponent : TwoBodyConstraintComponent<DistanceLimit>, ISpring, IWithTwoLocalOffset
 {
     public DistanceLimitConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
-    /// <summary>
-    /// Local offset from the center of body A to its attachment point.
-    /// </summary>
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -44,9 +42,7 @@ public sealed class DistanceLimitConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
-    /// <summary>
-    /// Local offset from the center of body B to its attachment point.
-    /// </summary>
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -92,6 +88,7 @@ public sealed class DistanceLimitConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -105,6 +102,7 @@ public sealed class DistanceLimitConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/DistanceServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/DistanceServoConstraintComponent.cs
@@ -25,7 +25,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponent<DistanceServo>
+public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponent<DistanceServo>, IServo, ISpring, IWithTwoLocalOffset
 {
     public DistanceServoConstraintComponent() => BepuConstraint = new()
     {
@@ -33,9 +33,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         ServoSettings = new ServoSettings(10, 1, 1000)
     };
 
-    /// <summary>
-    /// Local offset from the center of body A to its attachment point.
-    /// </summary>
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -49,9 +47,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
-    /// <summary>
-    /// Local offset from the center of body B to its attachment point.
-    /// </summary>
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -81,6 +77,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -94,6 +91,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get
@@ -107,6 +105,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -120,6 +119,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -133,6 +133,7 @@ public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponen
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/HingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/HingeConstraintComponent.cs
@@ -14,13 +14,14 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class HingeConstraintComponent : TwoBodyConstraintComponent<Hinge>
+public sealed class HingeConstraintComponent : TwoBodyConstraintComponent<Hinge>, ISpring, IWithTwoLocalOffset
 {
     public HingeConstraintComponent() => BepuConstraint = new()
     {
         SpringSettings = new SpringSettings(30, 5)
     };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -47,6 +48,7 @@ public sealed class HingeConstraintComponent : TwoBodyConstraintComponent<Hinge>
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -73,6 +75,7 @@ public sealed class HingeConstraintComponent : TwoBodyConstraintComponent<Hinge>
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -86,6 +89,7 @@ public sealed class HingeConstraintComponent : TwoBodyConstraintComponent<Hinge>
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/HingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/HingeConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IMotor.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IMotor.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+//  Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.BepuPhysics.Constraints;
+
+/// <summary>
+/// Motors try to reach a given relative velocity between the connected bodies
+/// </summary>
+public interface IMotor
+{
+    /// <summary>
+    /// Maximum amount of force the motor can apply in one unit of time.
+    /// </summary>
+    /// <userdoc>
+    /// Maximum amount of force the motor can apply in one unit of time.
+    /// </userdoc>
+    float MotorMaximumForce { get; set; }
+
+    /// <summary>
+    /// Mass-scaled damping constant, How rigid the constraint is.
+    /// </summary>
+    /// <remarks>
+    /// If you want to simulate a viscous damping coefficient of D with an object of mass M, set this damping value to D / M.
+    /// </remarks>
+    /// <userdoc>
+    /// Mass-scaled damping constant, How rigid the constraint is.
+    /// </userdoc>
+    float MotorDamping { get; set; }
+
+    /// <summary>
+    /// Gets or sets how soft the constraint is. Values range from 0 to infinity. Softness is inverse damping; 0 is perfectly rigid, 1 is very soft, float.MaxValue is effectively nonexistent.
+    /// </summary>
+    float MotorSoftness { get { return 1f / MotorDamping; } set { MotorDamping = value <= 0 ? float.MaxValue : 1f / value; } }
+}

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IOneBody.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IOneBody.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+//  Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.BepuPhysics.Constraints;
+
+public interface IOneBody
+{
+    public BodyComponent? A { get; set; }
+}

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IServo.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IServo.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+//  Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.BepuPhysics.Constraints;
+
+/// <summary>
+/// Servos change velocity of the connected bodies to achieve a position or orientation goal
+/// </summary>
+public interface IServo
+{
+    float ServoMaximumSpeed { get; set; }
+    float ServoBaseSpeed { get; set; }
+    float ServoMaximumForce { get; set; }
+}

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/ISpring.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/ISpring.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+//  Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.BepuPhysics.Constraints;
+
+public interface ISpring
+{
+    /// <summary>
+    /// The target number of undamped oscillations per unit of time.
+    /// Higher frequency values create stiffer connections, while lower values allow more elasticity in the joint.
+    /// </summary>
+    /// <userdoc>
+    /// The target number of undamped oscillations per unit of time.
+    /// Higher frequency values create stiffer connections, while lower values allow more elasticity in the joint.
+    /// </userdoc>
+    public float SpringFrequency { get; set; }
+
+    /// <summary>
+    /// The ratio of the spring's actual damping to its critical damping. 0 is undamped, 1 is critically damped, and higher values are overdamped.
+    /// Higher damping ratios reduce oscillations and make the connection less elastic.
+    /// </summary>
+    /// <userdoc>
+    /// The ratio of the spring's actual damping to its critical damping. 0 is undamped, 1 is critically damped, and higher values are overdamped.
+    /// Higher damping ratios reduce oscillations and make the connection less elastic.
+    /// </userdoc>
+    public float SpringDampingRatio { get; set; }
+}

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/ITwoBody.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/ITwoBody.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+//  Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.BepuPhysics.Constraints;
+
+public interface ITwoBody
+{
+    public BodyComponent? A { get; set; }
+    public BodyComponent? B { get; set; }
+}

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IWithTwoLocalOffset.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IWithTwoLocalOffset.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+//  Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Mathematics;
+
+namespace Stride.BepuPhysics.Constraints;
+
+public interface IWithTwoLocalOffset : ITwoBody
+{
+    /// <summary>
+    /// Offset from the center of body A to its attachment in A's local space.
+    /// </summary>
+    /// <userdoc>
+    /// Offset from the center of body A to its attachment in A's local space.
+    /// </userdoc>
+    public Vector3 LocalOffsetA { get; set; }
+
+    /// <summary>
+    /// Offset from the center of body B to its attachment in B's local space.
+    /// </summary>
+    /// <userdoc>
+    /// Offset from the center of body B to its attachment in B's local space.
+    /// </userdoc>
+    public Vector3 LocalOffsetB { get; set; }
+}

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisLimitConstraintComponent.cs
@@ -14,13 +14,14 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class LinearAxisLimitConstraintComponent : TwoBodyConstraintComponent<LinearAxisLimit>
+public sealed class LinearAxisLimitConstraintComponent : TwoBodyConstraintComponent<LinearAxisLimit>, ISpring, IWithTwoLocalOffset
 {
     public LinearAxisLimitConstraintComponent() => BepuConstraint = new()
     {
         SpringSettings = new SpringSettings(30, 5)
     };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -34,6 +35,7 @@ public sealed class LinearAxisLimitConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -86,6 +88,7 @@ public sealed class LinearAxisLimitConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -99,6 +102,7 @@ public sealed class LinearAxisLimitConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisLimitConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisMotorConstraintComponent.cs
@@ -14,13 +14,14 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class LinearAxisMotorConstraintComponent : TwoBodyConstraintComponent<LinearAxisMotor>
+public sealed class LinearAxisMotorConstraintComponent : TwoBodyConstraintComponent<LinearAxisMotor>, IMotor, IWithTwoLocalOffset
 {
     public LinearAxisMotorConstraintComponent() => BepuConstraint = new()
     {
         Settings = new MotorSettings(1000, 10)
     };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -34,6 +35,7 @@ public sealed class LinearAxisMotorConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -73,6 +75,7 @@ public sealed class LinearAxisMotorConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -86,6 +89,7 @@ public sealed class LinearAxisMotorConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisServoConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;
@@ -11,6 +10,12 @@ using Stride.Engine.Design;
 
 namespace Stride.BepuPhysics.Constraints;
 
+/// <summary>
+/// Constrains two bodies' position to a plane local to the first body
+/// </summary>
+/// <userdoc>
+/// Constrains two bodies' position to a plane local to the first body
+/// </userdoc>
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
@@ -50,6 +55,12 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <summary>
+    /// Direction of the plane normal in the local space of body A
+    /// </summary>
+    /// <userdoc>
+    /// Direction of the plane normal in the local space of body A
+    /// </userdoc>
     public Vector3 LocalPlaneNormal
     {
         get
@@ -63,6 +74,12 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <summary>
+    /// Target offset from A's plane anchor to B's anchor along the plane normal
+    /// </summary>
+    /// <userdoc>
+    /// Target offset from A's plane anchor to B's anchor along the plane normal
+    /// </userdoc>
     public float TargetOffset
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/LinearAxisServoConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintComponent<LinearAxisServo>
+public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintComponent<LinearAxisServo>, IServo, ISpring, IWithTwoLocalOffset
 {
     public LinearAxisServoConstraintComponent() => BepuConstraint = new()
     {
@@ -22,6 +22,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         ServoSettings = new ServoSettings(10, 1, 1000)
     };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -35,6 +36,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -74,6 +76,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -87,6 +90,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -100,6 +104,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get
@@ -113,6 +118,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -126,6 +132,7 @@ public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintCompon
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class OneBodyAngularMotorConstraintComponent : OneBodyConstraintComponent<OneBodyAngularMotor>
+public sealed class OneBodyAngularMotorConstraintComponent : OneBodyConstraintComponent<OneBodyAngularMotor>, IMotor, IOneBody
 {
     public OneBodyAngularMotorConstraintComponent() => BepuConstraint = new()
     {
@@ -34,6 +34,7 @@ public sealed class OneBodyAngularMotorConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -47,6 +48,7 @@ public sealed class OneBodyAngularMotorConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularServoConstraintComponent.cs
@@ -26,7 +26,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintComponent<OneBodyAngularServo>
+public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintComponent<OneBodyAngularServo>, IServo, ISpring, IOneBody
 {
     public OneBodyAngularServoConstraintComponent() => BepuConstraint = new()
     {
@@ -47,6 +47,7 @@ public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -60,6 +61,7 @@ public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get
@@ -73,6 +75,7 @@ public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -86,6 +89,7 @@ public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -99,6 +103,7 @@ public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintCo
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class OneBodyLinearMotorConstraintComponent : OneBodyConstraintComponent<OneBodyLinearMotor>
+public sealed class OneBodyLinearMotorConstraintComponent : OneBodyConstraintComponent<OneBodyLinearMotor>, IMotor, IOneBody
 {
     public OneBodyLinearMotorConstraintComponent() => BepuConstraint = new() { Settings = new MotorSettings(1000, 10) };
 
@@ -44,6 +44,7 @@ public sealed class OneBodyLinearMotorConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -57,6 +58,7 @@ public sealed class OneBodyLinearMotorConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearServoConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintComponent<OneBodyLinearServo>
+public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintComponent<OneBodyLinearServo>, IServo, ISpring, IOneBody
 {
     public OneBodyLinearServoConstraintComponent() => BepuConstraint = new()
     {
@@ -48,6 +48,7 @@ public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -61,6 +62,7 @@ public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get
@@ -74,6 +76,7 @@ public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -87,6 +90,7 @@ public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -100,6 +104,7 @@ public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintCom
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyLinearServoConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/PointOnLineServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/PointOnLineServoConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintComponent<PointOnLineServo>
+public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintComponent<PointOnLineServo>, IServo, ISpring, IWithTwoLocalOffset
 {
     public PointOnLineServoConstraintComponent() => BepuConstraint = new()
     {
@@ -22,6 +22,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         ServoSettings = new ServoSettings(10, 1, 1000)
     };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -35,6 +36,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -61,6 +63,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -74,6 +77,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -87,6 +91,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get
@@ -100,6 +105,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -113,6 +119,7 @@ public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintCompo
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/PointOnLineServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/PointOnLineServoConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwingLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwingLimitConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;
@@ -44,6 +43,7 @@ public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<S
         }
     }
 
+    [DataMemberIgnore]
     public float MinimumDot
     {
         get { return BepuConstraint.MinimumDot; }
@@ -54,6 +54,10 @@ public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<S
         }
     }
 
+    /// <remarks>
+    /// This is just a shortcut to <see cref="MinimumDot"/> were the value is in radians
+    /// </remarks>
+    /// <userdoc> In radians </userdoc>
     public float MaximumSwingAngle
     {
         get { return (float)Math.Acos(MinimumDot); }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwingLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwingLimitConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<SwingLimit>
+public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<SwingLimit>, ISpring
 {
     public SwingLimitConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -64,6 +64,7 @@ public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<S
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -77,6 +78,7 @@ public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<S
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwivelHingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwivelHingeConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwivelHingeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/SwivelHingeConstraintComponent.cs
@@ -14,10 +14,11 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class SwivelHingeConstraintComponent : TwoBodyConstraintComponent<SwivelHinge>
+public sealed class SwivelHingeConstraintComponent : TwoBodyConstraintComponent<SwivelHinge>, ISpring, IWithTwoLocalOffset
 {
     public SwivelHingeConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetA
     {
         get
@@ -44,6 +45,7 @@ public sealed class SwivelHingeConstraintComponent : TwoBodyConstraintComponent<
         }
     }
 
+    /// <inheritdoc/>
     public Vector3 LocalOffsetB
     {
         get
@@ -70,6 +72,7 @@ public sealed class SwivelHingeConstraintComponent : TwoBodyConstraintComponent<
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -83,6 +86,7 @@ public sealed class SwivelHingeConstraintComponent : TwoBodyConstraintComponent<
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistLimitConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<TwistLimit>
+public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<TwistLimit>, ISpring
 {
     public TwistLimitConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -64,6 +64,7 @@ public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -77,6 +78,7 @@ public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistLimitConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;
@@ -18,6 +17,14 @@ public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<T
 {
     public TwistLimitConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
+    /// <summary>
+    /// Local space basis attached to body A against which to measure body B's transformed axis.
+    /// Expressed as a 3x3 rotation matrix, the X axis corresponds with 0 degrees, the Y axis corresponds to 90 degrees, and the Z axis is the twist axis.
+    /// </summary>
+    /// <userdoc>
+    /// Local space basis attached to body A against which to measure body B's transformed axis.
+    /// Expressed as a 3x3 rotation matrix, the X axis corresponds with 0 degrees, the Y axis corresponds to 90 degrees, and the Z axis is the twist axis.
+    /// </userdoc>
     public Quaternion LocalBasisA
     {
         get
@@ -31,6 +38,16 @@ public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Local space basis attached to body B that will be measured against body A's basis.
+    /// Expressed as a 3x3 rotation matrix, the transformed X axis will be measured against A's X and Y axes.
+    /// The Z axis is the twist axis
+    /// </summary>
+    /// <userdoc>
+    /// Local space basis attached to body B that will be measured against body A's basis.
+    /// Expressed as a 3x3 rotation matrix, the transformed X axis will be measured against A's X and Y axes.
+    /// The Z axis is the twist axis
+    /// </userdoc>
     public Quaternion LocalBasisB
     {
         get
@@ -44,6 +61,12 @@ public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Minimum angle between B's axis to measure and A's measurement axis
+    /// </summary>
+    /// <userdoc>
+    /// Minimum angle between B's axis to measure and A's measurement axis
+    /// </userdoc>
     public float MinimumAngle
     {
         get { return BepuConstraint.MinimumAngle; }
@@ -54,6 +77,12 @@ public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Maximum angle between B's axis to measure and A's measurement axis
+    /// </summary>
+    /// <userdoc>
+    /// Maximum angle between B's axis to measure and A's measurement axis
+    /// </userdoc>
     public float MaximumAngle
     {
         get { return BepuConstraint.MaximumAngle; }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistMotorConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<TwistMotor>
+public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<TwistMotor>, IMotor
 {
     public TwistMotorConstraintComponent() => BepuConstraint = new() { Settings = new MotorSettings(1000, 10) };
 
@@ -54,6 +54,7 @@ public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float MotorDamping
     {
         get
@@ -67,6 +68,7 @@ public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float MotorMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistMotorConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistMotorConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;
@@ -18,6 +17,12 @@ public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<T
 {
     public TwistMotorConstraintComponent() => BepuConstraint = new() { Settings = new MotorSettings(1000, 10) };
 
+    /// <summary>
+    /// Local twist axis attached to body A
+    /// </summary>
+    /// <userdoc>
+    /// Local twist axis attached to body A
+    /// </userdoc>
     public Vector3 LocalAxisA
     {
         get
@@ -31,6 +36,12 @@ public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Local twist axis attached to body B
+    /// </summary>
+    /// <userdoc>
+    /// Local twist axis attached to body B
+    /// </userdoc>
     public Vector3 LocalAxisB
     {
         get
@@ -44,6 +55,12 @@ public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Goal relative twist velocity around the body axes
+    /// </summary>
+    /// <userdoc>
+    /// Goal relative twist velocity around the body axes
+    /// </userdoc>
     public float TargetVelocity
     {
         get { return BepuConstraint.TargetVelocity; }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistServoConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<TwistServo>
+public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<TwistServo>, IServo, ISpring
 {
     public TwistServoConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5), ServoSettings = new ServoSettings(10, 1, 1000) };
 
@@ -54,6 +54,7 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -67,6 +68,7 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get
@@ -80,6 +82,7 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumSpeed
     {
         get
@@ -93,6 +96,7 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float ServoBaseSpeed
     {
         get
@@ -106,6 +110,7 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <inheritdoc/>
     public float ServoMaximumForce
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistServoConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;
@@ -18,6 +17,16 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
 {
     public TwistServoConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5), ServoSettings = new ServoSettings(10, 1, 1000) };
 
+    /// <summary>
+    /// Local space basis attached to body A against which to measure body B's transformed axis.
+    /// Expressed as a 3x3 rotation matrix, the X axis corresponds with 0 degrees, the Y axis corresponds to 90 degrees, and the -Z axis is the twist axis.
+    /// When viewed along the twist axis, positive change in angle causes counterclockwise rotation in right handed coordinates.
+    /// </summary>
+    /// <userdoc>
+    /// Local space basis attached to body A against which to measure body B's transformed axis.
+    /// Expressed as a 3x3 rotation matrix, the X axis corresponds with 0 degrees, the Y axis corresponds to 90 degrees, and the -Z axis is the twist axis.
+    /// When viewed along the twist axis, positive change in angle causes counterclockwise rotation in right handed coordinates.
+    /// </userdoc>
     public Quaternion LocalBasisA
     {
         get
@@ -31,6 +40,16 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Local space basis attached to body B that will be measured against body A's basis.
+    /// Expressed as a 3x3 rotation matrix, the transformed X axis will be measured against A's X and Y axes.
+    /// The Z axis is the twist axis.
+    /// </summary>
+    /// <userdoc>
+    /// Local space basis attached to body B that will be measured against body A's basis.
+    /// Expressed as a 3x3 rotation matrix, the transformed X axis will be measured against A's X and Y axes.
+    /// The Z axis is the twist axis.
+    /// </userdoc>
     public Quaternion LocalBasisB
     {
         get
@@ -44,6 +63,9 @@ public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<T
         }
     }
 
+    /// <summary>
+    /// Target angle between B's axis to measure and A's measurement axis.
+    /// </summary>
     public float TargetAngle
     {
         get { return BepuConstraint.TargetAngle; }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/VolumeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/VolumeConstraintComponent.cs
@@ -12,7 +12,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class VolumeConstraintComponent : FourBodyConstraintComponent<VolumeConstraint>
+public sealed class VolumeConstraintComponent : FourBodyConstraintComponent<VolumeConstraint>, ISpring
 {
     public VolumeConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -26,6 +26,7 @@ public sealed class VolumeConstraintComponent : FourBodyConstraintComponent<Volu
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -39,6 +40,7 @@ public sealed class VolumeConstraintComponent : FourBodyConstraintComponent<Volu
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/VolumeConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/VolumeConstraintComponent.cs
@@ -16,6 +16,12 @@ public sealed class VolumeConstraintComponent : FourBodyConstraintComponent<Volu
 {
     public VolumeConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
+    /// <summary>
+    /// 6 times the target volume of the tetrahedra. Computed from (ab x ac) * ad; this may be negative depending on the winding of the tetrahedron.
+    /// </summary>
+    /// <userdoc>
+    /// 6 times the target volume of the tetrahedra. Computed from (ab x ac) * ad; this may be negative depending on the winding of the tetrahedron.
+    /// </userdoc>
     public float TargetScaledVolume
     {
         get { return BepuConstraint.TargetScaledVolume; }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/WeldConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/WeldConstraintComponent.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using BepuPhysics.Constraints;
-using Stride.BepuPhysics.Definitions;
 using Stride.BepuPhysics.Systems;
 using Stride.Core;
 using Stride.Core.Mathematics;
@@ -18,6 +17,12 @@ public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>, 
 {
     public WeldConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
+    /// <summary>
+    /// Offset from body A to body B in the local space of A
+    /// </summary>
+    /// <usedoc>
+    /// Offset from body A to body B in the local space of A
+    /// </usedoc>
     public Vector3 LocalOffset
     {
         get
@@ -31,6 +36,12 @@ public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>, 
         }
     }
 
+    /// <summary>
+    /// Target orientation of body B in body A's local space
+    /// </summary>
+    /// <usedoc>
+    /// Target orientation of body B in body A's local space
+    /// </usedoc>
     public Quaternion LocalOrientation
     {
         get

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/WeldConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/WeldConstraintComponent.cs
@@ -14,7 +14,7 @@ namespace Stride.BepuPhysics.Constraints;
 [DataContract]
 [DefaultEntityComponentProcessor(typeof(ConstraintProcessor), ExecutionMode = ExecutionMode.Runtime)]
 [ComponentCategory("Physics - Bepu Constraint")]
-public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>
+public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>, ISpring
 {
     public WeldConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
 
@@ -44,6 +44,7 @@ public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>
         }
     }
 
+    /// <inheritdoc/>
     public float SpringFrequency
     {
         get
@@ -57,6 +58,7 @@ public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>
         }
     }
 
+    /// <inheritdoc/>
     public float SpringDampingRatio
     {
         get


### PR DESCRIPTION
# PR Details
See title, also added interfaces to those constraints to help users create more generalized logic if they need to.

Note: Having all of those duplicate properties everywhere is a pain, but we can't generalize this logic because it reads and writes into bepu's structs under the hood, which do not share implementation between motors, servos, and springs for example.

## Related Issue
Fix: #2678

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
