### PR TITLE
feat: Mesh vertex buffer reading API

### DIFF
--- a/sources/engine/Stride.Graphics/ConcreteSemantics.cs
+++ b/sources/engine/Stride.Graphics/ConcreteSemantics.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Graphics.Semantic;
+
+namespace Stride.Graphics;
+
+public struct PositionSemantic : IFloat3Semantic
+{
+    public static string Name => VertexElementUsage.Position;
+}
+
+public struct NormalSemantic : IFloat3Semantic
+{
+    public static string Name => VertexElementUsage.Normal;
+}
+
+public struct ColorSemantic : IFloat4Semantic
+{
+    public static string Name => VertexElementUsage.Color;
+}
+
+public struct TangentSemantic : IFloat4Semantic
+{
+    public static string Name => VertexElementUsage.Tangent;
+}
+
+public struct BiTangentSemantic : IFloat4Semantic
+{
+    public static string Name => VertexElementUsage.BiTangent;
+}
+
+public struct TextureCoordinateSemantic : IFloat2Semantic
+{
+    public static string Name => VertexElementUsage.TextureCoordinate;
+}
+
+public struct BlendIndicesSemantic : IUShort4Semantic
+{
+    public static string Name => VertexElementUsage.BlendIndices;
+}
+
+public struct BlendWeightSemantic : IFloat4Semantic
+{
+    public static string Name => VertexElementUsage.BlendWeight;
+}
+
+/// <summary>
+/// A semantic extension to allow users to provide non default destination datatypes
+/// </summary>
+/// <example>
+/// Reading positions of a mesh into a Half3 array
+/// <code>
+/// <![CDATA[
+/// var positions = new Half3[count];
+/// helper.Read<Relaxed<PositionSemantic>, Half3>(positions);
+/// ]]>
+/// </code>
+/// </example>
+/// <typeparam name="T">The actual semantic used, for example <see cref="PositionSemantic"/></typeparam>
+public struct Relaxed<T> : 
+    IFloat4Semantic, 
+    IFloat3Semantic, 
+    IFloat2Semantic,
+    IHalf4Semantic, 
+    IHalf3Semantic, 
+    IHalf2Semantic,
+    IUShort4Semantic,
+    IByte4Semantic
+    where T : ISemantic
+{
+    public static string Name => T.Name;
+}

