### PR TITLE
[UI] Add gap support to layout panels

### DIFF
--- a/sources/engine/Stride.UI.Tests/Layering/UniformGridTests.cs
+++ b/sources/engine/Stride.UI.Tests/Layering/UniformGridTests.cs
@@ -23,29 +23,32 @@ namespace Stride.UI.Tests.Layering
             UIElementLayeringTests.TestMeasureInvalidation(this, () => Columns = 7);
             UIElementLayeringTests.TestMeasureInvalidation(this, () => Rows = 34);
             UIElementLayeringTests.TestMeasureInvalidation(this, () => Layers = 34);
+            UIElementLayeringTests.TestMeasureInvalidation(this, () => ColumnGap = 10f);
+            UIElementLayeringTests.TestMeasureInvalidation(this, () => RowGap = 5f);
+            UIElementLayeringTests.TestMeasureInvalidation(this, () => LayerGap = 15f);
         }
 
         /// <summary>
-        /// Test for the <see cref="StackPanel.GetSurroudingAnchorDistances"/>
+        /// Test for the <see cref="UniformGrid.GetSurroudingAnchorDistances"/>
         /// </summary>
         [Fact]
         public void TestSurroudingAnchor()
         {
             var childSize1 = new Vector3(50, 150, 250);
             var childSize2 = new Vector3(100, 200, 300);
-            
-            var grid = new UniformGrid { Columns = 2, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center};
+
+            var grid = new UniformGrid { Columns = 2, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center };
 
             var child1 = new UniformGrid { Size = childSize1 };
             var child2 = new UniformGrid { Size = childSize2 };
             child2.DependencyProperties.Set(ColumnPropertyKey, 1);
-            
+
             grid.Children.Add(child1);
             grid.Children.Add(child2);
 
             grid.Measure(1000 * Vector3.One);
             grid.Arrange(1000 * Vector3.One, false);
-            
+
             Assert.Equal(new Vector2(0, 100), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, -1));
             Assert.Equal(new Vector2(0, 100), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, 0));
             Assert.Equal(new Vector2(-50, 50), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, 50));
@@ -62,6 +65,285 @@ namespace Stride.UI.Tests.Layering
             Assert.Equal(new Vector2(0, 300), grid.GetSurroudingAnchorDistances(Orientation.InDepth, -1));
             Assert.Equal(new Vector2(-150, 150), grid.GetSurroudingAnchorDistances(Orientation.InDepth, 150));
             Assert.Equal(new Vector2(-300, 0), grid.GetSurroudingAnchorDistances(Orientation.InDepth, 500));
