### PR TITLE
feat: Toolbar overflow

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
+++ b/sources/editor/Stride.Core.Assets.Editor.Avalonia/Views/DefaultPropertyTemplateProviders.axaml
@@ -156,7 +156,7 @@
     <Grid Background="Transparent">
       <Path x:Name="Up_Arrow" IsVisible="{Binding !IsChecked, RelativeSource={RelativeSource TemplatedParent}}"
             HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{DynamicResource SystemBaseHighColor}"
-            Data="M 0 6 V 0 l 5 3 z" RenderTransformOrigin="0.5,0.5" Stretch="Uniform" StrokeThickness="0"/>
+            Data="M 0 6 V 0 L 6 3 Z" RenderTransformOrigin="0.5,0.5" Stretch="Uniform" StrokeThickness="0"/>
       <Path x:Name="Down_Arrow" IsVisible="{Binding IsChecked, RelativeSource={RelativeSource TemplatedParent}}"
             HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{DynamicResource SystemBaseHighColor}"
             Data="M 0 0 H 6 L 3 6 Z" RenderTransformOrigin="0.5,0.5" Stretch="Uniform" StrokeThickness="0"/>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBar.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBar.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+// This source file is adapted from the Windows Presentation Foundation project. 
+// (https://github.com/dotnet/wpf/)
+// Licensed under MIT license, courtesy of The .NET Foundation.
+
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
@@ -13,7 +17,7 @@ public sealed class ToolBar : ItemsControl
     /// Defines the <see cref="Orientation"/> property.
     /// </summary>
     public static readonly StyledProperty<Orientation> OrientationProperty =
-        AvaloniaProperty.RegisterAttached<ToolBar, Orientation>(nameof(Orientation), typeof(ToolBar), coerce: CoerceOrientation);
+        AvaloniaProperty.Register<ToolBar, Orientation>(nameof(Orientation), coerce: CoerceOrientation);
 
     private static Orientation CoerceOrientation(AvaloniaObject d, Orientation value)
     {

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBar.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBar.cs
@@ -5,14 +5,30 @@
 // (https://github.com/dotnet/wpf/)
 // Licensed under MIT license, courtesy of The .NET Foundation.
 
+using System.Collections.Specialized;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 
 namespace Stride.Core.Presentation.Avalonia.Controls;
 
+[TemplatePart("PART_ToolBarPanel", typeof(ToolBarPanel), IsRequired = true)]
 public sealed class ToolBar : ItemsControl
 {
+    /// <summary>
+    /// Defines the <see cref="Band"/> Property
+    /// </summary>
+    public static readonly StyledProperty<int> BandProperty =
+        AvaloniaProperty.Register<ToolBar, int>(nameof(Band));
+
+    /// <summary>
+    /// Defines the <see cref="BandIndex"/> Property
+    /// </summary>
+    public static readonly StyledProperty<int> BandIndexProperty =
+        AvaloniaProperty.Register<ToolBar, int>(nameof(BandIndex));
+
     /// <summary>
     /// Defines the <see cref="Orientation"/> property.
     /// </summary>
@@ -25,16 +41,119 @@ public sealed class ToolBar : ItemsControl
         return toolBarTray?.Orientation ?? value;
     }
 
+    public ToolBar()
+    {
+        Items.CollectionChanged += OnItemsChanged;
+        return;
+
+        void OnItemsChanged(object? o, NotifyCollectionChangedEventArgs e)
+        {
+            InvalidateLayout();
+        }
+    }
+
+    public int Band
+    {
+        get => GetValue(BandProperty);
+        set => SetValue(BandProperty, value);
+    }
+
+    public int BandIndex
+    {
+        get => GetValue(BandIndexProperty);
+        set => SetValue(BandIndexProperty, value);
+    }
+
     public Orientation Orientation
     {
         get => GetValue(OrientationProperty);
     }
 
+    internal double MaxLength { get; private set; }
+
+    internal double MinLength { get; private set; }
+
+    internal ToolBarPanel? ToolBarPanel { get; private set; }
+
     private ToolBarTray? ToolBarTray => Parent as ToolBarTray;
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var desiredSize = base.MeasureOverride(availableSize);
+
+        // note: MinLength and MaxLength are used by ToolBarTray.
+        if (ToolBarPanel is not null)
+        {
+            var margin = ToolBarPanel.Margin;
+            var extraLength = ToolBarPanel.Orientation is Orientation.Horizontal
+                ? Math.Max(0.0, desiredSize.Width - ToolBarPanel.DesiredSize.Width + margin.Left + margin.Right)
+                : Math.Max(0.0, desiredSize.Height - ToolBarPanel.DesiredSize.Height + margin.Top + margin.Bottom);
+
+            MaxLength = ToolBarPanel.MaxLength + extraLength;
+            MinLength = ToolBarPanel.MinLength + extraLength;
+        }
+
+        return desiredSize;
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+
+        ToolBarPanel = e.NameScope.Find<ToolBarPanel>("PART_ToolBarPanel");
+        ArgumentNullException.ThrowIfNull(ToolBarPanel);
+    }
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
         CoerceValue(OrientationProperty);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == BandProperty || change.Property == BandIndexProperty)
