### PR TITLE
feat: NuGet resolution & start from new Launcher

### DIFF
--- a/build/Stride.sln
+++ b/build/Stride.sln
@@ -1857,6 +1857,7 @@ Global
 		SolutionGuid = {FF877973-604D-4EA7-B5F5-A129961F9EF2}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\sources\shared\Stride.NuGetResolver.Targets\Stride.NuGetResolver.Targets.projitems*{19838bc4-e889-422b-b234-b94a3996a4aa}*SharedItemsImports = 5
 		..\sources\assets\Stride.Core.Assets.Yaml\Stride.Core.Assets.Yaml.projitems*{1e54a9a2-4439-4444-ae57-6d2ed3c0dc47}*SharedItemsImports = 5
 		..\sources\shared\Stride.Core.ShellHelper\Stride.Core.ShellHelper.projitems*{1e54a9a2-4439-4444-ae57-6d2ed3c0dc47}*SharedItemsImports = 5
 		..\sources\shared\Stride.NuGetResolver.Targets\Stride.NuGetResolver.Targets.projitems*{2fc40214-a4aa-45dc-9c93-72ed800c40b0}*SharedItemsImports = 5

--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -450,7 +450,7 @@ public partial class NugetStore : INugetDownloadProgress
     /// </summary>
     /// <remarks>It is safe to call it concurrently be cause we operations are done using the FileLock.</remarks>
     /// <param name="package">Package to uninstall.</param>
-    public async Task UninstallPackage(NugetPackage package, ProgressReport progress)
+    public async Task UninstallPackage(NugetPackage package, ProgressReport? progress)
     {
 #if DEBUG
         var installedPackages = GetPackagesInstalled([package.Id]);

--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -143,11 +143,13 @@ public partial class NugetStore : INugetDownloadProgress
     /// List of package Ids under which the main package is known. Usually just one entry, but
     /// we could have several in case there is a product name change.
     /// </summary>
-    public IReadOnlyCollection<string> MainPackageIds { get; } = ["Stride.GameStudio", "Xenko.GameStudio", "Xenko"];
+    // FIXME xplat-editor these names should be parameterized and given to the constructor
+    public IReadOnlyCollection<string> MainPackageIds { get; } = ["Stride.GameStudio.Avalonia.Desktop", "Stride.GameStudio", "Xenko.GameStudio", "Xenko"];
 
     /// <summary>
     /// Package Id of the Visual Studio Integration plugin.
     /// </summary>
+    // FIXME xplat-editor this name should be parameterized and given to the constructor
     public string VsixPackageId { get; } = "Stride.VisualStudio.Package";
 
     /// <summary>

--- a/sources/assets/Stride.Core.Packages/ProgressReport.cs
+++ b/sources/assets/Stride.Core.Packages/ProgressReport.cs
@@ -10,7 +10,7 @@ public class ProgressReport : IDisposable
     private ProgressAction action;
     private int progress;
 
-    public ProgressReport(NugetStore store, NugetPackage package)
+    public ProgressReport(NugetStore store, NugetPackage? package)
     {
         ArgumentNullException.ThrowIfNull(store);
         this.store = store;

--- a/sources/editor/Stride.GameStudio.Avalonia.Desktop/Module.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia.Desktop/Module.cs
@@ -9,7 +9,23 @@ internal static class Module
     public static void Initialize()
     {
         // Override import resolution for Avalonia native dependencies
-        NativeLibrary.SetDllImportResolver(typeof(HarfBuzzSharp.ContentType).Assembly, (name, _, _) => NativeLibraryHelper.PreloadLibrary(name, typeof(HarfBuzzSharp.ContentType)));
-        NativeLibrary.SetDllImportResolver(typeof(SkiaSharp.GRBackend).Assembly, (name, _, _) => NativeLibraryHelper.PreloadLibrary(name, typeof(SkiaSharp.GRBackend)));
+        OverrideImportResolution<HarfBuzzSharp.ContentType>();
+        OverrideImportResolution<SkiaSharp.GRBackend>();
+        return;
+
+        static void OverrideImportResolution<T>()
+        {
+            NativeLibrary.SetDllImportResolver(typeof(T).Assembly, (name, _, _) =>
+            {
+                try
+                {
+                    return NativeLibraryHelper.PreloadLibrary(name, typeof(T));
+                }
+                catch (Exception)
+                {
+                    return nint.Zero;
+                }
+            });
+        }
     }
 }

--- a/sources/editor/Stride.GameStudio.Avalonia.Desktop/Module.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia.Desktop/Module.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+using Stride.Core;
+
+namespace Stride.GameStudio.Avalonia.Desktop;
+
+internal static class Module
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        // Override import resolution for Avalonia native dependencies
+        NativeLibrary.SetDllImportResolver(typeof(HarfBuzzSharp.ContentType).Assembly, (name, _, _) => NativeLibraryHelper.PreloadLibrary(name, typeof(HarfBuzzSharp.ContentType)));
+        NativeLibrary.SetDllImportResolver(typeof(SkiaSharp.GRBackend).Assembly, (name, _, _) => NativeLibraryHelper.PreloadLibrary(name, typeof(SkiaSharp.GRBackend)));
+    }
+}

--- a/sources/editor/Stride.GameStudio.Avalonia.Desktop/Stride.GameStudio.Avalonia.Desktop.csproj
+++ b/sources/editor/Stride.GameStudio.Avalonia.Desktop/Stride.GameStudio.Avalonia.Desktop.csproj
@@ -1,11 +1,13 @@
-<Project>
+﻿<Project>
   <Import Project="..\..\targets\Stride.props" />
 
   <PropertyGroup>
     <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+    <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <StrideNuGetResolverUI>false</StrideNuGetResolverUI>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,5 +45,6 @@
     <Compile Include="..\..\launcher\Stride.Launcher\Crash\CrashReportWindow.axaml.cs" Link="Crash\CrashReportWindow.axaml.cs" />
   </ItemGroup>
 
+  <Import Project="..\..\shared\Stride.NuGetResolver.Targets\Stride.NuGetResolver.Targets.projitems" Label="Shared" />
   <Import Project="$(StrideSdkTargets)" />
 </Project>