+        }
+
+
+        /// <summary>
+        /// Test for the <see cref="UniformGrid.GetSurroudingAnchorDistances"/>
+        /// </summary>
+        [Fact]
+        public void TestSurroudingAnchorWithGap()
+        {
+            var childSize1 = new Vector3(50, 150, 250);
+            var childSize2 = new Vector3(100, 200, 300);
+
+            var grid = new UniformGrid { Columns = 2, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center };
+            grid.ColumnGap = 10f; // Add gap for testing
+
+            var child1 = new UniformGrid { Size = childSize1 };
+            var child2 = new UniformGrid { Size = childSize2 };
+            child2.DependencyProperties.Set(ColumnPropertyKey, 1);
+
+            grid.Children.Add(child1);
+            grid.Children.Add(child2);
+
+            grid.Measure(1000 * Vector3.One);
+            grid.Arrange(1000 * Vector3.One, false);
+
+            // With gaps, the anchor distance is based on cell content size + gap
+            // Cell size is determined by content (100) + gap (10) = 110
+            var anchorSpacing = 110f;
+
+            Assert.Equal(new Vector2(0, anchorSpacing), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, -1));
+            Assert.Equal(new Vector2(0, anchorSpacing), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, 0));
+            Assert.Equal(new Vector2(-55f, 55f), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, 55f));
+            Assert.Equal(new Vector2(-55f, 55f), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, 55f));
+            Assert.Equal(new Vector2(0, anchorSpacing), grid.GetSurroudingAnchorDistances(Orientation.Horizontal, anchorSpacing));
+        }
+
+
+        /// <summary>
+        /// Test the gap properties and their effects on layout
+        /// </summary>
+        [Fact]
+        public void TestGapProperties()
+        {
+            var uniformGrid = new UniformGrid();
+
+            // Test default values
+            Assert.Equal(0f, uniformGrid.ColumnGap);
+            Assert.Equal(0f, uniformGrid.RowGap);
+            Assert.Equal(0f, uniformGrid.LayerGap);
+
+            // Test setting values
+            uniformGrid.ColumnGap = 10f;
+            uniformGrid.RowGap = 5f;
+            uniformGrid.LayerGap = 15f;
+
+            Assert.Equal(10f, uniformGrid.ColumnGap);
+            Assert.Equal(5f, uniformGrid.RowGap);
+            Assert.Equal(15f, uniformGrid.LayerGap);
+
+            // Test negative values are clamped to 0
+            uniformGrid.ColumnGap = -5f;
+            uniformGrid.RowGap = -10f;
+            uniformGrid.LayerGap = -20f;
+
+            Assert.Equal(0f, uniformGrid.ColumnGap);
+            Assert.Equal(0f, uniformGrid.RowGap);
+            Assert.Equal(0f, uniformGrid.LayerGap);
+        }
+
+        /// <summary>
+        /// Test measure with gaps
+        /// </summary>
+        [Fact]
+        public void TestMeasureWithGaps()
+        {
+            var uniformGrid = new UniformGrid { Columns = 3, Rows = 2, Layers = 1 };
+            uniformGrid.ColumnGap = 10f;
+            uniformGrid.RowGap = 5f;
+            uniformGrid.LayerGap = 0f; // No layer gap for 2D grid
+
+            // Create test children
+            var child1 = new UniformGridTests { Width = 50, Height = 30 };
+            var child2 = new UniformGridTests { Width = 40, Height = 25 };
+            var child3 = new UniformGridTests { Width = 45, Height = 35 };
+
+            child1.DependencyProperties.Set(ColumnPropertyKey, 0);
+            child1.DependencyProperties.Set(RowPropertyKey, 0);
+            child2.DependencyProperties.Set(ColumnPropertyKey, 1);
+            child2.DependencyProperties.Set(RowPropertyKey, 0);
+            child3.DependencyProperties.Set(ColumnPropertyKey, 2);
+            child3.DependencyProperties.Set(RowPropertyKey, 0);
+
+            uniformGrid.Children.Add(child1);
+            uniformGrid.Children.Add(child2);
+            uniformGrid.Children.Add(child3);
+
+            var measureSize = new Vector3(300, 200, 100);
+            uniformGrid.Measure(measureSize);
+
+            // Calculate expected size:
+            // Cell size: max child size (50x35) 
+            // Total width: 3 * 50 + 2 * 10 (gaps) = 170
+            // Total height: 2 * 35 + 1 * 5 (gap) = 75
+            var expectedSize = new Vector3(170, 75, 0);
+            Assert.Equal(expectedSize, uniformGrid.DesiredSizeWithMargins);
+        }
+
+        /// <summary>
+        /// Test arrange with gaps
+        /// </summary>
+        [Fact]
+        public void TestArrangeWithGaps()
+        {
+            var uniformGrid = new UniformGrid { Columns = 2, Rows = 2, Layers = 1 };
+            uniformGrid.ColumnGap = 8f;
+            uniformGrid.RowGap = 4f;
+
+            // Create test children
+            var child1 = new UniformGridTests { Width = 30, Height = 20 };
+            var child2 = new UniformGridTests { Width = 25, Height = 18 };
+            var child3 = new UniformGridTests { Width = 35, Height = 22 };
+            var child4 = new UniformGridTests { Width = 28, Height = 19 };
+
+            // Position children in grid
+            child1.DependencyProperties.Set(ColumnPropertyKey, 0);
+            child1.DependencyProperties.Set(RowPropertyKey, 0);
+            child2.DependencyProperties.Set(ColumnPropertyKey, 1);
+            child2.DependencyProperties.Set(RowPropertyKey, 0);
+            child3.DependencyProperties.Set(ColumnPropertyKey, 0);
+            child3.DependencyProperties.Set(RowPropertyKey, 1);
+            child4.DependencyProperties.Set(ColumnPropertyKey, 1);
+            child4.DependencyProperties.Set(RowPropertyKey, 1);
+
+            uniformGrid.Children.Add(child1);
+            uniformGrid.Children.Add(child2);
+            uniformGrid.Children.Add(child3);
+            uniformGrid.Children.Add(child4);
+
+            var arrangeSize = new Vector3(200, 150, 100);
+            uniformGrid.Measure(arrangeSize);
+            uniformGrid.Arrange(arrangeSize, false);
+
+            // Verify children are positioned correctly with gaps
+            var child1Matrix = child1.DependencyProperties.Get(PanelArrangeMatrixPropertyKey);
+            var child2Matrix = child2.DependencyProperties.Get(PanelArrangeMatrixPropertyKey);
+            var child3Matrix = child3.DependencyProperties.Get(PanelArrangeMatrixPropertyKey);
+            var child4Matrix = child4.DependencyProperties.Get(PanelArrangeMatrixPropertyKey);
+
+            // Calculate expected positions accounting for gaps
+            var cellWidth = (arrangeSize.X - uniformGrid.ColumnGap) / 2; // (200 - 8) / 2 = 96
+            var cellHeight = (arrangeSize.Y - uniformGrid.RowGap) / 2; // (150 - 4) / 2 = 73
+
+            // Child 1 at (0,0) - should be at top-left
+            var expectedChild1X = -arrangeSize.X / 2;
+            var expectedChild1Y = -arrangeSize.Y / 2;
+            Assert.Equal(expectedChild1X, child1Matrix.TranslationVector.X);
+            Assert.Equal(expectedChild1Y, child1Matrix.TranslationVector.Y);
+
+            // Child 2 at (1,0) - should be at top-right with column gap
+            var expectedChild2X = -arrangeSize.X / 2 + cellWidth + uniformGrid.ColumnGap;
+            var expectedChild2Y = -arrangeSize.Y / 2;
+            Assert.Equal(expectedChild2X, child2Matrix.TranslationVector.X);
+            Assert.Equal(expectedChild2Y, child2Matrix.TranslationVector.Y);
+
+            // Child 3 at (0,1) - should be at bottom-left with row gap
+            var expectedChild3X = -arrangeSize.X / 2;
+            var expectedChild3Y = -arrangeSize.Y / 2 + cellHeight + uniformGrid.RowGap;
+            Assert.Equal(expectedChild3X, child3Matrix.TranslationVector.X);
+            Assert.Equal(expectedChild3Y, child3Matrix.TranslationVector.Y);
+
+            // Child 4 at (1,1) - should be at bottom-right with both gaps
+            var expectedChild4X = -arrangeSize.X / 2 + cellWidth + uniformGrid.ColumnGap;
+            var expectedChild4Y = -arrangeSize.Y / 2 + cellHeight + uniformGrid.RowGap;
+            Assert.Equal(expectedChild4X, child4Matrix.TranslationVector.X);
+            Assert.Equal(expectedChild4Y, child4Matrix.TranslationVector.Y);
+        }
+
+        /// <summary>
+        /// Test gaps with 3D grid (including layer gaps)
+        /// </summary>
+        [Fact]
+        public void TestGapsWith3DGrid()
+        {
+            var uniformGrid = new UniformGrid { Columns = 2, Rows = 2, Layers = 2 };
+            uniformGrid.ColumnGap = 5f;
+            uniformGrid.RowGap = 3f;
+            uniformGrid.LayerGap = 7f;
+
+            // Create test children for all positions
+            for (int layer = 0; layer < 2; layer++)
+            {
+                for (int row = 0; row < 2; row++)
+                {
+                    for (int col = 0; col < 2; col++)
+                    {
+                        var child = new UniformGridTests { Width = 20, Height = 15, Depth = 10 };
+                        child.DependencyProperties.Set(ColumnPropertyKey, col);
+                        child.DependencyProperties.Set(RowPropertyKey, row);
+                        child.DependencyProperties.Set(LayerPropertyKey, layer);
+                        uniformGrid.Children.Add(child);
+                    }
+                }
+            }
+
+            var measureSize = new Vector3(200, 150, 100);
+            uniformGrid.Measure(measureSize);
+
+            // Expected total size with gaps:
+            // Width: 2 * 20 + 1 * 5 = 45
+            // Height: 2 * 15 + 1 * 3 = 33
+            // Depth: 2 * 10 + 1 * 7 = 27
+            var expectedSize = new Vector3(45, 33, 27);
+            Assert.Equal(expectedSize, uniformGrid.DesiredSizeWithMargins);
+        }
+
+        /// <summary>
+        /// Test gaps with single column/row (no gaps should be added)
+        /// </summary>
+        [Fact]
+        public void TestGapsWithSingleDimensions()
+        {
+            var uniformGrid = new UniformGrid { Columns = 1, Rows = 1, Layers = 1 };
+            uniformGrid.ColumnGap = 10f;
+            uniformGrid.RowGap = 5f;
+            uniformGrid.LayerGap = 15f;
+
+            var child = new UniformGridTests { Width = 50, Height = 30, Depth = 20 };
+            child.DependencyProperties.Set(ColumnPropertyKey, 0);
+            child.DependencyProperties.Set(RowPropertyKey, 0);
+            child.DependencyProperties.Set(LayerPropertyKey, 0);
+            uniformGrid.Children.Add(child);
+
+            var measureSize = new Vector3(200, 150, 100);
+            uniformGrid.Measure(measureSize);
+
+            // With single cell, no gaps should be added
+            var expectedSize = new Vector3(50, 30, 20);
+            Assert.Equal(expectedSize, uniformGrid.DesiredSizeWithMargins);
+        }
+
+        /// <summary>
+        /// Test gaps with spanned elements
+        /// </summary>
+        [Fact]
+        public void TestGapsWithSpannedElements()
+        {
+            var uniformGrid = new UniformGrid { Columns = 3, Rows = 2, Layers = 1 };
+            uniformGrid.ColumnGap = 6f;
+            uniformGrid.RowGap = 4f;
+
+            // Create a child that spans 2 columns
+            var spannedChild = new UniformGridTests { Width = 80, Height = 40 };
+            spannedChild.DependencyProperties.Set(ColumnPropertyKey, 0);
+            spannedChild.DependencyProperties.Set(RowPropertyKey, 0);
+            spannedChild.DependencyProperties.Set(ColumnSpanPropertyKey, 2);
+
+            // Create a normal child
+            var normalChild = new UniformGridTests { Width = 30, Height = 25 };
+            normalChild.DependencyProperties.Set(ColumnPropertyKey, 2);
+            normalChild.DependencyProperties.Set(RowPropertyKey, 0);
+
+            uniformGrid.Children.Add(spannedChild);
+            uniformGrid.Children.Add(normalChild);
+
+            var measureSize = new Vector3(300, 200, 100);
+            uniformGrid.Measure(measureSize);
+            uniformGrid.Arrange(measureSize, false);
+
+            // Verify that spanned elements work correctly with gaps
+            var spannedMatrix = spannedChild.DependencyProperties.Get(PanelArrangeMatrixPropertyKey);
+            var normalMatrix = normalChild.DependencyProperties.Get(PanelArrangeMatrixPropertyKey);
+
+            // The spanned child should start at the left edge
+            Assert.Equal(-measureSize.X / 2, spannedMatrix.TranslationVector.X);
+
+            // The normal child should be positioned after the spanned child and gaps
+            var cellWidth = (measureSize.X - 2 * uniformGrid.ColumnGap) / 3;
+            var expectedNormalX = -measureSize.X / 2 + 2 * cellWidth + 2 * uniformGrid.ColumnGap;
+            Assert.Equal(expectedNormalX, normalMatrix.TranslationVector.X);
         }
     }
 }

