### PR TITLE
fix: Add mouse wheel delta to virtual button

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -32,7 +32,7 @@ using Stride.Core.Presentation.Interop;
 using Stride.Core.Presentation.Services;
 using Stride.Core.Translation;
 using Stride.Core.Presentation.ViewModels;
-using Stride.Core.Presentation.Windows;
+using System.Collections;
 
 namespace Stride.Core.Assets.Editor.ViewModel
 {
@@ -554,16 +554,15 @@ namespace Stride.Core.Assets.Editor.ViewModel
             var path = directory.Path;
             var message = Tr._p("Message", "Do you want to place the resource in the default location ?");
             var finalPath = Path.GetFullPath(Path.Combine(directory.Package.Package.ResourceFolders[0], path, file.GetFileName()));
-
             var pathResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (pathResult == MessageBoxResult.No)
             {
                 while (true)
                 {
-                    var filePath = await Dialogs.SaveFilePickerAsync(
-                        Path.GetFullPath(directory.Package.Package.ResourceFolders[0].FullPath),
-                        [new FilePickerFilter("") { Patterns = [file.GetFileExtension()] }],
-                        defaultFileName: file.GetFileName());
+                   var filePath = await Dialogs.SaveFilePickerAsync(
+                       Path.GetFullPath(directory.Package.Package.ResourceFolders[0].FullPath),
+                       [new FilePickerFilter("") { Patterns = [file.GetFileExtension()]}],
+                       defaultFileName: file.GetFileName());
 
                     // If the user closes the dialog, assume that they want to use the default directory
                     if (filePath is null)
@@ -583,42 +582,12 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     await Dialogs.MessageBoxAsync(message, MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
-
             return finalPath;
         }
 
         private async Task<List<AssetViewModel>> InvokeAddAssetTemplate(LoggerResult logger, string name, DirectoryBaseViewModel directory, TemplateAssetDescription templateDescription, [CanBeNull] IList<UFile> files, PropertyContainer? customParameters)
         {
             List<AssetViewModel> newAssets = new List<AssetViewModel>();
-            IReadOnlyList<DialogButtonInfo> copyPromptButtons = DialogHelper.CreateButtons(files is not null && files.Count > 1 ?
-            [
-                Tr._p("Button", "Yes"),
-                Tr._p("Button", "No"),
-                Tr._p("Button", "Yes to all"),
-                Tr._p("Button", "No to all")
-            ]
-            :
-            [
-                Tr._p("Button", "Yes"),
-                Tr._p("Button", "No")
-            ], 1, 2);
-
-            IReadOnlyList<DialogButtonInfo> overwritePromptButtons = DialogHelper.CreateButtons(files is not null && files.Count > 1 ?
-            [
-                Tr._p("Button", "Yes"),
-                Tr._p("Button", "No"),
-                Tr._p("Button", "Yes to all")
-            ]
-            :
-            [
-                Tr._p("Button", "Yes"),
-                Tr._p("Button", "No")
-            ], 1, 2);
-
-            bool yesToAll = false;
-            bool overwriteAll = false;
-            string finalPath = string.Empty;
-
             if (files is not null)
             {
                 for (int i = 0; i < files.Count; i++)
@@ -629,48 +598,28 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     if (inResourceFolder)
                         continue;
 
-                    if (!yesToAll)
-                    {
-                        var message = Tr._p("Message", "Source file '{0}' is not inside of your project's resource folders, do you want to copy it?").ToFormat(file.FullPath);
+                    var message = Tr._p("Message", "Source file '{0}' is not inside of your project's resource folders, do you want to copy it?").ToFormat(file.FullPath);
 
-                        var copyResult = await Dialogs.MessageBoxAsync(message, copyPromptButtons, MessageBoxImage.Warning);
+                    var copyResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
-                        yesToAll = copyResult is 3;
+                    if (copyResult != MessageBoxResult.Yes)
+                        continue;
 
-                        // If no or close, skip this file
-                        if (copyResult is 0 or 2)
-                            continue;
-
-                        // If "No to all", abort the entire copy process
-                        if (copyResult is 4)
-                            break;
-
-                        finalPath = await GetAssetCopyDirectory(directory, file);
-                    }
-                    else
-                    {
-                        // If "Yes to all" we're going to assume they want to use the same directory as the initial file.
-                        finalPath = Path.Combine(Path.GetDirectoryName(finalPath), file.GetFileName());
-                    }
+                    string finalPath = await GetAssetCopyDirectory(directory, file);
 
                     try
                     {
                         Directory.CreateDirectory(Path.GetDirectoryName(finalPath));
                         if (File.Exists(finalPath))
                         {
-                            if (!overwriteAll)
+                            message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(finalPath);
+
+                            copyResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Warning);
+
+                            // Abort if the user says no or closes the prompt
+                            if (copyResult != MessageBoxResult.Yes)
                             {
-                                var message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(finalPath);
-
-                                var copyResult = await Dialogs.MessageBoxAsync(message, overwritePromptButtons, MessageBoxImage.Warning);
-
-                                overwriteAll = copyResult is 3;
-
-                                // Abort if the user says no or closes the prompt
-                                if (copyResult is 0 or 2)
-                                {
-                                    return newAssets;
-                                }
+                                return newAssets;
                             }
                             File.Copy(file.FullPath, finalPath, true);
                         }
@@ -683,7 +632,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     }
                     catch (Exception ex)
                     {
-                        var message = Tr._p("Message", $"An error occurred while copying the asset to the resources folder : {ex.Message}");
+                        message = Tr._p("Message", $"An error occurred while copying the asset to the resources folder : {ex.Message}");
                         await Dialogs.MessageBoxAsync(message, MessageBoxButton.OK, MessageBoxImage.Error);
                         return newAssets;
                     }
@@ -1205,11 +1154,11 @@ namespace Stride.Core.Assets.Editor.ViewModel
             {
                 if (filter.IsReadOnly)
                     continue; // Skip engine defined filters
-
+                
                 AssetFilterViewModelData obj = new AssetFilterViewModelData
                 {
-                    DisplayName = filter.DisplayName,
-                    Filter = filter.Filter,
+                    DisplayName = filter.DisplayName, 
+                    Filter = filter.Filter, 
                     IsActive = filter.IsActive,
                     category = filter.Category
                 };


### PR DESCRIPTION
# PR Details

This is sort of a mix of a feat/fix given that no one seems to have really mentioned it (github or discord), so not sure what to really mark it as. Currently, Mouse WheelDelta can only be grabbed directly from the InputManager rather than passed through VirtualButton like all other Mouse fields. 

This change adds Mouse WheelDelta as a new field on the VirtualButton.Mouse, so that you can use the full range of the mouse through VirtualButtons.

Using it like so returns values just as if it were a GamePad thumbstick axis for example:
                new VirtualButtonBinding(InputActions.FIELD_CAM_ZOOM_BACKWARD, VirtualButton.Mouse.WheelDelta),

I haven't run into any issues with my local fork, albeit I'm still new to Stride so not entirely sure of _all_ scenarios worth testing beyond using it directly as a normal input.

## Related Issue

[2944](https://github.com/stride3d/stride/issues/2944)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
