### PR TITLE
fix: Bepu, ctor with valid orientation for constraints

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/AngularServoConstraintComponent.cs
@@ -17,6 +17,7 @@ public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent
 {
     public AngularServoConstraintComponent() => BepuConstraint = new()
     {
+        TargetRelativeRotationLocalA = Quaternion.Identity,
         SpringSettings = new SpringSettings(30, 5),
         ServoSettings = new ServoSettings(10, 1, 1000)
     };

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IServo.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IServo.cs
@@ -8,7 +8,32 @@ namespace Stride.BepuPhysics.Constraints;
 /// </summary>
 public interface IServo
 {
+    /// <summary>
+    /// Maximum speed that the constraint can try to use to move towards the target.
+    /// </summary>
+    /// <userdoc>
+    /// Maximum speed that the constraint can try to use to move towards the target.
+    /// </userdoc>
     float ServoMaximumSpeed { get; set; }
+    /// <summary>
+    /// Minimum speed that the constraint will try to use to move towards the target.
+    /// If the speed implied by the spring configuration is higher than this, the servo will attempt to use the higher speed.
+    /// Will be clamped by the MaximumSpeed.
+    /// </summary>
+    /// <userdoc>
+    /// Minimum speed that the constraint will try to use to move towards the target.
+    /// If the speed implied by the spring configuration is higher than this, the servo will attempt to use the higher speed.
+    /// Will be clamped by the MaximumSpeed.
+    /// </userdoc>
     float ServoBaseSpeed { get; set; }
+    /// <summary>
+    /// The maximum force that the constraint can apply to move towards the target.
+    /// </summary>
+    /// <remarks>
+    /// This value is specified in terms of force: a change in momentum over time. It is approximated as a maximum impulse (an instantaneous change in momentum) on a per-substep basis. In other words, for a given velocity iteration, the constraint's impulse can be no larger than <see cref="MaximumForce"/> * dt where dt is the substep duration.
+    /// </remarks>
+    /// <userdoc>
+    /// The maximum force that the constraint can apply to move towards the target.
+    /// </userdoc>
     float ServoMaximumForce { get; set; }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/OneBodyAngularServoConstraintComponent.cs
@@ -30,6 +30,7 @@ public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintCo
 {
     public OneBodyAngularServoConstraintComponent() => BepuConstraint = new()
     {
+        TargetOrientation = Quaternion.Identity,
         ServoSettings = new ServoSettings(),
         SpringSettings = new SpringSettings(30, 5)
     };

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistLimitConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistLimitConstraintComponent.cs
@@ -15,7 +15,12 @@ namespace Stride.BepuPhysics.Constraints;
 [ComponentCategory("Physics - Bepu Constraint")]
 public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<TwistLimit>, ISpring
 {
-    public TwistLimitConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
+    public TwistLimitConstraintComponent() => BepuConstraint = new()
+    {
+        LocalBasisA = Quaternion.Identity,
+        LocalBasisB = Quaternion.Identity,
+        SpringSettings = new SpringSettings(30, 5)
+    };
 
     /// <summary>
     /// Local space basis attached to body A against which to measure body B's transformed axis.

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistServoConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/TwistServoConstraintComponent.cs
@@ -15,7 +15,13 @@ namespace Stride.BepuPhysics.Constraints;
 [ComponentCategory("Physics - Bepu Constraint")]
 public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<TwistServo>, IServo, ISpring
 {
-    public TwistServoConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5), ServoSettings = new ServoSettings(10, 1, 1000) };
+    public TwistServoConstraintComponent() => BepuConstraint = new()
+    {
+        LocalBasisA = Quaternion.Identity,
+        LocalBasisB = Quaternion.Identity,
+        SpringSettings = new SpringSettings(30, 5),
+        ServoSettings = new ServoSettings(10, 1, 1000)
+    };
 
     /// <summary>
     /// Local space basis attached to body A against which to measure body B's transformed axis.

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/WeldConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/WeldConstraintComponent.cs
@@ -15,7 +15,11 @@ namespace Stride.BepuPhysics.Constraints;
 [ComponentCategory("Physics - Bepu Constraint")]
 public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>, ISpring
 {
-    public WeldConstraintComponent() => BepuConstraint = new() { SpringSettings = new SpringSettings(30, 5) };
+    public WeldConstraintComponent() => BepuConstraint = new()
+    {
+        LocalOrientation = Quaternion.Identity,
+        SpringSettings = new SpringSettings(30, 5)
+    };
 
     /// <summary>
     /// Offset from body A to body B in the local space of A

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/_OneBodyConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/_OneBodyConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Stride.BepuPhysics.Constraints;
 
-public abstract class OneBodyConstraintComponent<T> : ConstraintComponent<T> where T : unmanaged, IConstraintDescription<T>, IOneBodyConstraintDescription<T>
+public abstract class OneBodyConstraintComponent<T> : ConstraintComponent<T>, IOneBody where T : unmanaged, IConstraintDescription<T>, IOneBodyConstraintDescription<T>
 {
     public BodyComponent? A
     {

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/_TwoBodyConstraintComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/_TwoBodyConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Stride.BepuPhysics.Constraints;
 
-public abstract class TwoBodyConstraintComponent<T> : ConstraintComponent<T> where T : unmanaged, IConstraintDescription<T>, ITwoBodyConstraintDescription<T>
+public abstract class TwoBodyConstraintComponent<T> : ConstraintComponent<T>, ITwoBody where T : unmanaged, IConstraintDescription<T>, ITwoBodyConstraintDescription<T>
 {
     public BodyComponent? A
     {


### PR DESCRIPTION
# PR Details
Constraints with Quaternion values are not initialized with valid values, this PR ensures that they are initialized to Identity.
Also adds a couple of summaries.

N.B.: I mistakenly made it as a new branch under stride, I'll delete it as soon as I'm done

## Related Issue
None reported

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**