--- a/sources/engine/Stride.Graphics/IndexBufferHelper.cs
+++ b/sources/engine/Stride.Graphics/IndexBufferHelper.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+using Stride.Core;
+
+namespace Stride.Graphics;
+
+/// <example>
+/// Reading the indices of a mesh:
+/// <code>
+/// <![CDATA[
+/// Model.Meshes[0].Draw.IndexBuffer.AsReadable(Services, out IndexBufferHelper helper, out int count)
+/// var indices = helper.To32Bit();
+/// ]]>
+/// </code>
+/// </example>
+public class IndexBufferHelper
+{
+    /// <summary>
+    /// Full index buffer, does not account for the binding offset or length
+    /// </summary>
+    public readonly byte[] DataOuter;
+    public readonly IndexBufferBinding Binding;
+
+    /// <summary>
+    /// Effective index buffer, handles the binding offset
+    /// </summary>
+    public Span<byte> DataInner => DataOuter.AsSpan(Binding.Offset, Binding.Count * (Binding.Is32Bit ? 4 : 2));
+
+    /// <inheritdoc cref="MeshExtension.AsReadable(IndexBufferBinding, IServiceRegistry, out IndexBufferHelper, out int)"/>
+    public IndexBufferHelper(IndexBufferBinding binding, IServiceRegistry services, out int count)
+    {
+        DataOuter = MeshExtension.FetchBufferContentOrThrow(binding.Buffer, services);
+        Binding = binding;
+        count = Binding.Count;
+    }
+
+    /// <summary>
+    /// Branch to read the buffer as a 16 or 32 bit buffer, does not allocate
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// if (Is32Bit(out var d32, out var d16))
+    /// {
+    ///     foreach (var value in d32)
+    ///     {
+    ///         // Your logic for 32 bit
+    ///     }
+    /// }
+    /// else
+    /// {
+    ///     foreach (var value in d16)
+    ///     {
+    ///         // Your logic for 16bit
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public bool Is32Bit(out Span<int> data32, out Span<ushort> data16)
+    {
+        if (Binding.Is32Bit)
+        {
+            data32 = MemoryMarshal.Cast<byte, int>(DataInner);
+            data16 = Span<ushort>.Empty;
+            return true;
+        }
+        else
+        {
+            data32 = Span<int>.Empty;
+            data16 = MemoryMarshal.Cast<byte, ushort>(DataInner);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Does not allocate if the buffer is already 32 bit,
+    /// otherwise allocates a new int[] and copies the data into it
+    /// </summary>
+    public Span<int> To32Bit()
+    {
+        if (Is32Bit(out var d32, out var d16))
+        {
+            return d32;
+        }
+        else
+        {
+            var output = new int[d16.Length];
+            for (int i = 0; i < d16.Length; i++)
+                output[i] = d16[i];
+
+            return output;
+        }
+    }
+
+    /// <summary>
+    /// Does not allocate if the buffer is already 16 bit,
+    /// otherwise allocates a new ushort[] and copies the data into it
+    /// </summary>
+    public Span<ushort> To16Bit()
+    {
+        if (Is32Bit(out var d32, out var d16))
+        {
+            var output = new ushort[d32.Length];
+            for (int i = 0; i < d32.Length; i++)
+                output[i] = (ushort)d32[i];
+
+            return output;
+        }
+        else
+        {
+            return d16;
+        }
+    }
+
+    public void CopyTo(Span<int> dest)
+    {
+        if (Is32Bit(out var d32, out var d16))
+        {
+            d32.CopyTo(dest);
+        }
+        else
+        {
+            for (int i = 0; i < d16.Length; i++)
+                dest[i] = d16[i];
+        }
+    }
+
+    public void CopyTo(Span<ushort> dest)
+    {
+        if (Is32Bit(out var d32, out var d16))
+        {
+            for (int i = 0; i < d32.Length; i++)
+                dest[i] = (ushort)d32[i];
+        }
+        else
+        {
+            d16.CopyTo(dest);
+        }
+    }
+}

--- a/sources/engine/Stride.Graphics/MeshExtension.cs
+++ b/sources/engine/Stride.Graphics/MeshExtension.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+#nullable enable
+
+using System;
+using Stride.Core;
+using Stride.Core.IO;
+using Stride.Core.Serialization;
+using Stride.Core.Serialization.Contents;
+using Stride.Graphics.Data;
+
+namespace Stride.Graphics;
+
+public static class MeshExtension
+{
+    /// <summary>
+    /// Fetch this buffer and create a helper to read from it.
+    /// </summary>
+    /// <remarks>
+    /// This operation loads the buffer from disk, or directly from the gpu. It is <b>very slow</b>, avoid calling this too often if at all possible.
+    /// </remarks>
+    /// <param name="binding"> The bindings for this buffer </param>
+    /// <param name="services"> The service used to retrieve the buffer from disk/GPU </param>
+    /// <param name="helper"> The helper class to interact with the loaded buffer </param>
+    /// <param name="count"> The amount of vertices this buffer holds </param>
+    /// <inheritdoc cref="VertexBufferHelper"/>
+    public static void AsReadable(this VertexBufferBinding binding, IServiceRegistry services, out VertexBufferHelper helper, out int count)
+    {
+        helper = new VertexBufferHelper(binding, services, out count);
+    }
+
+    /// <summary>
+    /// Fetch this buffer and create a helper to read from it.
+    /// </summary>
+    /// <remarks>
+    /// This operation loads the buffer from disk, or directly from the gpu. It is <b>very slow</b>, avoid calling this too often if at all possible.
+    /// </remarks>
+    /// <param name="binding"> The bindings for this buffer </param>
+    /// <param name="services"> The service used to retrieve the buffer from disk/GPU </param>
+    /// <param name="helper"> The helper class to interact with the loaded buffer </param>
+    /// <param name="count"> The amount of indices this buffer holds </param>
+    /// <inheritdoc cref="IndexBufferHelper"/>
+    public static void AsReadable(this IndexBufferBinding binding, IServiceRegistry services, out IndexBufferHelper helper, out int count)
+    {
+        helper = new IndexBufferHelper(binding, services, out count);
+    }
+
+    /// <summary>
+    /// Given a semantic and its index, returns its offset and size in the given vertex buffer. Similar to <see cref="VertexDeclaration.EnumerateWithOffsets"/>
+    /// </summary>
+    public static bool TryGetElement(this VertexBufferBinding binding, string vertexElementUsage, int semanticIndex, out VertexElementWithOffset result)
+    {
+        int offset = 0;
+        foreach (var element in binding.Declaration.VertexElements)
+        {
+            // Get new offset (if specified)
+            var currentElementOffset = element.AlignedByteOffset;
+            if (currentElementOffset != VertexElement.AppendAligned)
+                offset = currentElementOffset;
+
+            var elementSize = element.Format.SizeInBytes();
+            if (vertexElementUsage == element.SemanticName && semanticIndex == element.SemanticIndex)
+            {
+                result = new VertexElementWithOffset(element, offset, elementSize);
+                return true;
+            }
+
+            // Compute next offset (if automatic)
+            offset += elementSize;
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <inheritdoc cref="TryFetchBufferContent"/>
+    /// <remarks> Same as <see cref="TryFetchBufferContent"/> but throws on failure </remarks>
+    internal static byte[] FetchBufferContentOrThrow(Buffer buffer, IServiceRegistry services)
+    {
+        var data = TryFetchBufferContent(buffer, services);
+        if (data is null || data.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to find mesh buffers while attempting to {nameof(FetchBufferContentOrThrow)}. " +
+                $"Make sure that the mesh is either an asset on disk, or has its buffer data attached to the buffer through '{nameof(AttachedReference)}'\n");
+        }
+
+        return data;
+    }
+
+    /// <summary> Get buffer content from GPU, shared memory or disk </summary>
+    internal static byte[]? TryFetchBufferContent(Buffer buffer, IServiceRegistry services)
+    {
+        var bufRef = AttachedReferenceManager.GetAttachedReference(buffer);
+        if (bufRef?.Data != null && ((BufferData)bufRef.Data).Content is { } output)
+            return output;
+
+        // Try to load it from disk, a file provider is required, editor does not provide one
+        if (bufRef?.Url != null && services.GetService<IDatabaseFileProviderService>() is {} provider && provider.FileProvider is not null)
+        {
+            // We have to create a new one without providing services to ensure that it dumps the graphics buffer data to the attached reference below
+            var cleanManager = new ContentManager(provider);
+            var bufferCopy = cleanManager.Load<Buffer>(bufRef.Url);
+            try
+            {
+                return bufferCopy.GetSerializationData().Content;
+            }
+            finally
+            {
+                cleanManager.Unload(bufRef.Url);
+            }
+        }
+
+        // When the mesh is created at runtime, or when the file provider is null as can be the case in editor, fetch from GPU
+        // will most likely break on non-dx11 APIs
+        if (services.GetService<GraphicsContext>() is { } context)
+        {
+            output = new byte[buffer.SizeInBytes];
+            if (buffer.Description.Usage == GraphicsResourceUsage.Staging) // Directly if this is a staging resource
+            {
+                buffer.GetData(context.CommandList, buffer, output);
+            }
+            else // inefficient way to use the Copy method using dynamic staging texture
+            {
+                using var throughStaging = buffer.ToStaging();
+                buffer.GetData(context.CommandList, throughStaging, output);
+            }
+
+            return output;
+        }
+
+        return null;
+    }
+}

--- a/sources/engine/Stride.Graphics/Semantic/IConversion.cs
+++ b/sources/engine/Stride.Graphics/Semantic/IConversion.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Graphics.Semantic;
+
+public interface IConversion<TSource, TDest>
+{
+    static abstract void Convert(in TSource source, out TDest dest);
+}

--- a/sources/engine/Stride.Graphics/Semantic/ISemantic.cs
+++ b/sources/engine/Stride.Graphics/Semantic/ISemantic.cs
@@ -1,0 +1,122 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#nullable enable
+namespace Stride.Graphics.Semantic;
+using System;
+using Core.Mathematics;
+
+public interface ISemantic
+{
+    public static abstract string Name { get; }
+}
+
+
+public interface ISemantic<T> : 
+    ISemantic,
+    // Default source types we support for conversion
+    IConversion<Vector2, T>,
+    IConversion<Vector3, T>,
+    IConversion<Vector4, T>,
+    IConversion<Half2, T>,
+    IConversion<Half4, T>,
+    IConversion<UShort4, T>,
+    IConversion<Byte4, T>;
+
+public interface IFloat2Semantic : ISemantic<Vector2>
+{
+    static void IConversion<Vector2, Vector2>.Convert(in Vector2 source, out Vector2 dest) => dest = source;
+    static void IConversion<Vector3, Vector2>.Convert(in Vector3 source, out Vector2 dest) => dest = (Vector2)source;
+    static void IConversion<Vector4, Vector2>.Convert(in Vector4 source, out Vector2 dest) => dest = (Vector2)source;
+    static void IConversion<Half2, Vector2>.Convert(in Half2 source, out Vector2 dest) => dest = (Vector2)source;
+    static void IConversion<Half4, Vector2>.Convert(in Half4 source, out Vector2 dest) => dest = new(source.X, source.Y);
+    static void IConversion<UShort4, Vector2>.Convert(in UShort4 source, out Vector2 dest) => dest = new(source.X, source.Y);
+    static void IConversion<Byte4, Vector2>.Convert(in Byte4 source, out Vector2 dest) => dest = new(source.X, source.Y);
+}
+
+public interface IFloat3Semantic : ISemantic<Vector3>
+{
+    static void IConversion<Vector2, Vector3>.Convert(in Vector2 source, out Vector3 dest) => dest = (Vector3)source;
+    static void IConversion<Vector3, Vector3>.Convert(in Vector3 source, out Vector3 dest) => dest = source;
+    static void IConversion<Vector4, Vector3>.Convert(in Vector4 source, out Vector3 dest) => dest = (Vector3)source;
+    static void IConversion<Half2, Vector3>.Convert(in Half2 source, out Vector3 dest) => dest = new(source.X, source.Y, 0f);
+    static void IConversion<Half4, Vector3>.Convert(in Half4 source, out Vector3 dest) => dest = new(source.X, source.Y, source.Z);
+    static void IConversion<UShort4, Vector3>.Convert(in UShort4 source, out Vector3 dest) => dest = new(source.X, source.Y, source.Z);
+    static void IConversion<Byte4, Vector3>.Convert(in Byte4 source, out Vector3 dest) => dest = new(source.X, source.Y, source.Z);
+}
+
+public interface IFloat4Semantic : ISemantic<Vector4>
+{
+    static void IConversion<Vector2, Vector4>.Convert(in Vector2 source, out Vector4 dest) => dest = (Vector4)source;
+    static void IConversion<Vector3, Vector4>.Convert(in Vector3 source, out Vector4 dest) => dest = (Vector4)source;
+    static void IConversion<Vector4, Vector4>.Convert(in Vector4 source, out Vector4 dest) => dest = source;
+    static void IConversion<Half2, Vector4>.Convert(in Half2 source, out Vector4 dest) => dest = new(source.X, source.Y, 0f, 0f);
+    static void IConversion<Half4, Vector4>.Convert(in Half4 source, out Vector4 dest) => dest = (Vector4)source;
+    static void IConversion<UShort4, Vector4>.Convert(in UShort4 source, out Vector4 dest) => dest = new(source.X, source.Y, source.Z, source.W);
+    static void IConversion<Byte4, Vector4>.Convert(in Byte4 source, out Vector4 dest) => dest = new(source.X, source.Y, source.Z, source.W);
+}
+
+public interface IHalf2Semantic : ISemantic<Half2>
+{
+    static void IConversion<Vector2, Half2>.Convert(in Vector2 source, out Half2 dest) => dest = (Half2)source;
+    static void IConversion<Vector3, Half2>.Convert(in Vector3 source, out Half2 dest) => dest = new(source.X, source.Y);
+    static void IConversion<Vector4, Half2>.Convert(in Vector4 source, out Half2 dest) => dest = new(source.X, source.Y);
+    static void IConversion<Half2, Half2>.Convert(in Half2 source, out Half2 dest) => dest = source;
+    static void IConversion<Half4, Half2>.Convert(in Half4 source, out Half2 dest) => dest = new(source.X, source.Y);
+    static void IConversion<UShort4, Half2>.Convert(in UShort4 source, out Half2 dest) => dest = new(source.X, source.Y);
+    static void IConversion<Byte4, Half2>.Convert(in Byte4 source, out Half2 dest) => dest = new(source.X, source.Y);
+}
+
+public interface IHalf3Semantic : ISemantic<Half3>
+{
+    static void IConversion<Vector2, Half3>.Convert(in Vector2 source, out Half3 dest) => dest = new(source.X, source.Y, 0f);
+    static void IConversion<Vector3, Half3>.Convert(in Vector3 source, out Half3 dest) => dest = (Half3)source;
+    static void IConversion<Vector4, Half3>.Convert(in Vector4 source, out Half3 dest) => dest = new(source.X, source.Y, source.Z);
+    static void IConversion<Half2, Half3>.Convert(in Half2 source, out Half3 dest) => dest = new(source.X, source.Y, 0f);
+    static void IConversion<Half4, Half3>.Convert(in Half4 source, out Half3 dest) => dest = new(source.X, source.Y, source.Z);
+    static void IConversion<UShort4, Half3>.Convert(in UShort4 source, out Half3 dest) => dest = new(source.X, source.Y, source.Z);
+    static void IConversion<Byte4, Half3>.Convert(in Byte4 source, out Half3 dest) => dest = new(source.X, source.Y, source.Z);
+}
+
+public interface IHalf4Semantic : ISemantic<Half4>
+{
+    static void IConversion<Vector2, Half4>.Convert(in Vector2 source, out Half4 dest) => dest = new(source.X, source.Y, 0f, 0f);
+    static void IConversion<Vector3, Half4>.Convert(in Vector3 source, out Half4 dest) => dest = new(source.X, source.Y, source.Z, 0f);
+    static void IConversion<Vector4, Half4>.Convert(in Vector4 source, out Half4 dest) => dest = (Half4)source;
+    static void IConversion<Half2, Half4>.Convert(in Half2 source, out Half4 dest) => dest = new(source.X, source.Y, 0f, 0f);
+    static void IConversion<Half4, Half4>.Convert(in Half4 source, out Half4 dest) => dest = source;
+    static void IConversion<UShort4, Half4>.Convert(in UShort4 source, out Half4 dest) => dest = new(source.X, source.Y, source.Z, source.W);
+    static void IConversion<Byte4, Half4>.Convert(in Byte4 source, out Half4 dest) => dest = new(source.X, source.Y, source.Z, source.W);
+}
+
+public interface IUShort4Semantic : ISemantic<UShort4>
+{
+    static void IConversion<Vector2, UShort4>.Convert(in Vector2 source, out UShort4 dest) => dest = new((ushort)source.X, (ushort)source.Y, 0, 0);
+    static void IConversion<Vector3, UShort4>.Convert(in Vector3 source, out UShort4 dest) => dest = new((ushort)source.X, (ushort)source.Y, (ushort)source.Z, 0);
+    static void IConversion<Vector4, UShort4>.Convert(in Vector4 source, out UShort4 dest) => dest = new((ushort)source.X, (ushort)source.Y, (ushort)source.Z, (ushort)source.W);
+    static void IConversion<Half2, UShort4>.Convert(in Half2 source, out UShort4 dest) => dest = new((ushort)source.X, (ushort)source.Y, 0, 0);
+    static void IConversion<Half4, UShort4>.Convert(in Half4 source, out UShort4 dest) => dest = new((ushort)source.X, (ushort)source.Y, (ushort)source.Z, (ushort)source.W);
+    static void IConversion<UShort4, UShort4>.Convert(in UShort4 source, out UShort4 dest) => dest = source;
+    static void IConversion<Byte4, UShort4>.Convert(in Byte4 source, out UShort4 dest) => dest = new(source.X, source.Y, source.Z, source.W);
+}
+
+public interface IByte4Semantic : ISemantic<Byte4>
+{
+    static void IConversion<Vector2, Byte4>.Convert(in Vector2 source, out Byte4 dest) => dest = new((byte)source.X, (byte)source.Y, 0, 0);
+    static void IConversion<Vector3, Byte4>.Convert(in Vector3 source, out Byte4 dest) => dest = new((byte)source.X, (byte)source.Y, (byte)source.Z, 0);
+    static void IConversion<Vector4, Byte4>.Convert(in Vector4 source, out Byte4 dest) => dest = new((byte)source.X, (byte)source.Y, (byte)source.Z, (byte)source.W);
+    static void IConversion<Half2, Byte4>.Convert(in Half2 source, out Byte4 dest) => dest = new((byte)source.X, (byte)source.Y, 0, 0);
+    static void IConversion<Half4, Byte4>.Convert(in Half4 source, out Byte4 dest) => dest = new((byte)source.X, (byte)source.Y, (byte)source.Z, (byte)source.W);
+    static void IConversion<UShort4, Byte4>.Convert(in UShort4 source, out Byte4 dest) => dest = new((byte)source.X, (byte)source.Y, (byte)source.Z, (byte)source.W);
+    static void IConversion<Byte4, Byte4>.Convert(in Byte4 source, out Byte4 dest) => dest = source;
+}
+
+public struct UShort4(ushort x, ushort y, ushort z, ushort w)
+{
+    public ushort X = x, Y = y, Z = z, W = w;
+}
+
+public struct Byte4(byte x, byte y, byte z, byte w)
+{
+    public byte X = x, Y = y, Z = z, W = w;
+}

--- a/sources/engine/Stride.Graphics/VertexBufferHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexBufferHelper.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#nullable enable
+using System;
+using Stride.Core;
+using Stride.Core.Mathematics;
+using Stride.Graphics.Semantic;
+
+namespace Stride.Graphics;
+
+/// <example>
+/// Reading the vertex positions of a mesh:
+/// <code>
+/// <![CDATA[
+/// Model.Meshes[0].Draw.VertexBuffers[0].AsReadable(Services, out VertexBufferHelper helper, out int count);
+/// var vertexPositions = new Vector3[count];
+/// helper.Copy<PositionSemantic, Vector3>(vertexPositions);
+/// ]]>
+/// </code>
+/// </example>
+public class VertexBufferHelper
+{
+    /// <summary>
+    /// Full vertex buffer, does not account for the binding offset or length
+    /// </summary>
+    public readonly byte[] DataOuter;
+    public readonly VertexBufferBinding Binding;
+
+    /// <summary>
+    /// Effective vertex buffer, accounts for the binding offset and length
+    /// </summary>
+    public Span<byte> DataInner => DataOuter.AsSpan(Binding.Offset, Binding.Count * Binding.Stride);
+
+    /// <inheritdoc cref="MeshExtension.AsReadable(VertexBufferBinding, IServiceRegistry, out VertexBufferHelper, out int)"/>
+    public VertexBufferHelper(VertexBufferBinding binding, IServiceRegistry services, out int count)
+    {
+        var data = MeshExtension.FetchBufferContentOrThrow(binding.Buffer, services);
+        DataOuter = data;
+        Binding = binding;
+        count = Binding.Count;
+    }
+
+    /// <summary>
+    /// Extract individual element from each vertex contained in this vertex buffer and copies them into <paramref name="buffer"/>
+    /// </summary>
+    /// <param name="buffer">
+    /// The buffer which will be written to, must have exactly the same amount of items as there are <b>vertices</b> in the buffer
+    /// </param>
+    /// <param name="semanticIndex">
+    /// The semantic to read with that index, starts at zero.<br/>
+    /// For example, to sample the second TextureCoordinate, you would use
+    /// <code>
+    /// <![CDATA[
+    /// helper.Copy<TextureCoordinateSemantic, Vector2>(myUvs, 1);
+    /// ]]>
+    /// </code>
+    /// </param>
+    /// <typeparam name="TSemantic">The semantic to read, for example <see cref="PositionSemantic"/></typeparam>
+    /// <typeparam name="TValue">The value type to read, depends entirely on the <typeparamref name="TSemantic"/> used</typeparam>
+    /// <returns>True when this semantic exists in the vertex buffer, false otherwise</returns>
+    /// <exception cref="NotImplementedException">
+    /// When the data format for this semantic is too arcane - no conversion logic is implemented for that type
+    /// </exception>
+    /// <inheritdoc cref="VertexBufferHelper"/>
+    public bool Copy<TSemantic, TValue>(Span<TValue> buffer, int semanticIndex = 0) where TSemantic : ISemantic<TValue> where TValue : unmanaged
+    {
+        return Read<TSemantic, TValue, CopyToDest<TValue>>(buffer, new CopyToDest<TValue>(), semanticIndex);
+    }
+
+    /// <summary>
+    /// Provides custom access to the vertex buffer while having access to the auto-conversion
+    /// </summary>
+    /// <param name="reader">
+    /// An implementation of <see cref="IReader{TDestValue}"/>, implement this interface to read directly from the vertex buffer
+    /// while making use of the auto-conversion of the <typeparamref name="TSemantic"/> provided <br/>
+    /// Preferably as a struct to ensure it is inlined by the JIT
+    /// </param>
+    /// <param name="semanticIndex">
+    /// The semantic to read with that index, starts at zero.<br/>
+    /// For example, to sample the second TextureCoordinate, you would use
+    /// <code>
+    /// <![CDATA[
+    /// helper.Read<TextureCoordinateSemantic, Vector2>(yourReader, 1);
+    /// ]]>
+    /// </code>
+    /// </param>
+    /// <typeparam name="TSemantic">The semantic to read, <see cref="PositionSemantic"/> for example</typeparam>
+    /// <typeparam name="TValue">The value type to read, depends on the <typeparamref name="TSemantic"/> used, <see cref="Vector3"/> when your <typeparamref name="TSemantic"/> <see cref="PositionSemantic"/> for example</typeparam>
+    /// <typeparam name="TReader">The type of the reader you're providing</typeparam>
+    /// <returns>True when this semantic exists in the vertex buffer, false otherwise</returns>
+    /// <exception cref="NotImplementedException">
+    /// When the data format for this semantic is too arcane - no conversion logic is implemented for that type
+    /// </exception>
+    /// <inheritdoc cref="IReader{TDest}"/>
+    public bool Read<TSemantic, TValue, TReader>(Span<TValue> destination, TReader reader, int semanticIndex = 0)
+        where TSemantic : ISemantic<TValue> where TValue : unmanaged
+        where TReader : IReader<TValue>
+    {
+        if (Binding.TryGetElement(TSemantic.Name, semanticIndex, out var elementData))
+        {
+            switch (elementData.VertexElement.Format)
+            {
+                case PixelFormat.R32G32_Float: Inner<TSemantic, Vector2>(DataInner, destination, reader, Binding, elementData); break;
+                case PixelFormat.R32G32B32_Float: Inner<TSemantic, Vector3>(DataInner, destination, reader, Binding, elementData); break;
+                case PixelFormat.R32G32B32A32_Float: Inner<TSemantic, Vector4>(DataInner, destination, reader, Binding, elementData); break;
+                case PixelFormat.R16G16_Float: Inner<TSemantic, Half2>(DataInner, destination, reader, Binding, elementData); break;
+                case PixelFormat.R16G16B16A16_Float: Inner<TSemantic, Half4>(DataInner, destination, reader, Binding, elementData); break;
+                case PixelFormat.R16G16B16A16_UInt: Inner<TSemantic, UShort4>(DataInner, destination, reader, Binding, elementData); break;
+                case PixelFormat.R8G8B8A8_UInt: Inner<TSemantic, Byte4>(DataInner, destination, reader, Binding, elementData); break;
+                default: throw new NotImplementedException($"Unsupported format when converting vertex element ({elementData.VertexElement.Format})");
+            }
+
+            return true;
+        }
+
+        return false;
+
+        static unsafe void Inner<TConversion, TSource>(Span<byte> vertexBuffer, Span<TValue> destination, IReader<TValue> reader, VertexBufferBinding binding, VertexElementWithOffset element) 
+            where TConversion : IConversion<TSource, TValue> where TSource : unmanaged
+        {
+            var stride = binding.Declaration.VertexStride;
+            var offset = element.Offset;
+            var count = vertexBuffer.Length / element.Size;
+
+            if (sizeof(TSource) != element.Size)
+                throw new ArgumentException($"{typeof(TSource)} does not match element size ({sizeof(TSource)} != {element.Size})");
+            
+            fixed (byte* ptrSr = vertexBuffer)
+            {
+                byte* src = ptrSr + offset;
+                reader.Read<TConversion, TSource>(src, count, stride, destination);
+            }
+        }
+    }
+
+    public struct CopyAsTriangleList : IReader<Vector3>
+    {
+        public required IndexBufferHelper IndexBufferHelper;
+        
+        public unsafe void Read<TConversion, TSource>(byte* sourcePointer, int elementCount, int stride, Span<Vector3> destination)
+            where TConversion : IConversion<TSource, Vector3> where TSource : unmanaged
+        {
+            if (destination.Length != IndexBufferHelper.Binding.Count)
+                throw new ArgumentException($"{nameof(destination)} length does not match the amount of indices contained within the index buffer buffer ({destination.Length} / {IndexBufferHelper.Binding.Count})");
+
+            fixed (Vector3* destPtr = destination)
+            {
+                Vector3* dest = destPtr;
+                if (IndexBufferHelper.Is32Bit(out var indices32, out var indices16))
+                {
+                    foreach (var index in indices32)
+                    {
+                        TConversion.Convert(*(TSource*)(sourcePointer + index * stride), out *dest);
+                        dest++;
+                    }
+                }
+                else
+                {
+                    foreach (var index in indices16)
+                    {
+                        TConversion.Convert(*(TSource*)(sourcePointer + index * stride), out *dest);
+                        dest++;
+                    }
+                }
+            }
+        }
+    }
+
+    private struct CopyToDest<T> : IReader<T> where T : unmanaged
+    {
+        public unsafe void Read<TConversion, TSource>(byte* sourcePointer, int elementCount, int stride, Span<T> destination) 
+            where TConversion : IConversion<TSource, T> where TSource : unmanaged
+        {
+            if (destination.Length != elementCount)
+                throw new ArgumentException($"{nameof(destination)} length does not match the amount of vertices contained within this vertex buffer ({destination.Length} / {elementCount})");
+            
+            fixed (T* ptrDest = destination)
+            {
+                byte* end = sourcePointer + elementCount * stride;
+                T* dest = ptrDest;
+                for (; sourcePointer < end; sourcePointer += stride, dest++)
+                    TConversion.Convert(*(TSource*)sourcePointer, out *dest);
+            }
+        }
+    }
+
+    /// <example>
+    /// Implementing <see cref="Copy{TSemantic,TValue}"/> manually:
+    /// <code>
+    /// <![CDATA[
+    /// Model.Meshes[0].Draw.VertexBuffers[0].AsReadable(Services, out VertexBufferHelper helper, out int count);
+    /// var vertexPositions = new Vector3[count];
+    /// var myReader = new CopyTo();
+    /// helper.Read<PositionSemantic, Vector3, CopyTo>(vertexPositions, myReader);
+    /// 
+    /// struct CopyTo : IReader<Vector3>
+    /// {
+    ///    public unsafe void Read<TConversion, TSource>(byte* sourcePointer, int elementCount, int stride, Span<T> destination) 
+    ///     where TConversion : IConversion<TSource, T> where TSource : unmanaged
+    ///    {
+    ///        if (destination.Length != elementCount)
+    ///            throw new ArgumentException($"{nameof(destination)} length does not match the amount of vertices contained within this vertex buffer ({destination.Length} / {elementCount})");
+    ///            
+    ///        fixed (T* ptrDest = destination)
+    ///        {
+    ///            byte* end = sourcePointer + elementCount * stride;
+    ///            T* dest = ptrDest;
+    ///            for (; sourcePointer < end; sourcePointer += stride, dest++)
+    ///                TConversion.Convert(*(TSource*)sourcePointer, out *dest);
+    ///        }
+    ///    }
+    /// }
+    /// ]]>
+    /// </code>
+    /// </example>
+    public interface IReader<TDest>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sourcePointer">The pointer already offset by the buffer and element offset</param>
+        /// <param name="elementCount">The amount of vertices, this is not the same as the size of the vertex buffer, or the size in bytes taken by individual vertices</param>
+        /// <param name="stride">The size in bytes taken by individual vertices</param>
+        /// <param name="destination">The span passed into the <see cref="Read{TConversion,TSource}"/> method call</param>
+        /// <typeparam name="TConversion">A helper to convert between <typeparamref name="TSource"/> and <typeparamref name="TDest"/> properly</typeparam>
+        /// <typeparam name="TSource">
+        /// The source type this vertex buffer was built with, for example <see cref="Vector2"/> or <see cref="Byte4"/>,
+        /// use <typeparamref name="TConversion"/> to convert it into a <typeparamref name="TDest"/>.
+        /// </typeparam>
+        /// <inheritdoc cref="IReader{TDest}"/>
+        unsafe void Read<TConversion, TSource>(byte* sourcePointer, int elementCount, int stride, Span<TDest> destination)
+            where TConversion : IConversion<TSource, TDest> where TSource : unmanaged;
+    }
+}

--- a/sources/engine/Stride.Graphics/VertexBufferHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexBufferHelper.cs
@@ -71,6 +71,10 @@ public class VertexBufferHelper
     /// <summary>
     /// Provides custom access to the vertex buffer while having access to the auto-conversion
     /// </summary>
+    /// <param name="destination">
+    /// The destination span your <typeparamref name="TReader"/> <see cref="IReader{TDest}.Read{TConversion, TValue}"/> method receives,
+    /// you may pass <see cref="Span{T}.Empty"/> if you do not need one.
+    /// </param>
     /// <param name="reader">
     /// An implementation of <see cref="IReader{TDestValue}"/>, implement this interface to read directly from the vertex buffer
     /// while making use of the auto-conversion of the <typeparamref name="TSemantic"/> provided <br/>
@@ -172,7 +176,8 @@ public class VertexBufferHelper
     private struct CopyToDest<T> : IReader<T> where T : unmanaged
     {
         public unsafe void Read<TConversion, TSource>(byte* sourcePointer, int elementCount, int stride, Span<T> destination) 
-            where TConversion : IConversion<TSource, T> where TSource : unmanaged
+            where TConversion : IConversion<TSource, T> 
+            where TSource : unmanaged
         {
             if (destination.Length != elementCount)
                 throw new ArgumentException($"{nameof(destination)} length does not match the amount of vertices contained within this vertex buffer ({destination.Length} / {elementCount})");
@@ -218,12 +223,9 @@ public class VertexBufferHelper
     /// </example>
     public interface IReader<TDest>
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="sourcePointer">The pointer already offset by the buffer and element offset</param>
-        /// <param name="elementCount">The amount of vertices, this is not the same as the size of the vertex buffer, or the size in bytes taken by individual vertices</param>
-        /// <param name="stride">The size in bytes taken by individual vertices</param>
+        /// <param name="sourcePointer">Points to the first element in the vertex buffer, read it as a TSource* to retrieve its value</param>
+        /// <param name="elementCount">The amount of vertices. This is not equivalent to the size of the vertex buffer, or the size in bytes taken by individual vertices</param>
+        /// <param name="stride">The size in bytes taken by individual vertices, add it to <paramref name="sourcePointer"/> to point to the next element</param>
         /// <param name="destination">The span passed into the <see cref="Read{TConversion,TSource}"/> method call</param>
         /// <typeparam name="TConversion">A helper to convert between <typeparamref name="TSource"/> and <typeparamref name="TDest"/> properly</typeparam>
         /// <typeparam name="TSource">

--- a/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
+++ b/sources/engine/Stride.Physics/Shapes/StaticMeshColliderShape.cs
@@ -7,13 +7,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Stride.Core;
 using Stride.Core.Annotations;
-using Stride.Core.IO;
 using Stride.Core.Mathematics;
-using Stride.Core.Serialization;
 using Stride.Core.Serialization.Contents;
 using Stride.Extensions;
 using Stride.Graphics;
-using Stride.Graphics.Data;
 using Stride.Graphics.GeometricPrimitives;
 using Stride.Rendering;
 
@@ -101,7 +98,7 @@ namespace Stride.Physics
             return new GeometricPrimitive(device, meshData).ToMeshDraw();
         }
 
-        static unsafe SharedMeshData BuildAndShareMeshes(Model model, IServiceRegistry services)
+        static SharedMeshData BuildAndShareMeshes(Model model, IServiceRegistry services)
         {
             var sharedContent = services.GetService<ContentManager>();
 
@@ -117,9 +114,6 @@ namespace Stride.Physics
                     }
                 }
             }
-            
-            var dbProvider = services.GetService<IDatabaseFileProviderService>();
-            ContentManager rawContent = null;
             
             Matrix[] nodeTransforms = null;
             if (model.Skeleton != null)
@@ -159,60 +153,30 @@ namespace Stride.Physics
                 totalIndices += meshData.Draw.IndexBuffer.Count;
             }
 
