### PR TITLE
fix: Set default quality flags when saving in JPEG format

### DIFF
--- a/sources/engine/Stride/Graphics/StandardImageHelper.Desktop.cs
+++ b/sources/engine/Stride/Graphics/StandardImageHelper.Desktop.cs
@@ -21,8 +21,28 @@ internal partial class StandardImageHelper
     }
 
     /// <summary>
-    /// This class is responsible to provide image loader for png, gif, bmp.
+    ///   Loads an image from a block of unmanaged memory.
     /// </summary>
+    /// <param name="pSource">
+    ///   A pointer to the beginning of the unmanaged memory block containing the image data.
+    /// </param>
+    /// <param name="size">
+    ///   The size, in bytes, of the memory block pointed to by <paramref name="pSource"/>.
+    /// </param>
+    /// <param name="makeACopy">
+    ///   A value indicating whether to make a copy of the image data (<see langword="true"/>),
+    ///   or to use the provided memory directly (<see langword="false"/>).
+    ///   If <see langword="false"/>, the method may free the memory after loading.
+    /// </param>
+    /// <param name="handle">
+    ///   An optional <see cref="GCHandle"/> associated with the memory block.
+    ///   If provided, the handle will be freed after loading the image.
+    /// </param>
+    /// <returns>An <see cref="Image"/> object containing the loaded image data.</returns>
+    /// <remarks>
+    ///   The image is loaded with a pixel format of <see cref="PixelFormat.B8G8R8A8_UNorm"/>
+    ///   and is vertically flipped to match expected orientation.
+    /// </remarks>
     public static unsafe Image LoadFromMemory(IntPtr pSource, int size, bool makeACopy, GCHandle? handle)
     {
         using var memoryStream = new UnmanagedMemoryStream((byte*) pSource, size, capacity: size, access: FileAccess.Read);
@@ -55,6 +75,23 @@ internal partial class StandardImageHelper
     }
 
 
+    /// <summary>
+    ///   Saves a GIF image to the specified stream using pixel data from memory.
+    /// </summary>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="count">
+    ///   The number of pixel buffers to use when saving the image.
+    ///   Must be greater than zero and less than or equal to the length of <paramref name="pixelBuffers"/>.
+    /// </param>
+    /// <param name="description">
+    ///   An <see cref="ImageDescription"/> structure that specifies the properties of the image,
+    ///   such as width, height, and pixel format.
+    /// </param>
+    /// <param name="imageStream">
+    ///   The stream to which the GIF image will be written. The stream must be writable.
+    /// </param>
     public static void SaveGifFromMemory(PixelBuffer[] pixelBuffers, int count, ImageDescription description, Stream imageStream)
     {
         using var bitmap = new FreeImageBitmap(description.Width, description.Height);
@@ -62,6 +99,23 @@ internal partial class StandardImageHelper
         bitmap.Save(imageStream, FREE_IMAGE_FORMAT.FIF_GIF);
     }
 
+    /// <summary>
+    ///   Saves a TIFF image to the specified stream using pixel data from memory.
+    /// </summary>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="count">
+    ///   The number of pixel buffers to use when saving the image.
+    ///   Must be greater than zero and less than or equal to the length of <paramref name="pixelBuffers"/>.
+    /// </param>
+    /// <param name="description">
+    ///   An <see cref="ImageDescription"/> structure that specifies the properties of the image,
+    ///   such as width, height, and pixel format.
+    /// </param>
+    /// <param name="imageStream">
+    ///   The stream to which the TIFF image will be written. The stream must be writable.
+    /// </param>
     public static void SaveTiffFromMemory(PixelBuffer[] pixelBuffers, int count, ImageDescription description, Stream imageStream)
     {
         using var bitmap = new FreeImageBitmap(description.Width, description.Height);
@@ -69,6 +123,23 @@ internal partial class StandardImageHelper
         bitmap.Save(imageStream, FREE_IMAGE_FORMAT.FIF_TIFF);
     }
 
