### PR TITLE
feat: property grid improvements

### DIFF
--- a/sources/editor/Stride.Assets.Editor.Avalonia/EditorViewSelector.cs
+++ b/sources/editor/Stride.Assets.Editor.Avalonia/EditorViewSelector.cs
@@ -9,7 +9,6 @@ using Stride.Core.Assets.Editor.ViewModels;
 
 namespace Stride.Assets.Editor.Avalonia;
 
-// TODO xplat-editor consider moving this class to Stride.Assets.Editor.Avalonia
 public sealed class EditorViewSelector : AvaloniaObject, IDataTemplate
 {
     private SessionViewModel? session;

--- a/sources/editor/Stride.Assets.Editor.Avalonia/Stride.Assets.Editor.Avalonia.csproj
+++ b/sources/editor/Stride.Assets.Editor.Avalonia/Stride.Assets.Editor.Avalonia.csproj
@@ -6,8 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
-    <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/editor/Stride.Assets.Editor.Avalonia/Views/EntityPropertyTemplateProviders.axaml
+++ b/sources/editor/Stride.Assets.Editor.Avalonia/Views/EntityPropertyTemplateProviders.axaml
@@ -48,7 +48,7 @@
           </Button>
         </UniformGrid>
         <TextBox x:Name="TextBox" IsReadOnly="True" Margin="5"
-                 Text="{Binding NodeValue.Entity.Name, Mode=OneWay}"/>
+                 Text="{Binding ((engine:EntityComponent)NodeValue).Entity.Name, Mode=OneWay, FallbackValue={x:Null}}"/>
       </DockPanel>
     </DataTemplate>
   </aev:EntityComponentReferenceTemplateProvider>
@@ -108,7 +108,7 @@
           </Button>
         </UniformGrid>
         <TextBox x:Name="TextBox" IsReadOnly="True" Margin="5"
-                 Text="{Binding NodeValue.Name, Mode=OneWay}"/>
+                 Text="{Binding ((engine:Entity)NodeValue).Name, Mode=OneWay, FallbackValue={x:Null}}"/>
       </DockPanel>
     </DataTemplate>
   </aev:EntityReferenceTemplateProvider>

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Behaviors/PropertyViewAutoExpandNodesBehavior.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Behaviors/PropertyViewAutoExpandNodesBehavior.cs
@@ -1,0 +1,257 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+using Stride.Core.Assets.Editor.Quantum.NodePresenters.Keys;
+using Stride.Core.Extensions;
+using Stride.Core.Presentation.Avalonia.Controls;
+using Stride.Core.Presentation.Quantum.ViewModels;
+
+namespace Stride.Core.Assets.Editor.Avalonia.Behaviors;
+
+public sealed class PropertyViewAutoExpandNodesBehavior : StyledElementBehavior<PropertyView>
+{
+    private readonly List<PropertyViewItem> expandedItems = [];
+    // These are static so that we remember their state for the entire session.
+    private static readonly HashSet<string> expandedPropertyPaths = [];
+    private static readonly HashSet<string> collapsedPropertyPaths = [];
+
+    /// <summary>
+    /// Identifies the <see cref="ViewModel"/> dependency property.
+    /// </summary>
+    public static readonly StyledProperty<GraphViewModel?> ViewModelProperty =
+        AvaloniaProperty.Register<PropertyViewAutoExpandNodesBehavior, GraphViewModel?>(nameof(ViewModel));
+
+    static PropertyViewAutoExpandNodesBehavior()
+    {
+        ViewModelProperty.Changed.AddClassHandler<PropertyViewAutoExpandNodesBehavior, GraphViewModel?>(OnViewModelChanged);
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="GraphViewModel"/> associated to this behavior.
+    /// </summary>
+    public GraphViewModel? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        if (ViewModel is not null)
+        {
+            ViewModel.NodeValueChanged += NodeValueChanged;
+        }
+        if (AssociatedObject is { } propertyView)
+        {
+            propertyView.PrepareItem += PrepareItem;
+            propertyView.ClearItem += ClearItem;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject is { } propertyView)
+        {
+            propertyView.ClearItem -= ClearItem;
+            propertyView.PrepareItem -= PrepareItem;
+        }
+        if (ViewModel is not null)
+        {
+            ViewModel.NodeValueChanged -= NodeValueChanged;
+        }
+    }
+
+    private void ClearItem(object? sender, PropertyViewItemEventArgs e)
+    {
+        expandedItems.Clear();
+        UnregisterItem(e.Container);
+    }
+
+    private static void ExpandedChanged(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not PropertyViewItem item)
+            return;
+
+        var propertyPath = GetNode(item)!.DisplayPath;
+        if (item.IsExpanded)
+        {
+            expandedPropertyPaths.Add(propertyPath);
+            collapsedPropertyPaths.Remove(propertyPath);
+        }
+        else
+        {
+            expandedPropertyPaths.Remove(propertyPath);
+            collapsedPropertyPaths.Add(propertyPath);
+        }
+    }
+
+    private void ExpandSingleProperties(PropertyViewItem item)
+    {
+        var node = GetNode(item);
+        // The data context of the item might be a "disconnected object"
+        if (node is null)
+            return;
+
+        var rule = GetRule(node);
+
+        if (node.Parent is not null)
+        {
+            switch (rule)
+            {
+                case ExpandRule.Always:
+                    // Always expand nodes that have this rule (without tracking them)
+                    item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                    break;
+
+                case ExpandRule.Never:
+                    // Always collapse nodes that have this rule (without tracking them)
+                    item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, false);
+                    break;
+
+                case ExpandRule.Once:
+                    {
+                        // Expand nodes that have this rule only if they have never been collapsed previously
+                        var propertyPath = node.DisplayPath;
+                        if (!collapsedPropertyPaths.Contains(propertyPath))
+                        {
+                            item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                            break;
+                        }
+                    }
+                    goto default;
+
+                case ExpandRule.Auto:
+                default:
+                    {
+                        // If the node was saved as expanded, persist this behavior
+                        var propertyPath = node.DisplayPath;
+                        if (expandedPropertyPaths.Contains(propertyPath))
+                        {
+                            item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                        }
+                        else if (node.Parent.Children.Count == 1)
+                        {
+                            // If the node is an only child, let's expand it
+                            item.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+                            // And keep a track of it, in case it has some siblings incoming
+                            expandedItems.Add(item);
+                        }
+                        else
+                        {
+                            // If one of its siblings has been expanded because it was an only child at the time it was created, let's unexpand it.
+                            // This will prevent to always have the first item expanded since the property items are generated as soon as a child is added.
+                            expandedItems.Where(x => GetNode(x)?.Parent == node.Parent).ForEach(x => x.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, false));
+                        }
+                    }
+                    break;
+            }
+        }
+
+        foreach (var container in item.Properties)
+        {
+            ExpandSingleProperties(container);
+        }
+    }
+
+    private static PropertyViewItem? FindPropertyItemRecursively(PropertyViewItem root, NodeViewModel target)
+    {
+        return root.DataContext == target ? root : root.Properties.Select(x => FindPropertyItemRecursively(x, target)).FirstOrDefault(x => x is not null);
+    }
+
+    private static NodeViewModel? GetNode(PropertyViewItem item)
+    {
+        return item.DataContext as NodeViewModel;
+    }
+
+    private PropertyViewItem? GetPropertyItem(string propertyPath)
+    {
+        var currentPropertyCollection = AssociatedObject?.Properties;
+        string[] members = propertyPath.Split('.');
+        PropertyViewItem? item = null;
+
+        foreach (var member in members.Skip(1))
+        {
+            item = currentPropertyCollection?.FirstOrDefault(x =>
+            {
+                var node = x.DataContext as NodeViewModel;
+                return node is not null && node.Name == member;
+            });
+            if (item is null)
+                return null;
+
+            currentPropertyCollection = item.Properties;
+        }
+        return item;
+    }
+
+    private static ExpandRule GetRule(NodeViewModel node)
+    {
+        if (node.AssociatedData.TryGetValue(DisplayData.AutoExpandRule, out var value) && value is ExpandRule rule)
+        {
+            return rule;
+        }
+        return ExpandRule.Auto;
+    }
+
+    private void NodeValueChanged(object? sender, NodeViewModelValueChangedArgs e)
+    {
+        var rule = GetRule(e.Node);
+        if (rule == ExpandRule.Never)
+            return;
+
+        var match = AssociatedObject?.Properties.Select(x => FindPropertyItemRecursively(x, e.Node)).FirstOrDefault(x => x is not null);
+        match?.SetCurrentValue(ExpandableItemsControl.IsExpandedProperty, true);
+    }
+
+    private static void OnViewModelChanged(PropertyViewAutoExpandNodesBehavior sender, AvaloniaPropertyChangedEventArgs<GraphViewModel?> e)
+    {
+        if (e.OldValue.Value is { } previousViewModel)
+            previousViewModel.NodeValueChanged -= sender.NodeValueChanged;
+
+        if (e.NewValue.Value is { } newViewModel)
+            newViewModel.NodeValueChanged += sender.NodeValueChanged;
+    }
+
+    private void PrepareItem(object? sender, PropertyViewItemEventArgs e)
+    {
+        RegisterItem(e.Container);
+        foreach (var propertyItem in expandedPropertyPaths.ToList().Select(GetPropertyItem).NotNull())
+        {
+            propertyItem.IsExpanded = true;
+        }
+        foreach (var propertyItem in collapsedPropertyPaths.ToList().Select(GetPropertyItem).NotNull())
+        {
+            propertyItem.IsExpanded = false;
+        }
+        Dispatcher.UIThread.InvokeAsync(() => ExpandSingleProperties(e.Container));
+    }
+
+    private static void RegisterItem(PropertyViewItem item)
+    {
+        item.Expanded += ExpandedChanged;
+        item.Collapsed += ExpandedChanged;
+
+        foreach (var container in item.Properties)
+        {
+            RegisterItem(container);
+        }
+    }
+
+    private static void UnregisterItem(PropertyViewItem item)
+    {
+        item.Expanded -= ExpandedChanged;
+        item.Collapsed -= ExpandedChanged;
+        foreach (var container in item.Properties)
+        {
+            UnregisterItem(container);
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Stride.Core.Assets.Editor.Avalonia.csproj
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Stride.Core.Assets.Editor.Avalonia.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
@@ -4,7 +4,9 @@
                     xmlns:caec="using:Stride.Core.Assets.Editor.Avalonia.Converters"
                     xmlns:caeqnpc="using:Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands"
                     xmlns:caev="using:Stride.Core.Assets.Editor.Avalonia.Views"
+                    xmlns:capvm="using:Stride.Core.Assets.Presentation.ViewModels"
                     xmlns:cpqvm="using:Stride.Core.Presentation.Quantum.ViewModels"
+                    xmlns:yaml="using:Stride.Core.Yaml"
                     xmlns:io="using:Stride.Core.IO"
                     xmlns:math="using:Stride.Core.Mathematics"
                     xmlns:s="using:System"
@@ -27,7 +29,8 @@
     <Setter Property="Width" Value="16"/>
     <Setter Property="Height" Value="16"/>
   </ControlTheme>
-  <ControlTheme x:Key="AddNewItemButtonTheme" TargetType="Button" BasedOn="{StaticResource ImageButtonTheme}">
+  <ControlTheme x:Key="AddNewItemButtonTheme" TargetType="Button" BasedOn="{StaticResource ImageButtonTheme}"
+                x:DataType="cpqvm:NodeViewModel">
     <Setter Property="IsVisible"
             Value="{sd:MultiBinding {Binding [HasCommand_AddNewItem]}, {Binding HasCollection},
                                     {Binding [HasAssociatedData_ReadOnlyCollection], Converter={sd:InvertBool}},
@@ -41,7 +44,8 @@
       </DataTemplate>
     </Setter>
   </ControlTheme>
-  <ControlTheme x:Key="RemoveItemButtonTheme" TargetType="Button" BasedOn="{StaticResource ImageButtonTheme}">
+  <ControlTheme x:Key="RemoveItemButtonTheme" TargetType="Button" BasedOn="{StaticResource ImageButtonTheme}"
+                x:DataType="cpqvm:NodeViewModel">
     <Setter Property="IsVisible"
             Value="{sd:MultiBinding {Binding [HasCommand_RemoveItem]},
                                     {Binding [HasAssociatedData_ReadOnlyCollection], Converter={sd:InvertBool}},
@@ -56,7 +60,8 @@
   </ControlTheme>
 
   <!-- Themes for ComboBox -->
-  <ControlTheme x:Key="AbstractTypeSelectionComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+  <ControlTheme x:Key="AbstractTypeSelectionComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}"
+                x:DataType="cpqvm:NodeViewModel">
     <Setter Property="IsTextSearchEnabled" Value="False"/>
     <Setter Property="ToolTip.Tip" Value="{sd:LocalizeString Replace..., Context=ToolTip}"/>
     <Setter Property="IsVisible"
@@ -120,7 +125,8 @@
       </ControlTemplate>
     </Setter>
   </ControlTheme>
-  <ControlTheme x:Key="AddItemComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource AbstractTypeSelectionComboBoxTheme}">
+  <ControlTheme x:Key="AddItemComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource AbstractTypeSelectionComboBoxTheme}"
+                x:DataType="cpqvm:NodeViewModel">
     <Setter Property="Width" Value="18"/>
     <Setter Property="Height" Value="16"/>
     <Setter Property="BorderBrush" Value="Transparent"/>
@@ -132,12 +138,13 @@
     <Setter Property="ToolTip.Tip" Value="{sd:LocalizeString Add..., Context=ToolTip}"/>
     <Setter Property="Tag" Value="{StaticResource ImageAdd}"/>
   </ControlTheme>
-  <ControlTheme x:Key="EnumComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+  <ControlTheme x:Key="EnumComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}"
+                x:DataType="cpqvm:NodeViewModel">
     <Setter Property="Margin" Value="2"/>
     <Setter Property="SelectedItem" Value="{Binding NodeValue}"/>
     <Setter Property="ItemsSource" Value="{Binding Type, Converter={sd:EnumValues}, Mode=OneWay}"/>
     <Setter Property="ItemTemplate">
