### PR TITLE
[OpenGL] Removed an unnecessary check in CommandList that crashed the engine when resizing the window

### DIFF
--- a/sources/engine/Stride.Graphics/OpenGL/CommandList.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/CommandList.OpenGL.cs
@@ -1222,11 +1222,6 @@ namespace Stride.Graphics
                 // ensure size is coherent
                 var expectedWidth = renderTargets[0].Width;
                 var expectedHeight = renderTargets[0].Height;
-                if (depthStencilBuffer != null)
-                {
-                    if (expectedWidth != depthStencilBuffer.Width || expectedHeight != depthStencilBuffer.Height)
-                        throw new Exception("Depth buffer is not the same size as the render target");
-                }
                 for (int i = 1; i < renderTargetCount; ++i)
                 {
                     if (renderTargets[i] != null && (expectedWidth != renderTargets[i].Width || expectedHeight != renderTargets[i].Height))


### PR DESCRIPTION
# PR Details

When using OpenGL as the rendering API, resizing the window would cause an exception in `CommandList.OpenGL.cs` "Depth buffer is not the same size as the render target". This PR removes this check, which fixes the issue.

The reason why this check is unnecessary, is because the depth buffer eventually resizes itself (after a delay of 1 to a couple of frames) and during that time, nothing bad happens. The Direct X implementation - which is probably the best guide to how other API's should work - doesn't do any checks like this and also works just fine.

**As to why this check was there in the first place**: my idea is it's because this check is a relic of an older version of the engine or that it was just unfinished. Seeing how there are many methods and properties returning a default value, the second one is very likely. It's clear that the priority was put on Direct X, while Vulkan and OpenGL were only brought to a good enough state, to make the window appear and display the game.

Do note, I haven't tested if the depth buffer fails to resize itself on Direct X, but either way, this check shouldn't be there and it's already proven to work.

### What this PR doesn't fix
The depth buffer not being resized for a couple of frames seems to be an issue worth investigating, but because that isn't causing any issues on OpenGL and Direct X (if the problem is also present there), I am leaving it out of this PR.

### What this PR can break
Can't break something that's already broken. From my testing on my machine, this fixes the problem with resizing. In case that under some circumstances it doesn't work, then we won't really introduce a new bug, seeing as that would have caused a crash previously anyway.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

* https://github.com/stride3d/stride/issues/2412

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
