### PR TITLE
fix: Change the order of probing for loading native libraries

### DIFF
--- a/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
+++ b/sources/core/Stride.Core/Native/NativeLibraryHelper.cs
@@ -2,7 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 // Uncomment the following line to enable debug logging for native library loading
-#define DEBUG_NATIVE_LOADING
+//#define DEBUG_NATIVE_LOADING
 
 using System.Buffers;
 using System.Diagnostics;


### PR DESCRIPTION
This PR modifies the order in which `NativeLibraryHelper` in `Stride.Core` tries different strategies for locating the native libraries to load, so it tries first the Stride custom ones, and defers the default .NET strategy as a fallback.

# PR Details

Some context. I was running the tests in `Stride.Graphics.Tests` and found that all tests that made use of fonts, text rendering, etc., were being aborted (not failing) with the following error:
```
Fatal error.
0xC0000005
   at SharpFont.FT.FT_Render_Glyph(IntPtr, SharpFont.RenderMode)
   at SharpFont.GlyphSlot.RenderGlyph(SharpFont.RenderMode)
   at Stride.Graphics.Font.FontManager.RenderBitmap(Stride.Graphics.Font.CharacterSpecification, SharpFont.Face)
   at Stride.Graphics.Font.FontManager.GenerateCharacterGlyph(Stride.Graphics.Font.CharacterSpecification, Boolean)
```
After some investigation, I found that `NativeLibraryHelper` was trying to load `freetype` (a native dependency) using the default loading mechanism of .NET, even though that class implements strategies to find native libraries better suited to the custom nature of what Stride needs. The problem was that the tests were sometimes loading the wrong versión of some of our native dependencies.

It seems the .NET default strategy (`NativeLibrary.TryLoad`) was trying to look for `freetype.dll` in the directory where the executable is, the directory where the P/Invoking module is, the current directory, in `C:\Windows\System32`, etc., and finally, in the paths in the environment `PATH` variable.

So, instead of finding our version of `freetype` in `/runtimes/win-x64`, it was loading a different (and incompatible) version it found in `C:\Users\Mario\AppData\Local\Microsoft\WinGet\Packages\oschwartz10612.Poppler_Microsoft.Winget.Source_8wekyb3d8bbwe\poppler-25.07.0\Library\bin\freetype.DLL`.
And not only with `freetype`. Instead of loading our version of `d3d3dcompiler_47.dll`, it was loading `C:\WINDOWS\SYSTEM32\d3dcompiler_47.DLL` (this one is not a problem because they are identical).

So, I've restructured and reordered the logic a bit to first look for libraries using our custom logic, and only if none is found, fallback to the default logic. With this change, tests started running and passing as before this problem arised.

I have also:
* Modernized the `NativeLibraryLoader` class.
* Added new documentation and improved the existing one, and the comments.
* Added a debug switch and logic to be able to diagnose library loading problems in the future.

## Related Issue

There are several I've found: #1692 #1750 
Possibly also #1700 (the incorrectly loaded library does not manifest as crashes sometimes, but as corrupt data or wrong font metrics, etc.)

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
