### PR TITLE
WIP: Initial work to run game project from avalonia editor

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -118,7 +118,6 @@
     <AvaloniaBehaviorVersion>11.2.7.3</AvaloniaBehaviorVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -118,7 +118,7 @@
     <AvaloniaBehaviorVersion>11.2.7.3</AvaloniaBehaviorVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -118,7 +118,7 @@
     <AvaloniaBehaviorVersion>11.2.7.3</AvaloniaBehaviorVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.2.7" />
+    <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />

--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/ImageResources.axaml
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/ImageResources.axaml
@@ -151,4 +151,14 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+
+  <DrawingImage x:Key="ImageStart">
+		<DrawingImage.Drawing>
+			<GeometryDrawing Brush="#4CAF50">
+				<GeometryDrawing.Geometry>
+					<Geometry>F1 M 2,2 L 14,8 L 2,14 Z</Geometry>
+				</GeometryDrawing.Geometry>
+			</GeometryDrawing>
+		</DrawingImage.Drawing>
+   </DrawingImage>
 </ResourceDictionary>

--- a/sources/editor/Stride.GameStudio.Avalonia/App.axaml.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/App.axaml.cs
@@ -4,6 +4,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Stride.Core.Assets.Editor.Services;
 using Stride.Core.IO;

--- a/sources/editor/Stride.GameStudio.Avalonia/Stride.GameStudio.Avalonia.csproj
+++ b/sources/editor/Stride.GameStudio.Avalonia/Stride.GameStudio.Avalonia.csproj
@@ -30,7 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Xaml.Interactions" />

--- a/sources/editor/Stride.GameStudio.Avalonia/Stride.GameStudio.Avalonia.csproj
+++ b/sources/editor/Stride.GameStudio.Avalonia/Stride.GameStudio.Avalonia.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Xaml.Interactions" />

--- a/sources/editor/Stride.GameStudio.Avalonia/ViewModels/MainViewModel.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/ViewModels/MainViewModel.cs
@@ -45,7 +45,7 @@ internal sealed class MainViewModel : ViewModelBase, IMainViewModel
         OpenCommand = new AnonymousTaskCommand<UFile?>(serviceProvider, OnOpen);
         OpenDebugWindowCommand = new AnonymousTaskCommand(serviceProvider, OnOpenDebugWindow, () => DialogService.HasMainWindow);
         OpenWebPageCommand = new AnonymousTaskCommand<string>(serviceProvider, OnOpenWebPage);
-        RunCurrentProjectCommand = new AnonymousCommand(serviceProvider, RunCurrentProject);
+        RunCurrentProjectCommand = new AnonymousTaskCommand(serviceProvider, RunCurrentProject);
 
         Status = new StatusViewModel(ServiceProvider);
         Status.PushStatus("Ready");
@@ -178,7 +178,7 @@ internal sealed class MainViewModel : ViewModelBase, IMainViewModel
 
 
 
-    private async void RunCurrentProject()
+    private async Task RunCurrentProject()
     {
         var mainProjectPath = Session?.CurrentProject?.RootDirectory;
         if (mainProjectPath == null) return;

--- a/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml.cs
+++ b/sources/editor/Stride.GameStudio.Avalonia/Views/MainWindow.axaml.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Avalonia.Controls;
+using Avalonia.Input;
 
 namespace Stride.GameStudio.Avalonia.Views;
 
@@ -10,6 +11,17 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        this.KeyDown += MainWindow_KeyDown;
+    }
+
+    private void MainWindow_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.F5)
+        {
+            (DataContext as ViewModels.MainViewModel)?.RunCurrentProjectCommand.Execute(null);
+            e.Handled = true;
+            Console.WriteLine("Run");
+        }
     }
 
 }


### PR DESCRIPTION
# PR Details

This PR adds the ability to build the game project from within the new Avalonia-based editor. While the editor UI doesn't yet include a button for this feature, the F5 shortcut can be used to trigger the build.

Currently, this functionality only works on Windows due to the limitations of the AssetCompiler, which is platform-specific. I have started laying the groundwork for supporting other platforms in the future, but I am currently unable to test this feature on my Linux machine.

## Related Issue

#2742


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