-      <DataTemplate>
+      <DataTemplate DataType="cpqvm:NodeViewModel">
         <TextBlock Text="{Binding Converter={sd:EnumToDisplayName}}"/>
       </DataTemplate>
     </Setter>
@@ -232,8 +239,8 @@
           </TextBox>
           <CheckBox Grid.Column="3"
                     Margin="2,0" HorizontalAlignment="Left" VerticalAlignment="Center"
-                    IsChecked="{Binding [Enabled].NodeValue, Converter={caec:DifferentValuesToParam}, ConverterParameter={x:Null}, FallbackValue={x:False}, TargetNullValue={x:False}}"
-                    IsThreeState="{Binding [Enabled].NodeValue, Converter={sd:IsEqualToParam}, ConverterParameter={x:Static cpqvm:NodeViewModel.DifferentValues}, FallbackValue={x:False}, TargetNullValue={x:False}}"
+                    IsChecked="{ReflectionBinding [Enabled].NodeValue, Converter={caec:DifferentValuesToParam}, ConverterParameter={x:Null}, FallbackValue={x:False}, TargetNullValue={x:False}}"
+                    IsThreeState="{ReflectionBinding [Enabled].NodeValue, Converter={sd:IsEqualToParam}, ConverterParameter={x:Static cpqvm:NodeViewModel.DifferentValues}, FallbackValue={x:False}, TargetNullValue={x:False}}"
                     IsVisible="{Binding [HasChild_Enabled], FallbackValue={x:False}}"/>
           <Interaction.Behaviors>
             <DataTriggerBehavior Binding="{sd:MultiBinding {Binding ConverterParameter=[IsOverridden], Converter={caec:NodePathToObject}},
@@ -302,8 +309,8 @@
         <StackPanel Orientation="Horizontal" Margin="8,0,0,0">
           <CheckBox Margin="4,0" VerticalAlignment="Center"
                     IsVisible="{Binding [HasChild_Enabled]}"
-                    IsChecked="{Binding [Enabled].NodeValue, Converter={caec:DifferentValuesToParam}, ConverterParameter={x:Null}, FallbackValue={x:False}, TargetNullValue={x:False}}"
-                    IsThreeState="{Binding [Enabled].NodeValue, Converter={sd:IsEqualToParam}, ConverterParameter={x:Static cpqvm:NodeViewModel.DifferentValues}, FallbackValue={x:False}, TargetNullValue={x:False}}"/>
+                    IsChecked="{ReflectionBinding [Enabled].NodeValue, Converter={caec:DifferentValuesToParam}, ConverterParameter={x:Null}, FallbackValue={x:False}, TargetNullValue={x:False}}"
+                    IsThreeState="{ReflectionBinding [Enabled].NodeValue, Converter={sd:IsEqualToParam}, ConverterParameter={x:Static cpqvm:NodeViewModel.DifferentValues}, FallbackValue={x:False}, TargetNullValue={x:False}}"/>
           <Image Source="{Binding NodeValue, Converter={sd:Chained {sd:ObjectToType}, {caec:TypeToResource}}}"
                  MaxWidth="16" MaxHeight="16" Margin="0,0,4,0"/>
           <TextBlock x:Name="HeaderTextBlock" FontSize="16" TextTrimming="CharacterEllipsis"
@@ -421,7 +428,7 @@
 
   <!-- Provider for List item -->
   <caev:ListItemTemplateProvider x:Key="ListItemPropertyTemplateProvider" OverrideRule="Most" caev:PropertyViewHelper.TemplateCategory="PropertyEditor">
-    <DataTemplate>
+    <DataTemplate DataType="cpqvm:NodeViewModel">
       <DockPanel>
         <Button DockPanel.Dock="Right" Theme="{StaticResource RemoveItemButtonTheme}"/>
         <ContentControl Content="{Binding}" ContentTemplate="{x:Static caev:PropertyViewHelper.EditorProviders}"/>
@@ -508,7 +515,7 @@
 
   <!-- Provider for Array item -->
   <caev:ArrayItemTemplateProvider x:Key="ArrayItemPropertyTemplateProvider" OverrideRule="Most" caev:PropertyViewHelper.TemplateCategory="PropertyEditor">
-    <DataTemplate>
+    <DataTemplate DataType="cpqvm:NodeViewModel">
       <DockPanel>
         <ContentControl Content="{Binding}" ContentTemplate="{x:Static caev:PropertyViewHelper.EditorProviders}"/>
       </DockPanel>
@@ -1359,7 +1366,8 @@
   </caev:EnumTemplateProvider>
 
   <!-- Providers for content reference -->
-  <ContextMenu x:Key="ReferenceContextMenu">
+  <ContextMenu x:Key="ReferenceContextMenu"
+               x:DataType="cpqvm:NodeViewModel">
     <MenuItem Header="{sd:LocalizeString Select an asset}"
               IsVisible="{Binding [HasCommand_PickupAsset]}"
               Command="{Binding [PickupAsset]}"
@@ -1431,7 +1439,7 @@
                     ToolTip.Tip="{sd:LocalizeString Select the referenced asset, Context=ToolTip}">
               <Image x:Name="ThumbnailImage"
                      Width="64" Height="64"
-                     DataContext="{Binding NodeValue, Converter={caec:ContentReferenceToAsset}}"
+                     DataContext="{Binding ((capvm:AssetViewModel)NodeValue), Converter={caec:ContentReferenceToAsset}}"
                      Source="{Binding ThumbnailData.Presenter, Mode=OneWay}"/>
               <Interaction.Behaviors>
                 <!-- FIXME only on pointer down -->
@@ -1441,7 +1449,7 @@
               </Interaction.Behaviors>
             </Border>
             <ProgressBar Width="16" Height="4" IsIndeterminate="True"
-                         DataContext="{Binding NodeValue, Converter={caec:ContentReferenceToAsset}}"
+                         DataContext="{Binding ((capvm:AssetViewModel)NodeValue), Converter={caec:ContentReferenceToAsset}}"
                          IsVisible="{Binding ThumbnailData, Converter={sd:Chained {sd:ObjectToBool}, {sd:InvertBool}}, FallbackValue={sd:False}}"/>
             <Border Width="64" Height="64"
                     Background="Transparent"
@@ -1529,13 +1537,13 @@
                        Foreground="Orange"
                        TextTrimming="CharacterEllipsis" TextWrapping="WrapWithOverflow">
               <MultiBinding StringFormat="{sd:LocalizeString Unable to load the object of type {0} from assembly {1}}">
-                <Binding Path="NodeValue.TypeName"/>
-                <Binding Path="NodeValue.AssemblyName"/>
+                <Binding Path="((yaml:IUnloadable)NodeValue).TypeName" FallbackValue=""/>
+                <Binding Path="((yaml:IUnloadable)NodeValue).AssemblyName" FallbackValue=""/>
               </MultiBinding>
             </TextBlock>
             <TextBlock Margin="8"
                        TextTrimming="CharacterEllipsis" TextWrapping="WrapWithOverflow"
-                       Text="{Binding NodeValue.Error}"/>
+                       Text="{Binding ((yaml:IUnloadable)NodeValue).Error, FallbackValue={x:Null}}"/>
           </StackPanel>
         </Border>
       </DockPanel>

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
@@ -1254,7 +1254,7 @@
         </ToggleButton>
         <Popup Grid.Column="0"
                IsLightDismissEnabled="True"