-            var combinedVerts = new List<Vector3>(totalVerts);
-            var combinedIndices = new List<int>(totalIndices);
-
+            var combinedVerts = new Vector3[totalVerts];
+            var combinedIndices = new int[totalIndices];
+            var verticesLeft = combinedVerts.AsSpan();
+            var indicesLeft = combinedIndices.AsSpan();
+            
             foreach (var meshData in model.Meshes)
             {
-                var vBuffer = meshData.Draw.VertexBuffers[0].Buffer;
-                var iBuffer = meshData.Draw.IndexBuffer.Buffer;
-                byte[] verticesBytes = TryFetchBufferContent(vBuffer, ref rawContent, sharedContent, dbProvider);
-                byte[] indicesBytes = TryFetchBufferContent(iBuffer, ref rawContent, sharedContent, dbProvider);
+                meshData.Draw.VertexBuffers[0].AsReadable(services, out var vertexHelper, out var vertexCount);
+                meshData.Draw.IndexBuffer.AsReadable(services, out var indexHelper, out var indexCount);
 
-                if((verticesBytes?.Length ?? 0) == 0 || (indicesBytes?.Length ?? 0) == 0)
+                var sliceForTheseVertices = verticesLeft[..vertexCount];
+                vertexHelper.Copy<PositionSemantic, Vector3>(sliceForTheseVertices);
+                indexHelper.CopyTo(indicesLeft[..indexCount]);
+
+                verticesLeft = verticesLeft[vertexCount..];
+                indicesLeft = indicesLeft[indexCount..];
+
+                if (nodeTransforms != null)
                 {
-                    throw new InvalidOperationException(
-                        $"Failed to find mesh buffers while attempting to build a {nameof(StaticMeshColliderShape)}. " +
-                        $"Make sure that the {nameof(model)} is either an asset on disk, or has its buffer data attached to the buffer through '{nameof(AttachedReference)}'\n" +
-                        $"You can also explicitly build a {nameof(StaticMeshColliderShape)} using the second constructor instead of this one.");
-                }
-
-                int vertMappingStart = combinedVerts.Count;
-
-                fixed (byte* bytePtr = verticesBytes)
-                {
-                    var vBindings = meshData.Draw.VertexBuffers[0];
-                    int count = vBindings.Count;
-                    int stride = vBindings.Declaration.VertexStride;
-                    for (int i = 0, vHead = vBindings.Offset; i < count; i++, vHead += stride)
+                    for (int i = 0; i < sliceForTheseVertices.Length; i++)
                     {
-                        var pos = *(Vector3*)(bytePtr + vHead);
-                        if (nodeTransforms != null)
-                        {
-                            Matrix posMatrix = Matrix.Translation(pos);
-                            Matrix.Multiply(ref posMatrix, ref nodeTransforms[meshData.NodeIndex], out var finalMatrix);
-                            pos = finalMatrix.TranslationVector;
-                        }
-
-                        combinedVerts.Add(pos);
-                    }
-                }
-
-                fixed (byte* bytePtr = indicesBytes)
-                {
-                    if (meshData.Draw.IndexBuffer.Is32Bit)
-                    {
-                        foreach (int i in new Span<int>(bytePtr + meshData.Draw.IndexBuffer.Offset, meshData.Draw.IndexBuffer.Count))
-                        {
-                            combinedIndices.Add(vertMappingStart + i);
-                        }
-                    }
-                    else
-                    {
-                        foreach (ushort i in new Span<ushort>(bytePtr + meshData.Draw.IndexBuffer.Offset, meshData.Draw.IndexBuffer.Count))
-                        {
-                            combinedIndices.Add(vertMappingStart + i);
-                        }
+                        Matrix posMatrix = Matrix.Translation(sliceForTheseVertices[i]);
+                        Matrix.Multiply(ref posMatrix, ref nodeTransforms[meshData.NodeIndex], out var finalMatrix);
+                        sliceForTheseVertices[i] = finalMatrix.TranslationVector;
                     }
                 }
             }
