### PR TITLE
feat: Add CONTRIBUTING.md - A "Contributing" tab will surface in the repository overview

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# 🤝 Contributing
+
+For questions and general discussions, please join our [Discord server](https://discord.gg/f6aerfE) or participate in [GitHub Discussions](https://github.com/stride3d/stride/discussions).
+
+To report bugs or propose features, please use the [Issues](https://github.com/stride3d/stride/issues) section on GitHub.
+
+We welcome code contributions via pull requests. Issues tagged with **[`good first issue`](https://github.com/stride3d/stride/labels/good%20first%20issue)** are great starting points for code contributions.
+
+You can help us translate Stride; check out our [Localization Guide](https://doc.stride3d.net/latest/en/contributors/engine/localization.html).
+
+## Earn Money by Contributing
+
+If you are a developer with solid experience in C#, rendering techniques, or game development, we want to hire you! We have allocated funds from supporters on [Open Collective](https://opencollective.com/stride3d) and can pay for work on certain projects. [More information is available here](https://doc.stride3d.net/latest/en/contributors/engine/bug-bounties.html).
+

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This README is intended for users who want to build the Stride engine from sourc
 
 ## 🤝 Contributing
 
-Want to get involved? See our [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for how to ask questions, report bugs, submit pull requests (including good first issues), and how you can earn money by contributing via funded tasks/bug bounties.
+Want to get involved? See our [Contributing section](.github/CONTRIBUTING.md) for how to ask questions, report bugs, submit pull requests (including good first issues), and how you can earn money by contributing via funded tasks/bug bounties.
 
 ## 🗺️ Roadmap
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,7 @@ This README is intended for users who want to build the Stride engine from sourc
 
 ## 🤝 Contributing
 
-For questions and general discussions, please join our [Discord server](https://discord.gg/f6aerfE) or participate in [GitHub Discussions](https://github.com/stride3d/stride/discussions).
-
-To report bugs or propose features, please use the [Issues](https://github.com/stride3d/stride/issues) section on GitHub.
-
-We welcome code contributions via pull requests. Issues tagged with **[`good first issue`](https://github.com/stride3d/stride/labels/good%20first%20issue)** are great starting points for code contributions.
-
-You can help us translate Stride; check out our [Localization Guide](https://doc.stride3d.net/latest/en/contributors/engine/localization.html).
-
-### Earn Money by Contributing
-
-If you are a developer with solid experience in C#, rendering techniques, or game development, we want to hire you! We have allocated funds from supporters on [Open Collective](https://opencollective.com/stride3d) and can pay for work on certain projects. [More information is available here](https://doc.stride3d.net/latest/en/contributors/engine/bug-bounties.html).
+Want to get involved? See our [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for how to ask questions, report bugs, submit pull requests (including good first issues), and how you can earn money by contributing via funded tasks/bug bounties.
 
 ## 🗺️ Roadmap
 


### PR DESCRIPTION
# PR Details

If a repository includes a CONTRIBUTING.md file, GitHub also surfaces it in two other places to make it easier for contributors to discover:

- A " Contributing" tab in the repository overview (next to the " README" and " Code of conduct")
- A "Contributing" link in the repository sidebar

The original Contributing content was moved to this new file. README.md still contains a paragraph.

<img width="728" height="412" alt="image" src="https://github.com/user-attachments/assets/bbd69694-3108-4470-a646-c140433d1e22" />

## Related Issue

n/a

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**