--- a/sources/engine/Stride.UI.Tests/Layering/UniformGridTests.cs
+++ b/sources/engine/Stride.UI.Tests/Layering/UniformGridTests.cs
@@ -29,10 +29,10 @@ namespace Stride.UI.Tests.Layering
         }
 
         /// <summary>
-        /// Test for the <see cref="UniformGrid.GetSurroudingAnchorDistances"/>
+        /// Test for the <see cref="UniformGrid.GetSurroundingAnchorDistances"/>
         /// </summary>
         [Fact]
-        public void TestSurroudingAnchor()
+        public void TestSurroundingAnchor()
         {
             var childSize1 = new Vector3(50, 150, 250);
             var childSize2 = new Vector3(100, 200, 300);

--- a/sources/engine/Stride.UI/Panels/Grid.cs
+++ b/sources/engine/Stride.UI/Panels/Grid.cs
@@ -161,7 +161,7 @@ namespace Stride.UI.Panels
             //
             // We chose a kind of gross but simple/efficient algorithm. It works as follows:
             // - Initialize the strip sizes with the strip minimum size for star/auto strips and exact final size for fixed strips.
-            // - Remove the minimal strip size as well as the fixed strip size.
+            // - Remove the minimal strip size as well as the fixed strip size and gap sizes.
             // - Use this same remaining size to measure all the auto elements.
             // This algorithm put all the auto elements on an equal footing, but propose more space to the children that the grid really have.
             //
@@ -176,10 +176,13 @@ namespace Stride.UI.Panels
             for (var dim = 0; dim < 3; dim++)
                 InitializeStripDefinitionActualSize(dimensionData[dim].StripDefinitions);
 
-            // calculate size available for all auto elements.
+            // calculate size available for all auto elements, accounting for gaps
             var autoElementAvailableSize = availableSizeWithoutMargins;
             for (var dim = 0; dim < 3; dim++)
             {
+                var totalGapSize = CalculateTotalGapSize(dim, dimensionData[dim].StripDefinitions.Count);
+                autoElementAvailableSize[dim] -= totalGapSize;
+                
                 foreach (var definition in dimensionData[dim].StripDefinitions)
                 {
                     autoElementAvailableSize[dim] -= definition.Type == StripType.Fixed ? definition.ActualSize : definition.MinimumSize;
@@ -193,8 +196,10 @@ namespace Stride.UI.Panels
                 for (var dim = 0; dim < 3; dim++)
                 {
                     var autoAvailableWithMin = autoElementAvailableSize[dim];
-                    var currentDimChildAvailableSize = childAvailableSize[dim];
-                    foreach (var definition in dimensionData[dim].ElementToStripDefinitions[child])
+                    var currentDimChildAvailableSize = 0f;
+                    var elementStripDefinitions = dimensionData[dim].ElementToStripDefinitions[child];
+                    
+                    foreach (var definition in elementStripDefinitions)
                     {
                         autoAvailableWithMin += definition.Type == StripType.Fixed ? definition.ActualSize : definition.MinimumSize;
                         if (definition.Type == StripType.Fixed)
@@ -202,6 +207,11 @@ namespace Stride.UI.Panels
                         else
                             currentDimChildAvailableSize = Math.Min(autoAvailableWithMin, currentDimChildAvailableSize + definition.MaximumSize);
                     }
+                    
+                    // Add gaps for spanned elements
+                    if (elementStripDefinitions.Count > 1)
+                        currentDimChildAvailableSize += GetGapForDimension(dim) * (elementStripDefinitions.Count - 1);
+                        
                     childAvailableSize[dim] = currentDimChildAvailableSize;
                 }
                 child.Measure(childAvailableSize);
@@ -264,6 +274,11 @@ namespace Stride.UI.Panels
                             if (elementStripDefinitions[i] == currentDefinition)
                                 currentDefinitionIndex = i;
                         }
+
+                        // Add gaps for spanned elements
+                        if (elementStripDefinitions.Count > 1)
+                            spaceAvailable += GetGapForDimension(dim) * (elementStripDefinitions.Count - 1);
+                        
                         var spaceNeeded = Math.Max(0, element.DesiredSizeWithMargins[dim] - spaceAvailable);
 
                         // if no space is needed, go check the next element
@@ -287,7 +302,7 @@ namespace Stride.UI.Panels
                 }
             }
 
