### PR TITLE
fix: TransformProcessor.cs - Correct method name typo

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Processors/TransformProcessor.cs
+++ b/sources/engine/Stride.Engine/Engine/Processors/TransformProcessor.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using Stride.Core.Collections;
 using Stride.Core.Threading;
@@ -135,20 +133,20 @@ namespace Stride.Engine.Processors
             var sceneInstance = EntityManager as SceneInstance;
             if (sceneInstance?.RootScene != null)
             {
-                UpdateTransfromationsRecursive(sceneInstance.RootScene);
+                UpdateTransformationsRecursive(sceneInstance.RootScene);
             }
 
             // Special roots are already filtered out
             UpdateTransformations(notSpecialRootComponents);
         }
 
-        private static void UpdateTransfromationsRecursive(Scene scene)
+        private static void UpdateTransformationsRecursive(Scene scene)
         {
             scene.UpdateWorldMatrixInternal(false);
 
             foreach (var childScene in scene.Children)
             {
-                UpdateTransfromationsRecursive(childScene);
+                UpdateTransformationsRecursive(childScene);
             }
         }
         


### PR DESCRIPTION
# PR Details

This PR fixes a typo.

- Fixed a typo in the method name from `UpdateTransfromationsRecursive()` to `UpdateTransformationsRecursive()` in `TransformProcessor.cs`.
- Namespaces removed

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
