### PR TITLE
fix: Refactor IDEInfo to make Version optional #2900

### DIFF
--- a/sources/core/Stride.Core.Design/CodeEditorSupport/IDEInfo.cs
+++ b/sources/core/Stride.Core.Design/CodeEditorSupport/IDEInfo.cs
@@ -8,22 +8,20 @@ public sealed class IDEInfo
     /// <summary>
     /// Initializes a new instance of the <see cref="IDEInfo"/> class.
     /// </summary>
-    /// <param name="installationVersion">The version of the IDE instance.</param>
     /// <param name="displayName">The display name of the IDE instance</param>
     /// <param name="programPath">The path to the installation root of the IDE instance.</param>
-    /// <param name="instanceId">The unique identifier for this installation instance.</param>
     /// <param name="ideType">The type of IDE instance</param>
+    /// <param name="installationVersion">The version of the IDE instance.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public IDEInfo(Version installationVersion, string displayName, string? programPath, string instanceId, IDEType ideType)
+    public IDEInfo(string displayName, string? programPath, IDEType ideType, Version? installationVersion = null)
     {
         DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
-        InstallationVersion = installationVersion ?? throw new ArgumentNullException(nameof(installationVersion));
-        InstanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
         ProgramPath = programPath;
         IDEType = ideType;
+        InstallationVersion = installationVersion;
     }
     
-    public static readonly IDEInfo DefaultIDE = new(new Version("0.0"), "Default IDE", string.Empty, string.Empty, IDEType.VisualStudio);
+    public static readonly IDEInfo DefaultIDE = new( "Default IDE", string.Empty, IDEType.VisualStudio);
 
     /// <summary> 
     /// Gets the type of the IDE. 
@@ -37,22 +35,17 @@ public sealed class IDEInfo
 
     /// <summary>Gets the version of the product installed in this instance.</summary>
     /// <value>The version of the product installed in this instance.</value>
-    public Version InstallationVersion { get; }
+    public Version? InstallationVersion { get; }
 
     /// <summary>
     /// The path to the executable of this IDE, or <c>null</c>.
     /// </summary>
     public string? ProgramPath { get; }
-    
-    /// <summary>
-    /// The hex code for this installation instance. It is used, for example, to create a unique folder in %LocalAppData%
-    /// </summary>
-    public string InstanceId { get; }
 
     /// <summary>
     /// The path to the VSIX installer of this IDE, or <c>null</c>.
     /// </summary>
-    public string? VsixInstallerPath { get; set; }
+    public string? VsixInstallerPath { get; init; }
 
     /// <summary>
     /// The package names and versions of packages installed to this instance.

--- a/sources/core/Stride.Core.Design/CodeEditorSupport/Rider/RiderVersions.cs
+++ b/sources/core/Stride.Core.Design/CodeEditorSupport/Rider/RiderVersions.cs
@@ -19,7 +19,7 @@ public static class RiderVersions
         foreach (var info in pathLocator.GetAllRiderPaths())
         {
             if(info.Path != null)
-                instances.Add(new IDEInfo(pathLocator.GetBuildNumber(info.Path), $"Rider {pathLocator.GetBuildNumber(info.Path)}", info.Path , "", IDEType.Rider));
+                instances.Add(new IDEInfo($"Rider {pathLocator.GetBuildNumber(info.Path)}", info.Path, IDEType.Rider, pathLocator.GetBuildNumber(info.Path)));
         }
 
         return instances;

--- a/sources/core/Stride.Core.Design/CodeEditorSupport/VSCode/VSCodeVersions.cs
+++ b/sources/core/Stride.Core.Design/CodeEditorSupport/VSCode/VSCodeVersions.cs
@@ -24,10 +24,10 @@ public static class VSCodeVersions
             }
             
             if (File.Exists(vscodiumExe))
-                instances.Add(new IDEInfo(new(), "VS Codium", vscodiumExe, "", IDEType.VSCode));
+                instances.Add(new IDEInfo("VS Codium", vscodiumExe, IDEType.VSCode));
             
             if (File.Exists(vscodeExe))
-                instances.Add(new IDEInfo(new(), "VS Code", vscodeExe, "", IDEType.VSCode));
+                instances.Add(new IDEInfo("VS Code", vscodeExe, IDEType.VSCode));
             
         }
 

--- a/sources/core/Stride.Core.Design/CodeEditorSupport/VisualStudio/VisualStudioVersions.cs
+++ b/sources/core/Stride.Core.Design/CodeEditorSupport/VisualStudio/VisualStudioVersions.cs
@@ -14,7 +14,7 @@ public static class VisualStudioVersions
     /// <summary>
     /// Only lists VS2019+ (previous versions are not supported due to lack of buildTransitive targets).
     /// </summary>
-    public static IEnumerable<IDEInfo> AvailableInstances => IDEInfos.Value.Where(x => x.InstallationVersion.Major >= 16 && x.HasProgram);
+    public static IEnumerable<IDEInfo> AvailableInstances => IDEInfos.Value.Where(x => x.InstallationVersion?.Major >= 16 && x.HasProgram);
 
     private static List<IDEInfo> BuildIDEInfos()
     {
@@ -97,8 +97,8 @@ public static class VisualStudioVersions
                         vsixInstallerPath = null;
                     }
 
-                    var ideInfo = new IDEInfo(installationVersion, displayName,
-                        programPath, setupInstance2.GetInstanceId(), IDEType.VisualStudio) { VsixInstallerPath = vsixInstallerPath };
+                    var ideInfo = new IDEInfo(displayName,
+                        programPath, IDEType.VisualStudio, installationVersion) { VsixInstallerPath = vsixInstallerPath };
 
                     // Fill packages
                     foreach (var package in setupInstance2.GetPackages())


### PR DESCRIPTION
# PR Details

This PR improves IDEInfo class by removing unused `InstanceId` and making `installationVersion` optional, as intended.

## Related Issue

#2900

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
