### PR TITLE
fix: Use standard equality comparison for Int2/Int3

### DIFF
--- a/sources/core/Stride.Core.Mathematics/Int2.cs
+++ b/sources/core/Stride.Core.Mathematics/Int2.cs
@@ -684,8 +684,7 @@ public struct Int2 : IEquatable<Int2>, ISpanFormattable
     /// </returns>
     public readonly bool Equals(Int2 other)
     {
-        return MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-            MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance;
+        return other.X == X && other.Y == Y;
     }
 
     /// <summary>

--- a/sources/core/Stride.Core.Mathematics/Int3.cs
+++ b/sources/core/Stride.Core.Mathematics/Int3.cs
@@ -760,9 +760,7 @@ public struct Int3 : IEquatable<Int3>, ISpanFormattable
     /// </returns>
     public readonly bool Equals(Int3 other)
     {
-        return MathF.Abs(other.X - X) < MathUtil.ZeroTolerance &&
-            MathF.Abs(other.Y - Y) < MathUtil.ZeroTolerance &&
-            MathF.Abs(other.Z - Z) < MathUtil.ZeroTolerance;
+        return other.X == X && other.Y == Y && other.Z == Z;
     }
 
     /// <summary>


### PR DESCRIPTION
# PR Details
Probably a copy/paste mistake from Vec2 -> Int2 - Int4 does not have this issue

## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
