### PR TITLE
perf: soft revert of the performance regressions introduced in #1469

### DIFF
--- a/sources/core/Stride.Core.Serialization/Serialization/LZ4/LZ4Stream.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/LZ4/LZ4Stream.cs
@@ -380,7 +380,7 @@ public class LZ4Stream : Stream
                     fixed (byte* pDst = buffer)
                     {
                         Debug.Assert(pSrc is not null);
-                        Unsafe.CopyBlockUnaligned(pDst + offset, pSrc + bufferOffset, (uint)chunk);
+                        Utilities.CopyWithAlignmentFallback(pDst + offset, pSrc + bufferOffset, (uint)chunk);
                     }
                 }
 
@@ -511,7 +511,7 @@ public class LZ4Stream : Stream
                     fixed (byte* pDst = dataBuffer)
                     {
                         Debug.Assert(pDst is not null);
-                        Unsafe.CopyBlockUnaligned(pDst + bufferOffset, pSrc + offset, (uint)chunk);
+                        Utilities.CopyWithAlignmentFallback(pDst + bufferOffset, pSrc + offset, (uint)chunk);
                     }
                 }
 

--- a/sources/core/Stride.Core.Serialization/Storage/Blob.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/Blob.cs
@@ -24,7 +24,7 @@ public class Blob : ReferenceBase
         Debug.Assert(size >= 0);
         this.Size = size;
         this.Content = Marshal.AllocHGlobal(size);
-        Unsafe.CopyBlockUnaligned((void*)this.Content, (void*)content, (uint)size);
+        Utilities.CopyWithAlignmentFallback((void*)this.Content, (void*)content, (uint)size);
     }
 
     internal unsafe Blob(ObjectDatabase objectDatabase, ObjectId objectId, Stream stream)

--- a/sources/core/Stride.Core.Serialization/Streaming/ContentChunk.cs
+++ b/sources/core/Stride.Core.Serialization/Streaming/ContentChunk.cs
@@ -104,7 +104,7 @@ public sealed class ContentChunk
                     var read = (uint)stream.Read(buffer, 0, (int)Math.Min(count, bufferCapacity));
                     if (read <= 0)
                         break;
-                    Unsafe.CopyBlockUnaligned(chunkBytesPtr, bufferStart, read);
+                    Utilities.CopyWithAlignmentFallback(chunkBytesPtr, bufferStart, read);
                     chunkBytesPtr += read;
                     count -= read;
                 } while (count > 0);

--- a/sources/engine/Stride.Engine/Animations/AnimationBlender.cs
+++ b/sources/engine/Stride.Engine/Animations/AnimationBlender.cs
@@ -179,7 +179,7 @@ namespace Stride.Animations
                     if (factorLeft > 0.0f && factorRight == 0.0f)
                     {
                         *resultData++ = 1.0f;
-                        Unsafe.CopyBlockUnaligned(resultData, sourceLeftData, (uint)channel.Size);
+                        Utilities.CopyWithAlignmentFallback(resultData, sourceLeftData, (uint)channel.Size);
                         continue;
                     }
 
@@ -187,7 +187,7 @@ namespace Stride.Animations
                     if (factorRight > 0.0f && factorLeft == 0.0f)
                     {
                         *resultData++ = 1.0f;
-                        Unsafe.CopyBlockUnaligned(resultData, sourceRightData, (uint)channel.Size);
+                        Utilities.CopyWithAlignmentFallback(resultData, sourceRightData, (uint)channel.Size);
                         continue;
                     }
 
@@ -202,7 +202,7 @@ namespace Stride.Animations
                             switch (channel.BlendType)
                             {
                                 case BlendType.Blit:
-                                    Unsafe.CopyBlockUnaligned(
+                                    Utilities.CopyWithAlignmentFallback(
                                         resultData,
                                         blendFactor < 0.5f ? sourceLeftData : sourceRightData,
                                         (uint)channel.Size);
@@ -229,7 +229,7 @@ namespace Stride.Animations
                             switch (channel.BlendType)
                             {
                                 case BlendType.Blit:
-                                    Unsafe.CopyBlockUnaligned(resultData, sourceLeftData, (uint)channel.Size);
+                                    Utilities.CopyWithAlignmentFallback(resultData, sourceLeftData, (uint)channel.Size);
                                     break;
                                 case BlendType.Float2:
                                     Vector2 rightValue2;
@@ -257,7 +257,7 @@ namespace Stride.Animations
                             switch (channel.BlendType)
                             {
                                 case BlendType.Blit:
-                                    Unsafe.CopyBlockUnaligned(resultData, sourceLeftData, (uint)channel.Size);
+                                    Utilities.CopyWithAlignmentFallback(resultData, sourceLeftData, (uint)channel.Size);
                                     break;
                                 case BlendType.Float2:
                                     Vector2 rightValue2;

--- a/sources/engine/Stride.Engine/Animations/AnimationClipEvaluator.cs
+++ b/sources/engine/Stride.Engine/Animations/AnimationClipEvaluator.cs
@@ -114,7 +114,7 @@ namespace Stride.Animations
                     var channel = Channels.Items[index];
 
                     // For now, objects are not supported, so treat everything as a blittable struct.
-                    channel.Curve?.AddValue(newTime, (IntPtr)(structures + channel.Offset + sizeof(float)));
+                    channel.Curve?.AddValue(newTime, (structures + channel.Offset + sizeof(float)));
                 }
             }
         }

--- a/sources/engine/Stride.Engine/Animations/AnimationCurve.cs
+++ b/sources/engine/Stride.Engine/Animations/AnimationCurve.cs
@@ -50,7 +50,7 @@ namespace Stride.Animations
         /// </summary>
         /// <param name="newTime">The new time.</param>
         /// <param name="location">The location.</param>
-        public abstract void AddValue(CompressedTimeSpan newTime, IntPtr location);
+        public abstract unsafe void AddValue(CompressedTimeSpan newTime, byte* location);
 
         /// <summary>
         /// Meant for internal use, to call AnimationData{T}.FromAnimationChannels() without knowing the generic type.
@@ -142,9 +142,9 @@ namespace Stride.Animations
         }
 
         /// <inheritdoc/>
-        public override unsafe void AddValue(CompressedTimeSpan newTime, nint location)
+        public override unsafe void AddValue(CompressedTimeSpan newTime, byte* location)
         {
-            var value = Unsafe.ReadUnaligned<T>((void*)location);
+            var value = Unsafe.ReadUnaligned<T>(location);
             KeyFrames.Add(new(newTime, value));
         }
 

--- a/sources/engine/Stride.Engine/Updater/UpdatableField.cs
+++ b/sources/engine/Stride.Engine/Updater/UpdatableField.cs
@@ -73,7 +73,7 @@ namespace Stride.Updater
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void SetBlittable(IntPtr obj, IntPtr data)
         {
-            Unsafe.CopyBlockUnaligned((void*)obj, (void*)data, (uint)Size);
+            Utilities.CopyWithAlignmentFallback((void*)obj, (void*)data, (uint)Size);
         }
 
         /// <summary>

--- a/sources/engine/Stride.Graphics/Buffer.cs
+++ b/sources/engine/Stride.Graphics/Buffer.cs
@@ -326,7 +326,7 @@ namespace Stride.Graphics
             // Map the staging resource to a CPU accessible memory
             var mappedResource = commandList.MapSubresource(stagingTexture, 0, MapMode.Read);
             fixed (void* pointer = toData)
-                Unsafe.CopyBlockUnaligned(pointer, (void*)mappedResource.DataBox.DataPointer, (uint)toDataInBytes);
+                Utilities.CopyWithAlignmentFallback(pointer, (void*)mappedResource.DataBox.DataPointer, (uint)toDataInBytes);
             // Make sure that we unmap the resource in case of an exception
             commandList.UnmapSubresource(mappedResource);
         }
@@ -386,7 +386,7 @@ namespace Stride.Graphics
                         throw new ArgumentException("offset is only supported for textured declared with ResourceUsage.Default", "offsetInBytes");
 
                     var mappedResource = commandList.MapSubresource(this, 0, Usage == GraphicsResourceUsage.Staging ? MapMode.Write : MapMode.WriteDiscard);
