### PR TITLE
fix: Bepu, fix constraint tracking

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -456,8 +456,11 @@ public class BodyComponent : CollidableComponent
 
         if (BoundConstraints is not null)
         {
-            foreach (var constraint in BoundConstraints)
-                constraint.TryReattachConstraint();
+            // Reverse for loop as the constraints remove themselves from this list
+            for (int i = BoundConstraints.Count - 1; i >= 0; i--)
+            {
+                BoundConstraints[i].TryReattachConstraint();
+            }
         }
     }
 


### PR DESCRIPTION
# PR Details
Constraints bound to bodies were appended twice, once when setting `Body.A` and another when the constraint is added to the scene. This does not cause issues, just wasted cycles and the list having twice as many items as expected

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
