### PR TITLE
[SDL] fix : SetIsReallyFullscreen is not setting real fullscreen state if API is not DX

### DIFF
--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -210,9 +210,6 @@ namespace Stride.Games
         /// <summary>
         /// Allow the GraphicsDeviceManager to set the actual window state after applying the device changes.
         /// </summary>
-        /// <remarks>
-        /// Applies only to the Direct3D graphics API
-        /// </remarks>
         /// <param name="isReallyFullscreen"></param>
         internal void SetIsReallyFullscreen(bool isReallyFullscreen)
         {

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -206,17 +206,6 @@ namespace Stride.Games
             }
         }
 
-        /// <summary>
-        /// Allow the GraphicsDeviceManager to set the actual window state after applying the device changes.
-        /// </summary>
-        /// <param name="isReallyFullscreen"></param>
-        internal void SetIsReallyFullscreen(bool isReallyFullscreen)
-        {
-            #if !STRIDE_GRAPHICS_API_OPENGL && !STRIDE_GRAPHICS_API_VULKAN
-            isFullscreen = isReallyFullscreen;
-            #endif
-        }
-
         #endregion
 
         #region Public Methods and Operators

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -212,7 +212,9 @@ namespace Stride.Games
         /// <param name="isReallyFullscreen"></param>
         internal void SetIsReallyFullscreen(bool isReallyFullscreen)
         {
+            #if !STRIDE_GRAPHICS_API_OPENGL && !STRIDE_GRAPHICS_API_VULKAN
             isFullscreen = isReallyFullscreen;
+            #endif
         }
 
         #endregion

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -206,6 +206,20 @@ namespace Stride.Games
             }
         }
 
+#if STRIDE_GRAPHICS_API_DIRECT3D
+        /// <summary>
+        /// Allow the GraphicsDeviceManager to set the actual window state after applying the device changes.
+        /// </summary>
+        /// <remarks>
+        /// Applies only to the Direct3D graphics API
+        /// </remarks>
+        /// <param name="isReallyFullscreen"></param>
+        internal void SetIsReallyFullscreen(bool isReallyFullscreen)
+        {
+            isFullscreen = isReallyFullscreen;
+        }
+#endif
+
         #endregion
 
         #region Public Methods and Operators

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -87,8 +87,6 @@ namespace Stride.Games
 
         private IGraphicsDeviceFactory graphicsDeviceFactory;
 
-        private bool isReallyFullScreen;
-
         private ColorSpace preferredColorSpace;
 
         #endregion
@@ -1074,7 +1072,6 @@ namespace Stride.Games
                         }
 
                         var presentationParameters = GraphicsDevice.Presenter.Description;
-                        isReallyFullScreen = presentationParameters.IsFullScreen;
                         if (presentationParameters.BackBufferWidth != 0)
                         {
                             width = presentationParameters.BackBufferWidth;
@@ -1091,7 +1088,6 @@ namespace Stride.Games
                         if (isBeginScreenDeviceChange)
                         {
                             game.Window.EndScreenDeviceChange(width, height);
-                            game.Window.SetIsReallyFullscreen(isReallyFullScreen);
                         }
 
                         currentWindowOrientation = game.Window.CurrentOrientation;

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -87,6 +87,10 @@ namespace Stride.Games
 
         private IGraphicsDeviceFactory graphicsDeviceFactory;
 
+#if STRIDE_GRAPHICS_API_DIRECT3D
+        private bool isReallyFullScreen;
+#endif
+
         private ColorSpace preferredColorSpace;
 
         #endregion
@@ -1072,6 +1076,9 @@ namespace Stride.Games
                         }
 
                         var presentationParameters = GraphicsDevice.Presenter.Description;
+#if STRIDE_GRAPHICS_API_DIRECT3D
+                        isReallyFullScreen = presentationParameters.IsFullScreen;
+#endif
                         if (presentationParameters.BackBufferWidth != 0)
                         {
                             width = presentationParameters.BackBufferWidth;
@@ -1088,6 +1095,9 @@ namespace Stride.Games
                         if (isBeginScreenDeviceChange)
                         {
                             game.Window.EndScreenDeviceChange(width, height);
+#if STRIDE_GRAPHICS_API_DIRECT3D
+                            game.Window.SetIsReallyFullscreen(isReallyFullScreen);
+#endif
                         }
 
                         currentWindowOrientation = game.Window.CurrentOrientation;


### PR DESCRIPTION
# PR Details

PR fixes following bug:
- Change your app to full screen mode using `ALT+ENTER` combination
- Expected behaviour : IsFullScreen variable is set to `true`
- Actual behaviour: Is FullScreen is overriden by isReallyFullscreen variable from `false` to `false` for the first time.
This causes you to have to press `ALT+ENTER` **twice** to exit the fullscreen mode.

Applies for : OpenGL, Vulkan (Any OS)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