-                    Unsafe.CopyBlockUnaligned((void*)mappedResource.DataBox.DataPointer, pointer, (uint)sizeInBytes);
+                    Utilities.CopyWithAlignmentFallback((void*)mappedResource.DataBox.DataPointer, pointer, (uint)sizeInBytes);
                     commandList.UnmapSubresource(mappedResource);
                 }
             }

--- a/sources/engine/Stride.Graphics/Data/ImageTextureSerializer.cs
+++ b/sources/engine/Stride.Graphics/Data/ImageTextureSerializer.cs
@@ -122,7 +122,7 @@ namespace Stride.Graphics.Data
                             if (!chunk.IsLoaded)
                                 throw new ContentStreamingException("Data chunk is not loaded.", storage);
 
-                            Unsafe.CopyBlockUnaligned((void*)bufferPtr, (void*)data, (uint)chunk.Size);
+                            Utilities.CopyWithAlignmentFallback((void*)bufferPtr, (void*)data, (uint)chunk.Size);
                             bufferPtr += chunk.Size;
                         }
                     }

--- a/sources/engine/Stride.Graphics/Direct3D12/Buffer.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/Buffer.Direct3D12.cs
@@ -122,7 +122,7 @@ namespace Stride.Graphics
                 if (heapType == HeapType.Upload)
                 {
                     var uploadMemory = NativeResource.Map(0);
-                    Unsafe.CopyBlockUnaligned((void*) uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
+                    Core.Utilities.CopyWithAlignmentFallback((void*) uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
                     NativeResource.Unmap(0);
                 }
                 else
@@ -132,7 +132,7 @@ namespace Stride.Graphics
                     SharpDX.Direct3D12.Resource uploadResource;
                     int uploadOffset;
                     var uploadMemory = GraphicsDevice.AllocateUploadBuffer(SizeInBytes, out uploadResource, out uploadOffset);
-                    Unsafe.CopyBlockUnaligned((void*) uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
+                    Core.Utilities.CopyWithAlignmentFallback((void*) uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
 
                     // TODO D3D12 lock NativeCopyCommandList usages
                     var commandList = GraphicsDevice.NativeCopyCommandList;

--- a/sources/engine/Stride.Graphics/Direct3D12/CommandList.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/CommandList.Direct3D12.cs
@@ -777,7 +777,7 @@ namespace Stride.Graphics
                         var destinationMapped = destinationTexture.NativeResource.Map(0);
                         var sourceMapped = sourceTexture.NativeResource.Map(0, new SharpDX.Direct3D12.Range { Begin = 0, End = size });
 
-                        Unsafe.CopyBlockUnaligned((void*) destinationMapped, (void*) sourceMapped, (uint) size);
+                        Core.Utilities.CopyWithAlignmentFallback((void*) destinationMapped, (void*) sourceMapped, (uint) size);
 
                         sourceTexture.NativeResource.Unmap(0);
                         destinationTexture.NativeResource.Unmap(0);
@@ -976,7 +976,7 @@ namespace Stride.Graphics
                     var uploadSize = region.Right - region.Left;
                     var uploadMemory = GraphicsDevice.AllocateUploadBuffer(region.Right - region.Left, out var uploadResource, out var uploadOffset);
 
-                    Unsafe.CopyBlockUnaligned((void*) uploadMemory, (void*) databox.DataPointer, (uint) uploadSize);
+                    Core.Utilities.CopyWithAlignmentFallback((void*) uploadMemory, (void*) databox.DataPointer, (uint) uploadSize);
 
                     ResourceBarrierTransition(resource, GraphicsResourceState.CopyDestination);
                     FlushResourceBarriers();

--- a/sources/engine/Stride.Graphics/Direct3D12/QueryPool.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/QueryPool.Direct3D12.cs
@@ -26,7 +26,7 @@ namespace Stride.Graphics
                 var mappedData = readbackBuffer.Map(0);
                 fixed (long* dataPointer = &dataArray[0])
                 {
-                    Unsafe.CopyBlockUnaligned(dataPointer, (void*) mappedData, (uint) QueryCount * 8);
+                    Core.Utilities.CopyWithAlignmentFallback(dataPointer, (void*) mappedData, (uint) QueryCount * 8);
                 }
                 readbackBuffer.Unmap(subresource: 0);
                 return true;

--- a/sources/engine/Stride.Graphics/Direct3D12/Texture.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/Texture.Direct3D12.cs
@@ -150,7 +150,7 @@ namespace Stride.Graphics
                                 var dataPointerCurrent = databox.DataPointer;
                                 for (int rowIndex = 0; rowIndex < mipHeight; rowIndex++)
                                 {
-                                    Unsafe.CopyBlockUnaligned((void*) uploadMemoryCurrent, (void*) dataPointerCurrent, (uint) mipRowPitch);
+                                    Core.Utilities.CopyWithAlignmentFallback((void*) uploadMemoryCurrent, (void*) dataPointerCurrent, (uint) mipRowPitch);
                                     uploadMemoryCurrent += mipRowPitch;
                                     dataPointerCurrent += databox.RowPitch;
                                 }
@@ -208,7 +208,7 @@ namespace Stride.Graphics
                             var dataPointerCurrent = dataPointer + z * databox.SlicePitch;
                             for (int y = 0; y < rowCount; ++y)
                             {
-                                Unsafe.CopyBlockUnaligned((void*) uploadMemoryCurrent, (void*) dataPointerCurrent, (uint) rowSize);
+                                Utilities.CopyWithAlignmentFallback((void*) uploadMemoryCurrent, (void*) dataPointerCurrent, (uint) rowSize);
                                 uploadMemoryCurrent += destRowPitch;
                                 dataPointerCurrent += databox.RowPitch;
                             }

--- a/sources/engine/Stride.Graphics/Font/CharacterBitmap.cs
+++ b/sources/engine/Stride.Graphics/Font/CharacterBitmap.cs
@@ -68,8 +68,8 @@ namespace Stride.Graphics.Font
             var rowsLessBorders = rows - (borderSize.Y << 1);
 
             var resetBorderLineSize = width * borderSize.Y;
-            Unsafe.InitBlockUnaligned((byte*)dataBytes, 0, (uint)resetBorderLineSize);
-            Unsafe.InitBlockUnaligned((byte*)dataBytes + width * rows - resetBorderLineSize, 0, (uint)resetBorderLineSize); // set last border lines to null
+            Utilities.Clear((byte*)dataBytes, (uint)resetBorderLineSize);
+            Utilities.Clear((byte*)dataBytes + width * rows - resetBorderLineSize, (uint)resetBorderLineSize); // set last border lines to null
 
             var src = (byte*)data;
             var dst = (byte*)dataBytes + resetBorderLineSize;
@@ -104,8 +104,8 @@ namespace Stride.Graphics.Font
             var rowsLessBorders = rows - (borderSize.Y << 1);
 
             var resetBorderLineSize = (uint)(width * borderSize.Y);
-            Unsafe.InitBlockUnaligned((byte*)dataBytes, 0, resetBorderLineSize); // set first border lines to null
-            Unsafe.InitBlockUnaligned((byte*)dataBytes + rows * width - resetBorderLineSize, 0, resetBorderLineSize); // set last border lines to null
+            Utilities.Clear((byte*)dataBytes, resetBorderLineSize); // set first border lines to null 
+            Utilities.Clear((byte*)dataBytes + rows * width - resetBorderLineSize, resetBorderLineSize); // set last border lines to null
 
             var rowSrc = (byte*)data;
             var dst = (byte*)dataBytes + resetBorderLineSize;

--- a/sources/engine/Stride.Graphics/OpenGL/Texture.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/Texture.OpenGL.cs
@@ -3,6 +3,7 @@
 #if STRIDE_GRAPHICS_API_OPENGL
 using System;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 using Stride.Core.Mathematics;
 
 namespace Stride.Graphics
@@ -598,7 +599,7 @@ namespace Stride.Graphics
 
                         if (data != IntPtr.Zero)
                         {
-                            Unsafe.CopyBlockUnaligned((void*) (bufferData + offset), (void*) data, (uint) (width * height * depth * TexturePixelSize));
+                            Utilities.CopyWithAlignmentFallback((void*) (bufferData + offset), (void*) data, (uint) (width * height * depth * TexturePixelSize));
                         }
 
                         offset += width*height*TexturePixelSize;

--- a/sources/engine/Stride.Graphics/Rendering/EffectParameterUpdater.cs
+++ b/sources/engine/Stride.Graphics/Rendering/EffectParameterUpdater.cs
@@ -74,7 +74,7 @@ namespace Stride.Rendering
                 if (parameters.DataValues != null && resourceGroup.ConstantBuffer.Size > 0)
                 {
                     fixed (byte* dataValues = parameters.DataValues)
-                        Unsafe.CopyBlockUnaligned(
+                        Utilities.CopyWithAlignmentFallback(
                             destination: (void*)resourceGroup.ConstantBuffer.Data,
                             source: dataValues + bufferStartOffset,
                             byteCount: (uint)resourceGroup.ConstantBuffer.Size);

--- a/sources/engine/Stride.Graphics/ResourceGroupBufferUploader.cs
+++ b/sources/engine/Stride.Graphics/ResourceGroupBufferUploader.cs
@@ -76,7 +76,7 @@ namespace Stride.Graphics
                         if (hasResourceRenaming)
                         {
                             var mappedConstantBuffer = commandList.MapSubresource(preallocatedBuffer, 0, MapMode.WriteDiscard);
-                            Unsafe.CopyBlockUnaligned((void*)mappedConstantBuffer.DataBox.DataPointer, (void*)resourceGroup.ConstantBuffer.Data, (uint)resourceGroup.ConstantBuffer.Size);
+                            Utilities.CopyWithAlignmentFallback((void*)mappedConstantBuffer.DataBox.DataPointer, (void*)resourceGroup.ConstantBuffer.Data, (uint)resourceGroup.ConstantBuffer.Size);
                             commandList.UnmapSubresource(mappedConstantBuffer);
                         }
                         else

--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -863,7 +863,7 @@ namespace Stride.Graphics
             if (box.RowPitch == rowStride && boxDepthStride == textureDepthStride && !isFlippedTexture)
             {
                 fixed(void* destPtr = toData)
-                    Unsafe.CopyBlockUnaligned(destPtr, (void*)box.DataPointer, (uint)mipMapSize);
+                    Utilities.CopyWithAlignmentFallback(destPtr, (void*)box.DataPointer, (uint)mipMapSize);
             }
             else
             {
@@ -884,7 +884,7 @@ namespace Stride.Graphics
                             for (int i = height - 1; i >= 0; i--)
                             {
                                 // Copy a single row
-                                Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
+                                Utilities.CopyWithAlignmentFallback(destPtr, sourcePtr, (uint)rowStride);
                                 sourcePtr -= box.RowPitch;
                                 destPtr += rowStride;
                             }
@@ -894,7 +894,7 @@ namespace Stride.Graphics
                             for (int i = 0; i < height; i++)
                             {
                                 // Copy a single row
-                                Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
+                                Utilities.CopyWithAlignmentFallback(destPtr, sourcePtr, (uint)rowStride);
                                 sourcePtr += box.RowPitch;
                                 destPtr += rowStride;
                             }
@@ -1037,7 +1037,7 @@ namespace Stride.Graphics
                     // The fast way: If same stride, we can directly copy the whole texture in one shot
                     if (box.RowPitch == rowStride && boxDepthStride == textureDepthStride)
                     {
-                        Unsafe.CopyBlockUnaligned((void*)box.DataPointer, pointer, (uint)sizeOfTextureData);
+                        Utilities.CopyWithAlignmentFallback((void*)box.DataPointer, pointer, (uint)sizeOfTextureData);
                     }
                     else
                     {
@@ -1052,7 +1052,7 @@ namespace Stride.Graphics
                             // Iterate on each line
                             for (int i = 0; i < height; i++)
                             {
-                                Unsafe.CopyBlockUnaligned(destPtr, sourcePtr, (uint)rowStride);
+                                Utilities.CopyWithAlignmentFallback(destPtr, sourcePtr, (uint)rowStride);
                                 destPtr += box.RowPitch;
                                 sourcePtr += rowStride;
                             }

--- a/sources/engine/Stride.Graphics/VertexHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexHelper.cs
@@ -175,7 +175,7 @@ namespace Stride.Graphics
                 var newVertexOffset = 0;
                 for (int i = 0; i < vertexCount; ++i)
                 {
-                    Unsafe.CopyBlockUnaligned(newBuffer + newVertexOffset, oldBuffer + oldVertexOffset, (uint)vertexStride);
+                    Utilities.CopyWithAlignmentFallback(newBuffer + newVertexOffset, oldBuffer + oldVertexOffset, (uint)vertexStride);
 
                     var textureCoord = *(Vector2*)&oldBuffer[oldVertexOffset + vertexUVOffset];
                     for (int j = 0; j < newVertexElements.Count; j++)
@@ -351,7 +351,7 @@ namespace Stride.Graphics
                 var newVertexOffset = 0;
                 for (int i = 0; i < vertexCount; ++i)
                 {
-                    Unsafe.CopyBlockUnaligned(newBuffer + newVertexOffset, oldBuffer + oldVertexOffset, (uint)oldVertexStride);
+                    Utilities.CopyWithAlignmentFallback(newBuffer + newVertexOffset, oldBuffer + oldVertexOffset, (uint)oldVertexStride);
 
                     var normal = *(Vector3*)&oldBuffer[oldVertexOffset + normalOffset];
                     var newTangentPtr = ((float*)(&newBuffer[newVertexOffset + tangentOffset]));

--- a/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
@@ -3,6 +3,7 @@
 #if STRIDE_GRAPHICS_API_VULKAN
 using System;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 using Vortice.Vulkan;
 using static Vortice.Vulkan.Vulkan;
 
@@ -183,7 +184,7 @@ namespace Stride.Graphics
                     {
                         void* uploadMemory;
                         vkMapMemory(GraphicsDevice.NativeDevice, NativeMemory, 0, (ulong) SizeInBytes, VkMemoryMapFlags.None, &uploadMemory);
-                        Unsafe.CopyBlockUnaligned(uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
+                        Utilities.CopyWithAlignmentFallback(uploadMemory, (void*) dataPointer, (uint) SizeInBytes);
                         vkUnmapMemory(GraphicsDevice.NativeDevice, NativeMemory);
                     }
                     else
@@ -191,7 +192,7 @@ namespace Stride.Graphics
                         var sizeInBytes = bufferDescription.SizeInBytes;
                         var uploadMemory = GraphicsDevice.AllocateUploadBuffer(sizeInBytes, out var uploadResource, out var uploadOffset);
 
-                        Unsafe.CopyBlockUnaligned((void*) uploadMemory, (void*) dataPointer, (uint) sizeInBytes);
+                        Utilities.CopyWithAlignmentFallback((void*) uploadMemory, (void*) dataPointer, (uint) sizeInBytes);
 
                         // Barrier
                         var memoryBarrier = new VkBufferMemoryBarrier(uploadResource, VkAccessFlags.HostWrite, VkAccessFlags.TransferRead, (ulong) uploadOffset, (ulong) sizeInBytes);

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -1198,7 +1198,7 @@ namespace Stride.Graphics
             var uploadMemory = GraphicsDevice.AllocateUploadBuffer(lengthInBytes + alignmentMask, out var uploadResource, out var uploadOffset);
             var alignment = ((uploadOffset + alignmentMask) & ~alignmentMask) - uploadOffset;
 
-            Unsafe.CopyBlockUnaligned((void*) (uploadMemory + alignment), (void*) databox.DataPointer, (uint) lengthInBytes);
+            Utilities.CopyWithAlignmentFallback((void*) (uploadMemory + alignment), (void*) databox.DataPointer, (uint) lengthInBytes);
 
             var uploadBufferMemoryBarrier = new VkBufferMemoryBarrier(uploadResource, VkAccessFlags.HostWrite, VkAccessFlags.TransferRead, (ulong) (uploadOffset + alignment), (ulong) lengthInBytes);
 

--- a/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
@@ -3,6 +3,7 @@
 #if STRIDE_GRAPHICS_API_VULKAN
 using System;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 using Vortice.Vulkan;
 using static Vortice.Vulkan.Vulkan;
 
@@ -339,7 +340,7 @@ namespace Stride.Graphics
                     uploadMemory += alignment;
                     uploadOffset += alignment;
 
-                    Unsafe.CopyBlockUnaligned((void*) uploadMemory, (void*) (dataBoxes[i].DataPointer), (uint) slicePitch);
+                    Utilities.CopyWithAlignmentFallback((void*) uploadMemory, (void*) (dataBoxes[i].DataPointer), (uint) slicePitch);
 
                     if (Usage == GraphicsResourceUsage.Staging)
                     {

--- a/sources/engine/Stride.Particles/VertexLayouts/ParticleBufferState.cs
+++ b/sources/engine/Stride.Particles/VertexLayouts/ParticleBufferState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 
 namespace Stride.Particles.VertexLayouts
 {
@@ -62,7 +63,7 @@ namespace Stride.Particles.VertexLayouts
         /// <param name="ptrRef">Pointer to the source data</param>
         public unsafe void SetAttribute(AttributeAccessor accessor, nint ptrRef)
         {
-            Unsafe.CopyBlockUnaligned((byte*)VertexBuffer + accessor.Offset, (void*)ptrRef, (uint)accessor.Size);
+            Utilities.CopyWithAlignmentFallback((byte*)VertexBuffer + accessor.Offset, (void*)ptrRef, (uint)accessor.Size);
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Stride.Particles.VertexLayouts
         {
             for (var i = 0; i < vertexBuilder.VerticesPerParticle; i++)
             {
-                Unsafe.CopyBlockUnaligned((byte*)VertexBuffer + accessor.Offset + i * VertexStride, (void*)ptrRef, (uint)accessor.Size);
+                Utilities.CopyWithAlignmentFallback((byte*)VertexBuffer + accessor.Offset + i * VertexStride, (void*)ptrRef, (uint)accessor.Size);
             }
         }
 
@@ -87,7 +88,7 @@ namespace Stride.Particles.VertexLayouts
         {
             for (var i = 0; i < VerticesPerSegCurrent; i++)
             {
-                Unsafe.CopyBlockUnaligned((byte*)VertexBuffer + accessor.Offset + i * VertexStride, (void*)ptrRef, (uint)accessor.Size);
+                Utilities.CopyWithAlignmentFallback((byte*)VertexBuffer + accessor.Offset + i * VertexStride, (void*)ptrRef, (uint)accessor.Size);
             }
         }
 

--- a/sources/engine/Stride.Rendering/Extensions/HalfBufferExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/HalfBufferExtensions.cs
@@ -114,7 +114,7 @@ namespace Stride.Extensions
                         else
                         {
                             // Copy as is
-                            Unsafe.CopyBlockUnaligned(newBufferElementPtr, oldBufferElementPtr, (uint)element.VertexElementWithOffset.Size);
+                            Utilities.CopyWithAlignmentFallback(newBufferElementPtr, oldBufferElementPtr, (uint)element.VertexElementWithOffset.Size);
                         }
                     }
 

--- a/sources/engine/Stride.Rendering/Extensions/IndexExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/IndexExtensions.cs
@@ -52,7 +52,7 @@ namespace Stride.Extensions
                 for (int i = 0; i < indexBuffer.Count; ++i)
                 {
                     var index = ((int*)indexBufferStart)[i];
-                    Unsafe.CopyBlockUnaligned(newVerticesStart + i * stride, vertexBufferStart + index * stride, (uint)stride);
+                    Utilities.CopyWithAlignmentFallback(newVerticesStart + i * stride, vertexBufferStart + index * stride, (uint)stride);
                 }
             }
 
@@ -85,7 +85,7 @@ namespace Stride.Extensions
                 var vertexBufferDataCurrent = vertexBufferDataStart;
                 for (int i = 0; i < vertices.Length; ++i)
                 {
-                    Unsafe.CopyBlockUnaligned(vertexBufferDataCurrent, oldVertexBufferDataStart + oldVertexStride * vertices[i], (uint)newVertexStride);
+                    Utilities.CopyWithAlignmentFallback(vertexBufferDataCurrent, oldVertexBufferDataStart + oldVertexStride * vertices[i], (uint)newVertexStride);
                     vertexBufferDataCurrent += newVertexStride;
                 }
                 meshData.VertexBuffers[0] = new VertexBufferBinding(new BufferData(BufferFlags.VertexBuffer, vertexBufferData).ToSerializableVersion(), declaration, indexMapping.Vertices.Length);
@@ -96,7 +96,7 @@ namespace Stride.Extensions
             fixed (int* indexDataStart = &indexMapping.Indices[0])
             fixed (byte* indexBufferDataStart = &indexBufferData[0])
             {
-                Unsafe.CopyBlockUnaligned(indexBufferDataStart, indexDataStart, (uint)indexBufferData.Length);
+                Utilities.CopyWithAlignmentFallback(indexBufferDataStart, indexDataStart, (uint)indexBufferData.Length);
                 meshData.IndexBuffer = new IndexBufferBinding(new BufferData(BufferFlags.IndexBuffer, indexBufferData).ToSerializableVersion(), true, indexMapping.Indices.Length);
             }
         }
@@ -286,7 +286,7 @@ namespace Stride.Extensions
             fixed (int* indexDataStart = &newIndices[0])
             fixed (byte* indexBufferDataStart = &indexBufferData[0])
             {
-                Unsafe.CopyBlockUnaligned(indexBufferDataStart, indexDataStart, (uint)indexBufferData.Length);
+                Utilities.CopyWithAlignmentFallback(indexBufferDataStart, indexDataStart, (uint)indexBufferData.Length);
             }
 
             meshData.IndexBuffer = new IndexBufferBinding(new BufferData(BufferFlags.IndexBuffer, indexBufferData).ToSerializableVersion(), true, triangleCount * 12);

--- a/sources/engine/Stride.Rendering/Extensions/MergeExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/MergeExtensions.cs
@@ -91,7 +91,7 @@ namespace Stride.Extensions
                     var sourceBuffer = meshDrawData.VertexBuffers[0].Buffer.GetSerializationData();
                     fixed (byte* sourceBufferDataStart = &sourceBuffer.Content[0])
                     {
-                        Unsafe.CopyBlockUnaligned(destBufferDataCurrent, sourceBufferDataStart, (uint)sourceBuffer.Content.Length);
+                        Utilities.CopyWithAlignmentFallback(destBufferDataCurrent, sourceBufferDataStart, (uint)sourceBuffer.Content.Length);
                         destBufferDataCurrent += sourceBuffer.Content.Length;
                     }
                 }
@@ -135,7 +135,7 @@ namespace Stride.Extensions
 
                         fixed (byte* sourceBufferDataStart = &sourceBufferContent[0])
                         {
-                            Unsafe.CopyBlockUnaligned(destBufferDataCurrent, sourceBufferDataStart,
+                            Utilities.CopyWithAlignmentFallback(destBufferDataCurrent, sourceBufferDataStart,
                                 (uint)sourceBufferContent.Length);
                             destBufferDataCurrent += sourceBufferContent.Length;
                         }

--- a/sources/engine/Stride.Rendering/Extensions/PolySortExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/PolySortExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Graphics;
 using Stride.Graphics.Data;
@@ -72,7 +73,7 @@ namespace Stride.Extensions
 
                 foreach (var index in sortedIndices)
                 {
-                    Unsafe.CopyBlockUnaligned(
+                    Utilities.CopyWithAlignmentFallback(
                         destination: newIndexBufferPointer,
                         source: oldIndexDataStart + index * polyIndicesSize,
                         byteCount: polyIndicesSize);

--- a/sources/engine/Stride.Rendering/Extensions/SplitExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/SplitExtensions.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 using Stride.Graphics;
 using Stride.Graphics.Data;
 using Stride.Rendering;
@@ -124,7 +125,7 @@ namespace Stride.Extensions
                         {
                             //copy vertex buffer
                             foreach (var index in splitInfo.UsedIndices)
-                                Unsafe.CopyBlockUnaligned(
+                                Utilities.CopyWithAlignmentFallback(
                                     destination: newVertexBufferPtr + stride * splitInfo.IndexRemapping[index],
                                     source: vertexBufferPtr + stride * index,
                                     byteCount: (uint)stride);

--- a/sources/engine/Stride.Rendering/Extensions/VertexExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/VertexExtensions.cs
@@ -43,7 +43,7 @@ namespace Stride.Extensions
                 {
                     foreach (var vertexElementWithOffset in offsets)
                     {
-                        Unsafe.CopyBlockUnaligned(ptrOutput, ptrInput + vertexElementWithOffset.Offset, (uint)vertexElementWithOffset.Size);
+                        Utilities.CopyWithAlignmentFallback(ptrOutput, ptrInput + vertexElementWithOffset.Offset, (uint)vertexElementWithOffset.Size);
                         ptrOutput += vertexElementWithOffset.Size;
                     }
                     ptrInput += declaration.VertexStride;

--- a/sources/engine/Stride.Rendering/Rendering/Lights/RenderLightCollectionGroup.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/RenderLightCollectionGroup.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Stride.Core;
 using Stride.Core.Collections;
 
 namespace Stride.Rendering.Lights
@@ -119,14 +120,13 @@ namespace Stride.Rendering.Lights
         /// </summary>
         public Type LightType { get; }
 
-        internal unsafe void Clear()
+        internal void Clear()
         {
             allLights.Clear();
             allLightsWithShadows.Clear();
             allMasks.Clear();
 
-            fixed (void* ptr = groupMasks)
-                Unsafe.InitBlockUnaligned(ptr, 0, (uint)groupMasks.Length * sizeof(uint));
+            groupMasks.AsSpan().Clear();
 
             // Only clear collections that were previously allocated (no need to iterate on all collections from the pool)
             foreach (var collection in lightCollectionPool)

--- a/sources/engine/Stride.Rendering/Rendering/LogicalGroupExtensions.cs
+++ b/sources/engine/Stride.Rendering/Rendering/LogicalGroupExtensions.cs
@@ -56,7 +56,7 @@ namespace Stride.Rendering
                 var mappedDrawLighting = (byte*)resourceGroup.ConstantBuffer.Data + logicalGroup.ConstantBufferOffset;
 
                 fixed (byte* dataValues = sourceParameters.DataValues)
-                    Unsafe.CopyBlockUnaligned(mappedDrawLighting, dataValues + sourceOffset, (uint)logicalGroup.ConstantBufferSize);
+                    Utilities.CopyWithAlignmentFallback(mappedDrawLighting, dataValues + sourceOffset, (uint)logicalGroup.ConstantBufferSize);
             }
         }
     }

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialRenderFeature.cs
@@ -398,7 +398,7 @@ namespace Stride.Rendering.Materials
             {
                 var mappedCB = (byte*)materialInfo.Resources.ConstantBuffer.Data;
                 fixed (byte* dataValues = materialInfo.ParameterCollection.DataValues)
-                    Unsafe.CopyBlockUnaligned(mappedCB, dataValues, (uint)materialInfo.Resources.ConstantBuffer.Size);
+                    Utilities.CopyWithAlignmentFallback(mappedCB, dataValues, (uint)materialInfo.Resources.ConstantBuffer.Size);
             }
 
             return true;

--- a/sources/engine/Stride.Rendering/Rendering/SkinningRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/SkinningRenderFeature.cs
@@ -137,7 +137,7 @@ namespace Stride.Rendering
 
                     fixed (Matrix* blendMatricesPtr = renderModelObjectInfo)
                     {
-                        Unsafe.CopyBlockUnaligned(mappedCB, blendMatricesPtr, (uint)renderModelObjectInfo.Length * (uint)sizeof(Matrix));
+                        Utilities.CopyWithAlignmentFallback(mappedCB, blendMatricesPtr, (uint)renderModelObjectInfo.Length * (uint)sizeof(Matrix));
                     }
                 }
             });

--- a/sources/engine/Stride/Graphics/DDSHelper.cs
+++ b/sources/engine/Stride/Graphics/DDSHelper.cs
@@ -1070,7 +1070,7 @@ namespace Stride.Graphics
                         int pixsize = pixelBuffers[index].BufferStride;
                         Debug.Assert((uint)pixsize <= buffer.Length);
                         fixed (byte* pinned = buffer) {
-                            Unsafe.CopyBlockUnaligned(pinned, source: (void*)pixelBuffers[index].DataPointer, (uint)pixsize);
+                            Utilities.CopyWithAlignmentFallback(pinned, source: (void*)pixelBuffers[index].DataPointer, (uint)pixsize);
                         }
                         stream.Write(buffer, 0, pixsize);
                         ++index;
@@ -1146,7 +1146,7 @@ namespace Stride.Graphics
 
                         if (metadata.Format.IsCompressed())
                         {
-                            Unsafe.CopyBlockUnaligned((void*)pDest, (void*)pSrc, (uint)Math.Min(images[index].BufferStride, imagesDst[index].BufferStride));
+                            Utilities.CopyWithAlignmentFallback((void*)pDest, (void*)pSrc, (uint)Math.Min(images[index].BufferStride, imagesDst[index].BufferStride));
                         }
                         else
                         {
@@ -1515,7 +1515,7 @@ namespace Stride.Graphics
             if (pDestination == pSource)
                 return;
 
-            Unsafe.CopyBlockUnaligned((void*)pDestination, source: (void*)pSource, (uint)Math.Min(outSize, inSize));
+            Utilities.CopyWithAlignmentFallback((void*)pDestination, source: (void*)pSource, (uint)Math.Min(outSize, inSize));
         }
 
         /// <summary>
@@ -1628,7 +1628,7 @@ namespace Stride.Graphics
             if (pDestination == pSource)
                 return;
 
-            Unsafe.CopyBlockUnaligned((void*)pDestination, source: (void*)pSource, (uint)Math.Min(outSize, inSize));
+            Utilities.CopyWithAlignmentFallback((void*)pDestination, source: (void*)pSource, (uint)Math.Min(outSize, inSize));
         }
 
     }

--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -195,7 +195,7 @@ namespace Stride.Graphics
         /// </summary>
         public unsafe void Clear()
         {
-            Unsafe.InitBlockUnaligned((void*)buffer, 0, (uint)totalSizeInBytes);
+            Utilities.Clear((void*)buffer, (uint)totalSizeInBytes);
         }
 
         /// <summary>

--- a/sources/engine/Stride/Graphics/ImageHelper.cs
+++ b/sources/engine/Stride/Graphics/ImageHelper.cs
@@ -34,7 +34,7 @@ namespace Stride.Graphics
             if (makeACopy)
             {
                 var buffer = Utilities.AllocateMemory(size);
-                Unsafe.CopyBlockUnaligned((void*)buffer, source: (void*)pSource, (uint)size);
+                Utilities.CopyWithAlignmentFallback((void*)buffer, source: (void*)pSource, (uint)size);
                 pSource = buffer;
                 makeACopy = false;
             }

--- a/sources/engine/Stride/Graphics/PixelBuffer.cs
+++ b/sources/engine/Stride/Graphics/PixelBuffer.cs
@@ -150,7 +150,7 @@ namespace Stride.Graphics
             // If buffers have same size, than we can copy it directly
             if (this.BufferStride == pixelBuffer.BufferStride)
             {
-                Unsafe.CopyBlockUnaligned((void*)pixelBuffer.DataPointer, source: (void*)DataPointer, (uint)BufferStride);
+                Utilities.CopyWithAlignmentFallback((void*)pixelBuffer.DataPointer, source: (void*)DataPointer, (uint)BufferStride);
             }
             else
             {
@@ -161,7 +161,7 @@ namespace Stride.Graphics
                 // Copy per scanline
                 for (int i = 0; i < Height; i++)
                 {
-                    Unsafe.CopyBlockUnaligned(dstPointer, srcPointer, (uint)rowStride);
+                    Utilities.CopyWithAlignmentFallback(dstPointer, srcPointer, (uint)rowStride);
                     srcPointer += this.RowStride;
                     dstPointer += pixelBuffer.RowStride;
                 }

--- a/sources/engine/Stride/Graphics/StandardImageHelper.Android.cs
+++ b/sources/engine/Stride/Graphics/StandardImageHelper.Android.cs
@@ -102,7 +102,7 @@ namespace Stride.Graphics
                         }
                         else if (description.Format == PixelFormat.B8G8R8A8_UNorm || description.Format == PixelFormat.B8G8R8A8_UNorm_SRgb)
                         {
-                            Unsafe.CopyBlockUnaligned((void*)pixelData, (void*)pSrc, (uint)sizeToCopy);
+                            Utilities.CopyWithAlignmentFallback((void*)pixelData, (void*)pSrc, (uint)sizeToCopy);
                         }
                         else
                         {

--- a/sources/engine/Stride/Graphics/StandardImageHelper.Windows.cs
+++ b/sources/engine/Stride/Graphics/StandardImageHelper.Windows.cs
@@ -34,7 +34,7 @@ namespace Stride.Graphics
                 // Directly load image as RGBA instead of BGRA, because OpenGL ES devices don't support it out of the box (extension).
                 //image.Description.Format = PixelFormat.R8G8B8A8_UNorm;
                 //CopyMemoryBGRA(image.PixelBuffer[0].DataPointer, bitmapData.Scan0, image.PixelBuffer[0].BufferStride);
-                Unsafe.CopyBlockUnaligned((void*)image.PixelBuffer[0].DataPointer, (void*)bitmapData.Scan0, (uint)image.PixelBuffer[0].BufferStride);
+                Utilities.CopyWithAlignmentFallback((void*)image.PixelBuffer[0].DataPointer, (void*)bitmapData.Scan0, (uint)image.PixelBuffer[0].BufferStride);
             }
             finally
             {
@@ -97,7 +97,7 @@ namespace Stride.Graphics
                 }
                 else if (format == PixelFormat.B8G8R8A8_UNorm || format == PixelFormat.B8G8R8A8_UNorm_SRgb)
                 {
-                    Unsafe.CopyBlockUnaligned((void*)bitmapData.Scan0, (void*)pixelBuffers[0].DataPointer, (uint)pixelBuffers[0].BufferStride);
+                    Utilities.CopyWithAlignmentFallback((void*)bitmapData.Scan0, (void*)pixelBuffers[0].DataPointer, (uint)pixelBuffers[0].BufferStride);
                 }
                 else if (format == PixelFormat.R8_UNorm || format == PixelFormat.A8_UNorm)
                 {

--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -1157,7 +1157,7 @@ namespace Stride.Importer.ThreeD
             fixed (byte* bufferPointer = buffer)
             {
                 var sourcePointer = (byte*)texture->PcData;
-                System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(bufferPointer, sourcePointer, arraySize);
+                Core.Utilities.CopyWithAlignmentFallback(bufferPointer, sourcePointer, arraySize);
             }
             System.IO.File.WriteAllBytes(path, buffer);
         }

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/ArrayTexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/ArrayTexLib.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Stride.Core;
 using Stride.Core.Diagnostics;
 using Stride.Graphics;
 using Stride.TextureConverter.Requests;
@@ -124,7 +125,7 @@ namespace Stride.TextureConverter.TexLibraries
                 current = request.TextureList[i];
                 buffer = arrayData + offset1;
                 offset1 += current.DataSize;
-                Unsafe.CopyBlockUnaligned((void*)buffer, (void*)current.Data, (uint)current.DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)buffer, (void*)current.Data, (uint)current.DataSize);
 
                 offset2 = 0;
                 currentData = buffer;
@@ -258,7 +259,7 @@ namespace Stride.TextureConverter.TexLibraries
 
             for (int i = 0; i < subImageCount; ++i)
             {
-                Unsafe.CopyBlockUnaligned(
+                Utilities.CopyWithAlignmentFallback(
                     destination: (void*)array.SubImageArray[indice].Data,
                     source: (void*)request.Texture.SubImageArray[i].Data,
                     byteCount: (uint)request.Texture.SubImageArray[i].DataSize);
@@ -301,7 +302,7 @@ namespace Stride.TextureConverter.TexLibraries
             {
                 subImages[i] = array.SubImageArray[i];
                 subImages[i].Data = bufferData + offset;
-                Unsafe.CopyBlockUnaligned((void*)subImages[i].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)subImages[i].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
                 offset += array.SubImageArray[i].DataSize;
             }
 
@@ -310,7 +311,7 @@ namespace Stride.TextureConverter.TexLibraries
             for (int i = 0; i < subImageCount; ++i)
             {
                 subImages[ct] = request.Texture.SubImageArray[i];
-                Unsafe.CopyBlockUnaligned((void*)subImages[ct].Data, (void*)request.Texture.SubImageArray[i].Data, (uint)request.Texture.SubImageArray[i].DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)subImages[ct].Data, (void*)request.Texture.SubImageArray[i].Data, (uint)request.Texture.SubImageArray[i].DataSize);
                 offset += request.Texture.SubImageArray[i].DataSize;
                 ++ct;
             }
@@ -320,7 +321,7 @@ namespace Stride.TextureConverter.TexLibraries
             {
                 subImages[ct] = array.SubImageArray[i];
                 subImages[ct].Data = bufferData + offset;
-                Unsafe.CopyBlockUnaligned((void*)subImages[ct].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)subImages[ct].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
                 offset += array.SubImageArray[i].DataSize;
                 ++ct;
             }
@@ -368,7 +369,7 @@ namespace Stride.TextureConverter.TexLibraries
             {
                 subImages[i] = array.SubImageArray[i];
                 subImages[i].Data = buffer + offset;
-                Unsafe.CopyBlockUnaligned((void*)subImages[i].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)subImages[i].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
                 offset += array.SubImageArray[i].DataSize;
             }
 
@@ -376,7 +377,7 @@ namespace Stride.TextureConverter.TexLibraries
             {
                 subImages[indice] = array.SubImageArray[i];
                 subImages[indice].Data = buffer + offset;
-                Unsafe.CopyBlockUnaligned((void*)subImages[indice].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)subImages[indice].Data, (void*)array.SubImageArray[i].Data, (uint)array.SubImageArray[i].DataSize);
                 offset += array.SubImageArray[i].DataSize;
                 ++indice;
             }

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/AtlasTexLibrary.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/AtlasTexLibrary.cs
@@ -210,7 +210,7 @@ namespace Stride.TextureConverter.TexLibraries
 
                 for (int j = 0; j < h; ++j)
                 {
-                    Unsafe.CopyBlockUnaligned(
+                    Utilities.CopyWithAlignmentFallback(
                         destination: (byte*)atlasData + j * atlas.SubImageArray[i].RowPitch + yOffset + xOffset,
                         source: subImageData + j * request.Texture.SubImageArray[i].RowPitch,
                         byteCount: (uint)request.Texture.SubImageArray[i].RowPitch);
@@ -291,7 +291,7 @@ namespace Stride.TextureConverter.TexLibraries
                 {
                     srcPtr = atlasData + j * atlas.SubImageArray[i].RowPitch + yOffset + xOffset;
                     destPtr = textureData + j * rowPitch;
-                    Unsafe.CopyBlockUnaligned((void*)destPtr, (void*)srcPtr, (uint)rowPitch);
+                    Utilities.CopyWithAlignmentFallback((void*)destPtr, (void*)srcPtr, (uint)rowPitch);
                 }
 
                 offset += slicePitch;
@@ -554,7 +554,7 @@ namespace Stride.TextureConverter.TexLibraries
                     {
                         var destPtr = atlasData + j * atlas.SubImageArray[i].RowPitch + yOffset + xOffset;
                         var srcPtr = textureData + j * node.Texture.SubImageArray[i].RowPitch;
-                        Unsafe.CopyBlockUnaligned(destPtr, srcPtr, (uint)node.Texture.SubImageArray[i].RowPitch);
+                        Utilities.CopyWithAlignmentFallback(destPtr, srcPtr, (uint)node.Texture.SubImageArray[i].RowPitch);
                     }
 
                     x = x <= 1 ? 0 : x >>= 1;

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/FITexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/FITexLib.cs
@@ -115,7 +115,7 @@ namespace Stride.TextureConverter.TexLibraries
                     image.SubImageArray[i].RowPitch = rowPitch;
                     image.SubImageArray[i].SlicePitch = slicePitch;
 
-                    Unsafe.CopyBlockUnaligned((void*)image.SubImageArray[i].Data, (void*)FreeImage.GetBits(libraryData.Bitmaps[i]), (uint)size);
+                    Utilities.CopyWithAlignmentFallback((void*)image.SubImageArray[i].Data, (void*)FreeImage.GetBits(libraryData.Bitmaps[i]), (uint)size);
                     offset += size;
                 }
             }

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/PvrttTexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/PvrttTexLib.cs
@@ -134,7 +134,7 @@ namespace Stride.TextureConverter.TexLibraries
                     {
                         for (uint k = 0; k < image.MipmapCount; ++k)
                         {
-                            Unsafe.CopyBlockUnaligned(
+                            Core.Utilities.CopyWithAlignmentFallback(
                                 (void*)libraryData.Texture.GetDataPtr(k, j, i),
                                 (void*)image.SubImageArray[imageCount].Data,
                                 (uint)(image.SubImageArray[imageCount].DataSize * depth));
@@ -405,7 +405,7 @@ namespace Stride.TextureConverter.TexLibraries
                         {
                             for (uint k = 0; k < newMipMapCount; ++k)
                             {
-                                Unsafe.CopyBlockUnaligned(
+                                Core.Utilities.CopyWithAlignmentFallback(
                                     destination: (void*)texture.GetDataPtr(k, j, i),
                                     source: (void*)libraryData.Texture.GetDataPtr(k, j, i),
                                     byteCount: libraryData.Header.GetDataSize((int)k, false, false));
@@ -556,14 +556,14 @@ namespace Stride.TextureConverter.TexLibraries
                     var source = (byte*)image.Data + sourceOffset;
                     var dest = temporaryBuffer + destOffset;
 
-                    Unsafe.CopyBlockUnaligned(dest, source, slice);
+                    Core.Utilities.CopyWithAlignmentFallback(dest, source, slice);
                 }
 
                 sourceRowOffset += checked((int)(slice * (uint)image.FaceCount));
             }
 
             // Copy data back to the library
-            Unsafe.CopyBlockUnaligned(
+            Core.Utilities.CopyWithAlignmentFallback(
                 destination: (void*)libraryData.Texture.GetDataPtr(),
                 source: temporaryBuffer,
                 byteCount: (uint)image.DataSize);

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/StrideTexLibrary.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/StrideTexLibrary.cs
@@ -210,7 +210,7 @@ namespace Stride.TextureConverter.TexLibraries
                         {
                             for (int j = 0; j < ct; ++j)
                             {
-                                Unsafe.CopyBlockUnaligned(
+                                Utilities.CopyWithAlignmentFallback(
                                     (void*)sdImage.PixelBuffer[ct2].DataPointer,
                                     (void*)sdImage.PixelBuffer[j + i * SubImagePerArrayElement].DataPointer,
                                     (uint)sdImage.PixelBuffer[j + i * SubImagePerArrayElement].BufferStride);
@@ -268,7 +268,7 @@ namespace Stride.TextureConverter.TexLibraries
                         for (int i = 0; i < image.ArraySize * newMipMapCount; ++i)
                         {
                             if (i == newMipMapCount || (i > newMipMapCount && (i % newMipMapCount == 0))) j += gap;
-                            Unsafe.CopyBlockUnaligned((void*)sdImage.PixelBuffer[i].DataPointer, (void*)image.SubImageArray[j].Data, (uint)image.SubImageArray[j].DataSize);
+                            Utilities.CopyWithAlignmentFallback((void*)sdImage.PixelBuffer[i].DataPointer, (void*)image.SubImageArray[j].Data, (uint)image.SubImageArray[j].DataSize);
                             ++j;
                         }
                     }
@@ -305,7 +305,7 @@ namespace Stride.TextureConverter.TexLibraries
                     throw new InvalidOperationException("Image size different than expected.");
                 }
 
-                Unsafe.CopyBlockUnaligned((void*)sdImage.DataPointer, (void*)image.Data, (uint)image.DataSize);
+                Utilities.CopyWithAlignmentFallback((void*)sdImage.DataPointer, (void*)image.Data, (uint)image.DataSize);
             }
 
             using (var fileStream = new FileStream(request.FilePath, FileMode.Create, FileAccess.Write))
@@ -367,7 +367,7 @@ namespace Stride.TextureConverter.TexLibraries
                 throw new InvalidOperationException("Image size different than expected.");
             }
 
-            Unsafe.CopyBlockUnaligned((void*)sdImage.DataPointer, (void*)image.Data, (uint)image.DataSize);
+            Utilities.CopyWithAlignmentFallback((void*)sdImage.DataPointer, (void*)image.Data, (uint)image.DataSize);
 
             request.XkImage = sdImage;
         }

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
@@ -935,7 +935,7 @@ namespace Stride.TextureConverter.DxtWrapper
                 fixed (byte* ptr = buffer)
                 {
                     DDSHeaderDX9* headerPtr = &header;
-                    Unsafe.CopyBlockUnaligned(headerPtr, ptr, (uint)headerSize);
+                    Stride.Core.Utilities.CopyWithAlignmentFallback(headerPtr, ptr, (uint)headerSize);
                 }
                 if (header.dwMagic != 0x20534444 || header.dwPfSize != 32)
                     return -1;

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MemoryArray.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MemoryArray.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Stride.Core;
 
 namespace FreeImageAPI
 {
@@ -247,7 +248,7 @@ namespace FreeImageAPI
 				return (T)(object)(FI4BIT)(((index % 2) == 0) ? (baseAddress[index / 2] >> 4) : (baseAddress[index / 2] & 0x0F));
 			}
 
-			Unsafe.CopyBlockUnaligned(ptr, baseAddress + (index * size), (uint) size);
+			Utilities.CopyWithAlignmentFallback(ptr, baseAddress + (index * size), (uint) size);
 			return buffer[0];
 		}
 
@@ -297,7 +298,7 @@ namespace FreeImageAPI
 			else
 			{
 				buffer[0] = value;
-				Unsafe.CopyBlockUnaligned(baseAddress + (index * size), ptr, (uint) size);
+				Utilities.CopyWithAlignmentFallback(baseAddress + (index * size), ptr, (uint) size);
 			}
 		}
 
@@ -337,7 +338,7 @@ namespace FreeImageAPI
 			{
 				ref byte dst = ref Unsafe.As<T, byte>(ref data[0]);
 				ref byte src = ref Unsafe.AsRef<byte>(baseAddress + (size * index));
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, (uint) (size * length));
 			}
 			return data;
 		}
@@ -381,7 +382,7 @@ namespace FreeImageAPI
 			{
 				ref byte dst = ref Unsafe.AsRef<byte>(baseAddress + (index * size));
 				ref byte src = ref Unsafe.As<T, byte>(ref values[0]);
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, (uint) (size * length));
 			}
 		}
 
@@ -450,7 +451,7 @@ namespace FreeImageAPI
 			{
 				ref byte dst = ref Unsafe.As<T, byte>(ref array[destinationIndex]);
 				ref byte src = ref Unsafe.AsRef<byte>(baseAddress + (size * sourceIndex));
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, (uint) (size * length));
 			}
 		}
 
@@ -493,7 +494,7 @@ namespace FreeImageAPI
 			{
 				ref byte dst = ref Unsafe.AsRef<byte>(baseAddress + (size * destinationIndex));
 				ref byte src = ref Unsafe.As<T, byte>(ref array[sourceIndex]);
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) (size * length));
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, (uint) (size * length));
 			}
 		}
 