-            // 5. Calculate the actual size of 1-star strip.
+            // 5. Calculate the actual size of 1-star strip, accounting for gaps
             CalculateStarStripSize(availableSizeWithoutMargins);
 
             // 6. Re-measure all the children, this time with the exact available size.
@@ -295,7 +310,7 @@ namespace Stride.UI.Panels
             {
                 var availableToChildWithMargin = Vector3.Zero;
                 for (var dim = 0; dim < 3; dim++)
-                    availableToChildWithMargin[dim] = SumStripCurrentSize(dimensionData[dim].ElementToStripDefinitions[child]);
+                    availableToChildWithMargin[dim] = SumStripCurrentSizeWithGaps(dimensionData[dim].ElementToStripDefinitions[child], dim);
 
                 child.Measure(availableToChildWithMargin);
             }
@@ -337,6 +352,11 @@ namespace Stride.UI.Panels
                         }
                         availableSpace += def.ActualSize;
                     }
+
+                    // Add gaps for spanned elements
+                    if (elementDefinitions.Count > 1)
+                        availableSpace += GetGapForDimension(dim) * (elementDefinitions.Count - 1);
+
                     var currentNeededSpace = Math.Max(0, element.DesiredSizeWithMargins[dim] - availableSpace);
 
                     // sort the star definition by increasing relative minimum and maximum values
