### PR TITLE
fix: Bepu and InputSystem update order

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/SystemsOrderHelper.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/SystemsOrderHelper.cs
@@ -1,19 +1,23 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Stride.Engine;
 using Stride.Engine.Processors;
 
 namespace Stride.BepuPhysics.Definitions;
 
 internal static class SystemsOrderHelper
 {
-
     //Note : transform processor's Draw() is at -200;
 
     /// <summary> Creation and management of constraints </summary>
     public const int ORDER_OF_CONSTRAINT_P = -900;
-    /// <summary> Simulation Step(dt) & Transform Update() </summary>
-    public const int ORDER_OF_GAME_SYSTEM = int.MaxValue;
+    /// <summary> Simulation Step(dt) & Transform Update()</summary>
+    /// <remarks>
+    /// Must happen before <see cref="ScriptSystem.Update"/> to make sure interpolated bodies update their positions before users read them,
+    /// but after <see cref="InputSystem.Update"/> otherwise users would be reading last frame's input in <see cref="Components.ISimulationUpdate"/>
+    /// </remarks>
+    public const int ORDER_OF_GAME_SYSTEM = InputSystem.DefaultUpdateOrder + 1;
     /// <summary> Drawing debug wireframe, must occur after <see cref="TransformProcessor.Draw"/> </summary>
     public const int ORDER_OF_DEBUG_P = 1000;
     /// <summary> Creation and management of collidable, rebuilds static meshes when they are moved, must occur after <see cref="TransformProcessor.Draw"/> </summary>

--- a/sources/engine/Stride.Engine/Engine/InputSystem.cs
+++ b/sources/engine/Stride.Engine/Engine/InputSystem.cs
@@ -13,10 +13,13 @@ namespace Stride.Engine
     /// </summary>
     public sealed class InputSystem : GameSystemBase
     {
+        public const int DefaultUpdateOrder = -50;
+        
         public InputSystem(IServiceRegistry registry) : base(registry)
         {
             Enabled = true;
             Manager = new InputManager().DisposeBy(this);
+            UpdateOrder = DefaultUpdateOrder;
         }
 
         public InputManager Manager { get; }


### PR DESCRIPTION
# PR Details
Set the update order for the `InputSystem` to a non-zero value, it will now always run before other systems with unset order.
Previously, users may inadvertently introduce a one-frame input latency to their scripts by creating the `ScriptSystem` before the `InputSystem`.
Also provides a way for users to insert systems that may run after the `InputSystem` but before the `ScriptSystem` without touching those two systems or creating a custom game implementation.

Given the above, moved the execution point of `Bepu` earlier in the frame, before `ScriptSystem` runs to make sure interpolated bodies update their positions before users may read them in update, but after `InputSystem` otherwise users would be reading last frame's input when they implement `Components.ISimulationUpdate`.

The above will reduce/eliminate apparent stuttering with user script when moving objects based on physics object transforms.

## Related Issue
None afaict.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
