### PR TITLE
fix: VS workload detection logic for iOS and Android workloads on modern VS

### DIFF
--- a/sources/engine/Stride.Assets/StrideConfig.cs
+++ b/sources/engine/Stride.Assets/StrideConfig.cs
@@ -240,14 +240,14 @@ namespace Stride.Assets
             {
                 if (pair.Key == VS2015Version)
                 {
-                    if(IsFileInProgramFilesx86Exist(pair.Value))
+                    if (IsFileInProgramFilesx86Exist(pair.Value))
                     {
                         return true;
                     }
                     continue;
                 }
 
-                if(VisualStudioVersions.AvailableInstances.Any(
+                if (VisualStudioVersions.AvailableInstances.Any(
                     ideInfo => ideInfo.PackageVersions.ContainsKey(pair.Value)
                 ))
                 {


### PR DESCRIPTION
# PR Details
Updates the Visual Studio workload detection logic for Android and iOS to properly detect the modern post-Xamarin workloads. Also fixes a logical error in IsVSComponentAvailableAnyVersion when multiple versions of Visual Studio are installed, regardless of what order the components are defined in the dictionary: previously, if the first version check fails, it would return false, even if later checks would succeed. Now it checks all entries and returns true if any check succeeds.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue
https://github.com/stride3d/stride/issues/3020
This PR is a partial fix for the above issue. There are still references to Xamarin in a "test" project template, and there are still rendering/fullscreen issues when run in the android emulator. These are out of scope for this PR, which fixes the new project creation process to properly detect the .net for mobile workloads in modern versions of Visual Studio, where Xamarin is no longer installable.
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**

NOTE: I have not been able to get the project tests to pass, before or after this change. This change does not cause more tests to fail on my machine compared to the master branch. I was also not able to find any tests for this specific part of the code that was changed - understandable given that to fully test this logic, you'd have to run the tests on multiple dev environments with different versions of Visual Studio installed with or without workloads installed. I tested the editor after this change with Visual Studio 2026 installed, with the .net for mobile workloads installed, ran and created a new project with various templates, checking the iOS and Android platforms when creating the project, and verifying the proper android/iOS TFMs are added to the target frameworks for the main "Game" project (some templates use ".Game" suffix, others don't).

NOTE 2: This is my first PR for the Stride project. Apologies if I missed something in the contribution workflow. I did read the docs here: https://doc.stride3d.net/latest/en/contributors/contribution-workflow/index.html