@@ -397,8 +417,8 @@ namespace Stride.UI.Panels
                 foreach (var starDefinition in dimData.StarDefinitions)
                     starDefinition.ActualSize = starDefinition.ClampSizeByMinimumMaximum(oneStarSize * starDefinition.SizeValue);
 
-                // determine to size needed by the grid
-                neededSize[dim] += SumStripCurrentSize(definitions);
+                // determine to size needed by the grid, including gaps
+                neededSize[dim] += SumStripCurrentSize(definitions) + CalculateTotalGapSize(dim, definitions.Count);
             }
 
             return neededSize;
@@ -452,9 +472,9 @@ namespace Stride.UI.Panels
 
                 // calculate the size provided to the child
                 var providedSize = new Vector3(
-                    SumStripCurrentSize(dimensionData[0].ElementToStripDefinitions[child]),
-                    SumStripCurrentSize(dimensionData[1].ElementToStripDefinitions[child]),
-                    SumStripCurrentSize(dimensionData[2].ElementToStripDefinitions[child]));
+                    SumStripCurrentSizeWithGaps(dimensionData[0].ElementToStripDefinitions[child], 0),
+                    SumStripCurrentSizeWithGaps(dimensionData[1].ElementToStripDefinitions[child], 1),
+                    SumStripCurrentSizeWithGaps(dimensionData[2].ElementToStripDefinitions[child], 2));
 
                 // arrange the child
                 child.Arrange(providedSize, IsCollapsed);