+    /// <summary>
+    ///   Saves a BMP image to the specified stream using pixel data from memory.
+    /// </summary>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="count">
+    ///   The number of pixel buffers to use when saving the image.
+    ///   Must be greater than zero and less than or equal to the length of <paramref name="pixelBuffers"/>.
+    /// </param>
+    /// <param name="description">
+    ///   An <see cref="ImageDescription"/> structure that specifies the properties of the image,
+    ///   such as width, height, and pixel format.
+    /// </param>
+    /// <param name="imageStream">
+    ///   The stream to which the BMP image will be written. The stream must be writable.
+    /// </param>
     public static void SaveBmpFromMemory(PixelBuffer[] pixelBuffers, int count, ImageDescription description, Stream imageStream)
     {
         using var bitmap = new FreeImageBitmap(description.Width, description.Height);
@@ -76,6 +147,26 @@ internal partial class StandardImageHelper
         bitmap.Save(imageStream, FREE_IMAGE_FORMAT.FIF_BMP);
     }
 
+    /// <summary>
+    ///   Saves a JPEG image to the specified stream using pixel data from memory.
+    /// </summary>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="count">
+    ///   The number of pixel buffers to use when saving the image.
+    ///   Must be greater than zero and less than or equal to the length of <paramref name="pixelBuffers"/>.
+    /// </param>
+    /// <param name="description">
+    ///   An <see cref="ImageDescription"/> structure that specifies the properties of the image,
+    ///   such as width, height, and pixel format.
+    /// </param>
+    /// <param name="imageStream">
+    ///   The stream to which the JPEG image will be written. The stream must be writable.
+    /// </param>
+    /// <remarks>
+    ///   The image is saved with a default quality of 90 and 4:2:0 chroma subsampling.
+    /// </remarks>
     public static void SaveJpgFromMemory(PixelBuffer[] pixelBuffers, int count, ImageDescription description, Stream imageStream)
     {
         using var bitmap = new FreeImageBitmap(description.Width, description.Height);
@@ -88,6 +179,23 @@ internal partial class StandardImageHelper
         bitmap.Save(imageStream, FREE_IMAGE_FORMAT.FIF_JPEG, flags);
     }
 
+    /// <summary>
+    ///   Saves a PNG image to the specified stream using pixel data from memory.
+    /// </summary>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="count">
+    ///   The number of pixel buffers to use when saving the image.
+    ///   Must be greater than zero and less than or equal to the length of <paramref name="pixelBuffers"/>.
+    /// </param>
+    /// <param name="description">
+    ///   An <see cref="ImageDescription"/> structure that specifies the properties of the image,
+    ///   such as width, height, and pixel format.
+    /// </param>
+    /// <param name="imageStream">
+    ///   The stream to which the PNG image will be written. The stream must be writable.
+    /// </param>
     public static void SavePngFromMemory(PixelBuffer[] pixelBuffers, int count, ImageDescription description, Stream imageStream)
     {
         using var bitmap = new FreeImageBitmap(description.Width, description.Height);
@@ -95,12 +203,46 @@ internal partial class StandardImageHelper
         bitmap.Save(imageStream, FREE_IMAGE_FORMAT.FIF_PNG);
     }
 
+    /// <summary>
+    ///   Saves a WMP (Windows Media Photo) image to the specified stream using pixel data from memory.
+    /// </summary>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="count">
+    ///   The number of pixel buffers to use when saving the image.
+    ///   Must be greater than zero and less than or equal to the length of <paramref name="pixelBuffers"/>.
+    /// </param>
+    /// <param name="description">
+    ///   An <see cref="ImageDescription"/> structure that specifies the properties of the image,
+    ///   such as width, height, and pixel format.
+    /// </param>
+    /// <param name="imageStream">
+    ///   The stream to which the WMP image will be written. The stream must be writable.
+    /// </param>
+    /// <exception cref="NotImplementedException">The method is not implemented.</exception>
     public static void SaveWmpFromMemory(PixelBuffer[] pixelBuffers, int count, ImageDescription description, Stream imageStream)
     {
         throw new NotImplementedException();
     }
 
 
