### PR TITLE
Revert "ci: .NET 10 - Update GitHub Actions and .NET version in workflows"

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -46,12 +46,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/build-assembly-processor.yml
+++ b/.github/workflows/build-assembly-processor.yml
@@ -42,12 +42,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - name: Build
         run: |
           dotnet build build\Stride.AssemblyProcessor.sln `

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -46,12 +46,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -44,12 +44,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/build-linux-runtime.yml
+++ b/.github/workflows/build-linux-runtime.yml
@@ -56,12 +56,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}, ${{ github.event.inputs.graphics-api || inputs.graphics-api || 'OpenGL' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/build-vs-package.yml
+++ b/.github/workflows/build-vs-package.yml
@@ -41,12 +41,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/build-windows-full.yml
+++ b/.github/workflows/build-windows-full.yml
@@ -41,12 +41,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/build-windows-runtime.yml
+++ b/.github/workflows/build-windows-runtime.yml
@@ -59,12 +59,12 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}, ${{ github.event.inputs.graphics-api || inputs.graphics-api || 'Direct3D11' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -39,12 +39,12 @@ jobs:
     name: Test (${{ github.event.inputs.build-type || inputs.build-type }}, ${{ github.event.inputs.test-category || inputs.test-category || 'Simple' }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - name: Build
         run: |
           dotnet build build\Stride.Tests.${{ github.event.inputs.test-category || inputs.test-category || 'Simple' }}.slnf `

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       build-type:
-        description: Build
+        description: Build 
         default: Release
         type: choice
         options:
@@ -52,12 +52,12 @@ jobs:
     name: Test (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}, ${{ github.event.inputs.test-category || inputs.test-category || 'Simple' }})
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |


### PR DESCRIPTION
Reverts stride3d/stride#2894 - doesn't actually fix dotnet10 for msbuild dependent projects