-               IsOpen="{Binding Path=#ToggleButton2.IsChecked}">
+               IsOpen="{Binding #ToggleButton2.IsChecked, Mode=TwoWay}">
           <Grid MinWidth="200" MaxWidth="400" MaxHeight="200">
             <DockPanel>
               <UniformGrid DockPanel.Dock="Bottom"

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
@@ -837,34 +837,32 @@
         <TextBox Grid.Column="0" Margin="2" Width="40" TextAlignment="Center"
                  Text="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:CharToString}}}"
                  ToolTip.Tip="{sd:LocalizeString Character, Context=ToolTip}"/>
-        <NumericUpDown x:Name="NumericUpDown"
-                       Grid.Column="1" Margin="2"
-                       Value="{Binding NodeValue, Converter={sd:CharToUnicode}}"
-                       ToolTip.Tip="{sd:LocalizeString Unicode value, Context=ToolTip}"
-                       ShowButtonSpinner="False">
+        <sd:NumericTextBox x:Name="NumericTextBox"
+                           Grid.Column="1" Margin="2"
+                           Value="{Binding NodeValue, Converter={sd:CharToUnicode}, UpdateSourceTrigger=Explicit}"
+                           ToolTip.Tip="{sd:LocalizeString Unicode value, Context=ToolTip}">
           <Interaction.Behaviors>
             <DataTriggerBehavior Binding="{Binding NodeValue}" Value="{x:Static cpqvm:NodeViewModel.DifferentValues}">
               <ChangePropertyAction PropertyName="Watermark" Value="{sd:LocalizeString (Different values)}"/>
             </DataTriggerBehavior>
           </Interaction.Behaviors>
-        </NumericUpDown>
+        </sd:NumericTextBox>
       </Grid>
     </DataTemplate>
   </caev:TypeMatchTemplateProvider>
 
   <!-- Providers for floating-point number -->
   <DataTemplate x:Key="FloatEditorTemplate" DataType="cpqvm:NodeViewModel">
-    <NumericUpDown x:Name="NumericUpDown"
-                   Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}}"
-                   Minimum="{Binding [Minimum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MinValue}}"
-                   Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MaxValue}}"
-                   ShowButtonSpinner="False">
+    <sd:NumericTextBox x:Name="NumericTextBox"
+                       Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, UpdateSourceTrigger=Explicit}"
+                       Minimum="{Binding [Minimum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MinValue}}"
+                       Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MaxValue}}">
       <Interaction.Behaviors>
         <DataTriggerBehavior Binding="{Binding NodeValue}" Value="{x:Static cpqvm:NodeViewModel.DifferentValues}">
           <ChangePropertyAction PropertyName="Watermark" Value="{sd:LocalizeString (Different values)}"/>
         </DataTriggerBehavior>
       </Interaction.Behaviors>
-    </NumericUpDown>
+    </sd:NumericTextBox>
   </DataTemplate>
   <caev:TypeMatchTemplateProvider x:Key="FloatPropertyTemplateProvider" Type="{x:Type s:Single}" caev:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                   Template="{StaticResource FloatEditorTemplate}"/>
@@ -873,17 +871,16 @@
 
   <!-- Providers for fixed-point number -->
   <DataTemplate x:Key="IntEditorTemplate" DataType="cpqvm:NodeViewModel">
-    <NumericUpDown x:Name="NumericUpDown"
-                   Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}}"
-                   Minimum="{Binding [Minimum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MinValue}}"
-                   Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MaxValue}}"
-                   ShowButtonSpinner="False">
+    <sd:NumericTextBox x:Name="NumericTextBox"
+                       Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, UpdateSourceTrigger=Explicit}"
+                       Minimum="{Binding [Minimum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MinValue}}"
+                       Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MaxValue}}">
       <Interaction.Behaviors>
         <DataTriggerBehavior Binding="{Binding NodeValue}" Value="{x:Static cpqvm:NodeViewModel.DifferentValues}">
           <ChangePropertyAction PropertyName="Watermark" Value="{sd:LocalizeString (Different values)}"/>
         </DataTriggerBehavior>
       </Interaction.Behaviors>
-    </NumericUpDown>
+    </sd:NumericTextBox>
   </DataTemplate>
   <caev:TypeMatchTemplateProvider x:Key="Int8PropertyTemplateProvider" Type="{x:Type s:SByte}" caev:PropertyViewHelper.TemplateCategory="PropertyEditor"
                                   Template="{StaticResource IntEditorTemplate}"/>
@@ -919,18 +916,17 @@
                 Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDouble}}, FallbackValue={x:Static s:Double.MaxValue}}"
                 SmallChange="{Binding [SmallStep], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDouble}}}"
                 LargeChange="{Binding [LargeStep], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDouble}}}"/>
-        <NumericUpDown Grid.Column="1"
-                       Margin="6,2,2,2"
-                       Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}}"
-                       Minimum="{Binding [Minimum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MinValue}}"
-                       Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MaxValue}}"
-                       ShowButtonSpinner="False">
+        <sd:NumericTextBox Grid.Column="1"
+                           Margin="6,2,2,2"
+                           Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, UpdateSourceTrigger=Explicit}"
+                           Minimum="{Binding [Minimum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MinValue}}"
+                           Maximum="{Binding [Maximum], Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:ToDecimal}}, FallbackValue={x:Static s:Decimal.MaxValue}}">
           <Interaction.Behaviors>
             <DataTriggerBehavior Binding="{Binding NodeValue}" Value="{x:Static cpqvm:NodeViewModel.DifferentValues}">
               <ChangePropertyAction PropertyName="Watermark" Value="{sd:LocalizeString (Different values)}"/>
             </DataTriggerBehavior>
           </Interaction.Behaviors>
-        </NumericUpDown>
+        </sd:NumericTextBox>
       </Grid>
     </DataTemplate>
   </caev:RangedValueTemplateProvider>
@@ -1166,15 +1162,14 @@
   <!-- Provider for AngleSingle -->
   <caev:TypeMatchTemplateProvider x:Key="AnglePropertyTemplateProvider" Type="{x:Type math:AngleSingle}" caev:PropertyViewHelper.TemplateCategory="PropertyEditor">
     <DataTemplate DataType="cpqvm:NodeViewModel">
-      <NumericUpDown Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:AngleSingleToDegrees}}}"
-                     ShowButtonSpinner="False"
-                     ToolTip.Tip="{sd:LocalizeString Angle in degrees, Context=Tooltip}">
+      <sd:NumericTextBox Value="{Binding NodeValue, Converter={sd:Chained {caec:DifferentValuesToNull}, {sd:AngleSingleToDegrees}}, UpdateSourceTrigger=Explicit}"
+                         ToolTip.Tip="{sd:LocalizeString Angle in degrees, Context=Tooltip}">
         <Interaction.Behaviors>
           <DataTriggerBehavior Binding="{Binding NodeValue}" Value="{x:Static cpqvm:NodeViewModel.DifferentValues}">
             <ChangePropertyAction PropertyName="Watermark" Value="{sd:LocalizeString (Different values)}"/>
           </DataTriggerBehavior>
         </Interaction.Behaviors>
-      </NumericUpDown>
+      </sd:NumericTextBox>
     </DataTemplate>
   </caev:TypeMatchTemplateProvider>
 

--- a/sources/editor/Stride.Editor.Avalonia/Stride.Editor.Avalonia.csproj
+++ b/sources/editor/Stride.Editor.Avalonia/Stride.Editor.Avalonia.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/editor/Stride.GameStudio.Avalonia/Controls/DebugLogUserControl.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Controls/DebugLogUserControl.axaml
@@ -2,10 +2,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"             
-             xmlns:ctrl="using:Stride.Core.Assets.Editor.Avalonia.Controls"
+             xmlns:caec="using:Stride.Core.Assets.Editor.Avalonia.Controls"
+             xmlns:caevm="using:Stride.Core.Assets.Editor.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="Stride.GameStudio.Avalonia.Controls.DebugLogUserControl">
+             x:Class="Stride.GameStudio.Avalonia.Controls.DebugLogUserControl"
+             x:DataType="caevm:LoggerViewModel">
   <Grid>
-    <ctrl:TextLogViewer LogMessages="{Binding Messages}" />
+    <caec:TextLogViewer LogMessages="{Binding Messages}" />
   </Grid>
 </UserControl>

--- a/sources/editor/Stride.GameStudio.Avalonia/Stride.GameStudio.Avalonia.csproj
+++ b/sources/editor/Stride.GameStudio.Avalonia/Stride.GameStudio.Avalonia.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/editor/Stride.GameStudio.Avalonia/Themes/DefaultStyles.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Themes/DefaultStyles.axaml
@@ -1,6 +1,9 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
+        xmlns:math="using:Stride.Core.Mathematics"
+        xmlns:s="using:System"
+        xmlns:scg="using:System.Collections.Generic"
         x:Class="Stride.GameStudio.Avalonia.Themes.DefaultStyles">
   <Styles.Resources>
     <!-- FIXME xplat-editor move those resources (they should be theme-dependent) -->
@@ -104,9 +107,12 @@
                   <ListBox ItemsSource="{TemplateBinding Palette}"
                            SelectedItem="{TemplateBinding SelectedPaletteColor, Mode=TwoWay}"
                            SelectedValue="{Binding Value, RelativeSource={RelativeSource TemplatedParent}}"
-                           SelectedValueBinding="{Binding Value}">
+                           SelectedValueBinding="{ReflectionBinding Value}">
                     <ListBox.ItemTemplate>
                       <DataTemplate>
+                        <DataTemplate.DataType>
+                          <x:Type TypeName="scg:KeyValuePair" x:TypeArguments="s:String,math:Color4"/>
+                        </DataTemplate.DataType>
                         <DockPanel>
                           <Rectangle DockPanel.Dock="Left"
                                      Stroke="Black" StrokeThickness="1"
@@ -159,9 +165,12 @@
                   <ListBox ItemsSource="{TemplateBinding Palette}"
                            SelectedItem="{TemplateBinding SelectedPaletteColor, Mode=TwoWay}"
                            SelectedValue="{Binding Value, RelativeSource={RelativeSource TemplatedParent}}"
-                           SelectedValueBinding="{Binding Value}">
+                           SelectedValueBinding="{ReflectionBinding Value}">
                     <ListBox.ItemTemplate>
                       <DataTemplate>
+                        <DataTemplate.DataType>
+                          <x:Type TypeName="scg:KeyValuePair" x:TypeArguments="s:String,math:Color4"/>
+                        </DataTemplate.DataType>
                         <DockPanel>
                           <Rectangle DockPanel.Dock="Left"
                                      Stroke="Black" StrokeThickness="1"
@@ -216,9 +225,12 @@
                   <ListBox ItemsSource="{TemplateBinding Palette}"
                            SelectedItem="{TemplateBinding SelectedPaletteColor, Mode=TwoWay}"
                            SelectedValue="{Binding Value, RelativeSource={RelativeSource TemplatedParent}}"
