### PR TITLE
fix: incorrect absolute trigger on FBX model import

### DIFF
--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -1171,7 +1171,7 @@ namespace Stride.Importer.ThreeD
             {
                 var lMaterial = scene->MMaterials[i];
                 // Replace slashes with an underscore to indicate it is not absolute to Strides asset system.
-                var materialName = materialNames[(IntPtr)lMaterial].Replace('/', '_'); ;
+                var materialName = materialNames[(IntPtr)lMaterial].Replace('/', '_');
 
                 materials.Add(materialName, ProcessMeshMaterial(scene, lMaterial));
             }


### PR DESCRIPTION
# PR Details

There was an issue with materials being added into the asset manager with FBX files due to the path starting with a "/". this replaces the slash with an underscore.

## Related Issue

None reported in GitHub. Logs from Tebjan in Discord:
```
ArgumentException: Asset location [/obj/geo1/quickmawterial4/matnet/principledshader] must be relative and not absolute (not start with '/') (Parameter 'item')
   at Stride.Core.Assets.PackageAssetCollection.CheckCanAdd(AssetItem item) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\assets\Stride.Core.Assets\PackageAssetCollection.cs:line 361
   at Stride.Core.Assets.PackageAssetCollection.Add(AssetItem item) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\assets\Stride.Core.Assets\PackageAssetCollection.cs:line 127
   at Stride.Assets.Presentation.Templates.AssetTemplateGenerator.Run(AssetTemplateGeneratorParameters parameters) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\editor\Stride.Assets.Presentation\Templates\AssetTemplateGenerator.cs:line 52
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