+        {
+            if (Parent is not Layoutable visualParent)
+                return;
+
+            visualParent.InvalidateMeasure();
+        }
+
+        base.OnPropertyChanged(change);
+    }
+
+    protected override void OnTemplateChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        // Invalidate template references
+        ToolBarPanel = null;
+
+        base.OnTemplateChanged(e);
+    }
+
+    internal void AddLogicalChild(Control c)
+    {
+        if (!LogicalChildren.Contains(c))
+        {
+            LogicalChildren.Add(c);
+        }
+    }
+
+    internal void RemoveLogicalChild(Control c)
+    {
+        LogicalChildren.Remove(c);
+    }
+
+    private void InvalidateLayout()
+    {
+        // reset the calculated min and max size
+        MinLength = 0.0;
+        MaxLength = 0.0;
+
+        // min and max sizes are calculated in ToolBar.MeasureOverride
+        InvalidateMeasure();
+
+        // whether children are in the overflow or not is decided in ToolBarPanel.MeasureOverride.
+        ToolBarPanel?.InvalidateMeasure();
     }
 }

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBarOverflowPanel.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBarOverflowPanel.cs
@@ -1,0 +1,183 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+// This source file is adapted from the Windows Presentation Foundation project. 
+// (https://github.com/dotnet/wpf/)
+// Licensed under MIT license, courtesy of The .NET Foundation.
+
+using Avalonia;
+using Avalonia.Controls;
+using Stride.Core.Presentation.Avalonia.Internal;
+
+namespace Stride.Core.Presentation.Avalonia.Controls;
+
+public sealed class ToolBarOverflowPanel : Panel
+{
+    /// <summary>
+    /// Defines the <see cref="WrapWidth"/> property.
+    /// </summary>
+    public static readonly StyledProperty<double> WrapWidthProperty =
+        AvaloniaProperty.Register<ToolBarOverflowPanel, double>(nameof(WrapWidth), double.NaN, validate: IsWrapWidthValid);
+
+    private static bool IsWrapWidthValid(double v)
+    {
+        return double.IsNaN(v) || DoubleUtil.GreaterThanOrClose(v, 0d) && !double.IsPositiveInfinity(v);
+    }
+
+    // calculated in MeasureOverride and used in ArrangeOverride
+    private double wrapWidth;
+    private Size panelSize;
+
+    internal ToolBar? ToolBar => TemplatedParent as ToolBar;
+
+    internal ToolBarPanel? ToolBarPanel => ToolBar?.ToolBarPanel;
+
+    public double WrapWidth
+    {
+        get => GetValue(WrapWidthProperty);
+        set => SetValue(WrapWidthProperty, value);
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var currentLineSize = new Size();
+        panelSize = new Size();
+        wrapWidth = double.IsNaN(WrapWidth) ? availableSize.Width : WrapWidth;
+        var childrenCount = Children.Count;
+
+        // add ToolBar items which have IsOverflowItem = true
+        var toolBarPanel = ToolBarPanel;
+        if (toolBarPanel is not null)
+        {
+            // Go through the generated items collection and add to the children collection
+            // any that are marked IsOverFlowItem but aren't already in the children collection.
+            //
+            // The order of both collections matters.
+            //
+            // It is assumed that any children that were removed from generated items will have
+            // already been removed from the children collection.
+            var generatedItemsCollection = toolBarPanel.GeneratedItems;
+            var generatedItemsCount = generatedItemsCollection?.Count ?? 0;
+            var childrenIndex = 0;
+            for (var i = 0; i < generatedItemsCount; i++)
+            {
+                var child = generatedItemsCollection?[i];
+                if (child is not null && ToolBar.GetIsOverflowItem(child) && child is not Separator)
+                {
+                    if (childrenIndex < childrenCount)
+                    {
+                        if (Children[childrenIndex] != child)
+                        {
+                            Children.Insert(childrenIndex, child);
+                            childrenCount++;
+                        }
+                    }
+                    else
+                    {
+                        Children.Add(child);
+                        childrenCount++;
+                    }
+
+                    childrenIndex++;
+                }
+            }
+        }
+
+        // measure all children to determine if we need to increase the desired wrapWidth
+        for (var i = 0; i < childrenCount; i++)
+        {
+            var child = Children[i];
+            child.Measure(availableSize);
+
+            var childSize = child.DesiredSize;
+            if (DoubleUtil.GreaterThan(childSize.Width, wrapWidth))
+            {
+                wrapWidth = childSize.Width;
+            }
+        }
+
+        // wrapWidth should not be larger than availableSize.Width
+        wrapWidth = Math.Min(wrapWidth, availableSize.Width);
+
+        foreach (var child in Children)
+        {
+            var childSize = child.DesiredSize;
+
+            // need to switch to another line
+            if (DoubleUtil.GreaterThan(currentLineSize.Width + childSize.Width, wrapWidth))
+            {
+                panelSize = panelSize.WithWidth(Math.Max(currentLineSize.Width, panelSize.Width));
+                panelSize = panelSize.WithHeight(panelSize.Height + currentLineSize.Height);
+                currentLineSize = childSize;
+
+                // the element is wider then the available width - give it a separate line
+                if (DoubleUtil.GreaterThan(childSize.Width, wrapWidth))
+                {
+                    panelSize = panelSize.WithWidth(Math.Max(childSize.Width, panelSize.Width));
+                    panelSize = panelSize.WithHeight(panelSize.Height + childSize.Height);
+                    currentLineSize = new Size();
+                }
+            }
+            // continue to accumulate a line
+            else
+            {
+                currentLineSize = currentLineSize.WithWidth(currentLineSize.Width + childSize.Width);
+                currentLineSize = currentLineSize.WithHeight(Math.Max(childSize.Height, currentLineSize.Height));
+            }
+        }
+
+        // the last line size, if any should be added
+        panelSize = panelSize.WithWidth(Math.Max(currentLineSize.Width, panelSize.Width));
+        panelSize = panelSize.WithHeight(panelSize.Height + currentLineSize.Height);
+
+        return panelSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        var firstInLine = 0;
+        var currentLineSize = new Size();
+        var accumulatedHeight = 0d;
+
+        // wrapWidth should not be larger than finalSize.Width
+        wrapWidth = Math.Min(wrapWidth, finalSize.Width);
+
+        for (var i = 0; i < Children.Count; i++)
+        {
+            var childSize = Children[i].DesiredSize;
+
+            // switch to a new line
+            if (DoubleUtil.GreaterThan(currentLineSize.Width + childSize.Width, wrapWidth))
+            {
+                // arrange the items in the current line not including the current item
+                ArrangeLine(accumulatedHeight, currentLineSize.Height, firstInLine, i);
+                accumulatedHeight += currentLineSize.Height;
+
+                // Current item will be first on the next line
+                firstInLine = i;
+                currentLineSize = childSize;
+            }
+            // continue to accumulate a line
+            else
+            {
+                currentLineSize = currentLineSize.WithWidth(currentLineSize.Width + childSize.Width);
+                currentLineSize = currentLineSize.WithHeight(Math.Max(childSize.Height, currentLineSize.Height));
+            }
+        }
+
+        ArrangeLine(accumulatedHeight, currentLineSize.Height, firstInLine, Children.Count);
+
+        return panelSize;
+
+        void ArrangeLine(double y, double lineHeight, int start, int end)
+        {
+            var x = 0.0;
+            for (var i = start; i < end; i++)
+            {
+                var child = Children[i];
+                child.Arrange(new Rect(x, y, child.DesiredSize.Width, lineHeight));
+                x += child.DesiredSize.Width;
+            }
+        }
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBarPanel.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBarPanel.cs
@@ -1,0 +1,265 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+// This source file is adapted from the Windows Presentation Foundation project. 
+// (https://github.com/dotnet/wpf/)
+// Licensed under MIT license, courtesy of The .NET Foundation.
+
+using System.Collections;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.VisualTree;
+
+namespace Stride.Core.Presentation.Avalonia.Controls;
+
+public sealed class ToolBarPanel : Panel
+{
+    /// <summary>
+    /// Defines the <see cref="Orientation"/> property.
+    /// </summary>
+    public static readonly StyledProperty<Orientation> OrientationProperty =
+        AvaloniaProperty.Register<ToolBarPanel, Orientation>(nameof(Orientation));
+
+    public Orientation Orientation
+    {
+        get => GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+
+    public double MaxLength { get; private set; }
+
+    public double MinLength { get; private set; }
+
+    internal global::Avalonia.Controls.Controls? GeneratedItems { get; private set; }
+
+    internal ToolBar? ToolBar => TemplatedParent as ToolBar;
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var desiredSize = new Size();
+        var childSlotSize = availableSize;
+        bool isHorizontal = Orientation is Orientation.Horizontal;
+        childSlotSize = isHorizontal
+            ? childSlotSize.WithWidth(double.PositiveInfinity)
+            : childSlotSize.WithHeight(double.PositiveInfinity);
+
+        var childrenCount = Children.Count;
+        var childrenIndex = 0;
+
+        foreach (var child in GeneratedItems!)
+        {
+            var visualParent = child.GetVisualParent();
+
+            child.Measure(childSlotSize);
+            var childDesiredSize = child.DesiredSize;
+
+            // accumulate the size
+            if (isHorizontal)
+            {
+                desiredSize = desiredSize.WithWidth(desiredSize.Width + childDesiredSize.Width);
+                desiredSize = desiredSize.WithHeight(Math.Max(desiredSize.Height, childDesiredSize.Height));
+            }
+            else
+            {
+                desiredSize = desiredSize.WithWidth(Math.Max(desiredSize.Width, childDesiredSize.Width));
+                desiredSize = desiredSize.WithHeight(desiredSize.Height + childDesiredSize.Height);
+            }
+
+            if (visualParent != this)
+            {
+                if (childrenIndex < childrenCount)
+                {
+                    Children.Insert(childrenIndex, child);
+                }
+                else
+                {
+                    Children.Add(child);
+                }
+                childrenCount++;
+            }
+
+            Debug.Assert(Children[childrenIndex] == child, "Children is out of sync with generatedItems.");
+            childrenIndex++;
+        }
+
+        MinLength = isHorizontal ? desiredSize.Width : desiredSize.Height;
+        MaxLength = isHorizontal ? desiredSize.Width : desiredSize.Height; // will be different when we have overflow
+
+        return desiredSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        bool isHorizontal = Orientation is Orientation.Horizontal;
+        Rect rectChild = new(finalSize);
+        double previousDimension = 0.0;
+
+        foreach (var child in Children)
+        {
+            // skip calculation if child isn't visible
+            if (!child.IsVisible)
+                continue;
+
+            if (isHorizontal)
+            {
+                rectChild = rectChild.WithX(rectChild.X + previousDimension);
+                previousDimension = child.DesiredSize.Width;
+                rectChild = rectChild.WithWidth(previousDimension);
+                rectChild = rectChild.WithHeight(Math.Max(finalSize.Height, child.DesiredSize.Height));
+            }
+            else
+            {
+                rectChild = rectChild.WithY(rectChild.Y + previousDimension);
+                previousDimension = child.DesiredSize.Height;
+                rectChild = rectChild.WithHeight(previousDimension);
+                rectChild = rectChild.WithWidth(Math.Max(finalSize.Width, child.DesiredSize.Width));
+            }
+
+            child.Arrange(rectChild);
+        }
+
+        return finalSize;
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        if (ToolBar is { } toolBar)
+        {
+            toolBar.Items.CollectionChanged += ItemsOnCollectionChanged;
+
+            if (GeneratedItems is null)
+            {
+                GeneratedItems = [];
+            }
+            else
+            {
+                GeneratedItems.Clear();
+            }
+
+            AddItems(toolBar.Items);
+        }
+
+        return;
+
+        void ItemsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (GeneratedItems is null)
+                return;
+
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    AddItems(e.NewItems!, e.NewStartingIndex);
+                    break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    Remove(e.OldStartingIndex, e.OldItems!.Count);
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                case NotifyCollectionChangedAction.Move:
+                    Remove(e.OldStartingIndex, e.OldItems!.Count);
+                    AddItems(e.NewItems!, e.NewStartingIndex);
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    ClearItemsControlLogicalChildren();
+                    GeneratedItems.Clear();
+                    AddItems(toolBar.Items);
+                    break;
+            }
+
+            return;
+
+            void ClearItemsControlLogicalChildren()
+            {
+                if (GeneratedItems is null)
+                    return;
+
+                foreach (var child in GeneratedItems)
+                {
+                    toolBar.RemoveLogicalChild(child);
+                }
+            }
+
+            void Remove(int index, int count)
+            {
+                if (GeneratedItems == null)
+                    return;
+
+                var generator = toolBar.ItemContainerGenerator;
+                for (var i = 0; i < count; i++)
+                {
+                    var control = GeneratedItems[index + i];
+
+                    var visualParent = control.GetVisualParent();
+
+                    if (visualParent == this)
+                    {
+                        Children.Remove(control);
+                    }
+
+                    toolBar.RemoveLogicalChild(control);
+                    generator.ClearItemContainer(control);
+                }
+
+                GeneratedItems.RemoveRange(index, count);
+
+                var childCount = GeneratedItems.Count;
+
+                for (var i = index; i < childCount; ++i)
+                {
+                    generator.ItemContainerIndexChanged(GeneratedItems[i], i + count, i);
+                }
+            }
+        }
+    }
+
+    private void AddItems(IEnumerable items, int index = 0)
+    {
+        if (ToolBar is not { } toolBar || GeneratedItems is null)
+            return;
+
+        var generator = toolBar.ItemContainerGenerator;
+        var i = index;
+        foreach (var item in items)
+        {
+            InsertContainer(item, i++);
+        }
+
+        var childCount = GeneratedItems.Count;
+        var delta = i - index;
+
+        for (; i < childCount; ++i)
+        {
+            generator.ItemContainerIndexChanged(GeneratedItems[i], i - delta, i);
+        }
+    }
+
+    private void InsertContainer(object item, int index)
+    {
+        if (ToolBar is not { } toolBar || GeneratedItems is null)
+            return;
+
+        var generator = toolBar.ItemContainerGenerator;
+        Control container;
+        if (generator.NeedsContainer(item, index, out var recycleKey))
+        {
+            container = generator.CreateContainer(item, index, recycleKey);
+        }
+        else
+        {
+            container = (Control)item;
+        }
+
+        generator.PrepareItemContainer(container, item, index);
+        toolBar.AddLogicalChild(container);
+        GeneratedItems.Insert(index, container);
+        generator.ItemContainerPrepared(container, item, index);
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBarTray.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Controls/ToolBarTray.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+// This source file is adapted from the Windows Presentation Foundation project. 
+// (https://github.com/dotnet/wpf/)
+// Licensed under MIT license, courtesy of The .NET Foundation.
+
 using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Controls;
@@ -19,13 +23,16 @@ public sealed class ToolBarTray : Control, IAddChild<ToolBar>
 
     static ToolBarTray()
     {
-        OrientationProperty.Changed.AddClassHandler<ToolBarTray>((tray, _) =>
+        OrientationProperty.Changed.AddClassHandler<ToolBarTray>(OnOrientationChanged);
+        return;
+
+        static void OnOrientationChanged(ToolBarTray tray, AvaloniaPropertyChangedEventArgs _)
         {
             foreach (var toolBar in tray.ToolBars)
             {
                 toolBar.CoerceValue(ToolBar.OrientationProperty);
             }
-        });
+        }
     }
 
     private readonly ToolBarCollection toolBars;
@@ -48,7 +55,7 @@ public sealed class ToolBarTray : Control, IAddChild<ToolBar>
         ToolBars.Add(child);
     }
 
