### PR TITLE
Allow editing the animations on AnimationComponent

### DIFF
--- a/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
@@ -30,7 +30,7 @@ namespace Stride.Engine
         /// Gets the animations associated to the component.
         /// </summary>
         /// <userdoc>The list of the animation associated to the entity.</userdoc>
-        public Dictionary<string, AnimationClip> Animations { get; } = new();
+        public Dictionary<string, AnimationClip> Animations { get; set; } = new();
 
         /// <summary>
         /// Gets list of active animations. Use this to customize startup animations.


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

Enable programmatic animation assignment instead of requiring just editor setup.
Currently, users must configure animations in the editor, then reference them by name in code. This creates duplicate work and limits flexibility.

Use Case: We created an HSAnimator script that manages all animation clips and names in one place. By adding the AnimationComponent via code and populating its animations programmatically, we eliminate the need to configure animations twice and gain full control over the animation workflow.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] **I have built and run the editor to try this change out.**
