### PR TITLE
fix: Slider put in Canvas NaN Exception

### DIFF
--- a/sources/engine/Stride.UI/UIElement.cs
+++ b/sources/engine/Stride.UI/UIElement.cs
@@ -925,6 +925,10 @@ namespace Stride.UI
             if (float.IsNaN(desiredSize.Z))
                 desiredSize.Z = DefaultDepth;
 
+            // replace infinity with the parent's RenderSize
+            if (float.IsInfinity(desiredSize.X) || float.IsInfinity(desiredSize.Y) || float.IsInfinity(desiredSize.Z))
+                desiredSize = InfinityToParentRenderSize(desiredSize);
+
             // clamp the desired size between the maximum and minimum width/height of the UIElement
             desiredSize = new Vector3(
                 Math.Max(MinimumWidth, Math.Min(MaximumWidth, desiredSize.X)),
@@ -937,6 +941,24 @@ namespace Stride.UI
             // update Element state variables
             DesiredSize = desiredSize;
             DesiredSizeWithMargins = desiredSizeWithMargins;
+        }
+
+        /// <summary>
+        /// Recursively checks parents for infinity values, replacing infinity with the Parent's <see cref="RenderSize"/>.
+        /// </summary>
+        /// <param name="size">The size vector with possible infinity values to replace.</param>
+        /// <returns>The input <paramref name="size"/> value with the infinities replaced with the Parent's <see cref="RenderSize"/>.</returns>
+        internal Vector3 InfinityToParentRenderSize(Vector3 size)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                if (float.IsInfinity(size[i]))
+                    size[i] = Parent.RenderSize[i];
+            }
+            if (float.IsInfinity(size.X) || float.IsInfinity(size.Y) || float.IsInfinity(size.Z))
+                return Parent.InfinityToParentRenderSize(size);
+
+            return size;
         }
 
         private void ValidateChildrenMeasure()


### PR DESCRIPTION
Replacing PR #2604 for a more generalize approach as asked.

# PR Details
Canvas can provides children with Infinity values for `availableSizeWithMargins` when measuring. Most `UIElement`s handle Infinity in `MeasureOverride`. For UIElments that do not handle Infinity, an Infinity check was added to UIElement.Measure as a default behavior to check for Parent.RenderSize recursively in `InfinityToParentRenderSize`. 

This was done recursively in since the `Arrange` happens after `Measure`, and  `Arrange` is when RenderSize is normally set except for the root element RenderSize is set earlier. 

Note on UIElments Stretch:
I have tested UIElements like Canvas inside of another Canvas and currently the second Canvas size is set to 0. This appears to be caused by `childrenDesiredSize` being set to `NaN` then being replace in `Measure` with a size of 0. The recursion back to the root element in `InfinityToParentRenderSize` is never reached due to the second `Canvas` `childrenDesiredSize` is not set to infinity, so the parent s. Which means that the Stretch behavior is ignored due how the UI currently works. I choose to leave the recursion since it would allow for Stretch to behave as expected, rather than setting values to NaN, then to 0.

Fixing how the code is ignoring UIElement Stretch seemed to me to be scopecreep. I did not want to ignore the structure of the code by having the `InfinityToParentRenderSize` only look back one parent.

## Related Issue

https://github.com/stride3d/stride/issues/2236

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**