-                           SelectedValueBinding="{Binding Value}">
+                           SelectedValueBinding="{ReflectionBinding Value}">
                     <ListBox.ItemTemplate>
                       <DataTemplate>
+                        <DataTemplate.DataType>
+                          <x:Type TypeName="scg:KeyValuePair" x:TypeArguments="s:String,math:Color4"/>
+                        </DataTemplate.DataType>
                         <DockPanel>
                           <Rectangle DockPanel.Dock="Left"
                                      Stroke="Black" StrokeThickness="1"

--- a/sources/editor/Stride.GameStudio.Avalonia/Themes/DefaultStyles.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Themes/DefaultStyles.axaml
@@ -15,6 +15,20 @@
     <SolidColorBrush x:Key="WhiteBrush" Color="White"/>
   </Styles.Resources>
 
+  <!-- FIXME xplat-editor should styles be moved to a default theme in Core.Presentation.Avalonia? -->
+
+  <!-- Style for NumericTextBox -->
+  <Style Selector="sd|NumericTextBox">
+    <Setter Property="Template">
+      <ControlTemplate TargetType="sd:NumericTextBox">
+        <TextBox x:Name="PART_TextBox"
+                 Text="{TemplateBinding Text}"
+                 TextAlignment="{TemplateBinding TextAlignment}"
+                 Watermark="{TemplateBinding Watermark}"/>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+
   <!-- Style for DateTime editor -->
   <Style Selector="sd|DateTimeEditor">
     <Setter Property="Focusable" Value="False"/>
@@ -37,35 +51,35 @@
     <Setter Property="Template">
       <ControlTemplate TargetType="sd:TimeSpanEditor">
         <Grid ColumnDefinitions="2*, Auto, 2*, Auto, 2*, Auto, 3*, Auto">
-          <NumericUpDown Grid.Column="0"
-                         Margin="-1" TextAlignment="Right" ShowButtonSpinner="False"
-                         Minimum="0"
-                         Value="{Binding Days, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Grid.Column="0"
+                             Margin="-1" TextAlignment="Right"
+                             Minimum="0"
+                             Value="{Binding Days, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <Label Grid.Column="1"
                  Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center"
                  Content=" d "/>
-          <NumericUpDown Grid.Column="2"
-                         Margin="-1" TextAlignment="Right" ShowButtonSpinner="False"
-                         Minimum="0" Maximum="23"
-                         Value="{Binding Hours, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Grid.Column="2"
+                             Margin="-1" TextAlignment="Right"
+                             Minimum="0" Maximum="23"
+                             Value="{Binding Hours, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <Label Grid.Column="3"
                  Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center"
                  Content=" h "/>
-          <NumericUpDown Grid.Column="4"
-                         Margin="-1" TextAlignment="Right" ShowButtonSpinner="False"
-                         Minimum="0" Maximum="59"
-                         Value="{Binding Minutes, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Grid.Column="4"
+                             Margin="-1" TextAlignment="Right"
+                             Minimum="0" Maximum="59"
+                             Value="{Binding Minutes, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <Label Grid.Column="5"
                  Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center"
                  Content=" min "/>
-          <NumericUpDown Grid.Column="6"
-                         Margin="-1" TextAlignment="Right" ShowButtonSpinner="False"
-                         Minimum="0.0000000" Maximum="59.9999999"
-                         Value="{Binding Seconds, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Grid.Column="6"
+                             Margin="-1" TextAlignment="Right"
+                             Minimum="0.0000000" Maximum="59.9999999"
+                             Value="{Binding Seconds, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <Label Grid.Column="7"
                  Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center"
                  Content=" s "/>
@@ -263,10 +277,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -276,10 +289,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -300,10 +312,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -313,10 +324,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Z component -->
@@ -326,10 +336,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Z" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -350,10 +359,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -363,10 +371,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Z component -->
@@ -376,10 +383,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Z" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- W component -->
@@ -389,10 +395,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="W" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding W, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding W, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -413,10 +418,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -426,10 +430,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -450,10 +453,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -463,10 +465,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Z component -->
@@ -476,10 +477,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Z" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -500,10 +500,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -513,10 +512,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Z component -->
@@ -526,10 +524,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Z" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- W component -->
@@ -539,10 +536,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="W" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding W, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding W, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -562,10 +558,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectX, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectX, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <Border Grid.Column="1"
@@ -574,10 +569,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectY, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectY, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <Border Grid.Column="1"
@@ -586,10 +580,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="W" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectWidth, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectWidth, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <Border Grid.Column="7"
@@ -598,10 +591,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="H" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectHeight, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectHeight, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -621,10 +613,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectX, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectX, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <Border Grid.Column="1"
@@ -633,10 +624,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectY, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectY, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <Border Grid.Column="1"
@@ -645,10 +635,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="W" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectWidth, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectWidth, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <Border Grid.Column="7"
@@ -657,10 +646,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="H" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding RectHeight, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding RectHeight, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -682,10 +670,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="X" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding X, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Y component -->
@@ -695,10 +682,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Y" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Y, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
           <!-- Z component -->
@@ -708,10 +694,9 @@
                   BorderThickness="1" BorderBrush="{StaticResource TransparentBrush}">
             <DockPanel>
               <TextBlock Text="Z" Margin="3,0" MinWidth="12" VerticalAlignment="Center" TextAlignment="Center" Foreground="{StaticResource WhiteBrush}"/>
-              <NumericUpDown Margin="-1" TextAlignment="Center"
-                             ShowButtonSpinner="False"
-                             Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}}"
-                             Watermark="{TemplateBinding Watermark}"/>
+              <sd:NumericTextBox Margin="-1" TextAlignment="Center"
+                                 Value="{Binding Z, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                                 Watermark="{TemplateBinding Watermark}"/>
             </DockPanel>
           </Border>
         </Grid>
@@ -726,73 +711,57 @@
       <ControlTemplate TargetType="sd:MatrixEditor">
         <UniformGrid Rows="4" Columns="4">
           <!-- first row -->
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M11, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M12, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M13, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M14, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M11, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M12, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M13, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M14, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <!-- second row -->
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M21, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M22, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M23, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M24, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M21, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M22, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M23, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M24, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <!-- third row -->
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M31, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M32, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M33, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M34, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M31, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M32, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M33, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M34, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
           <!-- fourth row -->
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M41, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M42, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M43, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
-          <NumericUpDown Margin="2" TextAlignment="Center"
-                         ShowButtonSpinner="False"
-                         Value="{Binding M44, RelativeSource={RelativeSource TemplatedParent}}"
-                         Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M41, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M42, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M43, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
+          <sd:NumericTextBox Margin="2" TextAlignment="Center"
+                             Value="{Binding M44, RelativeSource={RelativeSource TemplatedParent}, UpdateSourceTrigger=Explicit}"
+                             Watermark="{TemplateBinding Watermark}"/>
         </UniformGrid>
       </ControlTemplate>
     </Setter>

--- a/sources/editor/Stride.GameStudio.Avalonia/Themes/DefaultStyles.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Themes/DefaultStyles.axaml
@@ -96,7 +96,7 @@
                    Text="{Binding Value, Converter={sd:ColorConverter}, RelativeSource={RelativeSource TemplatedParent}}"
                    Watermark="{TemplateBinding Watermark}"/>
           <Popup Grid.Column="0"
-                 IsOpen="{Binding #PickerToggleButton.IsChecked}" IsLightDismissEnabled="True">
+                 IsOpen="{Binding #PickerToggleButton.IsChecked, Mode=TwoWay}" IsLightDismissEnabled="True">
             <Grid MinWidth="200" MinHeight="200"
                   MaxWidth="400" MaxHeight="400">
               <TabControl>
@@ -154,7 +154,7 @@
                    Text="{Binding Value, Converter={sd:ColorConverter}, RelativeSource={RelativeSource TemplatedParent}}"
                    Watermark="{TemplateBinding Watermark}"/>
           <Popup Grid.Column="0"
-                 IsOpen="{Binding #PickerToggleButton.IsChecked}" IsLightDismissEnabled="True">
+                 IsOpen="{Binding #PickerToggleButton.IsChecked, Mode=TwoWay}" IsLightDismissEnabled="True">
             <Grid MinWidth="200" MinHeight="200"
                   MaxWidth="400" MaxHeight="400">
               <TabControl>
@@ -212,7 +212,7 @@
                    Text="{Binding Value, Converter={sd:ColorConverter}, RelativeSource={RelativeSource TemplatedParent}}"
                    Watermark="{TemplateBinding Watermark}"/>
           <Popup Grid.Column="0"
-                 IsOpen="{Binding #PickerToggleButton.IsChecked}" IsLightDismissEnabled="True">
+                 IsOpen="{Binding #PickerToggleButton.IsChecked, Mode=TwoWay}" IsLightDismissEnabled="True">
             <Grid MinWidth="200" MinHeight="200"
                   MaxWidth="400" MaxHeight="400">
               <TabControl>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/AssetExplorerView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/AssetExplorerView.axaml
@@ -2,12 +2,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="using:Stride.Core.Assets.Presentation.ViewModels"
-             xmlns:vm2="using:Stride.Core.Assets.Editor.ViewModels"
-             xmlns:cv="using:Stride.GameStudio.Avalonia.Converters"
+             xmlns:caevm="using:Stride.Core.Assets.Editor.ViewModels"
+             xmlns:capvm="using:Stride.Core.Assets.Presentation.ViewModels"
+             xmlns:gscv="using:Stride.GameStudio.Avalonia.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Stride.GameStudio.Avalonia.Views.AssetExplorerView"
-             x:DataType="vm2:AssetCollectionViewModel">
+             x:DataType="caevm:AssetCollectionViewModel">
   <DockPanel>
     <Grid DockPanel.Dock="Top">
       <TextBlock Text="Asset Explorer" />
@@ -22,16 +22,16 @@
         </ItemsPanelTemplate>
       </ItemsControl.ItemsPanel>
       <ItemsControl.ItemTemplate>
-        <DataTemplate DataType="{x:Type vm:AssetViewModel}">
+        <DataTemplate DataType="{x:Type capvm:AssetViewModel}">
           <StackPanel Orientation="Horizontal">
             <Interaction.Behaviors>
               <EventTriggerBehavior EventName="DoubleTapped">
-                <InvokeCommandAction Command="{Binding Session.EditSelectedContentCommand}" />
+                <InvokeCommandAction Command="{Binding ((caevm:SessionViewModel)Session).EditSelectedContentCommand}" />
               </EventTriggerBehavior>
             </Interaction.Behaviors>
             <TextBlock Text="Asset: " />
             <TextBlock Text="{Binding Name}" />
-            <Image Source="{Binding ThumbnailData.Presenter, Converter={cv:StrideImage}}"
+            <Image Source="{Binding ThumbnailData.Presenter, Converter={gscv:StrideImage}, FallbackValue={x:Static AvaloniaProperty.UnsetValue}}"
                    Width="64" Height="64"/>
           </StackPanel>
         </DataTemplate>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/DebugWindow.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/DebugWindow.axaml
