### PR TITLE
fix: DoubleExtension & IntExtension

### DIFF
--- a/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
@@ -18,7 +18,7 @@ public sealed class DoubleExtension : MarkupExtension
         Value = 0.0;
     }
 
-    public DoubleExtension(string value)
+    public DoubleExtension(object value)
     {
         Value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
     }

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Globalization;
 using Avalonia.Markup.Xaml;
 using Avalonia.Metadata;
@@ -19,7 +20,7 @@ public sealed class DoubleExtension : MarkupExtension
 
     public DoubleExtension(string value)
     {
-        Value = double.Parse(value, CultureInfo.InvariantCulture);
+        Value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
     }
     
     /// <inheritdoc/>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Globalization;
 using Avalonia.Markup.Xaml;
 using Avalonia.Metadata;
 
@@ -16,9 +17,9 @@ public sealed class DoubleExtension : MarkupExtension
         Value = 0.0;
     }
 
-    public DoubleExtension(object value)
+    public DoubleExtension(string value)
     {
-        Value = Convert.ToDouble(value);
+        Value = double.Parse(value, CultureInfo.InvariantCulture);
     }
     
     /// <inheritdoc/>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/DoubleExtension.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Globalization;
 using Avalonia.Markup.Xaml;
 using Avalonia.Metadata;

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/IntExtension.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/MarkupExtensions/IntExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Globalization;
 using Avalonia.Markup.Xaml;
 using Avalonia.Metadata;
 
@@ -18,7 +19,7 @@ public sealed class IntExtension : MarkupExtension
 
     public IntExtension(object value)
     {
-        Value = Convert.ToInt32(value);
+        Value = Convert.ToInt32(value, CultureInfo.InvariantCulture);
     }
     
     /// <inheritdoc/>


### PR DESCRIPTION
# PR Details

PR fixes following bug: 

1. Run new Avalonia Editor on Windows (`dotnet run`)
2. Load any game solution file.
3. Select any asset or go to settings.
4. Crash :

```
Exception: FormatException: The input string '0.5' was not in a correct format.
```

I simply used passed additional CultureInfo argument to take into account the different formats (dots or commas) that occur between languages.

My Current LocaleInfo : pl-PL

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
