### PR TITLE
feat: Initial work to save user settings

### DIFF
--- a/sources/core/Stride.Core.Design/Settings/SettingsContainer.cs
+++ b/sources/core/Stride.Core.Design/Settings/SettingsContainer.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections;
-using Stride.Core.Annotations;
 using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
 using Stride.Core.IO;
@@ -68,13 +67,12 @@ public class SettingsContainer
     /// <summary>
     /// Raised when a settings file has been loaded.
     /// </summary>
-    public event EventHandler<SettingsFileLoadedEventArgs> SettingsFileLoaded;
+    public event EventHandler<SettingsFileLoadedEventArgs>? SettingsFileLoaded;
 
     /// <summary>
     /// Gets a list of all registered <see cref="SettingsKey"/> instances.
     /// </summary>
     /// <returns>A list of all registered <see cref="SettingsKey"/> instances.</returns>
-    [NotNull]
     public List<SettingsKey> GetAllSettingsKeys()
     {
         return [.. settingsKeys.Values];
@@ -91,7 +89,6 @@ public class SettingsContainer
     /// If the profile is not registered to the container, it won't be able to receive <see cref="SettingsKey"/> that are registered after its
     /// creation. If the profile is registered to the container, <see cref="UnloadSettingsProfile"/> must be call in order to unregister it.
     /// </remarks>
-    [NotNull]
     public SettingsProfile CreateSettingsProfile(bool setAsCurrent, SettingsProfile? parent = null, bool registerInContainer = true)
     {
         if (setAsCurrent && !registerInContainer) throw new ArgumentException("Cannot set the profile as current if it's not registered to the container", nameof(setAsCurrent));

--- a/sources/core/Stride.Core.Design/Settings/SettingsProfile.cs
+++ b/sources/core/Stride.Core.Design/Settings/SettingsProfile.cs
@@ -19,7 +19,7 @@ public class SettingsProfile : IDisposable
     internal bool Saving;
     private readonly SortedList<UFile, SettingsEntry> settings = [];
     private readonly HashSet<UFile> modifiedSettings = [];
-    private readonly SettingsProfile parentProfile;
+    private readonly SettingsProfile? parentProfile;
     private FileSystemWatcher fileWatcher;
     private UFile filePath;
     private bool monitorFileModification;
@@ -29,7 +29,7 @@ public class SettingsProfile : IDisposable
     /// </summary>
     /// <param name="container">The <see cref="SettingsContainer"/> containing this profile.</param>
     /// <param name="parentProfile">The parent profile.</param>
-    internal SettingsProfile(SettingsContainer container, SettingsProfile parentProfile)
+    internal SettingsProfile(SettingsContainer container, SettingsProfile? parentProfile)
     {
         Container = container;
         this.parentProfile = parentProfile;

--- a/sources/editor/Stride.Core.Assets.Editor/Settings/InternalSettings.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Settings/InternalSettings.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Settings;
+
+namespace Stride.Core.Assets.Editor.Settings;
+
+public static class InternalSettings
+{
+    private static readonly SettingsProfile profile;
+
+    static InternalSettings()
+    {
+        profile = LoadProfile(true);
+        SettingsContainer.CurrentProfile = profile;
+    }
+
+    public static SettingsContainer SettingsContainer { get; } = new();
+
+    /// <summary>
+    /// Loads a copy of the internal settings from the file.
+    /// </summary>
+    /// <returns></returns>
+    private static SettingsProfile LoadProfile(bool registerProfile)
+    {
+        return SettingsContainer.LoadSettingsProfile(EditorPath.InternalConfigPath, false, null, registerProfile) ?? SettingsContainer.CreateSettingsProfile(false);
+    }
+
+    /// <summary>
+    /// Saves the settings into the settings file.
+    /// </summary>
+    public static void SaveProfile()
+    {
+        SettingsContainer.SaveSettingsProfile(profile, EditorPath.InternalConfigPath);
+    }
+}

--- a/sources/editor/Stride.GameStudio.Avalonia/Settings/GameStudioInternalSettings.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/Settings/GameStudioInternalSettings.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Stride.Core.Assets.Editor.Settings;
+using Stride.Core.Presentation.Avalonia.Services;
+using Stride.Core.Settings;
+
+namespace Stride.GameStudio.Avalonia.Settings;
+
+internal static class GameStudioInternalSettings
+{
+    public static SettingsContainer SettingsContainer => InternalSettings.SettingsContainer;
+
+    public static SettingsKey<bool> WindowMaximized = new("Internal/WindowMaximized", SettingsContainer, false);
+    public static SettingsKey<int> WindowWidth = new("Internal/WindowWidth", SettingsContainer, (int)WorkArea.Value.Width);
+    public static SettingsKey<int> WindowHeight = new("Internal/WindowHeight", SettingsContainer, (int)WorkArea.Value.Height);
+    public static SettingsKey<int> WorkAreaWidth = new("Internal/WorkAreaWidth", SettingsContainer, (int)WorkArea.Value.Width);
+    public static SettingsKey<int> WorkAreaHeight = new("Internal/WorkAreaHeight", SettingsContainer, (int)WorkArea.Value.Height);
+
+    private static Lazy<Rect> WorkArea => new(GetWorkArea);
+
+    // FIXME xplat-editor move to helper class (WindowHelper?)
+    public static Rect GetWorkArea()
+    {
+        if (DialogService.MainWindow is { } mainWindow)
+        {
+            if (mainWindow.Screens.ScreenFromWindow(mainWindow) is { } screen)
+            {
+                return screen.WorkingArea.ToRect(screen.Scaling);
+            }
+        }
+        // fallback to a reasonable value
+        return new Rect(0, 0, 800, 600);
+    }
+}

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Stride.GameStudio.Avalonia.Settings;
 
 namespace Stride.GameStudio.Avalonia.Views;
 
@@ -12,4 +15,51 @@ public partial class MainWindow : Window
         InitializeComponent();
     }
 
+    protected override void OnLoaded(RoutedEventArgs _)
+    {
+        // Size the window to best fit the current screen size
+        InitializeWindowSize();
+        return;
+
+        void InitializeWindowSize()
+        {
+            var previousWorkAreaWidth = GameStudioInternalSettings.WorkAreaWidth.GetValue();
+            var previousWorkAreaHeight = GameStudioInternalSettings.WorkAreaHeight.GetValue();
+            var wasWindowMaximized = GameStudioInternalSettings.WindowMaximized.GetValue();
+            var workArea = GameStudioInternalSettings.GetWorkArea();
+
+            if (wasWindowMaximized || previousWorkAreaWidth > workArea.Width || previousWorkAreaHeight > workArea.Height)
+            {
+                // Resolution has changed (and is now smaller), let's make the window fill all available space.
+                FillArea(workArea);
+                WindowState = WindowState.Maximized;
+            }
+            else
+            {
+                // Load state
+                var previousWindowWidth = GameStudioInternalSettings.WindowWidth.GetValue();
+                var previousWindowHeight = GameStudioInternalSettings.WindowHeight.GetValue();
+                // Set window size
+                Width = Math.Min(previousWindowWidth, workArea.Width);
+                Height = Math.Min(previousWindowHeight, workArea.Height);
+                // Window is centered by default
+                CenterToArea(workArea);
+                WindowState = WindowState.Normal;
+            }
+
+            return;
+
+            void CenterToArea(Rect area)
+            {
+                Position = new PixelPoint((int)Math.Abs(area.Width - Width) / 2, (int)Math.Abs(area.Height - Height) / 2) + new PixelPoint((int)area.Position.X, (int)area.Position.Y);
+            }
+
+            void FillArea(Rect area)
+            {
+                Width = area.Width;
+                Height = area.Height;
+                Position = new PixelPoint((int)area.Position.X, (int)area.Position.Y);
+            }
+        }
+    }
 }

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml.cs
@@ -15,6 +15,7 @@ namespace Stride.GameStudio.Avalonia.Views;
 public partial class MainWindow : Window
 {
     private TaskCompletionSource<bool>? closingTask;
+    private Size restoreBounds;
 
     public MainWindow()
     {
@@ -101,6 +102,18 @@ public partial class MainWindow : Window
         }
     }
 
+    protected override void OnResized(WindowResizedEventArgs e)
+    {
+        base.OnResized(e);
+        switch (e.Reason)
+        {
+            case WindowResizeReason.Layout:
+            case WindowResizeReason.User:
+                restoreBounds = e.ClientSize;
+                break;
+        }
+    }
+
     private async Task SaveAndClose()
     {
         try
@@ -130,8 +143,8 @@ public partial class MainWindow : Window
             // Save state
             GameStudioInternalSettings.WorkAreaWidth.SetValue((int)workArea.Width);
             GameStudioInternalSettings.WorkAreaHeight.SetValue((int)workArea.Height);
-            GameStudioInternalSettings.WindowWidth.SetValue((int)Math.Max(800, /*WindowState == WindowState.Maximized ? RestoreBounds.Width : */Bounds.Width));
-            GameStudioInternalSettings.WindowHeight.SetValue((int)Math.Max(600, /*WindowState == WindowState.Maximized ? RestoreBounds.Height : */Bounds.Height));
+            GameStudioInternalSettings.WindowWidth.SetValue((int)Math.Max(800, WindowState == WindowState.Maximized ? restoreBounds.Width : Bounds.Width));
+            GameStudioInternalSettings.WindowHeight.SetValue((int)Math.Max(600, WindowState == WindowState.Maximized ? restoreBounds.Height : Bounds.Height));
             GameStudioInternalSettings.WindowMaximized.SetValue(WindowState == WindowState.Maximized);
             // Write the settings file
             InternalSettings.SaveProfile();

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Services/DialogService.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Services/DialogService.cs
@@ -34,7 +34,7 @@ public class DialogService : IDialogService
     {
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
         {
-            lifetime.Shutdown(exitCode);
+            lifetime.TryShutdown(exitCode);
         }
         else
         {
@@ -111,7 +111,7 @@ public class DialogService : IDialogService
             return path;
         });
     }
-    
+
     public async Task<UFile?> SaveFilePickerAsync(UDirectory? initialPath = null, IReadOnlyList<FilePickerFilter>? filters = null, string? defaultExtension = null, string? defaultFileName = null)
     {
         if (StorageProvider is null) return null;
@@ -133,7 +133,7 @@ public class DialogService : IDialogService
             return path;
         });
     }
-    
+
     public async Task<CheckedMessageBoxResult> CheckedMessageBoxAsync(string message, bool? isChecked, string checkboxMessage, MessageBoxButton buttons, MessageBoxImage image)
     {
         return await Dispatcher.InvokeTask(() => CheckedMessageBox.ShowAsync(ApplicationName, message, isChecked, checkboxMessage, IDialogService.GetButtons(buttons), image, MainWindow));


### PR DESCRIPTION
# PR Details

Saves the window size and state (maximized or not) into the user local settings.

It should also work on Linux and Mac because according to https://jimrich.sk/environment-specialfolder-on-windows-linux-and-os-x/, `Environment.SpecialFolder.ApplicationData` is well-defined on all three platforms.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
