### PR TITLE
fix: Add null check for IsPrimitiveType to prevent crash when selecting multiple entities in GameStudio

### DIFF
--- a/sources/assets/Stride.Core.Assets.Quantum/AssetNodeContainer.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum/AssetNodeContainer.cs
@@ -48,6 +48,9 @@ public class AssetNodeContainer : NodeContainer, IPrimitiveTypeFilter
     
     public virtual bool IsPrimitiveType(Type type)
     {
+        if (type is null)
+            return false;
+
         if (Nullable.GetUnderlyingType(type) is { } underlyingType)
             type = underlyingType;
 


### PR DESCRIPTION
# PR Details

Attempting to select multiple entities may crash GameStudio due to an ArgumentNullException during the IsPrimitiveType check, as type is sometimes null. Selecting the entities individually does not appear to cause the issue.

I can recreate this pretty consistently with a New Game template specifically when multi-selecting the materials, as the Tessellation node property has a value of null. I am otherwise unable to recreate it with any other object/asset/entity types.

Given its specifically (for me at least) this Tessellation node property, I'm not entirely sure if this is more of a band-aid that is hiding something that should be dived into (like why is Tessellation node property null at this point) or not.

Running that guard locally seems to solve the problem though, and it still shows the property grid as expected.

## Related Issue

#2903 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
