### PR TITLE
refactor: Use CollectionsMarshal.SetCount to resize lists

### DIFF
--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -471,16 +471,7 @@ namespace Stride.Rendering.Compositing
         private void ResolveMSAA(RenderDrawContext drawContext)
         {
             // Resolve render targets
-            if (currentRenderTargetsNonMSAA.Count < currentRenderTargets.Count)
-            {
-                currentRenderTargetsNonMSAA.EnsureCapacity(currentRenderTargets.Count);
-                while (currentRenderTargetsNonMSAA.Count != currentRenderTargets.Count)
-                    currentRenderTargetsNonMSAA.Add(null);
-            }
-            else if (currentRenderTargetsNonMSAA.Count > currentRenderTargets.Count)
-            {
-                currentRenderTargetsNonMSAA.RemoveRange(currentRenderTargets.Count, currentRenderTargetsNonMSAA.Count - currentRenderTargets.Count);
-            }
+            CollectionsMarshal.SetCount(currentRenderTargetsNonMSAA, currentRenderTargets.Count);
 
             for (int index = 0; index < currentRenderTargets.Count; index++)
             {
@@ -849,16 +840,7 @@ namespace Stride.Rendering.Compositing
 
             var renderTargets = OpaqueRenderStage.OutputValidator.RenderTargets;
 
-            if (currentRenderTargets.Count < renderTargets.Count)
-            {
-                currentRenderTargets.EnsureCapacity(renderTargets.Count);
-                while (currentRenderTargets.Count != renderTargets.Count)
-                    currentRenderTargets.Add(null);
-            }
-            else if (currentRenderTargets.Count > renderTargets.Count)
-            {
-                currentRenderTargets.RemoveRange(renderTargets.Count, currentRenderTargets.Count - renderTargets.Count);
-            }
+            CollectionsMarshal.SetCount(currentRenderTargets, renderTargets.Count);
 
             for (int index = 0; index < renderTargets.Count; index++)
             {

--- a/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RenderSystem.cs
@@ -10,6 +10,7 @@ using Stride.Core.Collections;
 using Stride.Core.Threading;
 using Stride.Core.Diagnostics;
 using Stride.Graphics;
+using System.Runtime.InteropServices;
 
 namespace Stride.Rendering
 {
@@ -285,16 +286,7 @@ namespace Stride.Rendering
                         var renderStage = RenderStages[renderViewStage.Index];
                         var sortedRenderNodes = renderViewStage.SortedRenderNodes;
 
-                        if (sortedRenderNodes.Count < renderNodes.Count)
-                        {
-                            sortedRenderNodes.EnsureCapacity(renderNodes.Count);
-                            while (sortedRenderNodes.Count != renderNodes.Count)
-                                sortedRenderNodes.Add(default);
-                        }
-                        else if (sortedRenderNodes.Count > renderNodes.Count)
-                        {
-                            sortedRenderNodes.RemoveRange(renderNodes.Count, sortedRenderNodes.Count - renderNodes.Count);
-                        }
+                        CollectionsMarshal.SetCount(sortedRenderNodes, renderNodes.Count);
 
                         if (renderStage.SortMode != null)
                         {


### PR DESCRIPTION
# PR Details

Makes code easier to read (as it was before a122c71dc2fcfcd1d46c367c14a92471f0f57ecf). The [SetCount ](https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs#L85) implementation looks very similar to the previously used Resize method of FastList. For value types it just sets the internal count, for reference types it clears the pointers. Both what was done before as well.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
