### PR TITLE
fix: removed double brackets in error log string

### DIFF
--- a/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
+++ b/sources/engine/Stride.Physics/Engine/PhysicsComponent.cs
@@ -651,7 +651,7 @@ namespace Stride.Engine
 
             if (ColliderShapes.Count == 0 && ColliderShape == null)
             {
-                logger.Error($"Entity {{Entity.Name}} has a PhysicsComponent without any collider shape.");
+                logger.Error($"Entity {Entity.Name} has a PhysicsComponent without any collider shape.");
                 attachInProgress = false;
                 return; //no shape no purpose
             }


### PR DESCRIPTION
# PR Details

If a physicscomponent attached to an entity has no collidershapes, there is an error log from the physicscomponent. It should log the name of the entity in the message, but there are two brackets to much in the error string which results in "[PhysicsComponent]: Error: Entity {Entity.Name} has a PhysicsComponent without any collider shape." which dosn't include the real name of the entity.

## Related Issue

I didn't create an issue because it's a simple error and fixed it right away when i saw it.
To reproduce: add a e.g. RigidBodyComponent to an Entity but don't add a collidershape and run the game. You will then see the wrong error log.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [x ] **I have built and run the editor to try this change out.**
