### PR TITLE
Add 'behavioral-change' label to breaking changes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,7 @@ changelog:
     - title: 💥 Breaking Changes
       labels:
         - breaking-change
+        - behavioral-change
     - title: 🎉 New Features
       labels:
         - enhancement


### PR DESCRIPTION
# PR Details

This PR adds a new label, `behavioral-change`, under **Breaking changes** in `release.yml`. With this update, any PR tagged with this label will automatically appear under the **Breaking changes** section in the release notes.

## Related Issue

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