@@ -2,10 +2,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:ctrl="using:Stride.GameStudio.Avalonia.Controls"
-        xmlns:vm="using:Stride.Core.Assets.Editor.ViewModels"
+        xmlns:caevm="using:Stride.Core.Assets.Editor.ViewModels"
+        xmlns:gsc="using:Stride.GameStudio.Avalonia.Controls"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="Stride.GameStudio.Avalonia.Views.DebugWindow"
+        x:DataType="caevm:DebugWindowViewModel"
         Title="Debug Window" Width="1024" Height="768"
         WindowStartupLocation="CenterOwner">
   <Grid>
@@ -16,16 +17,16 @@
         </DataTemplate>
       </ItemsControl.ItemTemplate>
       <Control.DataTemplates>
-        <DataTemplate DataType="{x:Type vm:DebugAssetNodeCollectionViewModel}">
-          <ctrl:DebugAssetNodesUserControl />
+        <DataTemplate DataType="{x:Type caevm:DebugAssetNodeCollectionViewModel}">
+          <gsc:DebugAssetNodesUserControl />
         </DataTemplate>
 
-        <DataTemplate DataType="{x:Type vm:LoggerViewModel}">
-          <ctrl:DebugLogUserControl />
+        <DataTemplate DataType="{x:Type caevm:LoggerViewModel}">
+          <gsc:DebugLogUserControl />
         </DataTemplate>
 
-        <DataTemplate DataType="{x:Type vm:UndoRedoViewModel}">
-          <ctrl:DebugUndoRedoUserControl />
+        <DataTemplate DataType="{x:Type caevm:UndoRedoViewModel}">
+          <gsc:DebugUndoRedoUserControl />
         </DataTemplate>
       </Control.DataTemplates>
     </TabControl>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/EditorCollectionView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/EditorCollectionView.axaml
@@ -2,11 +2,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="using:Stride.Core.Assets.Editor.ViewModels"
-             xmlns:gs="using:Stride.Assets.Editor.Avalonia"
+             xmlns:ae="using:Stride.Assets.Editor.Avalonia"
+             xmlns:caevm="using:Stride.Core.Assets.Editor.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Stride.GameStudio.Avalonia.Views.EditorCollectionView"
-             x:DataType="vm:EditorCollectionViewModel">
+             x:DataType="caevm:EditorCollectionViewModel">
   <TabControl ItemsSource="{Binding Editors}"
               SelectedItem="{Binding ActiveEditor}">
     <ItemsControl.ItemTemplate>
@@ -15,7 +15,7 @@
       </DataTemplate>
     </ItemsControl.ItemTemplate>
     <TabControl.ContentTemplate>
-      <gs:EditorViewSelector Session="{Binding Session}" />
+      <ae:EditorViewSelector x:DataType="caevm:EditorCollectionViewModel" Session="{Binding Session}" />
     </TabControl.ContentTemplate>
   </TabControl>
 </UserControl>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainView.axaml
@@ -6,16 +6,16 @@
              xmlns:caec="using:Stride.Core.Assets.Editor.Avalonia.Controls"
              xmlns:caect="using:Stride.Core.Assets.Editor.Components.Transactions"
              xmlns:cpc="using:Stride.Core.Presentation.Commands"
-             xmlns:gh="using:Stride.GameStudio.Avalonia.Helpers"
-             xmlns:gvm="using:Stride.GameStudio.Avalonia.ViewModels"
-             xmlns:gvw="using:Stride.GameStudio.Avalonia.Views"
+             xmlns:gsh="using:Stride.GameStudio.Avalonia.Helpers"
+             xmlns:gsvm="using:Stride.GameStudio.Avalonia.ViewModels"
+             xmlns:gsvw="using:Stride.GameStudio.Avalonia.Views"
              mc:Ignorable="d" d:DesignWidth="1024" d:DesignHeight="768"
              x:Class="Stride.GameStudio.Avalonia.Views.MainView"
-             x:DataType="gvm:MainViewModel">
+             x:DataType="gsvm:MainViewModel">
   <Design.DataContext>
     <!-- This only sets the DataContext for the previewer in an IDE,
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-    <gvm:MainViewModel/>
+    <gsvm:MainViewModel/>
   </Design.DataContext>
   <UserControl.Resources>
     <ResourceDictionary>
@@ -46,26 +46,26 @@
       <MenuItem Header="{sd:LocalizeString Edit, Context=Menu}">
         <MenuItem Header="{sd:LocalizeString Undo, Context=Menu}"
                   Command="{Binding Session.ActionHistory.UndoCommand, FallbackValue={x:Static cpc:DisabledCommand.Instance}}"
-                  HotKey="{x:Static gvw:MainView.UndoGesture}" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
+                  HotKey="{x:Static gsvw:MainView.UndoGesture}" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
         <MenuItem Header="{sd:LocalizeString Redo, Context=Menu}"
                   Command="{Binding Session.ActionHistory.RedoCommand, FallbackValue={x:Static cpc:DisabledCommand.Instance}}"
-                  HotKey="{x:Static gvw:MainView.RedoGesture}" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
+                  HotKey="{x:Static gsvw:MainView.RedoGesture}" InputGesture="{Binding $self.HotKey, Mode=OneTime}"/>
       </MenuItem>
       <!-- Help menu -->
       <MenuItem Header="{sd:LocalizeString _Help, Context=Menu}">
         <MenuItem Header="{sd:LocalizeString Online documentation, Context=Menu}"
             Command="{Binding OpenWebPageCommand}"
-            CommandParameter="{x:Static gh:StrideGameStudio.DocumentationUrl}"/>
+            CommandParameter="{x:Static gsh:StrideGameStudio.DocumentationUrl}"/>
         <Separator/>
         <MenuItem Header="{sd:LocalizeString Questions and answers, Context=Menu}"
                   Command="{Binding OpenWebPageCommand}"
-                  CommandParameter="{x:Static gh:StrideGameStudio.AnswersUrl}"/>
+                  CommandParameter="{x:Static gsh:StrideGameStudio.AnswersUrl}"/>
         <MenuItem Header="{sd:LocalizeString Report an issue..., Context=Menu}"
                   Command="{Binding OpenWebPageCommand}"
-                  CommandParameter="{x:Static gh:StrideGameStudio.ReportIssueUrl}"/>
+                  CommandParameter="{x:Static gsh:StrideGameStudio.ReportIssueUrl}"/>
         <MenuItem Header="{sd:LocalizeString Discord forum, Context=Menu}"
                   Command="{Binding OpenWebPageCommand}"
-                  CommandParameter="{x:Static gh:StrideGameStudio.ForumsUrl}"/>
+                  CommandParameter="{x:Static gsh:StrideGameStudio.ForumsUrl}"/>
         <Separator/>
         <MenuItem Header="{sd:LocalizeString Show debug window, Context=Menu}"
                   Command="{Binding OpenDebugWindowCommand}"/>
@@ -84,7 +84,7 @@
       <Grid Grid.Row="0"
             ColumnDefinitions="2*, 2, *">
         <!-- Editors -->
-        <gvw:EditorCollectionView Grid.Column="0"
+        <gsvw:EditorCollectionView Grid.Column="0"
                                  BorderThickness="2"
                                  BorderBrush="Red"
                                  Padding="2"
@@ -102,7 +102,7 @@
                     HotKey="Alt+Right" ToolTip.Tip="{Binding $self.HotKey, Mode=OneTime}"/>
           </StackPanel>
           <!-- Property Grid -->
-          <gvw:PropertyGridView Grid.Row="1"
+          <gsvw:PropertyGridView Grid.Row="1"
                                BorderThickness="2"
                                BorderBrush="Orange"
                                Padding="2"
@@ -113,7 +113,7 @@
       <Grid Grid.Row="2"
             ColumnDefinitions="*, 2, 2*, 2, *">
         <!-- Solution Explorer -->
-        <gvw:SolutionExplorerView Grid.Column="0"
+        <gsvw:SolutionExplorerView Grid.Column="0"
                                  BorderThickness="2"
                                  BorderBrush="Black"
                                  Padding="2"
@@ -122,7 +122,7 @@
         <!-- Asset view and logs -->
         <TabControl Grid.Column="2">
           <TabItem Header="Asset view">
-            <gvw:AssetExplorerView BorderThickness="2"
+            <gsvw:AssetExplorerView BorderThickness="2"
                                   BorderBrush="Blue"
                                   Padding="2"
                                   DataContext="{Binding Session.AssetCollection, FallbackValue={x:Null}}"/>
@@ -138,7 +138,7 @@
         <!-- Asset preview, history and references -->
         <TabControl Grid.Column="4">
           <TabItem Header="Asset preview">
-            <gvw:AssetPreviewView BorderThickness="2"
+            <gsvw:AssetPreviewView BorderThickness="2"
                                  BorderBrush="Cyan"
                                  Padding="2"/>
           </TabItem>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml
@@ -3,11 +3,12 @@
         xmlns:vm="using:Stride.GameStudio.Avalonia.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:views="clr-namespace:Stride.GameStudio.Avalonia.Views"
+        xmlns:gsvw="using:Stride.GameStudio.Avalonia.Views"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
         x:Class="Stride.GameStudio.Avalonia.Views.MainWindow"
+        x:DataType="vm:MainViewModel"
         Icon="/Assets/GameStudio.ico"
         Title="{Binding Title}"
         Width="1280" Height="900">
-        <views:MainView />
+        <gsvw:MainView />
 </Window>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
@@ -9,7 +9,7 @@
              xmlns:behaviors="clr-namespace:Stride.Core.Assets.Editor.Avalonia.Behaviors;assembly=Stride.Core.Assets.Editor.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Stride.GameStudio.Avalonia.Views.PropertyGridView"
-             x:DataType="vm:PropertiesViewModel">
+             x:DataType="vm:SessionObjectPropertiesViewModel">
   <UserControl.Resources>
     <ControlTheme x:Key="PropertyExpanderTheme" TargetType="Expander">
       <Setter Property="Padding" Value="10,0,0,0"/>
@@ -47,7 +47,8 @@
         </ControlTemplate>
       </Setter>
     </ControlTheme>
-    <ControlTheme x:Key="{x:Type sd:PropertyViewItem}" TargetType="sd:PropertyViewItem">
+    <ControlTheme x:Key="{x:Type sd:PropertyViewItem}" TargetType="sd:PropertyViewItem"
+                  x:DataType="pqvm:NodeViewModel">
       <Setter Property="Background" Value="Transparent"/>
       <Setter Property="Increment" Value="12"/>
       <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -68,7 +69,7 @@
                                   Content="{TemplateBinding HeaderedContentControl.Header}"
                                   ContentTemplate="{TemplateBinding HeaderTemplate}"
                                   HorizontalAlignment="{TemplateBinding Control.HorizontalAlignment}"