@@ -244,55 +208,6 @@ namespace Stride.Physics
                 MeshSharingCache.Add(modelUrl, sharedData);
                 return sharedData;
             }
-        }
-        
-        static unsafe byte[] TryFetchBufferContent(Graphics.Buffer buffer, ref ContentManager rawContent, ContentManager sharedContent, IDatabaseFileProviderService dbProvider)
-        {
-            byte[] output;
-            var bufRef = AttachedReferenceManager.GetAttachedReference(buffer);
-            if (bufRef.Data != null && (output = ((BufferData)bufRef.Data).Content) != null)
-                return output;
-            
-            // Editor-specific workaround, we can't load assets when the file provider is null,
-            // will most likely break on non-dx11 APIs
-            if (dbProvider != null && dbProvider.FileProvider == null)
-            {
-                var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
-                var commandList = (CommandList)typeof(GraphicsDevice)
-                    .GetField("InternalMainCommandList", flags)
-                    .GetValue(buffer.GraphicsDevice);
-
-                output = new byte[buffer.SizeInBytes];
-                if (buffer.Description.Usage == GraphicsResourceUsage.Staging)
-                {
-                    // Directly if this is a staging resource
-                    buffer.GetData(commandList, buffer, output);
-                }
-                else
-                {
-                    // inefficient way to use the Copy method using dynamic staging texture
-                    using var throughStaging = buffer.ToStaging();
-                    buffer.GetData(commandList, throughStaging, output);
-                }
-
-                return output;
-            }
-
-            if (sharedContent.TryGetAssetUrl(buffer, out var url))
-            {
-                rawContent ??= new ContentManager(dbProvider);
-                var data = rawContent.Load<Graphics.Buffer>(url);
-                try
-                {
-                    return data.GetSerializationData().Content;
-                }
-                finally
-                {
-                    rawContent.Unload(url);
-                }
-            }
-
-            return null;
         }
 
         private record SharedMeshData : IDisposable