@@ -475,8 +495,11 @@ namespace Stride.UI.Panels
                 // compute the size taken by fixed and auto strips
                 var spaceTakenByFixedAndAutoStrips = SumStripAutoAndFixedSize(dimData.StripDefinitions);
 
+                // calculate the total gap size for this dimension
+                var totalGapSize = CalculateTotalGapSize(dim, dimData.StripDefinitions.Count);
+
                 // calculate the size remaining for the start-sized strips
-                var spaceRemainingForStarStrips = Math.Max(0f, finalSizeWithoutMargins[dim] - spaceTakenByFixedAndAutoStrips);
+                var spaceRemainingForStarStrips = Math.Max(0f, finalSizeWithoutMargins[dim] - spaceTakenByFixedAndAutoStrips - totalGapSize);
 
                 // calculate the total value of the stars.
                 var starValuesSum = SumValues(starDefinitionsCopy);
@@ -490,7 +513,7 @@ namespace Stride.UI.Panels
                 //   1. Finding saturated strips (by min or max)
                 //   2. Determine if size taken by star-sized strip will increase or decrease due to saturated strips.
                 //   3. Updating the total size dedicated of star-sized strips by removing the size taken by min (resp. max) saturated strips
-                //   4. Updating the total remaining star value by removing the star-values of min (resp. max) saturated strips
+                //   4. Updating the total remaining star value by removing the star-values of min (resp. max) saturated strips.
                 //   5. Updating size of 1-star-sized strip.
                 //   6. Removing from the star-sized strip list the min (resp. max) saturated strips.
                 //   7. As new strips can now reach min (resp. max) saturation with the decreased (resp. increase) of the 1-star-sized strip size,