-    // Note: for now follow a similar layouting than StackPanel
+    // note: for now follow a similar layouting than StackPanel
     protected override Size MeasureOverride(Size availableSize)
     {
         Size trayDesiredSize = new();
@@ -60,11 +67,11 @@ public sealed class ToolBarTray : Control, IAddChild<ToolBar>
 
         foreach (var toolBar in toolBars)
         {
-            // Measure the toolbar
+            // measure the toolbar
             toolBar.Measure(toolBarConstraint);
             var toolBarDesiredSize = toolBar.DesiredSize;
 
-            // Accumulate the size
+            // accumulate the size
             if (isHorizontal)
             {
                 trayDesiredSize = trayDesiredSize.WithWidth(trayDesiredSize.Width + toolBarDesiredSize.Width);
@@ -80,7 +87,7 @@ public sealed class ToolBarTray : Control, IAddChild<ToolBar>
         return trayDesiredSize;
     }
 
-    // Note: for now follow a similar layouting than StackPanel
+    // note: for now follow a similar layouting than StackPanel
     protected override Size ArrangeOverride(Size finalSize)
     {
         bool isHorizontal = Orientation == Orientation.Horizontal;

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Internal/DoubleUtil.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Internal/DoubleUtil.cs
@@ -23,6 +23,16 @@ internal static class DoubleUtil
         return (a - b) is < Epsilon and > -Epsilon;
     }
 
+    public static bool GreaterThan(double value1, double value2)
+    {
+        return (value1 > value2) && !AreClose(value1, value2);
+    }
+
+    public static bool GreaterThanOrClose(double value1, double value2)
+    {
+        return (value1 > value2) || AreClose(value1, value2);
+    }
+
     public static bool LessThan(double a, double b)
     {
         return (a < b) && !AreClose(a, b);

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Internal/DoubleUtil.cs
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Internal/DoubleUtil.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+// This source file is adapted from the Windows Presentation Foundation project. 
+// (https://github.com/dotnet/wpf/)
+// Licensed under MIT license, courtesy of The .NET Foundation.
+
+namespace Stride.Core.Presentation.Avalonia.Internal;
+
+// ReSharper disable CompareOfFloatsByEqualityOperator
+
+/// <summary>
+/// This class provides "fuzzy" comparison functionalities for doubles.
+/// </summary>
+internal static class DoubleUtil
+{
+    internal const double Epsilon = 1e-6;
+
+    public static bool AreClose(double a, double b)
+    {
+        if (a == b) return true;
+
+        return (a - b) is < Epsilon and > -Epsilon;
+    }
+
+    public static bool LessThan(double a, double b)
+    {
+        return (a < b) && !AreClose(a, b);
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Themes/TextLogViewerStyle.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Themes/TextLogViewerStyle.axaml
@@ -53,15 +53,16 @@
           <sd:ToolBarTray DockPanel.Dock="Top" x:Name="ToolBarTray"
                           IsVisible="{TemplateBinding IsToolBarVisible}">
             <sd:ToolBar x:Name="ToolBarClear"
-                        IsVisible="{TemplateBinding CanClearLog}">
+                        IsVisible="{TemplateBinding CanClearLog}"
+                        Margin="0">
               <Button x:Name="PART_ClearLog"
                       ToolTip.Tip="{sd:LocalizeString Clear Log, Context=ToolTip}">
                 <Path Width="12" Height="12" Stretch="Uniform" Fill="{StaticResource TextBrush}" Data="{StaticResource GeometryDelete}"/>
               </Button>
-              <Border Background="Transparent" Width="12" />
             </sd:ToolBar>
             <sd:ToolBar x:Name="ToolBarFilter"
-                        IsVisible="{TemplateBinding CanFilterLog}">
+                        IsVisible="{TemplateBinding CanFilterLog}"
+                        Margin="8 0 0 0">
               <ToggleButton IsChecked="{TemplateBinding ShowDebugMessages, Mode=TwoWay}"
                             ToolTip.Tip="{sd:LocalizeString Toggle Debug, Context=ToolTip}">
                 <Path Width="12" Height="12" Stretch="Uniform" Fill="{DynamicResource TextLogDebugBrush}" Data="{StaticResource GeometryDebugMessage}"/>
@@ -90,10 +91,10 @@
                             ToolTip.Tip="{sd:LocalizeString Toggle Exception Stack Trace, Context=ToolTip}">
                 <TextBlock Width="16" Height="12" Text="(...)" FontSize="10" />
               </ToggleButton>
-              <Border Background="Transparent" Width="12" />
             </sd:ToolBar>
             <sd:ToolBar x:Name="ToolBarSearch"
-                        IsVisible="{TemplateBinding CanSearchLog}">
+                        IsVisible="{TemplateBinding CanSearchLog}"
+                        Margin="8 0 0 0">
               <TextBox x:Name="TextBoxSearch"
                        Text="{Binding SearchToken, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Delay=300}"
                        Width="256"

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Themes/ToolBarStyle.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Themes/ToolBarStyle.axaml
@@ -1,18 +1,98 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sd="http://schemas.stride3d.net/xaml/presentation">
+  <Styles.Resources>
+    <ControlTheme x:Key="HorizontalToolBarOverflowButton" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type ToggleButton}}">
+      <Setter Property="HorizontalAlignment" Value="Left" />
+      <Setter Property="VerticalAlignment" Value="Stretch" />
+      <Setter Property="ContentTemplate">
+        <DataTemplate>
+          <Path Data="M 0 0 H 6 L 3 6 Z"
+                Width="6"
+                HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Stretch="Uniform"
+                Fill="{DynamicResource ToggleButtonForeground}"/>
+        </DataTemplate>
+      </Setter>
+    </ControlTheme>
+    <ControlTheme x:Key="VerticalToolBarOverflowButton" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type ToggleButton}}">
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="VerticalAlignment" Value="Top" />
+      <Setter Property="ContentTemplate">
+        <DataTemplate>
+          <Path Data="M 0 6 V 0 L 6 3 Z"
+                Height="6"
+                HorizontalAlignment="Right" VerticalAlignment="Stretch" Stretch="Uniform"
+                Fill="{DynamicResource ToggleButtonForeground}"/>
+        </DataTemplate>
+      </Setter>
+    </ControlTheme>
+  </Styles.Resources>
   <Style Selector="sd|ToolBar">
+    <Setter Property="Margin" Value="4 0 0 0"/>
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Background="{TemplateBinding Background}"
-                BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}"
-                CornerRadius="{TemplateBinding CornerRadius}"
-                Padding="{TemplateBinding Padding}">
-          <sd:ToolBarPanel x:Name="PART_ToolBarPanel"
-                           Orientation="{TemplateBinding Orientation}"/>
-        </Border>
+        <Grid x:Name="Grid"
+              Margin="{TemplateBinding Margin}">
+          <!-- overflow -->
+          <Grid x:Name="OverflowGrid"
+                HorizontalAlignment="Right">
+            <ToggleButton x:Name="OverflowToggleButton"
+                          ClickMode="Press"
+                          IsChecked="{TemplateBinding IsOverflowOpen, Mode=TwoWay}"
+                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                          IsVisible="{TemplateBinding HasOverflowItems}"
+                          Padding="2"
+                          Theme="{StaticResource HorizontalToolBarOverflowButton}"/>
+            <Popup x:Name="OverflowPopup"
+                   PlacementTarget="OverflowToggleButton" Placement="BottomEdgeAlignedLeft"
+                   IsOpen="{Binding #OverflowToggleButton.IsChecked, Mode=TwoWay}"
+                   IsLightDismissEnabled="True">
+              <sd:ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                       Background="{DynamicResource SystemRegionColor}"
+                                       WrapWidth="256"/>
+            </Popup>
+          </Grid>
+          <!-- main panel -->
+          <Border x:Name="MainPanelBorder"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  Padding="{TemplateBinding Padding}"
+                  Margin="0">
+            <sd:ToolBarPanel x:Name="PART_ToolBarPanel"
+                             Orientation="{TemplateBinding Orientation}"/>
+          </Border>
+        </Grid>
       </ControlTemplate>
     </Setter>