--- a/sources/engine/Stride.Rendering/Extensions/IndexExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/IndexExtensions.cs
@@ -47,7 +47,7 @@ namespace Stride.Extensions
 
             fixed (byte* newVerticesStart = &newVertices[0]) // throw for null or empty
             fixed (byte* indexBufferStart = &indexBuffer.Buffer.GetDataSafe()[indexBuffer.Offset])
-            fixed (byte* vertexBufferStart = &vertexBuffer.Buffer.GetDataSafe()[indexBuffer.Offset])
+            fixed (byte* vertexBufferStart = &vertexBuffer.Buffer.GetDataSafe()[vertexBuffer.Offset])
             {
                 for (int i = 0; i < indexBuffer.Count; ++i)
                 {


### PR DESCRIPTION
# PR Details
Adding in an API to read mesh data efficiently.

## Why
A vertex buffer, like its name implies, contain the vertices of a mesh.
Vertex buffers do not have a standardized layout, each mesh may have its own layout and data type it uses for their vertices. Some have blend weights, or tangents, while others only have positions - they may also use different data types, for example Half4 positions, 4byte color ...

All of those permutations and subtleties make reading a mesh's vertex buffer tedious and error prone.

Index buffers are significantly easier, but still easy to mess up given that they may be defined as a 16bit or 32bit indices and that buffers may or may not use the whole data - they have offset and lengths.

There's also the lack of documentation around the fact that vertex buffers are not kept in cpu memory, they are uploaded as soon as they are deserialized. Reading it requires loading it from disk or the gpu, both of which are definitely not straightforward.

## Example
Quick example for the most common method:
```cs
Model.Meshes[0].Draw.VertexBuffers[0].AsReadable(Services, out VertexBufferHelper helper, out int count);
var vertexPositions = new Vector3[count];
var textureCoordinates = new Vector2[count];
// Copies the vertex positions of this mesh into the array provided
// The position's data type will be automatically converted into a Vector3 if needed
helper.Copy<PositionSemantic, Vector3>(vertexPositions);
helper.Copy<TextureCoordinateSemantic, Vector2>(textureCoordinates); // Copies the vertex texture coordinates
```
The semantic generic used there informs the API as to what it should read from the vertices, but it also helps in preventing user error; they enforce the use of the right type for a given semantic - `TextureCoordinateSemantic` only accepts `Vector2` as the span type, providing anything else would show a syntax error.

There is also a `Read<>` method which provides user with a direct access to the buffer and all the tools they may need to deal with the issues outlined above. When they have other needs than just a dumb copy.

There are other examples baked into the documentation for the API.

## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
   - improves support for non-standard mesh layout with physics collision 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**