--- a/sources/launcher/Stride.Launcher/App.axaml.cs
+++ b/sources/launcher/Stride.Launcher/App.axaml.cs
@@ -31,7 +31,7 @@ public partial class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = MainWindow = new MainWindow
+            desktop.MainWindow = MainWindow = new()
             {
                 DataContext = InitializeMainViewModel()
             };
@@ -50,7 +50,7 @@ public partial class App : Application
 
     private static MainViewModel InitializeMainViewModel()
     {
-        return new MainViewModel(InitializeServiceProvider());
+        return new(InitializeServiceProvider());
     }
 
     private static IViewModelServiceProvider InitializeServiceProvider()

--- a/sources/launcher/Stride.Launcher/Constants.cs
+++ b/sources/launcher/Stride.Launcher/Constants.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Launcher;
+
+internal struct Names
+{
+    public const string GameStudio = nameof(GameStudio);
+    public const string Stride = nameof(Stride);
+    public const string Xenko = nameof(Xenko);
+}
+
+internal struct GameStudioNames
+{
+    public const string Stride = $"{Names.Stride}.{Names.GameStudio}";
+    public const string StrideAvalonia = $"{Names.Stride}.{Names.GameStudio}.Avalonia.Desktop";
+    public const string Xenko = $"{Names.Xenko}.{Names.GameStudio}";
+}

--- a/sources/launcher/Stride.Launcher/Crash/CrashReportViewModel.cs
+++ b/sources/launcher/Stride.Launcher/Crash/CrashReportViewModel.cs
@@ -16,7 +16,6 @@ internal sealed class CrashReportViewModel : ViewModelBase
     private readonly string applicationName;
     private readonly CancellationTokenSource exitToken;
     private readonly Func<string?, Task> setClipboard;
-    private readonly CrashReportData report;
 
     private bool isReportVisible;
 
@@ -31,7 +30,7 @@ internal sealed class CrashReportViewModel : ViewModelBase
         ServiceProvider.RegisterService(dispatcher);
         ServiceProvider.RegisterService(new DialogService(dispatcher) { ApplicationName = applicationName });
 
-        report = ComputeReport(args);
+        Report = ComputeReport(args);
 
         CopyReportCommand = new AnonymousTaskCommand(ServiceProvider, OnCopyReport);
         CloseCommand = new AnonymousCommand(ServiceProvider, OnClose);
@@ -47,10 +46,7 @@ internal sealed class CrashReportViewModel : ViewModelBase
         set => SetValue(ref isReportVisible, value);
     }
 
-    public CrashReportData Report
-    {
-        get => report;
-    }
+    public CrashReportData Report { get; }
 
     public ICommandBase CopyReportCommand { get; }
     public ICommandBase CloseCommand { get; }
