### PR TITLE
docs: fix incorrect documentation from pr #2930

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/_ConstraintComponentBase.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Constraints/_ConstraintComponentBase.cs
@@ -54,7 +54,7 @@ public abstract class ConstraintComponentBase : EntityComponent
     public abstract bool Attached { get; }
 
     /// <summary>
-    /// Returns the squared sum of all impulses this constraint applied on the last tick
+    /// Returns the sum of all impulses this constraint applied on the last tick
     /// </summary>
     /// <remarks>
     /// Impulses increase depending on <see cref="BepuSimulation.FixedTimeStep"/>, as well as the amount of <see cref="BepuSimulation.SolverSubStep"/>.
@@ -63,7 +63,7 @@ public abstract class ConstraintComponentBase : EntityComponent
     public abstract float GetAccumulatedImpulseMagnitude();
 
     /// <summary>
-    /// Returns the squared sum of all forces this constraint applied on the last tick
+    /// Returns the sum of all forces this constraint applied on the last tick
     /// </summary>
     /// <remarks>
     /// This can be used to compare with a given motor constraints' MaximumForce property for example.


### PR DESCRIPTION
# PR Details
See title, docs mentioned squared sum while implementation returns the sum.

## Related Issue
#2930

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