@@ -520,7 +521,7 @@ namespace FreeImageAPI
 
 			ref byte dst = ref result[0];
 			ref byte src = ref Unsafe.AsRef<byte>(baseAddress);
-			Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) result.Length);
+			Utilities.CopyWithAlignmentFallback(ref dst, ref src, (uint) result.Length);
 
 			return result;
 		}

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MetadataTag.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/MetadataTag.cs
@@ -39,6 +39,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Stride.Core;
 
 namespace FreeImageAPI.Metadata
 {
@@ -412,7 +413,7 @@ namespace FreeImageAPI.Metadata
 
 					ref byte dst = ref MemoryMarshal.GetArrayDataReference(array);
 					ref byte src = ref Unsafe.AsRef<byte>((void*) FreeImage.GetTagValue(tag));
-					Unsafe.CopyBlockUnaligned(ref dst, ref src, Length);
+					Utilities.CopyWithAlignmentFallback(ref dst, ref src, Length);
 
 					return array;
 				}
@@ -532,7 +533,7 @@ namespace FreeImageAPI.Metadata
 
 				ref byte dst = ref data[0];
 				ref byte src = ref MemoryMarshal.GetArrayDataReference(array);
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, Length);
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, Length);
 			}
 
 			return FreeImage.SetTagValue(tag, data);
