### PR TITLE
feat: Match constructors between Index and VertexBufferHelper and improve documentation

### DIFF
--- a/sources/engine/Stride.Graphics/IndexBufferHelper.cs
+++ b/sources/engine/Stride.Graphics/IndexBufferHelper.cs
@@ -31,9 +31,18 @@ public readonly struct IndexBufferHelper
     public Span<byte> DataInner => DataOuter.AsSpan(Binding.Offset, Binding.Count * (Binding.Is32Bit ? 4 : 2));
 
     /// <inheritdoc cref="MeshExtension.AsReadable(IndexBufferBinding, IServiceRegistry, out IndexBufferHelper, out int)"/>
-    public IndexBufferHelper(IndexBufferBinding binding, IServiceRegistry services, out int count)
+    public IndexBufferHelper(IndexBufferBinding binding, IServiceRegistry services, out int count) 
+        : this(binding, MeshExtension.FetchBufferContentOrThrow(binding.Buffer, services), out count)
     {
-        DataOuter = MeshExtension.FetchBufferContentOrThrow(binding.Buffer, services);
+    }
+
+    /// <inheritdoc cref="MeshExtension.AsReadable(IndexBufferBinding, IServiceRegistry, out IndexBufferHelper, out int)"/>
+    public IndexBufferHelper(IndexBufferBinding binding, byte[] dataOuter, out int count)
+    {
+        if (dataOuter.Length < binding.Offset + binding.Count * (binding.Is32Bit ? 4 : 2))
+            throw new ArgumentException($"Binding describes an array larger than {nameof(dataOuter)} ({dataOuter.Length} < {binding.Offset} + {binding.Count} * {(binding.Is32Bit ? 4 : 2)})");
+
+        DataOuter = dataOuter;
         Binding = binding;
         count = Binding.Count;
     }

--- a/sources/engine/Stride.Graphics/VertexBufferBinding.cs
+++ b/sources/engine/Stride.Graphics/VertexBufferBinding.cs
@@ -46,7 +46,7 @@ namespace Stride.Graphics
         public Buffer Buffer { get; private set; }
 
         /// <summary>
-        /// Gets the offset (vertex index) between the beginning of the buffer and the vertex data to use.
+        /// Gets the offset in bytes between the beginning of the buffer and the vertex data to use.
         /// </summary>
         public int Offset { get; private set; }
 

--- a/sources/engine/Stride.Graphics/VertexBufferHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexBufferHelper.cs
@@ -51,7 +51,7 @@ public readonly struct VertexBufferHelper
     public VertexBufferHelper(VertexBufferBinding binding, byte[] dataOuter, out int count)
     {
         if (dataOuter.Length < binding.Offset + binding.Count * binding.Stride)
-            throw new ArgumentException($"{nameof(dataOuter)} does not fit the bindings provided. Make sure that the span provided contains the entirety of the vertex buffer");
+            throw new ArgumentException($"Binding describes an array larger than {nameof(dataOuter)} ({dataOuter.Length} < {binding.Offset} + {binding.Count} * {binding.Stride})");
 
         DataOuter = dataOuter;
         Binding = binding;


### PR DESCRIPTION
# PR Details
Vertex buffer had a `(binding, dataOuter, out count)`, but not the index buffer, introduced that constructor. And changed the docs for a couple of minor things.

## Related Issue
None.

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