@@ -693,12 +716,13 @@ namespace Stride.UI.Panels
 
         private void RebuildStripPositionCacheData()
         {
-            // rebuild strip begin position cached data
+            // rebuild strip begin position cached data, accounting for gaps
             for (var dim = 0; dim < 3; dim++)
             {
                 ref var dimData = ref dimensionData[dim];
                 var cachedStripIndexToStripPosition = dimData.CachedStripIndexToStripPosition;
                 var stripDefinitions = dimData.StripDefinitions;
+                var gap = GetGapForDimension(dim);
 
                 //clear last cached data
                 cachedStripIndexToStripPosition.Clear();
@@ -709,6 +733,8 @@ namespace Stride.UI.Panels
                 {
                     cachedStripIndexToStripPosition.Add(startPosition);
                     startPosition += stripDefinitions[index].ActualSize;
+                    if (index < stripDefinitions.Count - 1) // Add gap except after the last strip
+                        startPosition += gap;
                 }
                 cachedStripIndexToStripPosition.Add(startPosition);
             }
@@ -722,6 +748,23 @@ namespace Stride.UI.Panels
                 sum += def.ActualSize;
 
             return sum;
+        }
+
+        /// <summary>
+        /// Calculates the total size for spanned elements including gaps.
+        /// </summary>
+        /// <param name="elementStripDefinitions">The strip definitions the element spans</param>
+        /// <param name="dimension">The dimension (0=Column, 1=Row, 2=Layer)</param>
+        /// <returns>The total size including gaps</returns>
+        private float SumStripCurrentSizeWithGaps(List<StripDefinition> elementStripDefinitions, int dimension)
+        {
+            if (elementStripDefinitions.Count <= 1)
+                return SumStripCurrentSize(elementStripDefinitions);
+
+            // For spanned elements: sum of strip sizes + gaps between strips
+            var sum = SumStripCurrentSize(elementStripDefinitions);
+            var gapSize = GetGapForDimension(dimension) * (elementStripDefinitions.Count - 1);
+            return sum + gapSize;
         }
 
         private static float SumStripCurrentSize(List<StripDefinition> definitions)

--- a/sources/engine/Stride.UI/Panels/Grid.cs
+++ b/sources/engine/Stride.UI/Panels/Grid.cs
@@ -513,7 +513,7 @@ namespace Stride.UI.Panels
                 //   1. Finding saturated strips (by min or max)
                 //   2. Determine if size taken by star-sized strip will increase or decrease due to saturated strips.
                 //   3. Updating the total size dedicated of star-sized strips by removing the size taken by min (resp. max) saturated strips
-                //   4. Updating the total remaining star value by removing the star-values of min (resp. max) saturated strips.
+                //   4. Updating the total remaining star value by removing the star-values of min (resp. max) saturated strips
                 //   5. Updating size of 1-star-sized strip.
                 //   6. Removing from the star-sized strip list the min (resp. max) saturated strips.
                 //   7. As new strips can now reach min (resp. max) saturation with the decreased (resp. increase) of the 1-star-sized strip size,

--- a/sources/engine/Stride.UI/Panels/GridBase.cs
+++ b/sources/engine/Stride.UI/Panels/GridBase.cs
@@ -161,6 +161,16 @@ namespace Stride.UI.Panels
             };
         }
 