@@ -627,7 +628,7 @@ namespace FreeImageAPI.Metadata
 
 			ref byte dst = ref item.Value[0];
 			ref byte src = ref Unsafe.AsRef<byte>((void*) FreeImage.GetTagValue(tag));
-			Unsafe.CopyBlockUnaligned(ref dst, ref src, Length);
+			Utilities.CopyWithAlignmentFallback(ref dst, ref src, Length);
 
 			return item;
 		}

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/Palette.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Classes/Palette.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using FreeImageAPI.Metadata;
+using Stride.Core;
 
 namespace FreeImageAPI
 {
@@ -397,7 +398,7 @@ namespace FreeImageAPI
 
 				ref byte dst = ref Unsafe.AsRef<byte>(baseAddress);
 				ref byte src = ref data[0];
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, (uint) data.Length);
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, (uint) data.Length);
 			}
 		}
 

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/FreeImageWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/FreeImageWrapper.cs
@@ -44,7 +44,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using FreeImageAPI.IO;
 using FreeImageAPI.Metadata;
-
+using Stride.Core;
 using StridePixelFormat = Stride.Graphics.PixelFormat;
 
 namespace FreeImageAPI
@@ -630,7 +630,7 @@ namespace FreeImageAPI
 						ref byte dst = ref Unsafe.AsRef<byte>((byte*) GetScanLine(dib, i));
 						ref byte src = ref Unsafe.AsRef<byte>(addr);
 