+
+    <Style Selector="^[HasOverflowItems=True]">
+      <Style Selector="^ /template/ Border#MainPanelBorder">
+        <Setter Property="Margin" Value="0 0 13 0"/>
+      </Style>
+    </Style>
+
+    <Style Selector="^[Orientation=Vertical]">
+      <Style Selector="^ /template/ Grid#Grid">
+        <Setter Property="Margin" Value="0 4 0 0" />
+      </Style>
+      <Style Selector="^/template/ Grid#OverflowGrid">
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
+      </Style>
+      <Style Selector="^/template/ ToggleButton#OverflowToggleButton">
+        <Setter Property="Theme" Value="{StaticResource VerticalToolBarOverflowButton}"/>
+      </Style>
+      <Style Selector="^/template/ Popup#OverflowPopup">
+        <Setter Property="Placement" Value="RightEdgeAlignedTop"/>
+      </Style>
+
+      <Style Selector="^[HasOverflowItems=True]">
+        <Style Selector="^ /template/ Border#MainPanelBorder">
+          <Setter Property="Margin" Value="0 0 0 13"/>
+        </Style>
+      </Style>
+    </Style>
   </Style>
 </Styles>

--- a/sources/presentation/Stride.Core.Presentation.Avalonia/Themes/ToolBarStyle.axaml
+++ b/sources/presentation/Stride.Core.Presentation.Avalonia/Themes/ToolBarStyle.axaml
@@ -9,13 +9,8 @@
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}"
                 Padding="{TemplateBinding Padding}">
-          <ItemsPresenter x:Name="PART_ItemsPresenter">
-            <ItemsPresenter.ItemsPanel>
-              <ItemsPanelTemplate>
-                <StackPanel Orientation="{Binding $parent[sd:ToolBar].Orientation}"/>
-              </ItemsPanelTemplate>
-            </ItemsPresenter.ItemsPanel>
-          </ItemsPresenter>
+          <sd:ToolBarPanel x:Name="PART_ToolBarPanel"
+                           Orientation="{TemplateBinding Orientation}"/>
         </Border>
       </ControlTemplate>
     </Setter>


### PR DESCRIPTION
# PR Details

Add overflow panel to toolbars (either when they don't fit the area pr when items are explicitly set to appear in an overflow).

The behavior is adapted from WPF (https://github.com/dotnet/wpf/).

Note: I purposely didn't implement drag/drop of toolbars within the tray. I assumed users would expect the new positions to be saved as local settings and I didn't want to deal with that yet.

## Related PR

#2830

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
