### PR TITLE
fix: skinning matrix not getting applied on mesh normals of imported FBX

### DIFF
--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -874,7 +874,10 @@ namespace Stride.Importer.ThreeD
 
                 totalClusterCount = (int)mesh->MNumBones;
                 if (totalClusterCount > 0)
+                {
                     hasSkinningPosition = true;
+                    hasSkinningNormal = mesh->MNormals != null;
+                }
             }
 
             // Build the vertex declaration


### PR DESCRIPTION
# PR Details

This is a regression which was introduced in 7b84fed673acdaaf08db36223c55d0491aad7c7f, it basically adds back this line: https://github.com/stride3d/stride/blob/b96860acf82aa80758117aa916a24b0d894b076d/sources/tools/Stride.Importer.FBX/MeshConverter.cpp#L273

## Related Issue

#2657

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