@@ -93,7 +89,7 @@ internal sealed class CrashReportViewModel : ViewModelBase
 
     private CrashReportData ComputeReport(CrashReportArgs args)
     {
-        return new CrashReportData
+        return new()
         {
             ["Application"] = applicationName,
             ["ThreadName"] = args.ThreadName,

--- a/sources/launcher/Stride.Launcher/Crash/CrashReportWindow.axaml
+++ b/sources/launcher/Stride.Launcher/Crash/CrashReportWindow.axaml
@@ -20,7 +20,7 @@
                Width="64" Margin="0,0,8,8"
                Source="/Assets/CrashReportImage.png"/>
         <TextBlock TextWrapping="WrapWithOverflow">
-          Unfortunately, <Run Text="{Binding ApplicationName}" /> has crashed.
+          Unfortunately, <Run Text="{Binding ApplicationName, Mode=OneWay}" /> has crashed.
           Please help us improve Stride by sending information about this crash through Github Issues.
         </TextBlock>
       </DockPanel>

--- a/sources/launcher/Stride.Launcher/PackageFilterExtensions.cs
+++ b/sources/launcher/Stride.Launcher/PackageFilterExtensions.cs
@@ -6,13 +6,13 @@ using Stride.Core.Packages;
 
 namespace Stride.Launcher;
 
-static class PackageFilterExtensions
+internal static class PackageFilterExtensions
 {
     public static IEnumerable<T> FilterStrideMainPackages<T>(this IEnumerable<T> packages) where T : NugetPackage
     {
         // Stride up to 3.0 package is Xenko, 3.x is Xenko.GameStudio, then Stride.GameStudio
-        return packages.Where(x => (x.Id == "Xenko" && x.Version < new PackageVersion(3, 1, 0, 0))
-                                || (x.Id == "Xenko.GameStudio" && x.Version < new PackageVersion(4, 0, 0, 0))
-                                || (x.Id == "Stride.GameStudio"));
+        return packages.Where(x => (x.Id is Names.Xenko && x.Version < new PackageVersion(3, 1, 0, 0))
+                                || (x.Id is GameStudioNames.Xenko && x.Version < new PackageVersion(4, 0, 0, 0))
+                                || (x.Id is GameStudioNames.Stride or GameStudioNames.StrideAvalonia));
     }
 }

--- a/sources/launcher/Stride.Launcher/Program.cs
+++ b/sources/launcher/Stride.Launcher/Program.cs
@@ -50,7 +50,7 @@ internal sealed class Program
             Dispatcher.UIThread.Invoke(() =>
             {
                 // First hide the main window
-                ((IClassicDesktopStyleApplicationLifetime?)Application.Current?.ApplicationLifetime)?.MainWindow?.Hide();
+                ((IClassicDesktopStyleApplicationLifetime?)Application.Current.ApplicationLifetime)?.MainWindow?.Hide();
                                 
                 var app = appBuilder.Instance!;
                 app.Run(appMain((TApp)app));

--- a/sources/launcher/Stride.Launcher/Services/GameStudioSettings.cs
+++ b/sources/launcher/Stride.Launcher/Services/GameStudioSettings.cs
@@ -83,7 +83,7 @@ public static class GameStudioSettings
         List<UFile> result;
         lock (LockObject)
         {
-            result = new List<UFile>(mostRecentlyUsed ?? Enumerable.Empty<UFile>());
+            result = new(mostRecentlyUsed ?? Enumerable.Empty<UFile>());
         }
         return result;
     }

--- a/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
+++ b/sources/launcher/Stride.Launcher/Stride.Launcher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <OutputType Condition="'$(Configuration)' == 'Debug'">Exe</OutputType>
@@ -18,6 +18,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/launcher/Stride.Launcher/ViewModels/DocumentationPageViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/DocumentationPageViewModel.cs
@@ -13,118 +13,118 @@ namespace Stride.Launcher.ViewModels;
 public sealed partial class DocumentationPageViewModel : DispatcherViewModel
 {
     private static readonly Regex ParsingRegex = GetParsingRegex();
-        private static readonly HttpClient httpClient = new();
-        private const string DocPageScheme = "page:";
-        private const string PageUrlFormatString = "{0}{1}";
+    private static readonly HttpClient httpClient = new();
+    private const string DocPageScheme = "page:";
+    private const string PageUrlFormatString = "{0}{1}";
 
-        public DocumentationPageViewModel(IViewModelServiceProvider serviceProvider, string version)
-            : base(serviceProvider)
+    public DocumentationPageViewModel(IViewModelServiceProvider serviceProvider, string version)
+        : base(serviceProvider)
+    {
+        Version = version;
+        OpenUrlCommand = new AnonymousTaskCommand(ServiceProvider, OpenUrl);
+    }
+
+    private async Task OpenUrl()
+    {
+        try
         {
-            Version = version;
-            OpenUrlCommand = new AnonymousTaskCommand(ServiceProvider, OpenUrl);
+            Process.Start(new ProcessStartInfo(Url) { UseShellExecute = true });
         }
-
-        private async Task OpenUrl()
+        catch (Exception)
         {
-            try
-            {
-                Process.Start(new ProcessStartInfo(Url) { UseShellExecute = true });
-            }
-            catch (Exception)
-            {
             await ServiceProvider.Get<IDialogService>().MessageBoxAsync(Strings.ErrorOpeningBrowser, MessageBoxButton.OK, MessageBoxImage.Error);
-            }
         }
+    }
 
-        /// <summary>
-        /// Gets the root url of the documentation that should be opened when the user want to open Stride help.
-        /// </summary>
-        public string DocumentationRootUrl => GetDocumentationRootUrl(Version);
+    /// <summary>
+    /// Gets the root url of the documentation that should be opened when the user want to open Stride help.
+    /// </summary>
+    public string DocumentationRootUrl => GetDocumentationRootUrl(Version);
 
-        /// <summary>
-        /// Gets the version related to this documentation page.
-        /// </summary>
-        public string Version { get; }
+    /// <summary>
+    /// Gets the version related to this documentation page.
+    /// </summary>
+    public string Version { get; }
 
-        /// <summary>
-        /// Gets or sets the title of this documentation page.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the title of this documentation page.
+    /// </summary>
     public string? Title { get; set; }
 
-        /// <summary>
-        /// Gets or sets the description of this documentation page.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the description of this documentation page.
+    /// </summary>
     public string? Description { get; set; }
 
-        /// <summary>
-        /// Gets or sets the url of this documentation page.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the url of this documentation page.
+    /// </summary>
     public string? Url { get; set; }
 
-        /// <summary>
-        /// Gets a command that will open the documentation page in the default web browser.
-        /// </summary>
-        public ICommandBase OpenUrlCommand { get; private set; }
+    /// <summary>
+    /// Gets a command that will open the documentation page in the default web browser.
+    /// </summary>
+    public ICommandBase OpenUrlCommand { get; private set; }
 
-        public static async Task<List<DocumentationPageViewModel>> FetchGettingStartedPages(IViewModelServiceProvider serviceProvider, string version)
+    public static async Task<List<DocumentationPageViewModel>> FetchGettingStartedPages(IViewModelServiceProvider serviceProvider, string version)
+    {
+        var result = new List<DocumentationPageViewModel>();
+        string urlData;
+        try
         {
-            var result = new List<DocumentationPageViewModel>();
-            string urlData;
-            try
-            {
-                using var response = await httpClient.GetAsync(string.Format(Urls.GettingStarted, version));
-                response.EnsureSuccessStatusCode();
-                urlData = await response.Content.ReadAsStringAsync();
+            using var response = await httpClient.GetAsync(string.Format(Urls.GettingStarted, version));
+            response.EnsureSuccessStatusCode();
+            urlData = await response.Content.ReadAsStringAsync();
 
             if (urlData is null)
-                {
-                    return result;
-                }
-                var urls = urlData.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var url in urls)
-                {
-                    var match = ParsingRegex.Match(url);
-                    if (!match.Success || match.Groups.Count != 4)
-                    {
-                        continue;
-                    }
-                    var link = match.Groups[3].Value;
-                    if (link.StartsWith(DocPageScheme))
-                    {
-                        link = GetDocumentationPageUrl(version, link.Substring(DocPageScheme.Length));
-                    }
-                    var page = new DocumentationPageViewModel(serviceProvider, version)
-                    {
-                        Title = match.Groups[1].Value.Trim(),
-                        Description = match.Groups[2].Value.Trim(),
-                        Url = link.Trim()
-                    };
-                    result.Add(page);
-                }
+            {
                 return result;
             }
-            catch (Exception)
+            var urls = urlData.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var url in urls)
             {
-                result.Clear();
+                var match = ParsingRegex.Match(url);
+                if (!match.Success || match.Groups.Count != 4)
+                {
+                    continue;
+                }
+                var link = match.Groups[3].Value;
+                if (link.StartsWith(DocPageScheme))
+                {
+                    link = GetDocumentationPageUrl(version, link.Substring(DocPageScheme.Length));
+                }
+                var page = new DocumentationPageViewModel(serviceProvider, version)
+                {
+                    Title = match.Groups[1].Value.Trim(),
+                    Description = match.Groups[2].Value.Trim(),
+                    Url = link.Trim()
+                };
+                result.Add(page);
             }
             return result;
         }
-
-        /// <summary>
-        /// Compute the url of a documentation page, given the page name.
-        /// </summary>
-        /// <param name="version">The version related to this documentation page.</param>
-        /// <param name="pageName">The name of the page.</param>
-        /// <returns>The complete url of the documentation page.</returns>
-        private static string GetDocumentationPageUrl(string version, string pageName)
+        catch (Exception)
         {
-            return string.Format(PageUrlFormatString, GetDocumentationRootUrl(version), pageName);
+            result.Clear();
         }
+        return result;
+    }
 
-        private static string GetDocumentationRootUrl(string version)
-        {
-            return string.Format(Urls.Documentation, version);
-        }
+    /// <summary>
+    /// Compute the url of a documentation page, given the page name.
+    /// </summary>
+    /// <param name="version">The version related to this documentation page.</param>
+    /// <param name="pageName">The name of the page.</param>
+    /// <returns>The complete url of the documentation page.</returns>
+    private static string GetDocumentationPageUrl(string version, string pageName)
+    {
+        return string.Format(PageUrlFormatString, GetDocumentationRootUrl(version), pageName);
+    }
+
+    private static string GetDocumentationRootUrl(string version)
+    {
+        return string.Format(Urls.Documentation, version);
+    }
 
     [GeneratedRegex(@"\{([^\{\}]+)\}\{([^\{\}]+)\}\{([^\{\}]+)\}")]
     private static partial Regex GetParsingRegex();

--- a/sources/launcher/Stride.Launcher/ViewModels/MainViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/MainViewModel.cs
@@ -109,7 +109,6 @@ public sealed class MainViewModel : DispatcherViewModel, IPackagesLogger, IDispo
         {
             if (SetValue(ref activeVersion, value))
             {
-                activeVersion?.UpdateSelectedFramework();
                 Dispatcher.InvokeAsync(() => StartStudioCommand.IsEnabled = value?.CanStart ?? false);
             }
         }
@@ -598,7 +597,6 @@ public sealed class MainViewModel : DispatcherViewModel, IPackagesLogger, IDispo
                     });
                     break;
             }
