### PR TITLE
fix: Model collision issues with more complex meshes

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Systems/CollidableGizmo.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Systems/CollidableGizmo.cs
@@ -112,7 +112,7 @@ public sealed class CollidableGizmo : IEntityGizmo
         var bepuShapeCacheSys = _services.GetOrCreate<ShapeCacheSystem>();
         var graphicsDevice = _services.GetSafeServiceAs<IGraphicsDeviceService>().GraphicsDevice;
 
-        if (_component.Collider is MeshCollider meshCollider && (meshCollider.Model.Meshes.Count == 0 || meshCollider.Model == null!/*May be null in editor*/))
+        if (_component.Collider is MeshCollider meshCollider && (meshCollider.Model == null!/*May be null in editor*/ || meshCollider.Model.Meshes.Count == 0))
         {
             // It looks like meshes take some time before being filled in by the editor ... ?
             // Schedule it for later


### PR DESCRIPTION
# PR Details
Collision shapes using models as input for both bullet and bepu did not merge the different meshes appropriately.
Additionally, bepu did not account for meshes with skeletons either.

## Related Issue
fixes #3018

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