-						Unsafe.CopyBlockUnaligned(ref dst, ref src, GetLine(dib));
+						Utilities.CopyWithAlignmentFallback(ref dst, ref src, GetLine(dib));
 
 						addr += pitch;
 					}
@@ -642,7 +642,7 @@ namespace FreeImageAPI
 						ref byte dst = ref Unsafe.AsRef<byte>((byte*) GetScanLine(dib, i));
 						ref byte src = ref Unsafe.AsRef<byte>(addr);
 
-						Unsafe.CopyBlockUnaligned(ref dst, ref src, GetLine(dib));
+						Utilities.CopyWithAlignmentFallback(ref dst, ref src, GetLine(dib));
 
 						addr += pitch;
 					}
@@ -1963,7 +1963,7 @@ namespace FreeImageAPI
 					// Copy the data into the dc
 					ref byte dst = ref Unsafe.AsRef<byte>((void*) ppvBits);
 					ref byte src = ref Unsafe.AsRef<byte>((void*) GetBits(dib));
-					Unsafe.CopyBlockUnaligned(ref dst, ref src, GetHeight(dib) * GetPitch(dib));
+					Utilities.CopyWithAlignmentFallback(ref dst, ref src, GetHeight(dib) * GetPitch(dib));
 
 					// Success: we unload the bitmap
 					if (unload)
