### PR TITLE
feat: Add CI workflows

### DIFF
--- a/.github/workflows/build-assembly-processor.yml
+++ b/.github/workflows/build-assembly-processor.yml
@@ -1,0 +1,41 @@
+name: Build Assembly Processor
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        description: Build Configuration?
+        default: Debug
+        type: choice
+        options:
+          - Debug
+          - Release
+  workflow_call:
+    inputs:
+      build-type:
+        default: Debug
+        type: string
+
+jobs:
+  #
+  # Build Assembly Processor
+  #
+  Assembly-Processor:
+    name: Build (${{ github.event.inputs.build-type || inputs.build-type }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build
+        run: |
+          dotnet build build\Stride.AssemblyProcessor.sln `
+            -restore -m:1 -nr:false `
+            -v:m -p:WarningLevel=0 `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type }} `
+            -p:StrideSkipUnitTests=true `
+            -p:StrideSkipAutoPack=true `
+            -p:StrideEnableCodeAnalysis=true

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,54 @@
+name: Build Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        description: Build Configuration?
+        default: Debug
+        type: choice
+        options:
+          - Debug
+          - Release
+      graphics-api:
+        description: Graphics API
+        default: OpenGL
+        type: choice
+        options:
+          - OpenGL
+          - Vulkan
+  workflow_call:
+    inputs:
+      build-type:
+        default: Debug
+        type: string
+      graphics-api:
+        default: OpenGL
+        type: string
+
+jobs:
+  #
+  # Build Stride for Linux
+  #
+  Linux:
+    name: Build (${{ github.event.inputs.build-type || inputs.build-type }}, ${{ github.event.inputs.graphics-api || inputs.graphics-api }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - uses: microsoft/setup-msbuild@v2
+      - name: Build
+        run: |
+          msbuild build\Stride.Runtime.sln `
+            -restore -m:1 -nr:false `
+            -v:m -p:WarningLevel=0 `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type }} `
+            -p:StridePlatforms=Linux `
+            -p:StrideGraphicsApis=${{ github.event.inputs.graphics-api || inputs.graphics-api }} `
+            -p:StrideSkipUnitTests=true `
+            -p:StrideSkipAutoPack=true `
+            -p:StrideEnableCodeAnalysis=true

--- a/.github/workflows/build-vs-package.yml
+++ b/.github/workflows/build-vs-package.yml
@@ -1,0 +1,42 @@
+name: Build Visual Studio Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        description: Build Configuration?
+        default: Debug
+        type: choice
+        options:
+          - Debug
+          # - Release # has a bug and cannot build
+  workflow_call:
+    inputs:
+      build-type:
+        default: Debug
+        type: string
+
+jobs:
+  #
+  # Build Visual Studio Package
+  #
+  VS-Package:
+    name: Build (${{ github.event.inputs.build-type || inputs.build-type }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - uses: microsoft/setup-msbuild@v2
+      - name: Build
+        run: |
+          msbuild build\Stride.VisualStudio.sln `
+            -restore -m:1 -nr:false `
+            -v:m -p:WarningLevel=0 `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type }} `
+            -p:StrideSkipUnitTests=true `
+            -p:StrideSkipAutoPack=true `
+            -p:StrideEnableCodeAnalysis=true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,43 @@
+name: Build Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        description: Build Configuration?
+        default: Debug
+        type: choice
+        options:
+          - Debug
+          - Release
+  workflow_call:
+    inputs:
+      build-type:
+        default: Debug
+        type: string
+
+jobs:
+  #
+  # Build Stride for Windows
+  #
+  Windows:
+    name: Build (${{ github.event.inputs.build-type || inputs.build-type }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - uses: microsoft/setup-msbuild@v2
+      - name: Build
+        run: |
+          msbuild build\Stride.sln `
+            -restore -m:1 -nr:false `
+            -v:m -p:WarningLevel=0 `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type }} `
+            -p:StridePlatforms=Windows `
+            -p:StrideSkipUnitTests=true `
+            -p:StrideSkipAutoPack=true `
+            -p:StrideEnableCodeAnalysis=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,13 @@ jobs:
     steps:
       - run: exit 0
 
+  Linux-Debug:
+    needs: Setup
+    uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
+    with:
+      build-type: Debug
+
   Windows-Debug:
     needs: Setup
     uses: ./.github/workflows/build-windows.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,27 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/**'
+      - 'build/**'
+      - 'deps/**'
+      - 'sources/**'
+      - '!**/.all-contributorsrc'
+      - '!**/.editorconfig'
+      - '!**/.gitignore'
+      - '!**/*.md'
   pull_request:
     branches:
       - master
+    paths:
+      - '.github/workflows/**'
+      - 'build/**'
+      - 'deps/**'
+      - 'sources/**'
+      - '!**/.all-contributorsrc'
+      - '!**/.editorconfig'
+      - '!**/.gitignore'
+      - '!**/*.md'
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,3 +23,11 @@ jobs:
     secrets: inherit
     with:
       build-type: Debug
+
+  Windows-Tests:
+    needs: Setup
+    uses: ./.github/workflows/test-windows.yml
+    secrets: inherit
+    with:
+      build-type: Release
+      test-category: Simple

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  Setup:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  Windows-Debug:
+    needs: Setup
+    uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
+    with:
+      build-type: Debug

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,60 @@
+name: Test Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        description: Build in Release or Debug?
+        required: true
+        default: Release
+        type: choice
+        options:
+          - Debug
+          - Release
+      test-category:
+        description: Which category of tests?
+        required: false
+        default: Simple
+        type: choice
+        options:
+          - Simple
+          - Game
+          - VSPackage
+  workflow_call:
+    inputs:
+      build-type:
+        required: true
+        default: Release
+        type: string
+      test-category:
+        required: false
+        default: Simple
+        type: string
+
+jobs:
+  #
+  # Test Stride on Windows
+  #
+  Windows:
+    name: Test (${{ github.event.inputs.test-category || inputs.test-category }}, ${{ github.event.inputs.build-type || inputs.build-type }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - uses: microsoft/setup-msbuild@v2
+      - name: Build
+        run: |
+          msbuild build\Stride.Tests.${{ github.event.inputs.test-category || inputs.test-category }}.slnf `
+            -restore -m:1 -nr:false `
+            -v:m -p:WarningLevel=0 `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type }} `
+            -p:StrideGraphicsApis=Direct3D11
+      - name: Test
+        run: |
+          dotnet test build\Stride.Tests.${{ github.event.inputs.test-category || inputs.test-category }}.slnf `
+            --no-build `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type }}


### PR DESCRIPTION
# PR Details

Add CI workflows that will run when PRs are opened, updated and merged.

The workflows can also be triggered manually if necessary.

## Results on my fork

[![image](https://github.com/user-attachments/assets/86dc9c83-4ecb-4cb3-8c83-8bea17891423)](https://github.com/Color-Rise/stride-xplat-editor/actions/runs/15072497191)

## Notes

Before merging, it would be good to restrict who can run workflows and use the most conservative settings at the beginning. As an example, here what I have on my fork:

![image](https://github.com/user-attachments/assets/d1d2ca80-9b79-4ce2-a99d-5c11f2106f1e)
![image](https://github.com/user-attachments/assets/d0725160-d998-4e98-b2d3-715a13af18a6)
![image](https://github.com/user-attachments/assets/f6caac54-60d3-412a-9fdc-235c64792b42)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
