### PR TITLE
feat: Load Services only on first call

### DIFF
--- a/sources/engine/Stride.Engine/Engine/ScriptComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/ScriptComponent.cs
@@ -57,14 +57,6 @@ namespace Stride.Engine
 
             Game = Services.GetSafeServiceAs<IGame>();
             Content = (ContentManager)Services.GetSafeServiceAs<IContentManager>();
-            Input = Services.GetSafeServiceAs<InputManager>();
-            Script = Services.GetSafeServiceAs<ScriptSystem>();
-            SceneSystem = Services.GetSafeServiceAs<SceneSystem>();
-            EffectSystem = Services.GetSafeServiceAs<EffectSystem>();
-            Audio = Services.GetSafeServiceAs<AudioSystem>();
-            SpriteAnimation = Services.GetSafeServiceAs<SpriteAnimationSystem>();
-            GameProfiler = Services.GetSafeServiceAs<GameProfilingSystem>();
-            DebugText = Services.GetSafeServiceAs<DebugTextSystem>();
             Streaming = Services.GetSafeServiceAs<StreamingManager>();
         }
 
@@ -91,12 +83,6 @@ namespace Stride.Engine
         }
 
         [DataMemberIgnore]
-        public AudioSystem Audio { get; private set; }
-
-        [DataMemberIgnore]
-        public SpriteAnimationSystem SpriteAnimation { get; private set; }
-
-        [DataMemberIgnore]
         public IServiceRegistry Services { get; private set; }
 
         [DataMemberIgnore]
@@ -106,25 +92,127 @@ namespace Stride.Engine
         public ContentManager Content { get; private set; }
 
         [DataMemberIgnore]
-        public GameProfilingSystem GameProfiler { get; private set; }
-
-        [DataMemberIgnore]
         public GraphicsDevice GraphicsDevice => graphicsDeviceService?.GraphicsDevice;
 
         [DataMemberIgnore]
-        public InputManager Input { get; private set; }
+        public GameProfilingSystem GameProfiler 
+        { 
+            get
+            {
+                gameProfilerSystem ??= Services.GetSafeServiceAs<GameProfilingSystem>();
+                return gameProfilerSystem;
+            }
+            private set
+            {
+                gameProfilerSystem = value;
+            }
+        }
+        private GameProfilingSystem gameProfilerSystem;
 
         [DataMemberIgnore]
-        public ScriptSystem Script { get; private set; }
+        public InputManager Input 
+        { 
+            get
+            {
+                inputManager ??= Services.GetSafeServiceAs<InputManager>();
+                return inputManager;
+            }
+            private set
+            {
+                inputManager = value;
+            }
+        }
+        private InputManager inputManager;
 
         [DataMemberIgnore]
-        public SceneSystem SceneSystem { get; private set; }
+        public ScriptSystem Script 
+        { 
+            get
+            {
+                scriptSystem ??= Services.GetSafeServiceAs<ScriptSystem>();
+                return scriptSystem;
+            }
+            private set
+            {
+                scriptSystem = value;
+            }
+        }
+        private ScriptSystem scriptSystem;
 
         [DataMemberIgnore]
-        public EffectSystem EffectSystem { get; private set; }
+        public SceneSystem SceneSystem 
+        { 
+            get
+            {
+                sceneSystem ??= Services.GetSafeServiceAs<SceneSystem>();
+                return sceneSystem;
+            }
+            private set
+            {
+                sceneSystem = value;
+            }
+        }
+        private SceneSystem sceneSystem;
 
         [DataMemberIgnore]
-        public DebugTextSystem DebugText { get; private set; }
+        public EffectSystem EffectSystem 
+        { 
+            get
+            {
+                effectSystem ??= Services.GetSafeServiceAs<EffectSystem>();
+                return effectSystem;
+            }
+            private set
+            {
+                effectSystem = value;
+            }
+        }
+        private EffectSystem effectSystem;
+
+        [DataMemberIgnore]
+        public DebugTextSystem DebugText 
+        { 
+            get
+            {
+                debugTextSystem ??= Services.GetSafeServiceAs<DebugTextSystem>();
+                return debugTextSystem;
+            }
+            private set
+            {
+                debugTextSystem = value;
+            }
+        }
+        private DebugTextSystem debugTextSystem;
+
+        [DataMemberIgnore]
+        public AudioSystem Audio
+        {
+            get
+            {
+                audioSystem ??= Services.GetSafeServiceAs<AudioSystem>();
+                return audioSystem;
+            }
+            private set
+            {
+                audioSystem = value;
+            }
+        }
+        private AudioSystem audioSystem;
+
+        [DataMemberIgnore]
+        public SpriteAnimationSystem SpriteAnimation
+        {
+            get
+            {
+                spriteAnimationSystem ??= Services.GetSafeServiceAs<SpriteAnimationSystem>();
+                return spriteAnimationSystem;
+            }
+            private set
+            {
+                spriteAnimationSystem = value;
+            }
+        }
+        private SpriteAnimationSystem spriteAnimationSystem;
 
         /// <summary>
         /// Gets the streaming system.


### PR DESCRIPTION
# PR Details

This PR is to allow systems to be modified from the `Game` class and not set services until it is first called.

## Related Issue

https://github.com/stride3d/stride/issues/2628 Semi related 
https://github.com/stride3d/stride/pull/2806 This will be useful when avoiding injecting systems at startup.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
