### PR TITLE
fix: Adjust target frameworks to only include available targets when creating new code library

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Templates/Core/Common.TargetFrameworks.targets.t4
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Core/Common.TargetFrameworks.targets.t4
@@ -1,4 +1,4 @@
 <#@ template inherits="ProjectTemplateTransformation" language="C#" #>
 <#@ assembly name="System.Linq" #>
 <#@ import namespace="System.Linq" #>
-    <TargetFrameworks><#= string.Join(";", ((IEnumerable<Stride.Core.Assets.SolutionPlatform>)Properties.Platforms).Select(x => x.TargetFramework).Distinct()) #></TargetFrameworks>
+    <TargetFrameworks><#= string.Join(";", ((IEnumerable<Stride.Core.Assets.SolutionPlatform>)Properties.Platforms).Where(x => x.IsAvailable).Select(x => x.TargetFramework).Distinct()) #></TargetFrameworks>


### PR DESCRIPTION
# PR Details

Currently trying to add a new code library project via the stride editor, results in an error:

<img width="1145" height="477" alt="image" src="https://github.com/user-attachments/assets/7b544830-6b8e-43e8-8c66-12d81a341efe" />

Rather than try to build everything, only do what's currently available. Adding a new library now compiles as expected with no errors without having UWP or Android workloads for example.

## Related Issue

#2154

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
