### PR TITLE
fix: Regression in mesh bounds calculation introduced through #2858

### DIFF
--- a/sources/engine/Stride.Graphics/VertexBufferHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexBufferHelper.cs
@@ -241,7 +241,7 @@ public readonly struct VertexBufferHelper
         IConverter<Color, TDest>,
         ISemantic 
         where TDest : unmanaged
-        where TReader : IReader<TDest>
+        where TReader : IReader<TDest>, allows ref struct
     {
         if (Binding.Declaration.TryGetElement(TSemantic.Name, semanticIndex, out var elementData))
         {
@@ -267,7 +267,7 @@ public readonly struct VertexBufferHelper
     private unsafe void InnerRead<TConverter, TReader, TSource, TDest>(Span<TDest> destination, TReader reader, VertexElementWithOffset element) 
         where TConverter : IConverter<TSource, TDest> 
         where TSource : unmanaged
-        where TReader : IReader<TDest>
+        where TReader : IReader<TDest>, allows ref struct
     {
         if (sizeof(TSource) != element.Size)
             throw new ArgumentException($"{typeof(TSource)} does not match element size ({sizeof(TSource)} != {element.Size})");

--- a/sources/engine/Stride.Rendering/Extensions/BoundingExtensions.cs
+++ b/sources/engine/Stride.Rendering/Extensions/BoundingExtensions.cs
@@ -16,22 +16,22 @@ namespace Stride.Extensions
         {
             var helper = new VertexBufferHelper(vertexBufferBinding, vertexBufferBinding.Buffer.GetSerializationData().Content, out _);
 
+            var box = BoundingBox.Empty;
+            boundingSphere = BoundingSphere.Empty;
             var computeBounds = new ComputeBoundsHelper
             {
-                Box = BoundingBox.Empty, 
-                Sphere = new BoundingSphere(),
+                Box = ref box, 
+                Sphere = ref boundingSphere,
                 Matrix = matrix
             };
             helper.Read<PositionSemantic, Vector3, ComputeBoundsHelper>(default, computeBounds);
-
-            boundingSphere = computeBounds.Sphere;
-            return computeBounds.Box;
+            return box;
         }
 
-        class ComputeBoundsHelper : VertexBufferHelper.IReader<Vector3>
+        ref struct ComputeBoundsHelper : VertexBufferHelper.IReader<Vector3>
         {
-            public required BoundingBox Box;
-            public required BoundingSphere Sphere;
+            public required ref BoundingBox Box;
+            public required ref BoundingSphere Sphere;
             public required Matrix Matrix;
 
             public unsafe void Read<TConverter, TSource>(byte* startPointer, int elementCount, int stride, Span<Vector3> destination) where TConverter : IConverter<TSource, Vector3> where TSource : unmanaged


### PR DESCRIPTION
Fixes #2948

Changed ComputeBounds helper to be class instead of struct as it contained stateful data that was not retained due to copy by value semantics.

## Related Issue

https://github.com/stride3d/stride/issues/2948

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