-
         }
         catch (Exception e)
         {

--- a/sources/launcher/Stride.Launcher/ViewModels/MainViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/MainViewModel.cs
@@ -423,11 +423,14 @@ public sealed class MainViewModel : DispatcherViewModel, IPackagesLogger, IDispo
             // Inform the user if we just switched offline
             if (IsOffline && !wasOffline)
             {
-                var message = $@"**{Strings.ErrorOfflineMode}**
-### Log
-```
-{LogMessages}
-```";
+                var message = 
+                    $"""
+                    **{Strings.ErrorOfflineMode}**
+                    ### Log
+                    ```
+                    {LogMessages}
+                    ```
+                    """;
                 await ServiceProvider.Get<IDialogService>().MessageBoxAsync(message, MessageBoxButton.OK, MessageBoxImage.Information);
             }
 
@@ -578,7 +581,24 @@ public sealed class MainViewModel : DispatcherViewModel, IPackagesLogger, IDispo
             var mainExecutable = ActiveVersion.LocateMainExecutable();
 
             // We set the WorkingDirectory so that global.json is properly resolved
-            Process.Start(new ProcessStartInfo(mainExecutable, argument) { WorkingDirectory = Path.GetDirectoryName(mainExecutable) });
+            switch (Path.GetExtension(mainExecutable))
+            {
+                case ".dll":
+                    argument = $"{mainExecutable} {argument}";
+                    Process.Start(new ProcessStartInfo("dotnet", argument)
+                    {
+                        WorkingDirectory = Path.GetDirectoryName(mainExecutable)
+                    });
+                    break;
+
+                default:
+                    Process.Start(new ProcessStartInfo(mainExecutable, argument)
+                    {
+                        WorkingDirectory = Path.GetDirectoryName(mainExecutable)
+                    });
+                    break;
+            }
+
         }
         catch (Exception e)
         {

--- a/sources/launcher/Stride.Launcher/ViewModels/MainViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/MainViewModel.cs
@@ -422,7 +422,7 @@ public sealed class MainViewModel : DispatcherViewModel, IPackagesLogger, IDispo
             // Inform the user if we just switched offline
             if (IsOffline && !wasOffline)
             {
-                var message = 
+                var message =
                     $"""
                     **{Strings.ErrorOfflineMode}**
                     ### Log
@@ -652,21 +652,31 @@ public sealed class MainViewModel : DispatcherViewModel, IPackagesLogger, IDispo
 
     public static bool HasDoneTask(string taskName)
     {
-        var localMachine32 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32);
-        using var subkey = localMachine32.OpenSubKey(@"SOFTWARE\Stride\");
-        if (subkey is not null)
+        // FIXME xplat-editor get that information from a config file on Linux (e.g. under /etc) and MacOS
+        if (OperatingSystem.IsWindows())
         {
-            var value = (string?)subkey.GetValue(taskName);
-            return value is not null && value.ToLowerInvariant() == "true";
+            var localMachine32 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32);
+            using var subkey = localMachine32.OpenSubKey(@"SOFTWARE\Stride\");
+            if (subkey is not null)
+            {
+                var value = (string?)subkey.GetValue(taskName);
+                return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
         }
-        return false;
+
+        return true;
     }
 
     public static void SaveTaskAsDone(string taskName)
     {
-        var localMachine32 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32);
-        using var subkey = localMachine32.CreateSubKey(@"SOFTWARE\Stride\");
-        subkey?.SetValue(taskName, "True");
+        // FIXME xplat-editor store that information to a config file on Linux (e.g. under /etc) and MacOS
+        if (OperatingSystem.IsWindows())
+        {
+            var localMachine32 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32);
+            using var subkey = localMachine32.CreateSubKey(@"SOFTWARE\Stride\");
+            subkey?.SetValue(taskName, "True");
+        }
     }
 
     private void DisplayReleaseAnnouncement()

--- a/sources/launcher/Stride.Launcher/ViewModels/NewsPageViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/NewsPageViewModel.cs
@@ -13,98 +13,98 @@ namespace Stride.Launcher.ViewModels;
 
 public sealed class NewsPageViewModel : DispatcherViewModel
 {
-        private static readonly HttpClient httpClient = new();
+    private static readonly HttpClient httpClient = new();
 
-        public NewsPageViewModel(IViewModelServiceProvider serviceProvider)
-            : base(serviceProvider)
-        {
-            OpenUrlCommand = new AnonymousTaskCommand(ServiceProvider, OpenUrl);
-        }
+    public NewsPageViewModel(IViewModelServiceProvider serviceProvider)
+        : base(serviceProvider)
+    {
+        OpenUrlCommand = new AnonymousTaskCommand(ServiceProvider, OpenUrl);
+    }
 
-        private async Task OpenUrl()
-        {
+    private async Task OpenUrl()
+    {
         if (Url is null) return;
 
-            try
-            {
-                Process.Start(new ProcessStartInfo(Url) { UseShellExecute = true });
-            }
-            catch (Exception)
-            {
-            await ServiceProvider.Get<IDialogService>().MessageBoxAsync(Strings.ErrorOpeningBrowser, MessageBoxButton.OK, MessageBoxImage.Error);
-            }
+        try
+        {
+            Process.Start(new ProcessStartInfo(Url) { UseShellExecute = true });
         }
+        catch (Exception)
+        {
+            await ServiceProvider.Get<IDialogService>().MessageBoxAsync(Strings.ErrorOpeningBrowser, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
 
-        /// <summary>
-        /// Gets or sets the title of this documentation page.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the title of this documentation page.
+    /// </summary>
     public string? Title { get; set; }
 
-        /// <summary>
-        /// Gets or sets the description of this documentation page.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the description of this documentation page.
+    /// </summary>
     public string? Description { get; set; }
 
-        /// <summary>
-        /// Gets or sets the url of this documentation page.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the url of this documentation page.
+    /// </summary>
     public string? Url { get; set; }
 
-        /// <summary>
-        /// Gets or sets the url of this documentation page.
-        /// </summary>
-        public DateTime Date { get; set; }
+    /// <summary>
+    /// Gets or sets the url of this documentation page.
+    /// </summary>
+    public DateTime Date { get; set; }
 
-        /// <summary>
-        /// Gets a command that will open the documentation page in the default web browser.
-        /// </summary>
-        public ICommandBase OpenUrlCommand { get; private set; }
+    /// <summary>
+    /// Gets a command that will open the documentation page in the default web browser.
+    /// </summary>
+    public ICommandBase OpenUrlCommand { get; private set; }
 
-        public static async Task<List<NewsPageViewModel>> FetchNewsPages(IViewModelServiceProvider serviceProvider, int maxCount)
+    public static async Task<List<NewsPageViewModel>> FetchNewsPages(IViewModelServiceProvider serviceProvider, int maxCount)
+    {
+        var result = new List<NewsPageViewModel>();
+        try
         {
-            var result = new List<NewsPageViewModel>();
-            try
+            using var response = await httpClient.GetAsync(Urls.RssFeed);
+            response.EnsureSuccessStatusCode();
+            var rss = await response.Content.ReadAsStreamAsync();
+
+            if (rss.Length == 0)
+                return result;
+
+            int count = 0;
+            using XmlReader rssReader = XmlReader.Create(rss, new XmlReaderSettings { Async = true });
+            await rssReader.MoveToContentAsync();
+            while (rssReader.ReadToFollowing("item") && count < maxCount)
             {
-                using var response = await httpClient.GetAsync(Urls.RssFeed);
-                response.EnsureSuccessStatusCode();
-                var rss = await response.Content.ReadAsStreamAsync();
-
-                if (rss.Length == 0)
-                    return result;
-
-                int count = 0;
-                using XmlReader rssReader = XmlReader.Create(rss);
-                rssReader.MoveToContent();
-                while (rssReader.ReadToFollowing("item") && count < maxCount)
-                {
-                    rssReader.ReadToFollowing("title");
-                    string title = rssReader.Read() ? rssReader.Value : null;
-                    rssReader.ReadToFollowing("description");
-                    string description = rssReader.Read() ? rssReader.Value : null;
-                    rssReader.ReadToFollowing("pubDate");
-                    var date = new DateTime();
-                    bool dateValid = rssReader.Read() && DateTime.TryParseExact(rssReader.Value, "ddd, dd MMM yyyy HH:mm:ss zz00", CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
-                    rssReader.ReadToFollowing("link");
-                    string link = rssReader.Read() ? rssReader.Value : null;
+                rssReader.ReadToFollowing("title");
+                string? title = await rssReader.ReadAsync() ? rssReader.Value : null;
+                rssReader.ReadToFollowing("description");
+                string? description = await rssReader.ReadAsync() ? rssReader.Value : null;
+                rssReader.ReadToFollowing("pubDate");
+                var date = new DateTime();
+                bool dateValid = await rssReader.ReadAsync() && DateTime.TryParseExact(rssReader.Value, "ddd, dd MMM yyyy HH:mm:ss zz00", CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
+                rssReader.ReadToFollowing("link");
+                string? link = await rssReader.ReadAsync() ? rssReader.Value : null;
                 if (dateValid && title is not null && link is not null && description is not null)
+                {
+                    var page = new NewsPageViewModel(serviceProvider)
                     {
-                        var page = new NewsPageViewModel(serviceProvider)
-                        {
-                            Title = title,
-                            Url = link,
-                            Description = description,
-                            Date = date
-                        };
-                        result.Add(page);
-                        ++count;
-                    }
+                        Title = title,
+                        Url = link,
+                        Description = description,
+                        Date = date
+                    };
+                    result.Add(page);
+                    ++count;
                 }
             }
-            catch (Exception)
-            {
-                result.Clear();
-            }
-
-            return result;
         }
+        catch (Exception)
+        {
+            result.Clear();
+        }
+
+        return result;
+    }
 }

--- a/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/PackageVersionViewModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp) 
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Diagnostics;
 using Stride.Core.Extensions;
 using Stride.Core.Packages;
 using Stride.Core.Presentation.Commands;
@@ -15,8 +16,8 @@ namespace Stride.Launcher.ViewModels;
 /// </summary>
 public abstract class PackageVersionViewModel : DispatcherViewModel
 {
-    protected NugetLocalPackage LocalPackage;
-    protected NugetServerPackage ServerPackage;
+    protected NugetLocalPackage? LocalPackage;
+    protected NugetServerPackage? ServerPackage;
     private ProgressAction currentProgressAction;
     private int currentProgress;
     private bool isProcessing;
@@ -30,7 +31,7 @@ public abstract class PackageVersionViewModel : DispatcherViewModel
     /// <param name="launcher">The parent <see cref="MainViewModel"/> instance.</param>
     /// <param name="store">The related <see cref="NugetStore"/> instance.</param>
     /// <param name="localPackage">The local package of this version, if a local package exists.</param>
-    internal PackageVersionViewModel(MainViewModel launcher, NugetStore store, NugetLocalPackage localPackage)
+    internal PackageVersionViewModel(MainViewModel launcher, NugetStore store, NugetLocalPackage? localPackage)
         : base(launcher.SafeArgument(nameof(launcher)).ServiceProvider)
     {
         ArgumentNullException.ThrowIfNull(launcher);
@@ -176,6 +177,7 @@ public abstract class PackageVersionViewModel : DispatcherViewModel
         return Task.Run(async () =>
         {
             IsProcessing = true;
+            Debug.Assert(ServerPackage is not null);
 
             // Uninstall previous version first, if it exists
             if (LocalPackage is not null)
@@ -279,6 +281,7 @@ public abstract class PackageVersionViewModel : DispatcherViewModel
     private async Task DeleteInternal(bool displayErrorMessage)
     {
         IsProcessing = true;
+        Debug.Assert(LocalPackage is not null);
         try
         {
             using var progressReport = new ProgressReport(Store, ServerPackage);

--- a/sources/launcher/Stride.Launcher/ViewModels/StrideStoreVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/StrideStoreVersionViewModel.cs
@@ -100,7 +100,7 @@ public sealed class StrideStoreVersionViewModel : StrideVersionViewModel
     /// Updates the local package of this version.
     /// </summary>
     /// <param name="package">The local package corresponding to this version.</param>
-    internal void UpdateLocalPackage(NugetLocalPackage package, IEnumerable<NugetLocalPackage>? alternateVersions)
+    internal void UpdateLocalPackage(NugetLocalPackage? package, IEnumerable<NugetLocalPackage>? alternateVersions)
     {
         OnPropertyChanging(nameof(FullName), nameof(Version));
         LocalPackage = package;

--- a/sources/launcher/Stride.Launcher/ViewModels/StrideStoreVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/StrideStoreVersionViewModel.cs
@@ -29,7 +29,7 @@ public sealed class StrideStoreVersionViewModel : StrideVersionViewModel
     /// <param name="localPackage"></param>
     /// <param name="major"></param>
     /// <param name="minor"></param>
-    internal StrideStoreVersionViewModel(MainViewModel launcher, NugetStore store, NugetLocalPackage localPackage, string packageId, int major, int minor)
+    internal StrideStoreVersionViewModel(MainViewModel launcher, NugetStore store, NugetLocalPackage? localPackage, string packageId, int major, int minor)
         : base(launcher, store, localPackage, packageId, major, minor)
     {
         FetchReleaseNotes();
@@ -119,7 +119,7 @@ public sealed class StrideStoreVersionViewModel : StrideVersionViewModel
                 });
             });
         }
-        Dispatcher.Invoke(() => UpdateFrameworks());
+        Dispatcher.Invoke(UpdateFrameworks);
     }
 
     /// <summary>
@@ -165,7 +165,7 @@ public sealed class StrideStoreVersionViewModel : StrideVersionViewModel
             if (index < 0)
             {
                 // If not, add it
-                alternateVersionViewModel = new StrideStoreAlternateVersionViewModel(this);
+                alternateVersionViewModel = new(this);
                 AlternateVersions.Add(alternateVersionViewModel);
             }
             else
@@ -206,7 +206,7 @@ public sealed class StrideStoreVersionViewModel : StrideVersionViewModel
                 try
                 {
                     var prerequisitesInstallerProcess = Process.Start(prerequisitesInstallerPath);
-                    prerequisitesInstallerProcess?.WaitForExit();
+                    await prerequisitesInstallerProcess?.WaitForExitAsync();
                     prerequisitesInstalled = true;
                 }
                 catch
@@ -280,14 +280,14 @@ public sealed class StrideStoreVersionViewModel : StrideVersionViewModel
     internal async void FetchDocumentation()
     {
         var pages = await DocumentationPageViewModel.FetchGettingStartedPages(ServiceProvider, $"{Major}.{Minor}");
-        Dispatcher.Invoke(() => { DocumentationPages.Clear(); DocumentationPages.AddRange(pages); });
+        await Dispatcher.InvokeAsync(() => { DocumentationPages.Clear(); DocumentationPages.AddRange(pages); });
     }
 
     internal void FetchReleaseNotes()
     {
         Dispatcher.Invoke(() =>
         {
-            ReleaseNotes = new ReleaseNotesViewModel(Launcher, $"{Major}.{Minor}");
+            ReleaseNotes = new(Launcher, $"{Major}.{Minor}");
             ReleaseNotes.FetchReleaseNotes();
         });
     }

--- a/sources/launcher/Stride.Launcher/ViewModels/StrideVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/StrideVersionViewModel.cs
@@ -22,7 +22,7 @@ public abstract class StrideVersionViewModel : PackageVersionViewModel, ICompara
     private bool canStart;
     private string selectedFramework;
 
-    internal StrideVersionViewModel(MainViewModel launcher, NugetStore store, NugetLocalPackage localPackage, string packageId, int major, int minor)
+    internal StrideVersionViewModel(MainViewModel launcher, NugetStore store, NugetLocalPackage? localPackage, string packageId, int major, int minor)
         : base(launcher, store, localPackage)
     {
         PackageSimpleName = packageId.Replace(".GameStudio", string.Empty);
@@ -201,7 +201,7 @@ public abstract class StrideVersionViewModel : PackageVersionViewModel, ICompara
 
         // Otherwise, old-style fallback
         var mainExecutableList = GetMainExecutables();
-        var fullExePath = mainExecutableList.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => Path.Combine(InstallPath, x)).FirstOrDefault(File.Exists);
+        var fullExePath = mainExecutableList.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(x => Path.Combine(InstallPath, x)).FirstOrDefault(File.Exists);
         if (fullExePath is null)
             throw new InvalidOperationException("Unable to locate the executable for the selected version");
 

--- a/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
+++ b/sources/launcher/Stride.Launcher/ViewModels/VsixVersionViewModel.cs
@@ -57,7 +57,7 @@ public sealed class VsixVersionViewModel : PackageVersionViewModel
     {
         Dispatcher.Invoke(() => Status = FormatStatus(Strings.ReportChecking));
         await UpdateVersionsFromStore();
-        Dispatcher.Invoke(UpdateStatus);
+        await Dispatcher.InvokeAsync(UpdateStatus);
     }
 
     /// <inheritdoc/>

--- a/sources/launcher/Stride.Launcher/Views/MainView.axaml
+++ b/sources/launcher/Stride.Launcher/Views/MainView.axaml
@@ -445,9 +445,9 @@
                                 </Button>
                                 <TextBlock Margin="16,0" IsHitTestVisible="False"
                                            HorizontalAlignment="Left" VerticalAlignment="Center">
-                                  <Run Text="{Binding DisplayName, StringFormat={x:Static l:Strings.VersionButton}}"/>
+                                  <Run Text="{Binding DisplayName, Mode=OneWay, StringFormat={x:Static l:Strings.VersionButton}}"/>
                                   <!-- Careful here, there must not be any space or line-break between the next two Run tags! -->
-                                  <Run Text="{Binding !CanDelete, Converter={sd:BoolToParam}, ConverterParameter={x:Static l:Strings.VersionButtonUninstalled}
+                                  <Run Text="{Binding !CanDelete, Mode=OneWay, Converter={sd:BoolToParam}, ConverterParameter={x:Static l:Strings.VersionButtonUninstalled}
                                        }"/><Run Text="{sd:MultiBinding {Binding CanDelete}, {Binding CanBeDownloaded}, {Binding IsLatestPackageRemote}, Converter={sd:MultiChained
                                        {sd:AndMulti}, {sd:BoolToParam}, Parameter1={x:Static l:Strings.VersionButtonUpdateAvailable}}}"/><Run Text="{sd:MultiBinding
                                        {Binding CanDelete}, {Binding CanBeDownloaded}, {Binding IsLatestPackageLocal}, Converter={sd:MultiChained {sd:AndMulti}, {sd:BoolToParam},

--- a/sources/launcher/Stride.Launcher/Views/MainView.axaml
+++ b/sources/launcher/Stride.Launcher/Views/MainView.axaml
@@ -387,7 +387,8 @@
                                 <Image Source="/Assets/Images/list.png"
                                        Width="20" Height="20" />
                               </ToggleButton>
-                              <Popup IsOpen="{Binding #Toggle.IsChecked, Mode=TwoWay}" IsLightDismissEnabled="True">
+                              <Popup x:Name="Popup"
+                                     IsOpen="{Binding #Toggle.IsChecked, Mode=TwoWay}" IsLightDismissEnabled="True">
                                 <Border Margin="4" Background="#434343">
                                   <Border.Effect>
                                     <DropShadowEffect BlurRadius="5" Opacity="0.4" />
@@ -401,7 +402,7 @@
                                                   HorizontalAlignment="Stretch" HorizontalContentAlignment="Left">
                                             <Interaction.Behaviors>
                                               <EventTriggerBehavior EventName="Click">
-                                                <ChangePropertyAction TargetObject="{Binding #Toggle}" PropertyName="IsChecked" Value="False" />
+                                                <ChangePropertyAction TargetObject="{Binding #Popup}" PropertyName="IsOpen" Value="False" />
                                               </EventTriggerBehavior>
                                             </Interaction.Behaviors>
                                           </Button>
@@ -468,7 +469,7 @@
                                   Content="{Binding}"
                                   Command="{Binding CheckDeprecatedSourcesCommand}">
                       <ToggleButton.ContentTemplate>
-                        <DataTemplate>
+                        <DataTemplate DataType="vm:MainViewModel">
                           <TextBlock Text="{x:Static l:Strings.ToggleShowBetaVersions}">
                             <Interaction.Behaviors>
                               <DataTriggerBehavior Binding="{Binding ShowBetaVersions}" Value="True">
@@ -535,7 +536,7 @@
                                         <ItemsControl.ItemTemplate>
                                           <DataTemplate DataType="{x:Type vm:StrideVersionViewModel}">
                                             <Button Content="{Binding DisplayName, StringFormat={x:Static l:Strings.OpenProjectWithVersion}}"
-                                                    Command="{Binding $parent[ScrollViewer].DataContext.OpenWithCommand}"
+                                                    Command="{Binding $parent[ScrollViewer].((vm:RecentProjectViewModel)DataContext).OpenWithCommand}"
                                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" />
                                           </DataTemplate>
                                         </ItemsControl.ItemTemplate>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Stride.Core.Presentation.Avalonia.csproj
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Stride.Core.Presentation.Avalonia.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/CheckedMessageBox.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/CheckedMessageBox.axaml
@@ -5,6 +5,7 @@
         xmlns:md="https://github.com/whistyun/Markdown.Avalonia.Tight"
         xmlns:cvt="using:Stride.Core.Presentation.Avalonia.Converters"
         xmlns:local="using:Stride.Core.Presentation.Windows"
+        xmlns:windows="using:Stride.Core.Presentation.Avalonia.Windows"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         MinHeight="120" MinWidth="320" MaxHeight="768"
         SizeToContent="WidthAndHeight" CanResize="False"
@@ -28,7 +29,7 @@
         <!--  buttons -->
         <ItemsControl DockPanel.Dock="Bottom"
                       HorizontalAlignment="Right"
-                      ItemsSource="{Binding $parent[Window].ButtonsSource}">
+                      ItemsSource="{Binding $parent[windows:MessageBox].ButtonsSource}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <UniformGrid Rows="1" />
@@ -38,7 +39,7 @@
             <DataTemplate DataType="{x:Type local:DialogButtonInfo}">
               <Button Margin="4,0" Padding="16,4" MinWidth="80"
                       HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                      Command="{Binding $parent[Window].ButtonCommand}"
+                      Command="{Binding $parent[windows:MessageBox].ButtonCommand}"
                       CommandParameter="{Binding Result}"
                       Content="{Binding Content}"
                       IsCancel="{Binding IsCancel}" IsDefault="{Binding IsDefault}" />
@@ -46,21 +47,21 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
         <!-- content -->
-        <ContentPresenter Content="{Binding}">
+        <ContentPresenter Content="{Binding $parent[ContentControl].Content}">
           <ContentPresenter.ContentTemplate>
             <DataTemplate>
               <DockPanel LastChildFill="True">
                 <CheckBox DockPanel.Dock="Bottom"
-                          Content="{Binding $parent[Window].CheckedMessage}"
-                          IsChecked="{Binding $parent[Window].IsChecked}"
+                          Content="{Binding $parent[windows:CheckedMessageBox].CheckedMessage}"
+                          IsChecked="{Binding $parent[windows:CheckedMessageBox].IsChecked}"
                           HorizontalAlignment="Left" VerticalAlignment="Bottom" 
                           Margin="0,12,0,4" />
                 <Image DockPanel.Dock="Left"
-                       Source="{Binding $parent[Window].Image}"
+                       Source="{Binding $parent[windows:MessageBox].Image}"
                        HorizontalAlignment="Left" VerticalAlignment="Top"
                        Height="32" Width="32" Margin="8,4"
-                       IsVisible="{Binding $parent[Window].Image, Converter={cvt:ObjectToBool}}" />
-                <md:MarkdownScrollViewer Markdown="{Binding}" VerticalAlignment="Center" />
+                       IsVisible="{Binding $parent[windows:MessageBox].Image, Converter={cvt:ObjectToBool}}" />
+                <md:MarkdownScrollViewer Markdown="{ReflectionBinding}" VerticalAlignment="Center" />
               </DockPanel>
             </DataTemplate>
           </ContentPresenter.ContentTemplate>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/MessageBox.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Windows/MessageBox.axaml
@@ -5,6 +5,7 @@
         xmlns:md="https://github.com/whistyun/Markdown.Avalonia.Tight"
         xmlns:cvt="using:Stride.Core.Presentation.Avalonia.Converters"
         xmlns:local="using:Stride.Core.Presentation.Windows"
+        xmlns:windows="using:Stride.Core.Presentation.Avalonia.Windows"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         MinHeight="120" MinWidth="320" MaxHeight="768"
         SizeToContent="WidthAndHeight" CanResize="False"
@@ -28,7 +29,7 @@
         <!--  buttons -->
         <ItemsControl DockPanel.Dock="Bottom"
                       HorizontalAlignment="Right"
-                      ItemsSource="{Binding $parent[Window].ButtonsSource}">
+                      ItemsSource="{Binding $parent[windows:MessageBox].ButtonsSource}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <UniformGrid Rows="1" />
@@ -38,7 +39,7 @@
             <DataTemplate DataType="{x:Type local:DialogButtonInfo}">
               <Button Margin="4,0" Padding="16,4" MinWidth="80"
                       HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                      Command="{Binding $parent[Window].ButtonCommand}"
+                      Command="{Binding $parent[windows:MessageBox].ButtonCommand}"
                       CommandParameter="{Binding Result}"
                       Content="{Binding Content}"
                       IsCancel="{Binding IsCancel}" IsDefault="{Binding IsDefault}" />
@@ -46,16 +47,16 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
         <!-- content -->
-        <ContentPresenter Content="{Binding}">
+        <ContentPresenter Content="{Binding $parent[ContentControl].Content}">
           <ContentPresenter.ContentTemplate>
             <DataTemplate>
               <DockPanel LastChildFill="True">
                 <Image DockPanel.Dock="Left"
-                       Source="{Binding $parent[Window].Image}"
+                       Source="{Binding $parent[windows:MessageBox].Image}"
                        HorizontalAlignment="Left" VerticalAlignment="Top"
                        Height="32" Width="32" Margin="4"
-                       IsVisible="{Binding $parent[Window].Image, Converter={cvt:ObjectToBool}}" />
-                <md:MarkdownScrollViewer Markdown="{Binding}" VerticalAlignment="Center" />
+                       IsVisible="{Binding $parent[windows:MessageBox].Image, Converter={cvt:ObjectToBool}}" />
+                <md:MarkdownScrollViewer Markdown="{ReflectionBinding}" VerticalAlignment="Center" />
               </DockPanel>
             </DataTemplate>
           </ContentPresenter.ContentTemplate>

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -257,7 +257,9 @@ public static partial class NuGetAssemblyResolver
         var registerDependencyMethod = nativeLibraryHelperType.GetMethod("RegisterDependency")
             ?? throw new InvalidOperationException($"Couldn't find method 'RegisterDependency' in {nativeLibraryHelperType}");
         foreach (var lib in nativeLibs)
+        {
             registerDependencyMethod.Invoke(null, [lib]);
+        } 
     }
 
     /// <summary>

--- a/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
+++ b/sources/shared/Stride.NuGetResolver/NuGetAssemblyResolver.cs
@@ -147,11 +147,13 @@ public static partial class NuGetAssemblyResolver
                             // Register the native libraries
                             var nativeLibs = RestoreHelper.ListNativeLibs(result.LockFile);
                             RegisterNativeDependencies(assemblyNameToPath, nativeLibs);
+                            // FIXME xplat-editor we should have a flag to determine whether native libraries need to be pre-loaded.
+                            // At the moment, we have an issue when using the new editor which forces us to preload all of them (not only Avalonia's native dependencies, but also ours like SDL).
+                            LoadNativeDependencies(assemblyNameToPath, nativeLibs);
 
 #if STRIDE_NUGET_RESOLVER_UI
                             if (packageName == AvaloniaPackageName)
                             {
-                                LoadNativeDependencies(assemblyNameToPath, nativeLibs);
                                 avaloniaLoaded.TrySetResult();
                             }
 #endif


### PR DESCRIPTION
# PR Details

Resolve and restore NuGet dependencies when launching the GameStudio from its package (for instance from the Launcher).

[08_LaunchingGameStudio.webm](https://github.com/user-attachments/assets/6b22fecb-98f3-4f45-9aba-437152475b59)

## Related issues

Contributes to #2767.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
