### PR TITLE
fix: add null check for oldNode in `GameEditorChangePropagator`

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorChangePropagator.cs
@@ -201,7 +201,11 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.ViewModels
                                     if (gameSideNode != null)
                                         removedNodes.Add(gameSideNode);
                                 };
-                                visitor.Visit(oldNode);
+
+                                if (oldNode != null)
+                                {
+                                    visitor.Visit(oldNode);
+                                }
 
                                 await Editor.Controller.InvokeTask(async () =>
                                 {


### PR DESCRIPTION

# PR Details

Added a null check for `oldNode` before invoking `visitor.Visit(oldNode)`.
This change prevents potential null reference exceptions during execution.

> The bug was introduced in the "User-defined assets support" feature in 5da9ae357eb795e99616e8d528bf295e1fa2c3c9 and is not in the release version.

## Related Issue

Closes #2850 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
