### PR TITLE
fix: UI depth bias does not account for facing direction

### DIFF
--- a/sources/engine/Stride.Graphics/UIBatch.cs
+++ b/sources/engine/Stride.Graphics/UIBatch.cs
@@ -510,11 +510,22 @@ namespace Stride.Graphics
             }
         }
 
+        /// <summary>
+        /// Returns +x when this rect is facing towards the camera, -x otherwise
+        /// </summary>
+        private static unsafe float FacingDirection(UIImageDrawInfo* drawInfo)
+        {
+            // Effectively -Vector3.Cross(drawInfo->UnitXWorld.XYZ(), drawInfo->UnitYWorld.XYZ()).Z
+            var left = drawInfo->UnitXWorld;
+            var right = drawInfo->UnitYWorld;
+            return (left.Y * right.X) - (left.X * right.Y);
+        }
+
         private static unsafe void CalculateCubeVertices(UIImageDrawInfo* drawInfo, VertexPositionColorTextureSwizzle* vertex)
         {
             const int VertexCountPerAxis = 2;
 
-            var depthBiasMultiplier = drawInfo->DepthBias * DepthBiasShiftOneUnit;
+            var depthBiasMultiplier = MathF.CopySign(drawInfo->DepthBias * DepthBiasShiftOneUnit, FacingDirection(drawInfo));
             var colorScale = drawInfo->ColorScale.ToColor4();
             var colorAdd = drawInfo->ColorAdd.ToColor4();
             var swizzle = (float)drawInfo->Swizzle;
@@ -604,7 +615,7 @@ namespace Stride.Graphics
 
             const int VertexCountPerAxis = 4;
 
-            var depthBiasMultiplier = drawInfo->DepthBias * DepthBiasShiftOneUnit;
+            var depthBiasMultiplier = MathF.CopySign(drawInfo->DepthBias * DepthBiasShiftOneUnit, FacingDirection(drawInfo));
             var colorScale = drawInfo->ColorScale.ToColor4();
             var colorAdd = drawInfo->ColorAdd.ToColor4();
             var swizzle = (float)drawInfo->Swizzle;
@@ -679,7 +690,7 @@ namespace Stride.Graphics
                 }
             }
 
-            var depthBiasMultiplier = drawInfo->DepthBias * DepthBiasShiftOneUnit;
+            var depthBiasMultiplier = MathF.CopySign(drawInfo->DepthBias * DepthBiasShiftOneUnit, FacingDirection(drawInfo));
             var colorScale = drawInfo->ColorScale.ToColor4();
             var colorAdd = drawInfo->ColorAdd.ToColor4();
             var swizzle = (float)drawInfo->Swizzle;


### PR DESCRIPTION
# PR Details
UI elements have individual depth bias applied to them to ensure they are drawn in the correct order. This works fine when you expect the UI to always face the camera, like is the case for billboards and fullscreen UI, but worldspace UI do not always face the camera, this PR reverses the bias if the UI is facing away from the camera.

Here, the orange line is a UI element from a world space UI facing away from the camera. The black cube is in front of the UI - the element should be completely occluded by the cube, but the depth bias pulled the UI towards the camera enough as to make it clip in front of it
![image](https://github.com/user-attachments/assets/14abd8c9-93f6-42bf-9dfe-caa155bcb380)
With this PR's change, the depth bias is reversed, when the element is facing away from the camera, pushing it away from the camera resolving this issue;
![image](https://github.com/user-attachments/assets/67adb1a8-c9de-4cdc-9b0a-c2a604b7ad78)

## Related Issue
None reported.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