+        /// <summary>
+        /// Calculates and returns the spacing gaps between columns, rows, and layers.
+        /// </summary>
+        /// <returns>A <see cref="Vector3"/> where the X, Y, and Z components represent the column gap, row gap, and layer gap,
+        /// respectively.</returns>
+        protected Vector3 GetGaps()
+        {
+            return new Vector3(columnGap, rowGap, layerGap);
+        }
+
         private static void InvalidateParentGridMeasure(object propertyowner, PropertyKey<int> propertykey, int propertyoldvalue)
         {
             var element = (UIElement)propertyowner;

--- a/sources/engine/Stride.UI/Panels/GridBase.cs
+++ b/sources/engine/Stride.UI/Panels/GridBase.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
+using System.ComponentModel;
 using System.Diagnostics;
 
 using Stride.Core;
@@ -66,6 +68,98 @@ namespace Stride.UI.Panels
         [DataMemberRange(1, 0)]
         [Display(category: LayoutCategory)]
         public static readonly PropertyKey<int> LayerSpanPropertyKey = DependencyPropertyFactory.RegisterAttached(nameof(LayerSpanPropertyKey), typeof(GridBase), 1, CoerceSpanValue, InvalidateParentGridMeasure);
+
+        private float columnGap = 0f;
+        private float rowGap = 0f;
+        private float layerGap = 0f;
+
+        /// <summary>
+        /// Gets or sets the gap between columns in virtual pixels.
+        /// </summary>
+        /// <userdoc>The gap between columns in virtual pixels.</userdoc>
+        [DataMember]
+        [Display(category: LayoutCategory)]
+        [DefaultValue(0f)]
+        public float ColumnGap
+        {
+            get { return columnGap; }
+            set
+            {
+                if (columnGap != value)
+                {
+                    columnGap = Math.Max(0, value);
+                    InvalidateMeasure();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the gap between rows in virtual pixels.
+        /// </summary>
+        /// <userdoc>The gap between rows in virtual pixels.</userdoc>
+        [DataMember]
+        [Display(category: LayoutCategory)]
+        [DefaultValue(0f)]
+        public float RowGap
+        {
+            get { return rowGap; }
+            set
+            {
+                if (rowGap != value)
+                {
+                    rowGap = Math.Max(0, value);
+                    InvalidateMeasure();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the gap between layers in virtual pixels.
+        /// </summary>
+        /// <userdoc>The gap between layers in virtual pixels.</userdoc>
+        [DataMember]
+        [Display(category: LayoutCategory)]
+        [DefaultValue(0f)]
+        public float LayerGap
+        {
+            get { return layerGap; }
+            set
+            {
+                if (layerGap != value)
+                {
+                    layerGap = Math.Max(0, value);
+                    InvalidateMeasure();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Calculates the total gap size for a dimension based on the number of cells.
+        /// </summary>
+        /// <param name="dimension">The dimension (0=Column, 1=Row, 2=Layer)</param>
+        /// <param name="cellCount">The number of cells in this dimension</param>
+        /// <returns>The total gap size</returns>
+        public float CalculateTotalGapSize(int dimension, int cellCount)
+        {
+            if (cellCount <= 1) return 0f;
+            return GetGapForDimension(dimension) * (cellCount - 1);
+        }
+
+        /// <summary>
+        /// Gets the gap value for the specified dimension.
+        /// </summary>
+        /// <param name="dimension">The dimension (0=Column, 1=Row, 2=Layer)</param>
+        /// <returns>The gap value</returns>
+        protected float GetGapForDimension(int dimension)
+        {
+            return dimension switch
+            {
+                0 => columnGap,
+                1 => rowGap,
+                2 => layerGap,
+                _ => 0f
+            };
+        }
 
         private static void InvalidateParentGridMeasure(object propertyowner, PropertyKey<int> propertykey, int propertyoldvalue)
         {

--- a/sources/engine/Stride.UI/Panels/UniformGrid.cs
+++ b/sources/engine/Stride.UI/Panels/UniformGrid.cs
@@ -92,8 +92,10 @@ namespace Stride.UI.Panels
         /// <returns>The total size including gaps</returns>
         private Vector3 CalculateSpannedSize(Vector3 cellSize, Vector3 span)
         {
-            var gaps = GetGaps() * (span - 1);
-            return Vector3.Max(cellSize * span + gaps, Vector3.One);
+            // Normalize span to be at least 1 in each dimension
+            var normalizedSpan = Vector3.Max(span, Vector3.One);
+            var gaps = GetGaps() * (normalizedSpan - 1);
+            return cellSize * normalizedSpan + gaps;
         }
 
         protected override Vector3 MeasureOverride(Vector3 availableSizeWithoutMargins)


### PR DESCRIPTION
# PR Details

Introduced gap functionality to Grid, UniformGrid and StackPanel similar to the `gap` in CSS.
Add `ColumnGap`, `RowGap`, and `LayerGap` properties in GridBase for Grid and UniformGrid to manage spacing between elements. Extend the StackPanel to include a gap property.

- Grid: <img width="1655" height="617" alt="image" src="https://github.com/user-attachments/assets/c2df9a35-a5c9-4fa0-8e20-65243ec9b54b" />
- UniformGrid: <img width="1691" height="665" alt="image" src="https://github.com/user-attachments/assets/213d85ed-0148-4fdd-9343-7ad5dfb19d9e" />
- Stackpanel: <img width="1675" height="650" alt="image" src="https://github.com/user-attachments/assets/11d4e742-eecd-4c22-b2cc-e3ca872f3028" />

## Related Issue

Closes #2852

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
