### PR TITLE
feat: adds on impulses to contact point

### DIFF
--- a/sources/engine/Stride.Physics/ContactPoint.cs
+++ b/sources/engine/Stride.Physics/ContactPoint.cs
@@ -17,6 +17,21 @@ namespace Stride.Physics
         public Vector3 PositionOnA;
         public Vector3 PositionOnB;
 
+        /// <summary>
+        /// The normal impulse applied to resolve a collision between two bodies
+        /// </summary>
+        public float AppliedImpulse;
+
+        /// <summary>
+        /// Tangential impulse to contact point of <see cref="AppliedImpulse"/>
+        /// </summary>
+        public float AppliedImpulseLateral1;
+
+        /// <summary>
+        /// Perpendicular impulse to both <see cref="AppliedImpulse"/> and <see cref="AppliedImpulseLateral1"/>
+        /// </summary>
+        public float AppliedImpulseLateral2;
+
 
         public bool Equals(ContactPoint other)
         {
@@ -25,7 +40,10 @@ namespace Stride.Physics
                    && Distance == other.Distance
                    && Normal == other.Normal
                    && PositionOnA == other.PositionOnA
-                   && PositionOnB == other.PositionOnB;
+                   && PositionOnB == other.PositionOnB
+                   && AppliedImpulse == other.AppliedImpulse
+                   && AppliedImpulseLateral1 == other.AppliedImpulseLateral1
+                   && AppliedImpulseLateral2 == other.AppliedImpulseLateral2;
         }
 
 
@@ -34,7 +52,17 @@ namespace Stride.Physics
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(ColliderA, ColliderB, Distance, Normal, PositionOnA, PositionOnB);
+            var hash = new HashCode();
+            hash.Add(ColliderA);
+            hash.Add(ColliderB);
+            hash.Add(Distance);
+            hash.Add(Normal);
+            hash.Add(PositionOnA);
+            hash.Add(PositionOnB);
+            hash.Add(AppliedImpulse);
+            hash.Add(AppliedImpulseLateral1);
+            hash.Add(AppliedImpulseLateral2);
+            return hash.ToHashCode();
         }
     }
 }

--- a/sources/engine/Stride.Physics/Simulation.cs
+++ b/sources/engine/Stride.Physics/Simulation.cs
@@ -501,6 +501,9 @@ namespace Stride.Physics
                         Normal = point.m_normalWorldOnB,
                         PositionOnA = point.m_positionWorldOnA,
                         PositionOnB = point.m_positionWorldOnB,
+                        AppliedImpulse = point.m_appliedImpulse,
+                        AppliedImpulseLateral1 = point.m_appliedImpulseLateral1,
+                        AppliedImpulseLateral2 = point.m_appliedImpulseLateral2
                     });
                 }
             }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

The `ContactPoint` object should store additional lateral impulse data. This is useful in certain scenarios:

- If you want to adjust physical interaction feedback (e.g. when hit by a bullet or a punch)
- If you want audio to be dependent on the normal forces (e.g. play louder sounds on a harder impact)
- If you want to debug the runtime bounce between objects (e.g. an object is bouncing too heavily)

By updating it, we enabled `BulletSharps'` data to be propagated and stored in this object. 

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/stride3d/stride/issues/2490

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