+    /// <summary>
+    ///   Prepares the specified bitmap for saving by converting its color depth to 32 bits per pixel,
+    ///   copying pixel data from the provided buffers according to the image format,
+    ///   and flipping the image vertically.
+    /// </summary>
+    /// <param name="bitmap">The bitmap to be prepared for saving.</param>
+    /// <param name="pixelBuffers">
+    ///   An array of pixel buffers containing the image data to copy into the bitmap.
+    /// </param>
+    /// <param name="description">The description of the image.</param>
+    /// <exception cref="ArgumentException">
+    ///   The pixel format specified in <paramref name="description"/> is not supported.
+    ///   Supported formats are <see cref="PixelFormat.B8G8R8A8_UNorm"/>, <see cref="PixelFormat.B8G8R8A8_UNorm_SRgb"/>,
+    ///   <see cref="PixelFormat.R8G8B8A8_UNorm"/>, <see cref="PixelFormat.R8G8B8A8_UNorm_SRgb"/>,
+    ///   <see cref="PixelFormat.R8_UNorm"/>, and <see cref="PixelFormat.A8_UNorm"/>.
+    /// </exception>
     private static unsafe void PrepareImageForSaving(FreeImageBitmap bitmap, PixelBuffer[] pixelBuffers, ImageDescription description)
     {
         // Ensure 32 bits per pixel

--- a/sources/engine/Stride/Graphics/StandardImageHelper.cs
+++ b/sources/engine/Stride/Graphics/StandardImageHelper.cs
@@ -1,48 +1,74 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using System;
 using System.Buffers.Binary;
 using System.Numerics;
 
-namespace Stride.Graphics
+namespace Stride.Graphics;
+
+/// <summary>
+///   Provides implementations to load and save <see cref="Image"/>s of different formats
+///   (e.g., PNG, GIF, BMP, JPEG, etc.)
+/// </summary>
+internal partial class StandardImageHelper
 {
     /// <summary>
-    /// This class is responsible to provide image loader for png, gif, bmp.
+    ///   Copies a block of memory from a source buffer to a destination buffer,
+    ///   converting each 32-bit pixel from RGBA to BGRA format.
     /// </summary>
-    partial class StandardImageHelper
+    /// <param name="dest">A pointer to the destination buffer that will receive the converted BGRA pixel data.</param>
+    /// <param name="src">A pointer to the source buffer containing the RGBA pixel data to copy and convert.</param>
+    /// <param name="sizeInBytesToCopy">
+    ///   The number of bytes to copy and convert. Must be a multiple of 4, as each pixel is represented by 4 bytes.
+    /// </param>
+    /// <exception cref="ArgumentException"><paramref name="sizeInBytesToCopy"/> is not a multiple of 4.</exception>
+    /// <remarks>
+    ///   The conversion swaps the red and blue channels for each pixel, effectively transforming the format
+    ///   from RGBA to BGRA.
+    /// </remarks>
+    private static unsafe void CopyMemoryBGRA(IntPtr dest, IntPtr src, int sizeInBytesToCopy)
     {
-        private static unsafe void CopyMemoryBGRA(IntPtr dest, IntPtr src, int sizeInBytesToCopy)
-        {
-            if ((sizeInBytesToCopy & 3) != 0)
-                throw new ArgumentException("Should be a multiple of 4.", "sizeInBytesToCopy");
+        if ((sizeInBytesToCopy & 3) != 0)
+            throw new ArgumentException("Should be a multiple of 4.", nameof(sizeInBytesToCopy));
 
-            var bufferSize = sizeInBytesToCopy / 4;
-            var srcPtr = (uint*)src;
-            var destPtr = (uint*)dest;
-            for (int i = 0; i < bufferSize; ++i)
-            {
-                var value = *srcPtr++;
-                // value: 0xAARRGGBB or in reverse 0xAABBGGRR
-                value = BinaryPrimitives.ReverseEndianness(value);
-                // value: 0xBBGGRRAA or in reverse 0xRRGGBBAA
-                value = BitOperations.RotateRight(value, 8);
-                // value: 0xAABBGGRR or in reverse 0xAARRGGBB
-                *destPtr++ = value;
-            }
+        var bufferSize = sizeInBytesToCopy / 4;
+        var srcPtr = (uint*) src;
+        var destPtr = (uint*) dest;
+        for (int i = 0; i < bufferSize; ++i)
+        {
+            var value = *srcPtr++;
+            // value: 0xAARRGGBB or in reverse 0xAABBGGRR
+            value = BinaryPrimitives.ReverseEndianness(value);
+            // value: 0xBBGGRRAA or in reverse 0xRRGGBBAA
+            value = BitOperations.RotateRight(value, 8);
+            // value: 0xAABBGGRR or in reverse 0xAARRGGBB
+            *destPtr++ = value;
         }
+    }
 
-        private static unsafe void CopyMemoryRRR1(IntPtr dest, IntPtr src, int sizeInBytesToCopy)
+    /// <summary>
+    ///   Copies a block of memory from a source buffer to a destination buffer,
+    ///   converting each source byte representing a red channel value into a 32-bit RGBA pixel
+    ///   with full opacity and equal red, green, and blue channels.
+    /// </summary>
+    /// <param name="dest">A pointer to the destination buffer where the converted RGBA pixel data will be written.</param>
+    /// <param name="src">A pointer to the source buffer containing the red channel byte values to copy and convert.</param>
+    /// <param name="sizeInBytesToCopy">
+    ///   The number of bytes to copy and convert from the source buffer.
+    ///   Each byte is treated as a single red channel value and converted to one 32-bit RGBA pixel.
+    /// </param>
+    private static unsafe void CopyMemoryRRR1(IntPtr dest, IntPtr src, int sizeInBytesToCopy)
+    {
+        var bufferSize = sizeInBytesToCopy;
+        var srcPtr = (byte*)src;
+        var destPtr = (uint*)dest;
+        for (int i = 0; i < bufferSize; ++i)
         {
-            var bufferSize = sizeInBytesToCopy;
-            var srcPtr = (byte*)src;
-            var destPtr = (uint*)dest;
-            for (int i = 0; i < bufferSize; ++i)
-            {
-                uint value = *srcPtr++;
-                // R => RGBA
-                value = 0xFF000000u | (value * 0x010101u);
-                *destPtr++ = value;
-            }
+            uint value = *srcPtr++;
+            // R => RGBA
+            value = 0xFF000000u | (value * 0x010101u);
+            *destPtr++ = value;
         }
     }
 }


### PR DESCRIPTION
# PR Details

**Context**: After the recent migration from `System.Drawing.Common` (using GDI+, Windows-specific) to FreeImage (cross-platform), the `TestLoadAndSave` of `TestImage` (in `Stride.Graphics.Tests`) started failing for me. However, it only fails when the source (reference image to compare against) and the destination formats are both JPEG.

The failure seems to be caused by differences in the way FreeImage encodes JPEGs, the quality, chroma subsampling, and possibly other things. This makes the resulting JPEG be more compressed and with worse quality, and the test image comparison fails because the differences are greater than the allowed difference of 30.

**Solution**: This PR sets quality and chroma subsampling flags so FreeImage can save an image more in line with the default configuration GDI+ was producing before the migration, making the test pass again. The key part is in `SaveJpegFromMemory()`, in `StandardImageHelper.Desktop.cs`.

As an extra, I've reorganized `StandardImageHelper` to be more readable and to be able to set custom format-specific flags easier in the future. **Currently the files are being saved using FreeImage defaults, and custom flags are hardcoded**. I've also improved the documentation and comments.

## Related Issue

No issue. Discussed briefly on Discord.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