@@ -2941,7 +2941,7 @@ namespace FreeImageAPI
 
 			ref byte dst = ref result[0];
 			ref byte src = ref Unsafe.AsRef<byte>((byte*) GetTransparencyTable(dib));
-			Unsafe.CopyBlockUnaligned(ref dst, ref src, count);
+			Utilities.CopyWithAlignmentFallback(ref dst, ref src, count);
 
 			return result;
 		}
@@ -3747,7 +3747,7 @@ namespace FreeImageAPI
 				ref byte dstMemory = ref Unsafe.AsRef<byte>((void*) dest);
 				ref byte srcMemory = ref Unsafe.AsRef<byte>((void*) src);
 
-				Unsafe.CopyBlockUnaligned(ref dstMemory, ref srcMemory, (uint) (paletteColors * sizeof(RGBQUAD)));
+				Utilities.CopyWithAlignmentFallback(ref dstMemory, ref srcMemory, (uint) (paletteColors * sizeof(RGBQUAD)));
 			}
 		}
 
@@ -4466,7 +4466,7 @@ namespace FreeImageAPI
 
 			ref byte dstPalleteBytes = ref Unsafe.AsRef<byte>((RGBQUAD*) GetPalette(dst));
 			ref byte srcPalleteBytes = ref Unsafe.AsRef<byte>((RGBQUAD*) GetPalette(src));
