### PR TITLE
perf: Optimize MSBuild project loading and dependency handling

### DIFF
--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -12,6 +12,11 @@ namespace Stride.Core.Assets;
 
 partial class PackageSession
 {
+    // Cache to avoid loading the same project multiple times
+    private readonly Dictionary<string, Microsoft.Build.Evaluation.Project> projectLoadCache = new(StringComparer.OrdinalIgnoreCase);
+    // Track projects being processed to avoid infinite recursion
+    private readonly HashSet<string> processingProjects = new(StringComparer.OrdinalIgnoreCase);
+
     private async Task PreLoadPackageDependencies(ILogger log, SolutionProject project, PackageLoadParameters loadParameters)
     {
         ArgumentNullException.ThrowIfNull(log);
@@ -26,27 +31,27 @@ partial class PackageSession
         if (package.State >= PackageState.DependenciesReady)
             return;
 
-        log.Verbose($"Process dependencies for {project.Name}...");
+        // Avoid processing the same project multiple times
+        var projectPath = project.FullPath.ToOSPath();
+        if (!processingProjects.Add(projectPath))
+            return;
 
-        var packageReferences = new Dictionary<string, PackageVersionRange>();
-
-        // Check if there is any package upgrade to do
-        var pendingPackageUpgrades = new List<PendingPackageUpgrade>();
-        pendingPackageUpgradesPerPackage.Add(package, pendingPackageUpgrades);
-
-        // Load some informations about the project
         try
         {
-            var extraProperties = new Dictionary<string, string>();
-            if (loadParameters.ExtraCompileProperties != null)
-            {
-                foreach (var extraProperty in loadParameters.ExtraCompileProperties)
-                    extraProperties.Add(extraProperty.Key, extraProperty.Value);
-            }
-            extraProperties.Add("SkipInvalidConfigurations", "true");
-            var msProject = VSProjectHelper.LoadProject(project.FullPath, loadParameters.BuildConfiguration, extraProperties: extraProperties);
+            log.Verbose($"Process dependencies for {project.Name}...");
+
+            var packageReferences = new Dictionary<string, PackageVersionRange>();
+
+            // Check if there is any package upgrade to do
+            var pendingPackageUpgrades = new List<PendingPackageUpgrade>();
+            pendingPackageUpgradesPerPackage.Add(package, pendingPackageUpgrades);
+
+            // Load project information once and cache it
+            Microsoft.Build.Evaluation.Project? msProject = null;
             try
             {
+                msProject = LoadOrGetCachedProject(projectPath, loadParameters);
+
                 var packageVersion = msProject.GetPropertyValue("PackageVersion");
                 if (!string.IsNullOrEmpty(packageVersion))
                     package.Meta.Version = new PackageVersion(packageVersion);
@@ -54,7 +59,7 @@ partial class PackageSession
                 project.TargetPath = msProject.GetPropertyValue("TargetPath");
                 project.AssemblyProcessorSerializationHashFile = msProject.GetProperty("StrideAssemblyProcessorSerializationHashFile")?.EvaluatedValue;
                 if (project.AssemblyProcessorSerializationHashFile != null)
-                    project.AssemblyProcessorSerializationHashFile = Path.Combine(Path.GetDirectoryName(project.FullPath), project.AssemblyProcessorSerializationHashFile);
+                    project.AssemblyProcessorSerializationHashFile = Path.Combine(Path.GetDirectoryName(projectPath), project.AssemblyProcessorSerializationHashFile);
                 package.Meta.Name = (msProject.GetProperty("PackageId") ?? msProject.GetProperty("AssemblyName"))?.EvaluatedValue ?? package.Meta.Name;
 
                 var outputType = msProject.GetPropertyValue("OutputType");
@@ -76,21 +81,19 @@ partial class PackageSession
                         packageReferences[packageReference.EvaluatedInclude] = packageRange;
                 }
 
-                // Need to go recursively
+                // Process project references recursively (must be sequential due to MSBuild limitations)
                 foreach (var projectReference in msProject.GetItems("ProjectReference").ToList())
                 {
-                    var projectFile = new UFile(Path.Combine(Path.GetDirectoryName(project.FullPath), projectReference.EvaluatedInclude));
+                    var projectFile = new UFile(Path.Combine(Path.GetDirectoryName(projectPath), projectReference.EvaluatedInclude));
                     if (File.Exists(projectFile))
                     {
                         var referencedProject = Projects.OfType<SolutionProject>().FirstOrDefault(x => x.FullPath == new UFile(projectFile));
                         if (referencedProject != null)
                         {
+                            // Process referenced projects sequentially (MSBuild doesn't support parallel evaluation)
                             await PreLoadPackageDependencies(log, referencedProject, loadParameters);
 
-                            // Get package upgrader from dependency (a project might depend on another project rather than referencing Stride directly)
-                            // A better system would be to evaluate nuget flattened dependencies WITHOUT doing the actual restore (dry-run).
-                            // However I am not sure it's easy/possible to do it (using API) without doing a full restore/download, which we don't want to do
-                            // with old version (it might be uninstalled already and we want to avoid re-downloading it again)
+                            // Get package upgrader from dependency
                             if (pendingPackageUpgradesPerPackage.TryGetValue(referencedProject.Package, out var dependencyPackageUpgraders))
                             {
                                 foreach (var dependencyPackageUpgrader in dependencyPackageUpgraders)
@@ -107,208 +110,223 @@ partial class PackageSession
                     }
                 }
             }
-            finally
+            catch (Exception ex)
             {
-                msProject.ProjectCollection.UnloadAllProjects();
-                msProject.ProjectCollection.Dispose();
+                log.Error($"Unexpected exception while loading project [{projectPath}]", ex);
             }
-        }
-        catch (Exception ex)
-        {
-            log.Error($"Unexpected exception while loading project [{project.FullPath.ToOSPath()}]", ex);
-        }
 
-        foreach (var packageReference in packageReferences)
-        {
-            var dependencyName = packageReference.Key;
-            var dependencyVersion = packageReference.Value;
-
-            var packageUpgrader = AssetRegistry.GetPackageUpgrader(dependencyName);
-            if (packageUpgrader != null)
+            foreach (var packageReference in packageReferences)
             {
-                // Check if this upgrader has already been added due to another package reference
-                if (pendingPackageUpgrades.Any(pendingPackageUpgrade => pendingPackageUpgrade.PackageUpgrader == packageUpgrader))
-                    continue;
+                var dependencyName = packageReference.Key;
+                var dependencyVersion = packageReference.Value;
 
-                // Check if upgrade is necessary
-                if (dependencyVersion.MinVersion >= packageUpgrader.Attribute.UpdatedVersionRange.MinVersion)
+                var packageUpgrader = AssetRegistry.GetPackageUpgrader(dependencyName);
+                if (packageUpgrader != null)
                 {
-                    continue;
-                }
+                    // Check if this upgrader has already been added due to another package reference
+                    if (pendingPackageUpgrades.Any(pendingPackageUpgrade => pendingPackageUpgrade.PackageUpgrader == packageUpgrader))
+                        continue;
 
-                // Check if upgrade is allowed
-                if (dependencyVersion.MinVersion < packageUpgrader.Attribute.PackageMinimumVersion)
-                {
-                    // Throw an exception, because the package update is not allowed and can't be done
-                    throw new InvalidOperationException($"Upgrading project [{project.Name}] to use [{dependencyName}] from version [{dependencyVersion}] to [{packageUpgrader.Attribute.UpdatedVersionRange.MinVersion}] is not supported (supported only from version [{packageUpgrader.Attribute.PackageMinimumVersion}]");
-                }
-
-                log.Info($"Upgrading project [{project.Name}] to use [{dependencyName}] from version [{dependencyVersion}] to [{packageUpgrader.Attribute.UpdatedVersionRange.MinVersion}] will be required");
-
-                pendingPackageUpgrades.Add(new PendingPackageUpgrade(packageUpgrader, new PackageDependency(dependencyName, dependencyVersion), null));
-            }
-        }
-
-        if (pendingPackageUpgrades.Count > 0)
-        {
-            var upgradeAllowed = packageUpgradeAllowed != false ? PackageUpgradeRequestedAnswer.Upgrade : PackageUpgradeRequestedAnswer.DoNotUpgrade;
-
-            // Need upgrades, let's ask user confirmation
-            if (loadParameters.PackageUpgradeRequested != null && !packageUpgradeAllowed.HasValue)
-            {
-                upgradeAllowed = loadParameters.PackageUpgradeRequested(package, pendingPackageUpgrades);
-                if (upgradeAllowed == PackageUpgradeRequestedAnswer.UpgradeAll)
-                    packageUpgradeAllowed = true;
-                if (upgradeAllowed == PackageUpgradeRequestedAnswer.DoNotUpgradeAny)
-                    packageUpgradeAllowed = false;
-            }
-
-            if (!PackageLoadParameters.ShouldUpgrade(upgradeAllowed))
-            {
-                log.Error($"Necessary package migration for [{package.Meta.Name}] has not been allowed");
-                return;
-            }
-
-            // Perform pre assembly load upgrade
-            foreach (var pendingPackageUpgrade in pendingPackageUpgrades)
-            {
-                var expectedVersion = pendingPackageUpgrade.PackageUpgrader.Attribute.UpdatedVersionRange?.MinVersion?.ToString();
-
-                // Update NuGet references
-                try
-                {
-                    var projectFile = project.FullPath;
-                    var msbuildProject = VSProjectHelper.LoadProject(projectFile.ToOSPath());
-                    var isProjectDirty = false;
-
-                    foreach (var packageReference in msbuildProject.GetItems("PackageReference").ToList())
+                    // Check if upgrade is necessary
+                    if (dependencyVersion.MinVersion >= packageUpgrader.Attribute.UpdatedVersionRange.MinVersion)
                     {
-                        if (packageReference.EvaluatedInclude == pendingPackageUpgrade.Dependency.Name && packageReference.GetMetadataValue("Version") != expectedVersion)
-                        {
-                            packageReference.SetMetadataValue("Version", expectedVersion);
-                            isProjectDirty = true;
-                        }
+                        continue;
                     }
 
-                    if (isProjectDirty)
-                        msbuildProject.Save();
+                    // Check if upgrade is allowed
+                    if (dependencyVersion.MinVersion < packageUpgrader.Attribute.PackageMinimumVersion)
+                    {
+                        // Throw an exception, because the package update is not allowed and can't be done
+                        throw new InvalidOperationException($"Upgrading project [{project.Name}] to use [{dependencyName}] from version [{dependencyVersion}] to [{packageUpgrader.Attribute.UpdatedVersionRange.MinVersion}] is not supported (supported only from version [{packageUpgrader.Attribute.PackageMinimumVersion}]");
+                    }
 
-                    msbuildProject.ProjectCollection.UnloadAllProjects();
-                    msbuildProject.ProjectCollection.Dispose();
-                }
-                catch (Exception e)
-                {
-                    log.Warning($"Unable to load project [{project.FullPath.GetFileName()}]", e);
-                }
+                    log.Info($"Upgrading project [{project.Name}] to use [{dependencyName}] from version [{dependencyVersion}] to [{packageUpgrader.Attribute.UpdatedVersionRange.MinVersion}] will be required");
 
-                var packageUpgrader = pendingPackageUpgrade.PackageUpgrader;
-                var dependencyPackage = pendingPackageUpgrade.DependencyPackage;
-                if (!packageUpgrader.UpgradeBeforeAssembliesLoaded(loadParameters, package.Session, log, package, pendingPackageUpgrade.Dependency, dependencyPackage))
-                {
-                    log.Error($"Error while upgrading package [{package.Meta.Name}] for [{dependencyPackage.Meta.Name}] from version [{pendingPackageUpgrade.Dependency.Version}] to [{dependencyPackage.Meta.Version}]");
-                    return;
+                    pendingPackageUpgrades.Add(new PendingPackageUpgrade(packageUpgrader, new PackageDependency(dependencyName, dependencyVersion), null));
                 }
             }
+
+            if (pendingPackageUpgrades.Count > 0)
+            {
+                var upgradeAllowed = packageUpgradeAllowed != false ? PackageUpgradeRequestedAnswer.Upgrade : PackageUpgradeRequestedAnswer.DoNotUpgrade;
+
+                // Need upgrades, let's ask user confirmation
+                if (loadParameters.PackageUpgradeRequested != null && !packageUpgradeAllowed.HasValue)
+                {
+                    upgradeAllowed = loadParameters.PackageUpgradeRequested(package, pendingPackageUpgrades);
+                    if (upgradeAllowed == PackageUpgradeRequestedAnswer.UpgradeAll)
+                        packageUpgradeAllowed = true;
+                    if (upgradeAllowed == PackageUpgradeRequestedAnswer.DoNotUpgradeAny)
+                        packageUpgradeAllowed = false;
+                }
+
+                if (!PackageLoadParameters.ShouldUpgrade(upgradeAllowed))
+                {
+                    log.Error($"Necessary package migration for [{package.Meta.Name}] has not been allowed");
+                    return;
+                }
+
+                // Perform pre assembly load upgrade - reuse cached project
+                foreach (var pendingPackageUpgrade in pendingPackageUpgrades)
+                {
+                    var expectedVersion = pendingPackageUpgrade.PackageUpgrader.Attribute.UpdatedVersionRange?.MinVersion?.ToString();
+
+                    // Update NuGet references using cached project
+                    try
+                    {
+                        msProject ??= LoadOrGetCachedProject(projectPath, loadParameters);
+                        var isProjectDirty = false;
+
+                        foreach (var packageReference in msProject.GetItems("PackageReference").ToList())
+                        {
+                            if (packageReference.EvaluatedInclude == pendingPackageUpgrade.Dependency.Name && packageReference.GetMetadataValue("Version") != expectedVersion)
+                            {
+                                packageReference.SetMetadataValue("Version", expectedVersion);
+                                isProjectDirty = true;
+                            }
+                        }
+
+                        if (isProjectDirty)
+                            msProject.Save();
+                    }
+                    catch (Exception e)
+                    {
+                        log.Warning($"Unable to load project [{project.FullPath.GetFileName()}]", e);
+                    }
+
+                    var packageUpgrader = pendingPackageUpgrade.PackageUpgrader;
+                    var dependencyPackage = pendingPackageUpgrade.DependencyPackage;
+                    if (!packageUpgrader.UpgradeBeforeAssembliesLoaded(loadParameters, package.Session, log, package, pendingPackageUpgrade.Dependency, dependencyPackage))
+                    {
+                        log.Error($"Error while upgrading package [{package.Meta.Name}] for [{dependencyPackage.Meta.Name}] from version [{pendingPackageUpgrade.Dependency.Version}] to [{dependencyPackage.Meta.Version}]");
+                        return;
+                    }
+                }
+            }
+
+            // Now that our references are upgraded, let's do a real nuget restore (download files)
+            log.Verbose($"Restore NuGet packages for {project.Name}...");
+            if (loadParameters.AutoCompileProjects)
+                await VSProjectHelper.RestoreNugetPackages(log, project.FullPath);
+
+            // If platform was unknown, check it again using cached project
+            if (project.Type == ProjectType.Executable && project.Platform == PlatformType.Shared)
+            {
+                try
+                {
+                    // Reload project after NuGet restore to get updated platform info
+                    ClearCachedProject(projectPath);
+                    msProject = LoadOrGetCachedProject(projectPath, loadParameters);
+                    project.Platform = VSProjectHelper.GetPlatformTypeFromProject(msProject) ?? PlatformType.Shared;
+                }
+                catch (Exception ex)
+                {
+                    log.Error($"Unexpected exception while loading project [{projectPath}]", ex);
+                }
+            }
+
+            UpdateDependencies(project, true, true);
+
+            // 1. Load store package
+            foreach (var projectDependency in project.FlattenedDependencies)
+            {
+                // Make all the assemblies known to the container to ensure that later assembly loads succeed
+                foreach (var assembly in projectDependency.Assemblies)
+                    AssemblyContainer.RegisterDependency(assembly);
+
+                var loadedPackage = packages.Find(projectDependency);
+                if (loadedPackage == null)
+                {
+                    string? file = null;
+                    switch (projectDependency.Type)
+                    {
+                        case DependencyType.Project:
+                            if (SupportedProgrammingLanguages.IsProjectExtensionSupported(Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant()))
+                                file = UPath.Combine(project.FullPath.GetFullDirectory(), (UFile)projectDependency.MSBuildProject);
+                            break;
+                        case DependencyType.Package:
+                            file = PackageStore.Instance.GetPackageFileName(projectDependency.Name, new PackageVersionRange(projectDependency.Version), constraintProvider);
+                            break;
+                    }
+
+                    if (file != null && File.Exists(file))
+                    {
+                        // Load package
+                        var loadedProject = LoadProject(log, file, loadParameters);
+                        loadedProject.Package.Meta.Name = projectDependency.Name;
+                        loadedProject.Package.Meta.Version = projectDependency.Version;
+                        Projects.Add(loadedProject);
+
+                        if (loadedProject is StandalonePackage standalonePackage)
+                        {
+                            standalonePackage.Assemblies.AddRange(projectDependency.Assemblies);
+                        }
+
+                        loadedPackage = loadedProject.Package;
+                    }
+                }
+
+                if (loadedPackage != null)
+                    projectDependency.Package = loadedPackage;
+            }
+
+            // 3. Update package state
+            if (!packageDependencyErrors)
+            {
+                package.State = PackageState.DependenciesReady;
+            }
         }
+        finally
+        {
+            processingProjects.Remove(projectPath);
+        }
+    }
 
-        // Now that our references are upgraded, let's do a real nuget restore (download files)
-        log.Verbose($"Restore NuGet packages for {project.Name}...");
-        if (loadParameters.AutoCompileProjects)
-            await VSProjectHelper.RestoreNugetPackages(log, project.FullPath);
+    private Microsoft.Build.Evaluation.Project LoadOrGetCachedProject(string projectPath, PackageLoadParameters loadParameters)
+    {
+        if (projectLoadCache.TryGetValue(projectPath, out var cachedProject))
+            return cachedProject;
 
-        // If platform was unknown (due to missing nuget packages during first pass), check it again
-        if (project.Type == ProjectType.Executable && project.Platform == PlatformType.Shared)
+        var extraProperties = new Dictionary<string, string>();
+        if (loadParameters.ExtraCompileProperties != null)
+        {
+            foreach (var extraProperty in loadParameters.ExtraCompileProperties)
+                extraProperties.Add(extraProperty.Key, extraProperty.Value);
+        }
+        extraProperties.Add("SkipInvalidConfigurations", "true");
+
+        var msProject = VSProjectHelper.LoadProject(projectPath, loadParameters.BuildConfiguration, extraProperties: extraProperties);
+        projectLoadCache[projectPath] = msProject;
+        return msProject;
+    }
+
+    private void ClearCachedProject(string projectPath)
+    {
+        if (projectLoadCache.TryGetValue(projectPath, out var cachedProject))
+        {
+            cachedProject.ProjectCollection.UnloadAllProjects();
+            cachedProject.ProjectCollection.Dispose();
+            projectLoadCache.Remove(projectPath);
+        }
+    }
+
+    // Call this to cleanup all cached projects when session loading is complete
+    private void ClearAllCachedProjects()
+    {
+        foreach (var kvp in projectLoadCache)
         {
             try
             {
-                var msProject = VSProjectHelper.LoadProject(project.FullPath, extraProperties: new Dictionary<string, string> { { "SkipInvalidConfigurations", "true" } });
-                try
-                {
-                    project.Platform = VSProjectHelper.GetPlatformTypeFromProject(msProject) ?? PlatformType.Shared;
-                }
-                finally
-                {
-                    msProject.ProjectCollection.UnloadAllProjects();
-                    msProject.ProjectCollection.Dispose();
-                }
+                kvp.Value.ProjectCollection.UnloadAllProjects();
+                kvp.Value.ProjectCollection.Dispose();
             }
-            catch (Exception ex)
+            catch
             {
-                log.Error($"Unexpected exception while loading project [{project.FullPath.ToOSPath()}]", ex);
+                // Ignore cleanup errors
             }
         }
-
-        UpdateDependencies(project, true, true);
-
-        // 1. Load store package
-        foreach (var projectDependency in project.FlattenedDependencies)
-        {
-            // Make all the assemblies known to the container to ensure that later assembly loads succeed
-            foreach (var assembly in projectDependency.Assemblies)
-                AssemblyContainer.RegisterDependency(assembly);
-
-            var loadedPackage = packages.Find(projectDependency);
-            if (loadedPackage == null)
-            {
-                string? file = null;
-                switch (projectDependency.Type)
-                {
-                    case DependencyType.Project:
-                        if (SupportedProgrammingLanguages.IsProjectExtensionSupported(Path.GetExtension(projectDependency.MSBuildProject).ToLowerInvariant()))
-                            file = UPath.Combine(project.FullPath.GetFullDirectory(), (UFile)projectDependency.MSBuildProject);
-                        break;
-                    case DependencyType.Package:
-                        file = PackageStore.Instance.GetPackageFileName(projectDependency.Name, new PackageVersionRange(projectDependency.Version), constraintProvider);
-                        break;
-                }
-
-                if (file != null && File.Exists(file))
-                {
-                    // Load package
-                    var loadedProject = LoadProject(log, file, loadParameters);
-                    loadedProject.Package.Meta.Name = projectDependency.Name;
-                    loadedProject.Package.Meta.Version = projectDependency.Version;
-                    Projects.Add(loadedProject);
-
-                    if (loadedProject is StandalonePackage standalonePackage)
-                    {
-                        standalonePackage.Assemblies.AddRange(projectDependency.Assemblies);
-                    }
-
-                    loadedPackage = loadedProject.Package;
-                }
-            }
-
-            if (loadedPackage != null)
-                projectDependency.Package = loadedPackage;
-        }
-
-        // 2. Load local packages
-        /*foreach (var packageReference in package.LocalDependencies)
-        {
-            // Check that the package was not already loaded, otherwise return the same instance
-            if (Packages.ContainsById(packageReference.Id))
-            {
-                continue;
-            }
-
-            // Expand the string of the location
-            var newLocation = packageReference.Location;
-
-            var subPackageFilePath = package.RootDirectory != null ? UPath.Combine(package.RootDirectory, newLocation) : newLocation;
-
-            // Recursive load
-            var loadedPackage = PreLoadPackage(log, subPackageFilePath.FullPath, false, loadedPackages, loadParameters);
-
-            if (loadedPackage == null || loadedPackage.State < PackageState.DependenciesReady)
-                packageDependencyErrors = true;
-        }*/
-
-        // 3. Update package state
-        if (!packageDependencyErrors)
-        {
-            package.State = PackageState.DependenciesReady;
-        }
+        projectLoadCache.Clear();
+        processingProjects.Clear();
     }
 
     public static void UpdateDependencies(SolutionProject project, bool directDependencies, bool flattenedDependencies)


### PR DESCRIPTION
# PR Details

Introduced caching for MSBuild project loading to improve performance and prevent redundant loads. Added mechanisms to avoid infinite recursion during dependency processing and ensured sequential handling of project references to address MSBuild limitations.

Refactored package upgrade logic to simplify checks and reuse cached projects for NuGet reference updates. Enhanced error handling with detailed logging for unexpected exceptions.

Added cleanup methods to unload and dispose of cached projects, ensuring proper resource management. Improved handling of NuGet restores and platform updates by re-evaluating project properties post-restore.

Updated dependency processing to ensure all assemblies are registered and dependencies are loaded recursively. Finalized with proper state updates for packages and session-wide cleanup of cached projects.

In my setup with 26 projects the time to restore the NuGet packages was reduced from ~60 seconds to ~30 seconds.

## Related Issue

No issue created yet.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