-                                  IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].DataContext.ShowOverridesOnly, FallbackValue={sd:True}},
+                                  IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].((vm:SessionObjectPropertiesViewModel)DataContext).ShowOverridesOnly, FallbackValue={sd:True}},
                                                                {Binding [IsOverridden]},
                                                                {Binding ![HasBase]},
                                                                Converter={sd:OrMulti}}"/>
@@ -82,7 +83,7 @@
                                     Content="{TemplateBinding HeaderedContentControl.Header}"
                                     ContentTemplate="{x:Static aev:PropertyViewHelper.FooterProviders}"
                                     HorizontalAlignment="{TemplateBinding Control.HorizontalAlignment}"
-                                    IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].DataContext.ShowOverridesOnly, FallbackValue={sd:True}},
+                                    IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].((vm:SessionObjectPropertiesViewModel)DataContext).ShowOverridesOnly, FallbackValue={sd:True}},
                                                                 {Binding [IsOverridden]},
                                                                 {Binding ![HasBase]},
                                                                 Converter={sd:OrMulti}}"/>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
@@ -47,6 +47,7 @@
       </Setter>
     </ControlTheme>
     <ControlTheme x:Key="{x:Type sd:PropertyViewItem}" TargetType="sd:PropertyViewItem">
+      <Setter Property="Background" Value="Transparent"/>
       <Setter Property="Increment" Value="12"/>
       <Setter Property="HorizontalAlignment" Value="Stretch"/>
       <Setter Property="HeaderTemplate">
@@ -92,6 +93,14 @@
       </Setter>
     </ControlTheme>
   </UserControl.Resources>
+  <UserControl.Styles>
+    <Style Selector="sd|PropertyViewItem[IsHovered=True]">
+      <Setter Property="Background" Value="#FF525252"/>
+    </Style>
+    <Style Selector="sd|PropertyViewItem[IsFocused=True]">
+      <Setter Property="Background" Value="#3E3E40"/>
+    </Style>
+  </UserControl.Styles>
   <DockPanel LastChildFill="True">
     <TextBlock DockPanel.Dock="Top" Text="Property Grid"/>
     <sd:PropertyView ItemsSource="{Binding ViewModel.RootNode.Children}"

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
@@ -6,6 +6,7 @@
              xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
              xmlns:aev="using:Stride.Core.Assets.Editor.Avalonia.Views"
              xmlns:pqvm="using:Stride.Core.Presentation.Quantum.ViewModels"
+             xmlns:behaviors="clr-namespace:Stride.Core.Assets.Editor.Avalonia.Behaviors;assembly=Stride.Core.Assets.Editor.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Stride.GameStudio.Avalonia.Views.PropertyGridView"
              x:DataType="vm:PropertiesViewModel">
@@ -104,6 +105,10 @@
   <DockPanel LastChildFill="True">
     <TextBlock DockPanel.Dock="Top" Text="Property Grid"/>
     <sd:PropertyView ItemsSource="{Binding ViewModel.RootNode.Children}"
-                     IsVisible="{Binding CanDisplayProperties}"/>
+                     IsVisible="{Binding CanDisplayProperties}">
+      <Interaction.Behaviors>
+        <behaviors:PropertyViewAutoExpandNodesBehavior ViewModel="{Binding ViewModel, Mode=OneWay}" />
+      </Interaction.Behaviors>
+    </sd:PropertyView>
   </DockPanel>
 </UserControl>

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/PropertyGridView.axaml
@@ -2,14 +2,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="using:Stride.Core.Assets.Editor.Components.Properties"
              xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
-             xmlns:aev="using:Stride.Core.Assets.Editor.Avalonia.Views"
-             xmlns:pqvm="using:Stride.Core.Presentation.Quantum.ViewModels"
-             xmlns:behaviors="clr-namespace:Stride.Core.Assets.Editor.Avalonia.Behaviors;assembly=Stride.Core.Assets.Editor.Avalonia"
+             xmlns:caeb="using:Stride.Core.Assets.Editor.Avalonia.Behaviors"
+             xmlns:caecp="using:Stride.Core.Assets.Editor.Components.Properties"
+             xmlns:caev="using:Stride.Core.Assets.Editor.Avalonia.Views"
+             xmlns:cpqvm="using:Stride.Core.Presentation.Quantum.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Stride.GameStudio.Avalonia.Views.PropertyGridView"
-             x:DataType="vm:SessionObjectPropertiesViewModel">
+             x:DataType="caecp:SessionObjectPropertiesViewModel">
   <UserControl.Resources>
     <ControlTheme x:Key="PropertyExpanderTheme" TargetType="Expander">
       <Setter Property="Padding" Value="10,0,0,0"/>
@@ -48,14 +48,14 @@
       </Setter>
     </ControlTheme>
     <ControlTheme x:Key="{x:Type sd:PropertyViewItem}" TargetType="sd:PropertyViewItem"
-                  x:DataType="pqvm:NodeViewModel">
+                  x:DataType="cpqvm:NodeViewModel">
       <Setter Property="Background" Value="Transparent"/>
       <Setter Property="Increment" Value="12"/>
       <Setter Property="HorizontalAlignment" Value="Stretch"/>
       <Setter Property="HeaderTemplate">
-        <TreeDataTemplate ItemsSource="{Binding Children, Mode=OneWay}" DataType="pqvm:NodeViewModel">
+        <TreeDataTemplate ItemsSource="{Binding Children, Mode=OneWay}" DataType="cpqvm:NodeViewModel">
           <ContentPresenter Content="{Binding}"
-                            ContentTemplate="{x:Static aev:PropertyViewHelper.HeaderProviders}"/>
+                            ContentTemplate="{x:Static caev:PropertyViewHelper.HeaderProviders}"/>
         </TreeDataTemplate>
       </Setter>
       <Setter Property="Template">
@@ -69,7 +69,7 @@
                                   Content="{TemplateBinding HeaderedContentControl.Header}"
                                   ContentTemplate="{TemplateBinding HeaderTemplate}"
                                   HorizontalAlignment="{TemplateBinding Control.HorizontalAlignment}"
-                                  IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].((vm:SessionObjectPropertiesViewModel)DataContext).ShowOverridesOnly, FallbackValue={sd:True}},
+                                  IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].((caecp:SessionObjectPropertiesViewModel)DataContext).ShowOverridesOnly, FallbackValue={sd:True}},
                                                                {Binding [IsOverridden]},
                                                                {Binding ![HasBase]},
                                                                Converter={sd:OrMulti}}"/>
@@ -81,9 +81,9 @@
                   <ItemsPresenter Name="ItemsHost"/>
                   <ContentPresenter Name="PART_Footer"
                                     Content="{TemplateBinding HeaderedContentControl.Header}"
-                                    ContentTemplate="{x:Static aev:PropertyViewHelper.FooterProviders}"
+                                    ContentTemplate="{x:Static caev:PropertyViewHelper.FooterProviders}"
                                     HorizontalAlignment="{TemplateBinding Control.HorizontalAlignment}"
-                                    IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].((vm:SessionObjectPropertiesViewModel)DataContext).ShowOverridesOnly, FallbackValue={sd:True}},
+                                    IsVisible="{sd:MultiBinding {Binding !$parent[sd:PropertyView].((caecp:SessionObjectPropertiesViewModel)DataContext).ShowOverridesOnly, FallbackValue={sd:True}},
                                                                 {Binding [IsOverridden]},
                                                                 {Binding ![HasBase]},
                                                                 Converter={sd:OrMulti}}"/>
@@ -108,7 +108,7 @@
     <sd:PropertyView ItemsSource="{Binding ViewModel.RootNode.Children}"
                      IsVisible="{Binding CanDisplayProperties}">
       <Interaction.Behaviors>
-        <behaviors:PropertyViewAutoExpandNodesBehavior ViewModel="{Binding ViewModel, Mode=OneWay}" />
+        <caeb:PropertyViewAutoExpandNodesBehavior ViewModel="{Binding ViewModel, Mode=OneWay}" />
       </Interaction.Behaviors>
     </sd:PropertyView>
   </DockPanel>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Behaviors/BindCurrentToolTipStringBehavior.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Behaviors/BindCurrentToolTipStringBehavior.cs
@@ -10,7 +10,7 @@ using Avalonia.Xaml.Interactivity;
 namespace Stride.Core.Presentation.Avalonia.Behaviors;
 
 /// <summary>
-/// Allows the bind the <see cref="Control.ToolTip"/> property of a control to a particular target property when the attached control is hovered by the mouse.
+/// Allows the bind the <see cref="ToolTip.TipProperty"/> of a control to a particular target property when the attached control is hovered by the mouse.
 /// This behavior can be used to display the same message that the tool-tip in a status bar, for example.
 /// </summary>
 /// <remarks>This behavior can be used to display the tool tip of some controls in another place, such as a status bar.</remarks>