-			Unsafe.CopyBlockUnaligned(ref dstPalleteBytes, ref srcPalleteBytes, size);
+			Utilities.CopyWithAlignmentFallback(ref dstPalleteBytes, ref srcPalleteBytes, size);
 		}
 
 		private static unsafe Scanline<FI4BIT>[] Get04BitScanlines(FIBITMAP dib)

--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Structs/FIICCPROFILE.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/FINetWrapper/Structs/FIICCPROFILE.cs
@@ -36,6 +36,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Stride.Core;
 
 namespace FreeImageAPI
 {
@@ -106,7 +107,7 @@ namespace FreeImageAPI
 				ref byte dst = ref result[0];
 				ref byte src = ref Unsafe.AsRef<byte>((void*) DataPointer);
 
-				Unsafe.CopyBlockUnaligned(ref dst, ref src, Size);
+				Utilities.CopyWithAlignmentFallback(ref dst, ref src, Size);
 
 				return result;
 			}

--- a/sources/tools/Stride.TextureConverter/Frontend/TexImage.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/TexImage.cs
@@ -280,7 +280,7 @@ namespace Stride.TextureConverter
                 Disposed = this.Disposed,
             };
 
-            if (CopyMemory) Unsafe.CopyBlockUnaligned((void*)newTex.Data, (void*)Data, (uint)DataSize);
+            if (CopyMemory) Utilities.CopyWithAlignmentFallback((void*)newTex.Data, (void*)Data, (uint)DataSize);
 
             int offset = 0;
             for (int i = 0; i < this.SubImageArray.Length; ++i)


