### PR TITLE
docs: Update xml comments in BodyComponent and IServo

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -271,7 +271,7 @@ public class BodyComponent : CollidableComponent
     /// Automatically computed size of the margin around the surface of the shape in which contacts can be generated. These contacts will have negative depth and only contribute if the frame's velocities
     /// would push the shapes of a pair into overlap.
     /// <para>This is automatically set by bounding box prediction each frame, and is bound by the collidable's <see cref="Collidable.MinimumSpeculativeMargin"/> and <see cref="Collidable.MaximumSpeculativeMargin"/> values.
-    /// The effective speculative margin for a collision pair can also be modified from <see cref="INarrowPhaseCallbacks"/> callbacks.</para>
+    /// The effective speculative margin for a collision pair can also be modified from <see cref="global::BepuPhysics.CollisionDetection.INarrowPhaseCallbacks"/> callbacks.</para>
     /// <para>This should be positive to avoid jittering.</para>
     /// <para>It can also be used as a form of continuous collision detection, but excessively high values combined with fast motion may result in visible 'ghost collision' artifacts.
     /// For continuous collision detection with less chance of ghost collisions, use <see cref="ContinuousDetectionMode.Continuous"/>.</para>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IServo.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/IServo.cs
@@ -30,7 +30,7 @@ public interface IServo
     /// The maximum force that the constraint can apply to move towards the target.
     /// </summary>
     /// <remarks>
-    /// This value is specified in terms of force: a change in momentum over time. It is approximated as a maximum impulse (an instantaneous change in momentum) on a per-substep basis. In other words, for a given velocity iteration, the constraint's impulse can be no larger than <see cref="MaximumForce"/> * dt where dt is the substep duration.
+    /// This value is specified in terms of force: a change in momentum over time. It is approximated as a maximum impulse (an instantaneous change in momentum) on a per-substep basis. In other words, for a given velocity iteration, the constraint's impulse can be no larger than <see cref="ServoMaximumForce"/> * dt where dt is the substep duration.
     /// </remarks>
     /// <userdoc>
     /// The maximum force that the constraint can apply to move towards the target.


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue
n/a
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**


docs: Update documentation in BodyComponent and IServo

- In the `BodyComponent.cs` file, updated the documentation comment to specify the full namespace for the `INarrowPhaseCallbacks` interface, changing it from `<see cref="INarrowPhaseCallbacks"/>` to `<see cref="global::BepuPhysics.CollisionDetection.INarrowPhaseCallbacks"/>`.
- In the `IServo.cs` file, modified the documentation comment to change the reference from `<see cref="MaximumForce"/>` to `<see cref="ServoMaximumForce"/>`.

#### PR Classification
Documentation update to improve clarity and accuracy of code references.

#### PR Summary
This pull request enhances the documentation in two files to provide clearer references to specific interfaces and properties. 
- `BodyComponent.cs`: Updated the reference to `INarrowPhaseCallbacks` to include its namespace for better clarity.
- `IServo.cs`: Changed the documentation reference from `MaximumForce` to `ServoMaximumForce` to accurately reflect the property being described.
