### PR TITLE
fix: Presentation, remove false-positive prone exception

### DIFF
--- a/sources/presentation/Stride.Core.Presentation/ViewModels/ViewModelBase.cs
+++ b/sources/presentation/Stride.Core.Presentation/ViewModels/ViewModelBase.cs
@@ -13,10 +13,6 @@ namespace Stride.Core.Presentation.ViewModels;
 /// </summary>
 public abstract class ViewModelBase : INotifyPropertyChanging, INotifyPropertyChanged, IDestroyable
 {
-#if DEBUG
-    private readonly List<string> changingProperties = [];
-#endif
-
     /// <summary>
     /// A collection of property names that are dependent. For each entry of this collection, if the key property name is notified
     /// as being changed, then the property names in the value will also be notified as being changed.
@@ -239,13 +235,6 @@ public abstract class ViewModelBase : INotifyPropertyChanging, INotifyPropertyCh
 
         foreach (var propertyName in propertyNames)
         {
-#if DEBUG
-            if (changingProperties.Contains(propertyName))
-                throw new InvalidOperationException($"OnPropertyChanging called twice for property '{propertyName}' without invoking OnPropertyChanged between calls.");
-
-            changingProperties.Add(propertyName);
-#endif
-
             propertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
 
             if (DependentProperties.TryGetValue(propertyName, out var dependentProperties))
@@ -274,13 +263,6 @@ public abstract class ViewModelBase : INotifyPropertyChanging, INotifyPropertyCh
                 OnPropertyChanged(reverseList);
             }
             propertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-#if DEBUG
-            if (!changingProperties.Contains(propertyName))
-                throw new InvalidOperationException($"OnPropertyChanged called for property '{propertyName}' but OnPropertyChanging was not invoked before.");
-
-            changingProperties.Remove(propertyName);
-#endif
         }
     }
 


### PR DESCRIPTION
# PR Details
See #2427 for the basics.
I did not change it into an assert as this would block execution every time someone change properties in the UI editor with a debugger attached, making for a poor experience.
Lastly, I could not find any straightforward path to specialize this check to avoid false positives as this scope is too low level.
Every time this one triggered for me was for a false positive, given that, I believe removing it altogether is preferable.

## Related Issue
Fix: #2427

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