### PR DESCRIPTION
# PR Details
Calls to `Utilities.CopyMemory` mapping to `System.Buffer.MemoryCopy` were swapped for `Unsafe.CopyBlockUnaligned` in #1469 without clarification.
Those two methods are not equivalent, `CopyBlockUnaligned` is safer but significantly slower compared to `MemoryCopy` as it does not have any fast path based on the allocation sizes.

As for the safety of the unaligned version, under x86/64 and recent ARM, reading or writing data outside of their natural alignment do not cause any issues besides slowdown. I've ensured that other platforms, like ARM7 and connected devices' memory, keep using the unaligned version.

The vast majority of our codebase ensures that fields and allocations are aligned, so using operations that expect to operate on aligned memory provides a significant performance improvement.

Scenes with a significant amount of draw calls rely on memcopy to fill in graphics commands and shader parameters. 
In one of the heavier sections I have at my disposal, frames can take up to 23 millisecond to prepare on the CPU side, introducing this change cuts it down to 14 millisecond.
Here's the [Profiler sessions.zip](https://github.com/user-attachments/files/22282460/Profile.session.zip)

More information in 
https://github.com/dotnet/runtime/issues/1650#issuecomment-573907109
https://github.com/dotnet/runtime/issues/80068#issuecomment-1376031943

## Related Issue
N/A

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
