### PR TITLE
fix: Stop failing to open project due to duplicate package references.

### DIFF
--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -965,6 +965,15 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
         }
         foreach (AssetLoadingInfo assetInfo in assetLoadInfos)
         {
+            // Check if the same package exists in the list but with a newer version.
+            var newerPackage = packages.FirstOrDefault(p => p.Meta.Name == assetInfo.package.Meta.Name && p.Meta.Version > assetInfo.package.Meta.Version);
+            if (newerPackage is not null)
+            {
+                // Skip loading assets for this package as a newer version exists in the list.
+                log.Warning($"Newer version of {assetInfo.package.Meta.Name} is already referenced in another package. Using version {newerPackage.Meta.Version} instead of {assetInfo.package.Meta.Version}");
+                continue;
+            }
+
             LoadAssets(assetInfo.session, assetInfo.log, assetInfo.package, assetInfo.loadParameters, assetInfo.pendingPackageUpgrades, assetInfo.newLoadParameters);
         }
     }


### PR DESCRIPTION
# PR Details

I kept running into an issue with packages being referenced in an external project but with a different version making GameStudio completely fail to open. This just adds a check in the PackageSession to make sure to only load the newest version to avoid the reference collisions that were happening.

Cause of the issue:
<img width="569" height="437" alt="{9C08A182-CC40-454C-B48A-9DA346D4C29C}" src="https://github.com/user-attachments/assets/0cb3a7d6-c812-4b73-91b4-74d8e923fda2" />

New Warning message should be a lot clearer and allows the person to still open the project instead of blocking them:
<img width="636" height="475" alt="{D48B823A-3962-49F7-A5B3-2B78856E1FD4}" src="https://github.com/user-attachments/assets/a0f83291-1de0-4468-bbfa-f3f302930d90" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
