### PR TITLE
feat: UI button color

### DIFF
--- a/sources/engine/Stride.UI/Controls/Button.cs
+++ b/sources/engine/Stride.UI/Controls/Button.cs
@@ -110,6 +110,15 @@ namespace Stride.UI.Controls
         }
 
         /// <summary>
+        /// Gets or set the color used to tint the image. Default value is White.
+        /// </summary>
+        /// <remarks>The initial image color is multiplied by this color.</remarks>
+        /// <userdoc>The color used to tint the image. The default value is white.</userdoc>
+        [DataMember]
+        [Display(category: AppearanceCategory)]
+        public Color Color { get; set; } = Color.White;
+
+        /// <summary>
         /// Gets or sets a value that describes how the button image should be stretched to fill the destination rectangle.
         /// </summary>
         /// <remarks>This property has no effect is <see cref="SizeToContent"/> is <c>true</c>.</remarks>

--- a/sources/engine/Stride.UI/Controls/ImageElement.cs
+++ b/sources/engine/Stride.UI/Controls/ImageElement.cs
@@ -44,7 +44,7 @@ namespace Stride.UI.Controls
         }
 
         /// <summary>
-        /// Gets or set the color used to tint the image. Default value is White/>.
+        /// Gets or set the color used to tint the image. Default value is White.
         /// </summary>
         /// <remarks>The initial image color is multiplied by this color.</remarks>
         /// <userdoc>The color used to tint the image. The default value is white.</userdoc>

--- a/sources/engine/Stride.UI/Controls/ToggleButton.cs
+++ b/sources/engine/Stride.UI/Controls/ToggleButton.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 
 using Stride.Core;
+using Stride.Core.Mathematics;
 using Stride.Engine;
 using Stride.UI.Attributes;
 using Stride.UI.Events;
@@ -99,6 +100,15 @@ namespace Stride.UI.Controls
                 OnToggleImageInvalidated();
             }
         }
+
+        /// <summary>
+        /// Gets or set the color used to tint the image. Default value is White.
+        /// </summary>
+        /// <remarks>The initial image color is multiplied by this color.</remarks>
+        /// <userdoc>The color used to tint the image. The default value is white.</userdoc>
+        [DataMember]
+        [Display(category: AppearanceCategory)]
+        public Color Color { get; set; } = Color.White;
 
         /// <summary>
         /// Determines whether the control supports two or three states.

--- a/sources/engine/Stride.UI/Renderers/DefaultButtonRenderer.cs
+++ b/sources/engine/Stride.UI/Renderers/DefaultButtonRenderer.cs
@@ -26,7 +26,7 @@ namespace Stride.UI.Renderers
             if (sprite?.Texture == null)
                 return;
 
-            var color = element.RenderOpacity * Color.White;
+            var color = element.RenderOpacity * button.Color;
             Batch.DrawImage(sprite.Texture, ref element.WorldMatrixInternal, ref sprite.RegionInternal, ref element.RenderSizeInternal, ref sprite.BordersInternal, ref color, context.DepthBias, sprite.Orientation);
         }
     }

--- a/sources/engine/Stride.UI/Renderers/DefaultToggleButtonRenderer.cs
+++ b/sources/engine/Stride.UI/Renderers/DefaultToggleButtonRenderer.cs
@@ -29,7 +29,7 @@ namespace Stride.UI.Renderers
             if (sprite?.Texture == null)
                 return;
             
-            var color = toggleButton.RenderOpacity * Color.White;
+            var color = toggleButton.RenderOpacity * toggleButton.Color;
             Batch.DrawImage(sprite.Texture, ref element.WorldMatrixInternal, ref sprite.RegionInternal, ref element.RenderSizeInternal, ref sprite.BordersInternal, ref color, context.DepthBias, sprite.Orientation);
         }
 


### PR DESCRIPTION
# PR Details
Adds color properties to tint buttons and toggle buttons - other image elements have this property but not those two for some reason, just background color.

## Related Issue
None logged.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