@@ -50,7 +50,7 @@ public class BindCurrentToolTipStringBehavior : Behavior<Control>
     protected override void OnAttached()
     {
         base.OnAttached();
-        if (AssociatedObject is { })
+        if (AssociatedObject is not null)
         {
             AssociatedObject.PointerEntered += MouseEnter;
             AssociatedObject.PointerExited += MouseLeave;
@@ -60,7 +60,7 @@ public class BindCurrentToolTipStringBehavior : Behavior<Control>
     /// <inheritdoc/>
     protected override void OnDetaching()
     {
-        if (AssociatedObject is { })
+        if (AssociatedObject is not null)
         {
             AssociatedObject.PointerEntered -= MouseEnter;
             AssociatedObject.PointerExited -= MouseLeave;
@@ -70,7 +70,7 @@ public class BindCurrentToolTipStringBehavior : Behavior<Control>
 
     private void MouseEnter(object? sender, PointerEventArgs e)
     {
-        if (AssociatedObject is { })
+        if (AssociatedObject is not null)
         {
             SetCurrentValue(ToolTipTargetProperty, ToolTip.GetTip(AssociatedObject));
         }

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/NumericTextBox.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/NumericTextBox.cs
@@ -1,0 +1,326 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Stride.Core.Mathematics;
+
+namespace Stride.Core.Presentation.Avalonia.Controls;
+
+[TemplatePart("PART_TextBox", typeof(TextBox), IsRequired = true)]
+public sealed class NumericTextBox : TemplatedControl
+{
+    private bool internalValueSet;
+    private bool isSyncingTextAndValueProperties;
+    private bool isTextChangedFromUI;
+    private IDisposable? textBoxTextChangedSubscription;
+
+    static NumericTextBox()
+    {
+        MaximumProperty.Changed.AddClassHandler<NumericTextBox>(OnMaximumPropertyChanged);
+        MinimumProperty.Changed.AddClassHandler<NumericTextBox>(OnMinimumPropertyChanged);
+        TextProperty.Changed.AddClassHandler<NumericTextBox, string?>(OnTextPropertyChanged);
+        ValueProperty.Changed.AddClassHandler<NumericTextBox, double?>(OnValuePropertyChanged);
+    }
+
+    public static readonly StyledProperty<int> DecimalPlacesProperty =
+        AvaloniaProperty.Register<NumericTextBox, int>(nameof(DecimalPlaces), -1);
+
+    public static readonly StyledProperty<double> MaximumProperty =
+        AvaloniaProperty.Register<NumericTextBox, double>(nameof(Maximum), double.MaxValue, defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<double> MinimumProperty =
+        AvaloniaProperty.Register<NumericTextBox, double>(nameof(Minimum), double.MinValue, defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<string?> TextProperty =
+        AvaloniaProperty.Register<NumericTextBox, string?>(nameof(Text), string.Empty, defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<TextAlignment> TextAlignmentProperty =
+        TextBox.TextAlignmentProperty.AddOwner<NumericTextBox>();
+
+    public static readonly StyledProperty<double?> ValueProperty =
+        AvaloniaProperty.Register<NumericTextBox, double?>(nameof(Value), 0.0, defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<string?> WatermarkProperty =
+        TextBox.WatermarkProperty.AddOwner<NumericTextBox>();
+
+    public static readonly RoutedEvent<NumericTextBoxValueChangedEventArgs> ValueChangedEvent =
+        RoutedEvent.Register<NumericTextBox, NumericTextBoxValueChangedEventArgs>(nameof(ValueChanged), RoutingStrategies.Bubble);
+
+    public int DecimalPlaces
+    {
+        get => GetValue(DecimalPlacesProperty);
+        set => SetValue(DecimalPlacesProperty, value);
+    }
+
+    public double Maximum
+    {
+        get => GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
+    }
+
+    public double Minimum
+    {
+        get => GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
+    }
+
+    public string? Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public TextAlignment TextAlignment
+    {
+        get => GetValue(TextAlignmentProperty);
+        set => SetValue(TextAlignmentProperty, value);
+    }
+
+    public double? Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public string? Watermark
+    {
+        get => GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
+    }
+
+    public event EventHandler<NumericTextBoxValueChangedEventArgs>? ValueChanged
+    {
+        add => AddHandler(ValueChangedEvent, value);
+        remove => RemoveHandler(ValueChangedEvent, value);
+    }
+
+    /// <summary>
+    /// Gets the TextBox template part.
+    /// </summary>
+    private TextBox? TextBox { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (!internalValueSet)
+        {
+            SyncTextAndValueProperties(false, null, true);
+        }
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        if (TextBox is not null)
+        {
+            textBoxTextChangedSubscription?.Dispose();
+        }
+        TextBox = e.NameScope.Find<TextBox>("PART_TextBox");
+        if (TextBox is not null)
+        {
+            textBoxTextChangedSubscription = TextBox.TextProperty.Changed.AddClassHandler<TextBox>((_, _) => TextBox_OnTextPropertyChanged());
+        }
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Enter:
+                var commitSuccess = CommitInput();
+                e.Handled = !commitSuccess;
+                break;
+        }
+    }
+
+    protected override void OnLostFocus(RoutedEventArgs e)
+    {
+        CommitInput(true);
+        base.OnLostFocus(e);
+    }
+
+    private bool CommitInput(bool forceTextUpdate = false)
+    {
+        if (SyncTextAndValueProperties(true, Text, forceTextUpdate))
+        {
+            BindingOperations.GetBindingExpressionBase(this, ValueProperty)?.UpdateSource();
+            return true;
+        }
+
+        return false;
+    }
+
+    private double? ConvertTextToValue(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return null;
+
+        var currentValueText = ConvertValueToText(Value);
+        if (Equals(currentValueText, text))
+            return Value;
+
+        if (double.TryParse(text, NumberStyles.Any, NumberFormatInfo.CurrentInfo, out var result))
+            return MathUtil.Clamp(result, Minimum, Maximum);
+
+        throw new InvalidDataException("Input string was not in a correct format.");
+
+    }
+
+    private string ConvertValueToText(double? value)
+    {
+        if (!value.HasValue)
+            return string.Empty;
+
+        var decimalPlaces = DecimalPlaces;
+        var coercedValue = decimalPlaces < 0 ? value.Value : Math.Round(value.Value, decimalPlaces);
+        return coercedValue.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private void OnTextPropertyChanged()
+    {
+        if (!IsInitialized)
+            return;
+
+        SyncTextAndValueProperties(true, Text);
+    }
+
+    private void OnValuePropertyChanged(double? oldValue, double? newValue)
+    {
+        if (!internalValueSet && IsInitialized)
+        {
+            SyncTextAndValueProperties(false, null, true);
+        }
+
+        RaiseEvent(new NumericTextBoxValueChangedEventArgs(ValueChangedEvent, oldValue, newValue));
+    }
+
+    private bool SyncTextAndValueProperties(bool updateValueFromText, string? text, bool forceTextUpdate = false)
+    {
+        if (isSyncingTextAndValueProperties)
+            return true;
+
+        isSyncingTextAndValueProperties = true;
+        var textIsValid = true;
+        try
+        {
+            if (updateValueFromText)
+            {
+                try
+                {
+                    var newValue = ConvertTextToValue(text);
+                    if (!Equals(newValue, Value))
+                    {
+                        SetValueInternal(newValue);
+                    }
+                }
+                catch
+                {
+                    textIsValid = false;
+                }
+            }
+
+            // Do not touch the ongoing text input from user.
+            if (!isTextChangedFromUI)
+            {
+                if (forceTextUpdate)
+                {
+                    var newText = ConvertValueToText(Value);
+                    if (!Equals(Text, newText))
+                    {
+                        SetCurrentValue(TextProperty, newText);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            isSyncingTextAndValueProperties = false;
+        }
+        return textIsValid;
+
+        void SetValueInternal(double? value)
+        {
+            internalValueSet = true;
+            try
+            {
+                SetCurrentValue(ValueProperty, value);
+            }
+            finally
+            {
+                internalValueSet = false;
+            }
+        }
+    }
+
+    private void TextBox_OnTextPropertyChanged()
+    {
+        try
+        {
+            isTextChangedFromUI = true;
+            if (TextBox is not null)
+            {
+                SetCurrentValue(TextProperty, TextBox.Text);
+            }
+        }
+        finally
+        {
+            isTextChangedFromUI = false;
+        }
+    }
+
+    private static void OnMaximumPropertyChanged(NumericTextBox sender, AvaloniaPropertyChangedEventArgs _)
+    {
+        var needValidation = false;
+        if (sender.Minimum > sender.Maximum)
+        {
+            sender.SetCurrentValue(MinimumProperty, sender.Maximum);
+            needValidation = true;
+        }
+        if (sender.Value > sender.Maximum)
+        {
+            sender.SetCurrentValue(ValueProperty, sender.Maximum);
+            needValidation = true;
+        }
+
+        if (needValidation)
+        {
+            sender.SyncTextAndValueProperties(false, null, true);
+        }
+    }
+
+    private static void OnMinimumPropertyChanged(NumericTextBox sender, AvaloniaPropertyChangedEventArgs _)
+    {
+        var needValidation = false;
+        if (sender.Maximum < sender.Minimum)
+        {
+            sender.SetCurrentValue(MaximumProperty, sender.Minimum);
+            needValidation = true;
+        }
+        if (sender.Value < sender.Minimum)
+        {
+            sender.SetCurrentValue(ValueProperty, sender.Minimum);
+            needValidation = true;
+        }
+
+        if (needValidation)
+        {
+            sender.SyncTextAndValueProperties(false, null, true);
+        }
+    }
+
+    private static void OnTextPropertyChanged(NumericTextBox sender, AvaloniaPropertyChangedEventArgs<string?> e)
+    {
+        sender.OnTextPropertyChanged();
+    }
+
+    private static void OnValuePropertyChanged(NumericTextBox sender, AvaloniaPropertyChangedEventArgs<double?> e)
+    {
+        sender.OnValuePropertyChanged(e.OldValue.GetValueOrDefault(), e.NewValue.GetValueOrDefault());
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/NumericTextBoxValueChangedEventArgs.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/NumericTextBoxValueChangedEventArgs.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Interactivity;
+
+namespace Stride.Core.Presentation.Avalonia.Controls;
+
+public sealed class NumericTextBoxValueChangedEventArgs : RoutedEventArgs
+{
+    public NumericTextBoxValueChangedEventArgs(RoutedEvent routedEvent, double? oldValue, double? newValue)
+        : base(routedEvent)
+    {
+        OldValue = oldValue;
+        NewValue = newValue;
+    }
+
+    public double? OldValue { get; }
+    public double? NewValue { get; }
+}

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyView.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyView.cs
@@ -4,16 +4,37 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
 using Stride.Core.Presentation.Collections;
 
 namespace Stride.Core.Presentation.Avalonia.Controls;
 
 public sealed class PropertyView : ItemsControl
 {
+    private PropertyViewItem? highlightedItem;
+    private PropertyViewItem? hoveredItem;
     private readonly ObservableList<PropertyViewItem> properties = [];
+
+    public static readonly DirectProperty<PropertyView, PropertyViewItem?> HighlightedItemProperty =
+        AvaloniaProperty.RegisterDirect<PropertyView, PropertyViewItem?>(nameof(HighlightedItem), o => o.HighlightedItem);
+
+    public static readonly DirectProperty<PropertyView, PropertyViewItem?> HoveredItemProperty =
+        AvaloniaProperty.RegisterDirect<PropertyView, PropertyViewItem?>(nameof(HoveredItem), o => o.HoveredItem);
 
     public static readonly StyledProperty<GridLength> NameColumnSizeProperty =
         AvaloniaProperty.Register<PropertyView, GridLength>(nameof(NameColumnSize), new GridLength(150), defaultBindingMode: BindingMode.TwoWay);
+
+    public PropertyViewItem? HighlightedItem
+    {
+        get => highlightedItem;
+        internal set => SetAndRaise(HighlightedItemProperty, ref highlightedItem, value);
+    }
+
+    public PropertyViewItem? HoveredItem
+    {
+        get => hoveredItem;
+        internal set => SetAndRaise(HoveredItemProperty, ref hoveredItem, value);
+    }
 
     public GridLength NameColumnSize
     {
@@ -23,9 +44,22 @@ public sealed class PropertyView : ItemsControl
 
     public IReadOnlyCollection<PropertyViewItem> Properties => properties;
 
+    protected override void ClearContainerForItemOverride(Control container)
+    {
+        var property = (PropertyViewItem)container;
+        properties.Remove(property);
+        base.ClearContainerForItemOverride(container);
+    }
+
     protected override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey)
     {
         return new PropertyViewItem(this);
+    }
+
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        HighlightItem(null);
+        HoverItem(null);
     }
 
     protected override void PrepareContainerForItemOverride(Control container, object? item, int index)
@@ -35,10 +69,37 @@ public sealed class PropertyView : ItemsControl
         properties.Add(property);
     }
 
-    protected override void ClearContainerForItemOverride(Control container)
+    internal void ItemMouseMove(PropertyViewItem item)
     {
-        var property = (PropertyViewItem)container;
-        properties.Remove(property);
-        base.ClearContainerForItemOverride(container);
+        if (item.IsHighlightable)
+            HighlightItem(item);
+
+        HoverItem(item);
+    }
+
+    private void HighlightItem(PropertyViewItem? item)
+    {
+        var previousItem = HighlightedItem;
+        if (previousItem == item)
+            return;
+
+        if (previousItem is not null)
+            previousItem.IsHighlighted = false;
+        HighlightedItem = item;
+        if (item is not null)
+            item.IsHighlighted = true;
+    }
+
+    private void HoverItem(PropertyViewItem? item)
+    {
+        var previousItem = HoveredItem;
+        if (previousItem == item)
+            return;
+
+        if (previousItem is not null)
+            previousItem.IsHovered = false;
+        HoveredItem = item;
+        if (item is not null)
+            item.IsHovered = true;
     }
 }

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyViewItem.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyViewItem.cs
@@ -42,7 +42,7 @@ public sealed class PropertyViewItem : ExpandableItemsControl
         ArgumentNullException.ThrowIfNull(propertyView);
         PropertyView = propertyView;
 
-        AddHandler<PointerEventArgs>(PointerMovedEvent, OnPreviewPointerMoved, RoutingStrategies.Tunnel);
+        AddHandler(PointerMovedEvent, OnPreviewPointerMoved, RoutingStrategies.Tunnel);
     }
 
     public double Increment
@@ -82,6 +82,7 @@ public sealed class PropertyViewItem : ExpandableItemsControl
     protected override void ClearContainerForItemOverride(Control container)
     {
         var property = (PropertyViewItem)container;
+        RaiseEvent(new PropertyViewItemEventArgs(PropertyView.ClearItemEvent, this, property));
         properties.Remove(property);
         base.ClearContainerForItemOverride(container);
     }
@@ -96,6 +97,7 @@ public sealed class PropertyViewItem : ExpandableItemsControl
         base.PrepareContainerForItemOverride(container, item, index);
         var property = (PropertyViewItem)container;
         properties.Add(property);
+        RaiseEvent(new PropertyViewItemEventArgs(PropertyView.PrepareItemEvent, this, property));
     }
 
     private static void OnIncrementChanged(PropertyViewItem sender, AvaloniaPropertyChangedEventArgs<double> e)

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyViewItemEventArgs.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyViewItemEventArgs.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+using Avalonia.Interactivity;
+
+namespace Stride.Core.Presentation.Avalonia.Controls;
+
+public sealed class PropertyViewItemEventArgs : RoutedEventArgs
+{
+    public PropertyViewItem Container { get; private set; }
+
+    public PropertyViewItemEventArgs(RoutedEvent routedEvent, object source, PropertyViewItem container)
+        : base(routedEvent, source)
+    {
+        Container = container;
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyViewItemEventArgs.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/PropertyViewItemEventArgs.cs
@@ -1,4 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using Avalonia.Interactivity;
 
 namespace Stride.Core.Presentation.Avalonia.Controls;

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/VectorEditorBase.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/VectorEditorBase.cs
@@ -45,7 +45,7 @@ public abstract class VectorEditorBase<T> : VectorEditorBase
 
     static VectorEditorBase()
     {
-        ValueProperty.Changed.AddClassHandler<VectorEditorBase<T>>(OnValueValueChanged);
+        ValueProperty.Changed.AddClassHandler<VectorEditorBase<T>>(OnValuePropertyChanged);
     }
 
     public static readonly StyledProperty<T> ValueProperty =
@@ -107,7 +107,7 @@ public abstract class VectorEditorBase<T> : VectorEditorBase
     /// <summary>
     /// Raised when the <see cref="Value"/> property is modified.
     /// </summary>
-    private void OnValueValueChanged()
+    private void OnValuePropertyChanged()
     {
         var isInitializing = !templateApplied && initializingProperty is null;
         if (isInitializing)
@@ -172,8 +172,8 @@ public abstract class VectorEditorBase<T> : VectorEditorBase
         return decimalPlaces < 0 ? basevalue : MathF.Round(basevalue.Value, decimalPlaces);
     }
 
-    private static void OnValueValueChanged(VectorEditorBase<T> sender, AvaloniaPropertyChangedEventArgs e)
+    private static void OnValuePropertyChanged(VectorEditorBase<T> sender, AvaloniaPropertyChangedEventArgs e)
     {
-        sender.OnValueValueChanged();
+        sender.OnValuePropertyChanged();
     }
 }

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Stride.Core.Presentation.Avalonia.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Stride.Core.Presentation.Avalonia.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/CheckedMessageBox.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/CheckedMessageBox.axaml
@@ -5,6 +5,7 @@
         xmlns:md="https://github.com/whistyun/Markdown.Avalonia.Tight"
         xmlns:cvt="using:Stride.Core.Presentation.Avalonia.Converters"
         xmlns:local="using:Stride.Core.Presentation.Windows"
+        xmlns:windows="using:Stride.Core.Presentation.Avalonia.Windows"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         MinHeight="120" MinWidth="320" MaxHeight="768"
         SizeToContent="WidthAndHeight" CanResize="False"
@@ -28,7 +29,7 @@
         <!--  buttons -->
         <ItemsControl DockPanel.Dock="Bottom"
                       HorizontalAlignment="Right"
-                      ItemsSource="{Binding $parent[Window].ButtonsSource}">
+                      ItemsSource="{Binding $parent[windows:MessageBox].ButtonsSource}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <UniformGrid Rows="1" />
@@ -38,7 +39,7 @@
             <DataTemplate DataType="{x:Type local:DialogButtonInfo}">
               <Button Margin="4,0" Padding="16,4" MinWidth="80"
                       HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                      Command="{Binding $parent[Window].ButtonCommand}"
+                      Command="{Binding $parent[windows:MessageBox].ButtonCommand}"
                       CommandParameter="{Binding Result}"
                       Content="{Binding Content}"
                       IsCancel="{Binding IsCancel}" IsDefault="{Binding IsDefault}" />
@@ -46,21 +47,21 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
         <!-- content -->
-        <ContentPresenter Content="{Binding}">
+        <ContentPresenter Content="{Binding $parent[ContentControl].Content}">
           <ContentPresenter.ContentTemplate>
             <DataTemplate>
               <DockPanel LastChildFill="True">
                 <CheckBox DockPanel.Dock="Bottom"
-                          Content="{Binding $parent[Window].CheckedMessage}"
-                          IsChecked="{Binding $parent[Window].IsChecked}"
+                          Content="{Binding $parent[windows:CheckedMessageBox].CheckedMessage}"
+                          IsChecked="{Binding $parent[windows:CheckedMessageBox].IsChecked}"
                           HorizontalAlignment="Left" VerticalAlignment="Bottom" 
                           Margin="0,12,0,4" />
                 <Image DockPanel.Dock="Left"
-                       Source="{Binding $parent[Window].Image}"
+                       Source="{Binding $parent[windows:MessageBox].Image}"
                        HorizontalAlignment="Left" VerticalAlignment="Top"
                        Height="32" Width="32" Margin="8,4"
-                       IsVisible="{Binding $parent[Window].Image, Converter={cvt:ObjectToBool}}" />
-                <md:MarkdownScrollViewer Markdown="{Binding}" VerticalAlignment="Center" />
+                       IsVisible="{Binding $parent[windows:MessageBox].Image, Converter={cvt:ObjectToBool}}" />
+                <md:MarkdownScrollViewer Markdown="{ReflectionBinding}" VerticalAlignment="Center" />
               </DockPanel>
             </DataTemplate>
           </ContentPresenter.ContentTemplate>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/MessageBox.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/MessageBox.axaml
@@ -5,6 +5,7 @@
         xmlns:md="https://github.com/whistyun/Markdown.Avalonia.Tight"
         xmlns:cvt="using:Stride.Core.Presentation.Avalonia.Converters"
         xmlns:local="using:Stride.Core.Presentation.Windows"
+        xmlns:windows="using:Stride.Core.Presentation.Avalonia.Windows"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         MinHeight="120" MinWidth="320" MaxHeight="768"
         SizeToContent="WidthAndHeight" CanResize="False"
@@ -28,7 +29,7 @@
         <!--  buttons -->
         <ItemsControl DockPanel.Dock="Bottom"
                       HorizontalAlignment="Right"
-                      ItemsSource="{Binding $parent[Window].ButtonsSource}">
+                      ItemsSource="{Binding $parent[windows:MessageBox].ButtonsSource}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <UniformGrid Rows="1" />
@@ -38,7 +39,7 @@
             <DataTemplate DataType="{x:Type local:DialogButtonInfo}">
               <Button Margin="4,0" Padding="16,4" MinWidth="80"
                       HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                      Command="{Binding $parent[Window].ButtonCommand}"
+                      Command="{Binding $parent[windows:MessageBox].ButtonCommand}"
                       CommandParameter="{Binding Result}"
                       Content="{Binding Content}"
                       IsCancel="{Binding IsCancel}" IsDefault="{Binding IsDefault}" />
@@ -46,16 +47,16 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
         <!-- content -->
-        <ContentPresenter Content="{Binding}">
+        <ContentPresenter Content="{Binding $parent[ContentControl].Content}">
           <ContentPresenter.ContentTemplate>
             <DataTemplate>
               <DockPanel LastChildFill="True">
                 <Image DockPanel.Dock="Left"
-                       Source="{Binding $parent[Window].Image}"
+                       Source="{Binding $parent[windows:MessageBox].Image}"
                        HorizontalAlignment="Left" VerticalAlignment="Top"
                        Height="32" Width="32" Margin="4"
-                       IsVisible="{Binding $parent[Window].Image, Converter={cvt:ObjectToBool}}" />
-                <md:MarkdownScrollViewer Markdown="{Binding}" VerticalAlignment="Center" />
+                       IsVisible="{Binding $parent[windows:MessageBox].Image, Converter={cvt:ObjectToBool}}" />
+                <md:MarkdownScrollViewer Markdown="{ReflectionBinding}" VerticalAlignment="Center" />
               </DockPanel>
             </DataTemplate>
           </ContentPresenter.ContentTemplate>


### PR DESCRIPTION
# PR Details

Some improvements of the property grid to bring it closer to feature parity with the old editor.

* highlighting
* rule-based auto-expanding

As well as some Avalonia-specific improvements such as using compiled bindings by default, which should bring better performance (https://docs.avaloniaui.net/docs/basics/data/data-binding/compiled-bindings)

## Related Issue

#2739

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
