### PR TITLE
fix: Rollback breaking changes made to the pixel format public API

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/SpriteEditor/Services/SpriteEditorImageCache.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/SpriteEditor/Services/SpriteEditorImageCache.cs
@@ -92,7 +92,7 @@ namespace Stride.Assets.Presentation.AssetEditors.SpriteEditor.Services
                     using (var texTool = new TextureTool())
                     {
                         texImage = texTool.Load(filePath, false);
-                        texTool.Decompress(texImage, texImage.Format.IsSRgb);
+                        texTool.Decompress(texImage, texImage.Format.IsSRgb());
                         if (texImage.Format == PixelFormat.R16G16B16A16_UNorm)
                             texTool.Convert(texImage, PixelFormat.R8G8B8A8_UNorm);
                         var image = texTool.ConvertToStrideImage(texImage);

--- a/sources/editor/Stride.Editor/Thumbnails/StaticThumbnailCommand.cs
+++ b/sources/editor/Stride.Editor/Thumbnails/StaticThumbnailCommand.cs
@@ -51,7 +51,7 @@ namespace Stride.Editor.Thumbnails
             using (var texImage = texTool.Load(image, Parameters.SRgb))
             {
                 // Rescale image so that it fits the thumbnail asked resolution
-                texTool.Decompress(texImage, texImage.Format.IsSRgb);
+                texTool.Decompress(texImage, texImage.Format.IsSRgb());
                 texTool.Resize(texImage, thumbnailSize.X, thumbnailSize.Y, Filter.Rescaling.Lanczos3);
 
                 // Save

--- a/sources/engine/Stride.Assets.Tests/TexturePackerTests.cs
+++ b/sources/engine/Stride.Assets.Tests/TexturePackerTests.cs
@@ -748,7 +748,7 @@ namespace Stride.Assets.Tests
 
             var source = Image.New2D(width, height, 1, PixelFormat.R8G8B8A8_UNorm);
 
-            Assert.Equal(source.TotalSizeInBytes, PixelFormat.R8G8B8A8_UNorm.SizeInBytes * width * height);
+            Assert.Equal(source.TotalSizeInBytes, PixelFormat.R8G8B8A8_UNorm.SizeInBytes() * width * height);
             Assert.Equal(1, source.PixelBuffer.Count);
 
             Assert.Equal(1, source.Description.MipLevels);
@@ -777,7 +777,7 @@ namespace Stride.Assets.Tests
 
             var source = Image.New2D(width, height, 1, PixelFormat.R8G8B8A8_UNorm);
 
-            Assert.Equal(source.TotalSizeInBytes, PixelFormat.R8G8B8A8_UNorm.SizeInBytes * width * height);
+            Assert.Equal(source.TotalSizeInBytes, PixelFormat.R8G8B8A8_UNorm.SizeInBytes() * width * height);
             Assert.Equal(1, source.PixelBuffer.Count);
 
             Assert.Equal(1, source.Description.MipLevels);

--- a/sources/engine/Stride.Assets/Skyboxes/SkyboxGenerator.cs
+++ b/sources/engine/Stride.Assets/Skyboxes/SkyboxGenerator.cs
@@ -146,7 +146,7 @@ namespace Stride.Assets.Skyboxes
             if (textureSize < 64) textureSize = 64;
 
             // TODO: Add support for HDR 32bits
-            var filteringTextureFormat = skyboxTexture.Format.IsHDR ? skyboxTexture.Format : PixelFormat.R8G8B8A8_UNorm;
+            var filteringTextureFormat = skyboxTexture.Format.IsHDR() ? skyboxTexture.Format : PixelFormat.R8G8B8A8_UNorm;
 
             //var outputTexture = Texture.New2D(graphicsDevice, 256, 256, skyboxTexture.Format, TextureFlags.ShaderResource | TextureFlags.UnorderedAccess, 6);
             using (var outputTexture = Texture.New2D(context.GraphicsDevice, textureSize, textureSize, true, filteringTextureFormat, TextureFlags.ShaderResource | TextureFlags.RenderTarget, 6))

--- a/sources/engine/Stride.Assets/Textures/TextureHelper.cs
+++ b/sources/engine/Stride.Assets/Textures/TextureHelper.cs
@@ -205,7 +205,7 @@ namespace Stride.Assets.Textures
                     {
                         case PlatformType.Android:
                         case PlatformType.iOS:
-                            if (inputImageFormat.IsHDR)
+                            if (inputImageFormat.IsHDR())
                             {
                                 outputFormat = inputImageFormat;
                             }
@@ -304,7 +304,7 @@ namespace Stride.Assets.Textures
                                         {
                                             outputFormat = PixelFormat.BC4_UNorm;
                                         }
-                                        else if (inputImageFormat.IsHDR)
+                                        else if (inputImageFormat.IsHDR())
                                         {
                                             // BC6H is too slow to compile
                                             //outputFormat = parameters.GraphicsProfile >= GraphicsProfile.Level_11_0 && alphaMode == AlphaFormat.None ? PixelFormat.BC6H_Uf16 : inputImageFormat;
@@ -314,7 +314,7 @@ namespace Stride.Assets.Textures
                                     }
                                     break;
                                 case GraphicsPlatform.OpenGLES: // OpenGLES on Windows
-                                    if (inputImageFormat.IsHDR)
+                                    if (inputImageFormat.IsHDR())
                                     {
                                         outputFormat = inputImageFormat;
                                     }
@@ -452,7 +452,7 @@ namespace Stride.Assets.Textures
                 return ResultStatus.Cancelled;
 
             // Pre-multiply alpha only for relevant formats
-            if (parameters.PremultiplyAlpha && texImage.Format.Is32bppWithAlpha)
+            if (parameters.PremultiplyAlpha && texImage.Format.Is32bppWithAlpha())
                 textureTool.PreMultiplyAlpha(texImage);
 
             if (cancellationToken.IsCancellationRequested) // abort the process if cancellation is demanded
@@ -462,7 +462,7 @@ namespace Stride.Assets.Textures
             // Generate mipmaps
             if (parameters.GenerateMipmaps)
             {
-                var boxFilteringIsSupported = !texImage.Format.IsSRgb || (MathUtil.IsPow2(targetSize.Width) && MathUtil.IsPow2(targetSize.Height));
+                var boxFilteringIsSupported = !texImage.Format.IsSRgb() || (MathUtil.IsPow2(targetSize.Width) && MathUtil.IsPow2(targetSize.Height));
                 textureTool.GenerateMipMaps(texImage, boxFilteringIsSupported? Filter.MipMapGeneration.Box: Filter.MipMapGeneration.Linear);
             }
 

--- a/sources/engine/Stride.Engine/Rendering/Skyboxes/CubemapFromTextureRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Skyboxes/CubemapFromTextureRenderer.cs
@@ -43,7 +43,7 @@ namespace Stride.Rendering.Skyboxes
 
         public static Texture GenerateCubemap(IServiceRegistry services, RenderDrawContext renderDrawContext, Texture input, int outputSize)
         {
-            var pixelFormat = input.Format.IsHDR ? PixelFormat.R16G16B16A16_Float : input.Format.IsSRgb ? PixelFormat.R8G8B8A8_UNorm_SRgb : PixelFormat.R8G8B8A8_UNorm;
+            var pixelFormat = input.Format.IsHDR() ? PixelFormat.R16G16B16A16_Float : input.Format.IsSRgb() ? PixelFormat.R8G8B8A8_UNorm_SRgb : PixelFormat.R8G8B8A8_UNorm;
             return GenerateCubemap(new CubemapFromTextureRenderer(services, renderDrawContext, input, outputSize, pixelFormat), Vector3.Zero);
         }
     }

--- a/sources/engine/Stride.Graphics.Regression/ImageTester.cs
+++ b/sources/engine/Stride.Graphics.Regression/ImageTester.cs
@@ -65,7 +65,7 @@ namespace Stride.Graphics.Regression
                         || buffer.RowStride != referenceBuffer.RowStride)
                         return false;
 
-                    var swapBGR = buffer.Format.IsBgraOrder != referenceBuffer.Format.IsBgraOrder;
+                    var swapBGR = buffer.Format.IsBgraOrder() != referenceBuffer.Format.IsBgraOrder();
                     // For now, we handle only those specific cases
                     if ((buffer.Format != PixelFormat.R8G8B8A8_UNorm_SRgb && buffer.Format != PixelFormat.B8G8R8A8_UNorm_SRgb)
                         || referenceBuffer.Format != PixelFormat.B8G8R8A8_UNorm)
@@ -74,7 +74,7 @@ namespace Stride.Graphics.Regression
                         return false;
                     }
 
-                    bool checkAlpha = buffer.Format.AlphaSizeInBits > 0;
+                    bool checkAlpha = buffer.Format.AlphaSizeInBits() > 0;
 
                     // Compare remaining bytes.
                     int allowedDiff = 2;

--- a/sources/engine/Stride.Graphics.Regression/ImageTester.cs
+++ b/sources/engine/Stride.Graphics.Regression/ImageTester.cs
@@ -65,7 +65,7 @@ namespace Stride.Graphics.Regression
                         || buffer.RowStride != referenceBuffer.RowStride)
                         return false;
 
-                    var swapBGR = buffer.Format.IsBgraOrder() != referenceBuffer.Format.IsBgraOrder();
+                    var swapBGR = buffer.Format.IsBGRAOrder() != referenceBuffer.Format.IsBGRAOrder();
                     // For now, we handle only those specific cases
                     if ((buffer.Format != PixelFormat.R8G8B8A8_UNorm_SRgb && buffer.Format != PixelFormat.B8G8R8A8_UNorm_SRgb)
                         || referenceBuffer.Format != PixelFormat.B8G8R8A8_UNorm)

--- a/sources/engine/Stride.Graphics.Tests/TestTexture.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestTexture.cs
@@ -553,7 +553,7 @@ namespace Stride.Graphics.Tests
                     {
                         foreach (var pixelFormat in pixelFormats)
                         {
-                            ColorComputer colorComputer = pixelFormat.SizeInBytes == 1
+                            ColorComputer colorComputer = pixelFormat.SizeInBytes() == 1
                                 ? ColorComputerR8
                                 : DefaultColorComputer;
 
@@ -592,7 +592,7 @@ namespace Stride.Graphics.Tests
         /// <returns>A byte array containing the generated Texture data.</returns>
         private static byte[] CreateDebugTextureData(int width, int height, int mipmaps, int arraySize, PixelFormat format, ColorComputer dataComputer)
         {
-            var formatSize = format.SizeInBytes;
+            var formatSize = format.SizeInBytes();
 
             var mipmapSize = 0;
             for (int i = 0; i < mipmaps; i++)
@@ -650,7 +650,7 @@ namespace Stride.Graphics.Tests
         /// </returns>
         private unsafe Texture CreateDebugTexture(GraphicsDevice device, byte[] data, int width, int height, int mipmaps, int arraySize, PixelFormat format, TextureFlags flags, GraphicsResourceUsage usage)
         {
-            var sizeInBytes = format.SizeInBytes;
+            var sizeInBytes = format.SizeInBytes();
 
             var offset = 0;
             var dataBoxes = new DataBox[arraySize * mipmaps];
@@ -701,7 +701,7 @@ namespace Stride.Graphics.Tests
             int width, int height, int mipmaps, int arraySize,
             PixelFormat format, TextureFlags flags, GraphicsResourceUsage usage, ColorComputer dataComputer)
         {
-            var pixelSize = format.SizeInBytes;
+            var pixelSize = format.SizeInBytes();
 
             for (int arraySlice = 0; arraySlice < arraySize; arraySlice++)
             for (int mipLevel = 0; mipLevel < mipmaps; mipLevel++)

--- a/sources/engine/Stride.Graphics/Buffer.Typed.cs
+++ b/sources/engine/Stride.Graphics/Buffer.Typed.cs
@@ -57,7 +57,7 @@ namespace Stride.Graphics
             /// <returns>A new instance of <see cref="Buffer"/>.</returns>
             public static Buffer New(GraphicsDevice device, int elementCount, PixelFormat elementFormat, bool unorderedAccess = false, GraphicsResourceUsage usage = GraphicsResourceUsage.Default)
             {
-                return Buffer.New(device, bufferSize: elementCount * elementFormat.SizeInBytes, BufferFlags.ShaderResource | (unorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), elementFormat, usage);
+                return Buffer.New(device, bufferSize: elementCount * elementFormat.SizeInBytes(), BufferFlags.ShaderResource | (unorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), elementFormat, usage);
             }
 
             /// <summary>

--- a/sources/engine/Stride.Graphics/Data/TextureSerializationData.cs
+++ b/sources/engine/Stride.Graphics/Data/TextureSerializationData.cs
@@ -79,7 +79,7 @@ namespace Stride.Graphics.Data
 
                 // Determine whether we can store initial image
                 StorageHeader.InitialImage = true;
-                if (Image.Description.Format.IsCompressed)
+                if (Image.Description.Format.IsCompressed())
                 {
                     // Compressed: mips need to be multiple of 4, otherwise we can't do it
                     var initialImageWidth = Image.PixelBuffers[skippedMipCount].Width;

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -144,7 +144,7 @@ namespace Stride.Graphics
 
             // Texture.InitializeFromImpl also increments the reference count when storing the COM pointer;
             // compensate with Release() to return the reference count to its previous value
-            backBuffer.InitializeFromImpl(nativeBackBuffer, Description.BackBufferFormat.IsSRgb);
+            backBuffer.InitializeFromImpl(nativeBackBuffer, Description.BackBufferFormat.IsSRgb());
             nativeBackBuffer.Release();
 
             // Reload should get Back-Buffer from Swap-Chain as well
@@ -440,7 +440,7 @@ namespace Stride.Graphics
             // Put it in our Back-Buffer Texture
             //   Texture.InitializeFromImpl also increments the reference count when storing the COM pointer;
             //   compensate with Release() to return the reference count to its previous value
-            backBuffer.InitializeFromImpl(backBufferTexture, Description.BackBufferFormat.IsSRgb);
+            backBuffer.InitializeFromImpl(backBufferTexture, Description.BackBufferFormat.IsSRgb());
             backBufferTexture.Release();
 
             backBuffer.LifetimeState = GraphicsResourceLifetimeState.Active;
@@ -506,7 +506,7 @@ namespace Stride.Graphics
             // Put it in our Back-Buffer Texture
             //   Texture.InitializeFromImpl also increments the reference count when storing the COM pointer;
             //   compensate with Release() to return the reference count to its previous value
-            backBuffer.InitializeFromImpl(backBufferTexture, Description.BackBufferFormat.IsSRgb);
+            backBuffer.InitializeFromImpl(backBufferTexture, Description.BackBufferFormat.IsSRgb());
             backBufferTexture.Release();
 
             foreach (var childTexture in childrenTextures)

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -395,7 +395,7 @@ namespace Stride.Graphics
 
             // Texture.InitializeFromImpl also increments the reference count when storing the COM pointer;
             // compensate with Release() to return the reference count to its previous value
-            backBuffer.InitializeFromImpl(nextBackBuffer, Description.BackBufferFormat.IsSRgb);
+            backBuffer.InitializeFromImpl(nextBackBuffer, Description.BackBufferFormat.IsSRgb());
             nextBackBuffer.Release();
 #endif
         }

--- a/sources/engine/Stride.Graphics/Direct3D11/Buffer.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/Buffer.Direct3D11.cs
@@ -149,7 +149,7 @@ namespace Stride.Graphics
                 {
                     // TODO: The way to calculate the count is not always correct depending on the ViewFlags...etc.
                     count = ViewFlags.HasFlag(BufferFlags.RawBuffer) ? Description.SizeInBytes / sizeof(int) :
-                            ViewFlags.HasFlag(BufferFlags.ShaderResource) ? Description.SizeInBytes / viewFormat.SizeInBytes :
+                            ViewFlags.HasFlag(BufferFlags.ShaderResource) ? Description.SizeInBytes / viewFormat.SizeInBytes() :
                             0;
                 }
                 else
@@ -298,7 +298,7 @@ namespace Stride.Graphics
 
                     Buffer = new()
                     {
-                        ElementWidth = (uint) (pixelFormat.SizeInBytes * width),
+                        ElementWidth = (uint) (pixelFormat.SizeInBytes() * width),
                         ElementOffset = 0
                     }
                 };

--- a/sources/engine/Stride.Graphics/Direct3D11/Texture.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/Texture.Direct3D11.cs
@@ -42,7 +42,7 @@ namespace Stride.Graphics
         private const int TextureRowPitchAlignment = 1;
         private const int TextureSubresourceAlignment = 1;
 
-        private int TexturePixelSize => Format.SizeInBytes;
+        private int TexturePixelSize => Format.SizeInBytes();
 
         private ID3D11RenderTargetView* renderTargetView;
         private ID3D11DepthStencilView* depthStencilView;
@@ -1109,7 +1109,7 @@ namespace Stride.Graphics
         private static TextureDescription CheckMipLevels(GraphicsDevice device, ref TextureDescription description)
         {
             if (device.Features.CurrentProfile < GraphicsProfile.Level_10_0 &&
-                description.Flags.HasFlag(TextureFlags.DepthStencil) && description.Format.IsCompressed)
+                description.Flags.HasFlag(TextureFlags.DepthStencil) && description.Format.IsCompressed())
             {
                 description.MipLevelCount = Math.Min(CalculateMipCount(description.Width, description.Height), description.MipLevelCount);
             }

--- a/sources/engine/Stride.Graphics/Direct3D12/Buffer.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/Buffer.Direct3D12.cs
@@ -99,7 +99,7 @@ namespace Stride.Graphics
                 {
                     // TODO: The way to calculate the count is not always correct depending on the ViewFlags...etc.
                     count = ViewFlags.HasFlag(BufferFlags.RawBuffer) ? Description.SizeInBytes / sizeof(int) :
-                            ViewFlags.HasFlag(BufferFlags.ShaderResource) ? Description.SizeInBytes / viewFormat.SizeInBytes :
+                            ViewFlags.HasFlag(BufferFlags.ShaderResource) ? Description.SizeInBytes / viewFormat.SizeInBytes() :
                             0;
                 }
                 else

--- a/sources/engine/Stride.Graphics/Direct3D12/Texture.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/Texture.Direct3D12.cs
@@ -44,7 +44,7 @@ namespace Stride.Graphics
         private const int TextureRowPitchAlignment = D3D12.TextureDataPitchAlignment;
         private const int TextureSubresourceAlignment = D3D12.TextureDataPlacementAlignment;
 
-        private int TexturePixelSize => Format.SizeInBytes;
+        private int TexturePixelSize => Format.SizeInBytes();
 
         /// <summary>
         ///   A handle to the CPU-accessible Render Target View (RTV) Descriptor.
@@ -1052,7 +1052,7 @@ namespace Stride.Graphics
             // TODO: Stale comment?
 
             if (device.Features.CurrentProfile < GraphicsProfile.Level_10_0 &&
-                !description.Flags.HasFlag(TextureFlags.DepthStencil) && description.Format.IsCompressed)
+                !description.Flags.HasFlag(TextureFlags.DepthStencil) && description.Format.IsCompressed())
             {
                 description.MipLevelCount = Math.Min(CalculateMipCount(description.Width, description.Height), description.MipLevelCount);
             }

--- a/sources/engine/Stride.Graphics/MeshExtension.cs
+++ b/sources/engine/Stride.Graphics/MeshExtension.cs
@@ -58,7 +58,7 @@ public static class MeshExtension
             if (currentElementOffset != VertexElement.AppendAligned)
                 offset = currentElementOffset;
 
-            var elementSize = element.Format.SizeInBytes;
+            var elementSize = element.Format.SizeInBytes();
             if (vertexElementUsage == element.SemanticName && semanticIndex == element.SemanticIndex)
             {
                 result = new VertexElementWithOffset(element, offset, elementSize);

--- a/sources/engine/Stride.Graphics/OpenGL/CommandList.OpenGL.cs
+++ b/sources/engine/Stride.Graphics/OpenGL/CommandList.OpenGL.cs
@@ -508,7 +508,7 @@ namespace Stride.Graphics
             // TODO find a better way to detect if sRGB conversion is needed (need to detect if main frame buffer is sRGB or not at init time)
 #if STRIDE_GRAPHICS_API_OPENGLES
             // If we are copying from an SRgb texture to a non SRgb texture, we use a special SRGb copy shader
-            bool needSRgbConversion = sourceTexture.Description.Format.IsSRgb && destTexture == GraphicsDevice.WindowProvidedRenderTexture;
+            bool needSRgbConversion = sourceTexture.Description.Format.IsSRgb() && destTexture == GraphicsDevice.WindowProvidedRenderTexture;
 #else
             bool needSRgbConversion = false;
 #endif

--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -274,7 +274,7 @@ namespace Stride.Graphics
         ///   Gets a value indicating if the Texture is a using a block compress format (BC1, BC2, BC3, BC4, BC5, BC6H, BC7).
         /// </summary>
         /// <seealso cref="Format"/>
-        public bool IsBlockCompressed => Description.Format.IsCompressed;
+        public bool IsBlockCompressed => Description.Format.IsCompressed();
 
         /// <summary>
         ///   Gets the largestSize of the Texture or Texture View.
@@ -830,7 +830,7 @@ namespace Stride.Graphics
         {
             var mipWidth = CalculateMipSize(Width, mipLevel);
 
-            var rowStride = mipWidth * Format.SizeInBytes;
+            var rowStride = mipWidth * Format.SizeInBytes();
             var dataStrideInBytes = mipWidth * sizeof(TData);
 
             var (width, rem) = Math.DivRem(rowStride * mipWidth, dataStrideInBytes);
@@ -1453,7 +1453,7 @@ namespace Stride.Graphics
                 depth = regionToCheck.Depth;
             }
 
-            var sizePerElement = Format.SizeInBytes;
+            var sizePerElement = Format.SizeInBytes();
 
             // Compute actual pitch
             Image.ComputePitch(Format, width, height, out var rowStride, out var textureDepthStride, out width, out height);

--- a/sources/engine/Stride.Graphics/VertexDeclaration.cs
+++ b/sources/engine/Stride.Graphics/VertexDeclaration.cs
@@ -100,7 +100,7 @@ public sealed class VertexDeclaration : IEquatable<VertexDeclaration>
             if (currentElementOffset != VertexElement.AppendAligned)
                 offset = currentElementOffset;
 
-            var elementSize = element.Format.SizeInBytes;
+            var elementSize = element.Format.SizeInBytes();
             yield return new VertexElementWithOffset(element, offset, elementSize);
 
             // Compute next offset (if automatic)
@@ -123,7 +123,7 @@ public sealed class VertexDeclaration : IEquatable<VertexDeclaration>
             if (currentElementOffset != VertexElement.AppendAligned)
                 offset = currentElementOffset;
 
-            var elementSize = element.Format.SizeInBytes;
+            var elementSize = element.Format.SizeInBytes();
 
             // Compute next offset (if automatic)
             offset += elementSize;

--- a/sources/engine/Stride.Graphics/VertexElementValidator.cs
+++ b/sources/engine/Stride.Graphics/VertexElementValidator.cs
@@ -26,7 +26,7 @@ internal static class VertexElementValidator
         int stride = 0;
 
         for (int i = 0; i < elements.Length; i++)
-            stride += elements[i].Format.SizeInBytes;
+            stride += elements[i].Format.SizeInBytes();
 
         return stride;
     }
@@ -76,12 +76,12 @@ internal static class VertexElementValidator
             int elementOffset = elements[elementIndex].AlignedByteOffset;
             if (elementOffset == VertexElement.AppendAligned)
             {
-                elementOffset = elementIndex == 0 ? 0 : totalOffset + elements[elementIndex - 1].Format.SizeInBytes;
+                elementOffset = elementIndex == 0 ? 0 : totalOffset + elements[elementIndex - 1].Format.SizeInBytes();
             }
             totalOffset = elementOffset;
 
             // Validate the element offset
-            int typeSize = elements[elementIndex].Format.SizeInBytes;
+            int typeSize = elements[elementIndex].Format.SizeInBytes();
             if (elementOffset == VertexElement.AppendAligned || (elementOffset + typeSize) > vertexStride)
             {
                 throw new ArgumentException($"The {nameof(VertexElement)}'s offset and size makes it extend beyond the vertex stride", nameof(elements));

--- a/sources/engine/Stride.Graphics/VertexHelper.cs
+++ b/sources/engine/Stride.Graphics/VertexHelper.cs
@@ -141,7 +141,7 @@ namespace Stride.Graphics
             // Use R16G16_SNorm as it is supported from HW Level 9.1
             // See https://msdn.microsoft.com/en-us/library/windows/desktop/ff471324%28v=vs.85%29.aspx
             const PixelFormat DefaultUVFormat = PixelFormat.R16G16_SNorm;
-            var newUvSize = DefaultUVFormat.SizeInBytes;
+            var newUvSize = DefaultUVFormat.SizeInBytes();
 
             for (int i = 0; i <= maxTexcoord; i++)
             {

--- a/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
@@ -274,7 +274,7 @@ namespace Stride.Graphics
                 }
                 else if ((ViewFlags & BufferFlags.ShaderResource) != 0)
                 {
-                    count = Description.SizeInBytes / viewFormat.SizeInBytes;
+                    count = Description.SizeInBytes / viewFormat.SizeInBytes();
                 }
                 else
                 {

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -1317,7 +1317,7 @@ namespace Stride.Graphics
             if (texture != null)
             {
                 lengthInBytes = databox.SlicePitch * (region.Back - region.Front);
-                blockSize = texture.Format.BlockSize;
+                blockSize = texture.Format.BlockSize();
             }
             else
             {
@@ -1350,8 +1350,8 @@ namespace Stride.Graphics
                 {
                     bufferOffset = (ulong) (uploadOffset + alignment),
                     imageSubresource = new VkImageSubresourceLayers { aspectMask = VkImageAspectFlags.Color, baseArrayLayer = (uint) arraySlice, layerCount = 1, mipLevel = (uint) mipSlice },
-                    bufferRowLength = (uint) (databox.RowPitch * texture.Format.BlockWidth / texture.Format.BlockSize),
-                    bufferImageHeight = (uint) (databox.SlicePitch * texture.Format.BlockHeight / databox.RowPitch),
+                    bufferRowLength = (uint) (databox.RowPitch * texture.Format.BlockWidth() / texture.Format.BlockSize()),
+                    bufferImageHeight = (uint) (databox.SlicePitch * texture.Format.BlockHeight() / databox.RowPitch),
                     imageOffset = new VkOffset3D(region.Left, region.Top, region.Front),
                     imageExtent = new VkExtent3D(region.Right - region.Left, region.Bottom - region.Top, region.Back - region.Front)
                 };

--- a/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
@@ -10,7 +10,7 @@ namespace Stride.Graphics
     public partial class Texture
     {
         // Note: block size for compressed formats
-        internal int TexturePixelSize => Format.SizeInBytes;
+        internal int TexturePixelSize => Format.SizeInBytes();
 
         internal const int TextureSubresourceAlignment = 4;
         internal const int TextureRowPitchAlignment = 1;
@@ -291,7 +291,7 @@ namespace Stride.Graphics
             if (dataBoxes != null && dataBoxes.Length > 0)
             {
                 // Buffer-to-image copies need to be aligned to the pixel size and 4 (always a power of 2)
-                var blockSize = Format.BlockSize;
+                var blockSize = Format.BlockSize();
                 var alignmentMask = (blockSize < 4 ? 4 : blockSize) - 1;
 
                 int totalSize = dataBoxes.Length * alignmentMask;
@@ -351,8 +351,8 @@ namespace Stride.Graphics
                         {
                             bufferOffset = (ulong) uploadOffset,
                             imageSubresource = new VkImageSubresourceLayers(VkImageAspectFlags.Color, (uint) mipSlice, (uint) arraySlice, layerCount: 1),
-                            bufferRowLength = (uint) (dataBoxes[i].RowPitch * Format.BlockWidth / Format.BlockSize),
-                            bufferImageHeight = (uint) (dataBoxes[i].SlicePitch * Format.BlockHeight / dataBoxes[i].RowPitch),
+                            bufferRowLength = (uint) (dataBoxes[i].RowPitch * Format.BlockWidth() / Format.BlockSize()),
+                            bufferImageHeight = (uint) (dataBoxes[i].SlicePitch * Format.BlockHeight() / dataBoxes[i].RowPitch),
                             imageOffset = new VkOffset3D(0, 0, 0),
                             imageExtent = new VkExtent3D(mipMapDescription.Width, mipMapDescription.Height, mipMapDescription.Depth)
                         };
@@ -641,7 +641,7 @@ namespace Stride.Graphics
         /// <returns>The updated texture description.</returns>
         private static TextureDescription CheckMipLevels(GraphicsDevice device, ref TextureDescription description)
         {
-            if (device.Features.CurrentProfile < GraphicsProfile.Level_10_0 && (description.Flags & TextureFlags.DepthStencil) == 0 && description.Format.IsCompressed)
+            if (device.Features.CurrentProfile < GraphicsProfile.Level_10_0 && (description.Flags & TextureFlags.DepthStencil) == 0 && description.Format.IsCompressed())
             {
                 description.MipLevelCount = Math.Min(CalculateMipCount(description.Width, description.Height), description.MipLevelCount);
             }

--- a/sources/engine/Stride.Particles/VertexLayouts/ParticleVertexBuilder.cs
+++ b/sources/engine/Stride.Particles/VertexLayouts/ParticleVertexBuilder.cs
@@ -101,7 +101,7 @@ namespace Stride.Particles.VertexLayouts
                     DefaultTexCoords = attrDesc;
                 }
 
-                var stride = vertexElement.Format.SizeInBytes;
+                var stride = vertexElement.Format.SizeInBytes();
                 var attrAccs = new AttributeAccessor { Offset = totalOffset, Size = stride };
                 totalOffset += stride;
 

--- a/sources/engine/Stride.Rendering/Rendering/ComputeEffect/LambertianPrefiltering/LambertianPrefilteringSH.cs
+++ b/sources/engine/Stride.Rendering/Rendering/ComputeEffect/LambertianPrefiltering/LambertianPrefilteringSH.cs
@@ -131,7 +131,7 @@ namespace Stride.Rendering.ComputeEffect.LambertianPrefiltering
             prefilteredLambertianSH = new SphericalHarmonics(HarmonicOrder);
 
             // Get the data out of the final buffer
-            var sizeResult = coefficientsCount * sumsToPerfomRemaining * PixelFormat.R32G32B32A32_Float.SizeInBytes;
+            var sizeResult = coefficientsCount * sumsToPerfomRemaining * PixelFormat.R32G32B32A32_Float.SizeInBytes();
             var stagedBuffer = NewScopedBuffer(new BufferDescription(sizeResult, BufferFlags.None, GraphicsResourceUsage.Staging));
             context.CommandList.CopyRegion(secondPassInputBuffer, 0, new ResourceRegion(0, 0, 0, sizeResult, 1, 1), stagedBuffer, 0);
             var finalsValues = stagedBuffer.GetData<Vector4>(context.CommandList);

--- a/sources/engine/Stride.Rendering/Rendering/Images/LuminanceEffect/LuminanceEffect.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/LuminanceEffect/LuminanceEffect.cs
@@ -63,7 +63,7 @@ namespace Stride.Rendering.Images
             get => luminanceFormat;
             set
             {
-                if (value.IsCompressed || value.IsPacked || value.IsTypeless || value == PixelFormat.None)
+                if (value.IsCompressed() || value.IsPacked() || value.IsTypeless() || value == PixelFormat.None)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), "Unsupported format [{0}] (must be not none, compressed, packed or typeless)".ToFormat(value));
                 }

--- a/sources/engine/Stride.Rendering/Rendering/RendererCoreBase.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RendererCoreBase.cs
@@ -168,7 +168,7 @@ namespace Stride.Rendering
         /// <returns>A new instance of texture.</returns>
         protected Buffer NewScopedTypedBuffer(int count, PixelFormat viewFormat, bool isUnorderedAccess, GraphicsResourceUsage usage = GraphicsResourceUsage.Default)
         {
-            return NewScopedBuffer(new BufferDescription(count * viewFormat.SizeInBytes, BufferFlags.ShaderResource | (isUnorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), usage), viewFormat);
+            return NewScopedBuffer(new BufferDescription(count * viewFormat.SizeInBytes(), BufferFlags.ShaderResource | (isUnorderedAccess ? BufferFlags.UnorderedAccess : BufferFlags.None), usage), viewFormat);
         }
 
         /// <summary>

--- a/sources/engine/Stride.Rendering/Streaming/StreamingTexture.cs
+++ b/sources/engine/Stride.Rendering/Streaming/StreamingTexture.cs
@@ -140,7 +140,7 @@ namespace Stride.Streaming
             var result = Math.Max(1, (int)(TotalMipLevels * quality));
 
             // Compressed formats have aligment restrictions on the dimensions of the texture (minimum size must be 4)
-            if (Format.IsCompressed && TotalMipLevels >= 3)
+            if (Format.IsCompressed() && TotalMipLevels >= 3)
                 result = MathUtil.Clamp(result, 3, TotalMipLevels);
 
             return result;

--- a/sources/engine/Stride/Graphics/DDSHelper.cs
+++ b/sources/engine/Stride/Graphics/DDSHelper.cs
@@ -331,7 +331,7 @@ namespace Stride.Graphics
                     throw new InvalidOperationException("Unexpected ArraySize == 0 from DDS HeaderDX10 ");
 
                 description.Format = headerDX10.DXGIFormat;
-                if (!description.Format.IsValid)
+                if (!description.Format.IsValid())
                     throw new InvalidOperationException("Invalid Format from DDS HeaderDX10 ");
 
                 switch (headerDX10.ResourceDimension)
@@ -676,7 +676,7 @@ namespace Stride.Graphics
             int newHeight;
             Image.ComputePitch(description.Format, description.Width, description.Height, out rowPitch, out slicePitch, out newWidth, out newHeight);
 
-            if (description.Format.IsCompressed)
+            if (description.Format.IsCompressed())
             {
                 header->Flags |= DDS.HeaderFlags.LinearSize;
                 header->PitchOrLinearSize = slicePitch;
@@ -1144,7 +1144,7 @@ namespace Stride.Graphics
                         if (checkSize < 0)
                             throw new InvalidOperationException("Unexpected end of buffer");
 
-                        if (metadata.Format.IsCompressed)
+                        if (metadata.Format.IsCompressed())
                         {
                             MemoryUtilities.CopyWithAlignmentFallback((void*)pDest, (void*)pSrc, (uint)Math.Min(images[index].BufferStride, imagesDst[index].BufferStride));
                         }

--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -763,7 +763,7 @@ namespace Stride.Graphics
 
         internal unsafe void Initialize(ImageDescription description, IntPtr dataPointer, int offset, GCHandle? handle, bool bufferIsDisposable, PitchFlags pitchFlags = PitchFlags.None, int rowStride = 0)
         {
-            if (!description.Format.IsValid || description.Format.IsVideoFormat)
+            if (!description.Format.IsValid() || description.Format.IsVideoFormat())
                 throw new InvalidOperationException("Unsupported DXGI Format");
 
             if (rowStride > 0 && description.MipLevels != 1)
@@ -886,7 +886,7 @@ namespace Stride.Graphics
             widthPacked = width;
             heightPacked = height;
 
-            if (format.IsCompressed)
+            if (format.IsCompressed())
             {
                 int minWidth = 1;
                 int minHeight = 1;
@@ -912,7 +912,7 @@ namespace Stride.Graphics
 
                 slicePitch = rowPitch * heightPacked;
             }
-            else if (format.IsPacked)
+            else if (format.IsPacked())
             {
                 rowPitch = ((width + 1) >> 1) * 4;
 
@@ -929,7 +929,7 @@ namespace Stride.Graphics
                 else if (flags.HasFlag(PitchFlags.Bpp8))
                     bitsPerPixel = 8;
                 else
-                    bitsPerPixel = format.SizeInBits;
+                    bitsPerPixel = format.SizeInBits();
 
                 if (flags.HasFlag(PitchFlags.LegacyDword))
                 {

--- a/sources/engine/Stride/Graphics/Image.cs
+++ b/sources/engine/Stride/Graphics/Image.cs
@@ -763,7 +763,7 @@ namespace Stride.Graphics
 
         internal unsafe void Initialize(ImageDescription description, IntPtr dataPointer, int offset, GCHandle? handle, bool bufferIsDisposable, PitchFlags pitchFlags = PitchFlags.None, int rowStride = 0)
         {
-            if (!description.Format.IsValid() || description.Format.IsVideoFormat())
+            if (!description.Format.IsValid() || description.Format.IsVideo())
                 throw new InvalidOperationException("Unsupported DXGI Format");
 
             if (rowStride > 0 && description.MipLevels != 1)

--- a/sources/engine/Stride/Graphics/PixelBuffer.cs
+++ b/sources/engine/Stride/Graphics/PixelBuffer.cs
@@ -71,7 +71,7 @@ namespace Stride.Graphics
             this.rowStride = rowStride;
             this.bufferStride = bufferStride;
             this.dataPointer = dataPointer;
-            this.pixelSize = format.SizeInBytes;
+            this.pixelSize = format.SizeInBytes();
             this.isStrictRowStride = (pixelSize * width) == rowStride;
         }
 

--- a/sources/engine/Stride/Graphics/PixelFormatExtensions.cs
+++ b/sources/engine/Stride/Graphics/PixelFormatExtensions.cs
@@ -45,7 +45,7 @@ public static class PixelFormatExtensions
         ///   This property returns the size of each block in bytes.
         ///   For non-compressed formats, this value corresponds to the size of a single pixel.
         /// </remarks>
-        public int BlockSize => sizeInfos[GetIndex(format)].BlockSize;
+        public int BlockSize() => sizeInfos[GetIndex(format)].BlockSize;
 
         /// <summary>
         ///   Gets the width, in pixels, of a single block for the <see cref="PixelFormat"/>.
@@ -55,7 +55,7 @@ public static class PixelFormatExtensions
         ///   This property returns the width of each block in pixels.
         ///   For non-compressed formats, this value is always 1.
         /// </remarks>
-        public int BlockWidth => sizeInfos[GetIndex(format)].BlockWidth;
+        public int BlockWidth() => sizeInfos[GetIndex(format)].BlockWidth;
         /// <summary>
         ///   Gets the height, in pixels, of a single block for the <see cref="PixelFormat"/>.
         /// </summary>
@@ -64,30 +64,24 @@ public static class PixelFormatExtensions
         ///   This property returns the height of each block in pixels.
         ///   For non-compressed formats, this value is always 1.
         /// </remarks>
-        public int BlockHeight => sizeInfos[GetIndex(format)].BlockHeight;
+        public int BlockHeight() => sizeInfos[GetIndex(format)].BlockHeight;
 
         /// <summary>
         ///   Gets the size of the <see cref="PixelFormat"/> in bytes.
         /// </summary>
-        public int SizeInBytes
+        public int SizeInBytes()
         {
-            get
-            {
-                var sizeInfo = sizeInfos[GetIndex(format)];
-                return sizeInfo.BlockSize / (sizeInfo.BlockWidth * sizeInfo.BlockHeight);
-            }
+            var sizeInfo = sizeInfos[GetIndex(format)];
+            return sizeInfo.BlockSize / (sizeInfo.BlockWidth * sizeInfo.BlockHeight);
         }
 
         /// <summary>
         ///   Gets the size of the <see cref="PixelFormat"/> in bits.
         /// </summary>
-        public int SizeInBits
+        public int SizeInBits()
         {
-            get
-            {
-                var sizeInfo = sizeInfos[GetIndex(format)];
-                return sizeInfo.BlockSize * 8 / (sizeInfo.BlockWidth * sizeInfo.BlockHeight);
-            }
+            var sizeInfo = sizeInfos[GetIndex(format)];
+            return sizeInfo.BlockSize * 8 / (sizeInfo.BlockWidth * sizeInfo.BlockHeight);
         }
 
         /// <summary>
@@ -97,7 +91,7 @@ public static class PixelFormatExtensions
         ///   The size of the alpha channel in bits.
         ///   If the format does not have an alpha channel, this value is 0.
         /// </value>
-        public int AlphaSizeInBits => format switch
+        public int AlphaSizeInBits() => format switch
         {
             R32G32B32A32_Typeless or R32G32B32A32_Float or R32G32B32A32_UInt or R32G32B32A32_SInt => 32,
 
@@ -127,7 +121,7 @@ public static class PixelFormatExtensions
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> is a compressed format.
         /// </summary>
-        public bool IsCompressed => sizeInfos[GetIndex(format)].IsCompressed;
+        public bool IsCompressed() => sizeInfos[GetIndex(format)].IsCompressed;
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> is a valid pixel format.
@@ -136,21 +130,30 @@ public static class PixelFormatExtensions
         ///   <see langword="true"/> if the format is valid, i.e., recognized by Stride;
         ///   <see langword="false"/> otherwise.
         /// </value>
-        public bool IsValid
+        public bool IsValid()
             => ((int) format >= 1    && (int) format <= 115)   // DirectX formats
             || ((int) format >= 1088 && (int) format <= 1097); // ETC formats
 
+        /// <summary>
+        /// Returns true if the <see cref="PixelFormat"/> is an uncompressed 32-bit color with an Alpha channel.
+        /// </summary>
+        /// <returns>True if the <see cref="PixelFormat"/> is an uncompressed 32-bit color with an Alpha channel</returns>
+        public bool HasAlpha32Bits()
+        {
+            return format.Is32bppWithAlpha();
+        }
+        
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> is an
         ///   uncompressed 32-bit-per-pixel (8-bit per channel) color format
         ///   with an Alpha channel.
         /// </summary>
-        public bool Is32bppWithAlpha => alpha32Formats[GetIndex(format)];
+        public bool Is32bppWithAlpha() => alpha32Formats[GetIndex(format)];
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> has an Alpha channel.
         /// </summary>
-        public bool HasAlpha => format.AlphaSizeInBits != 0;
+        public bool HasAlpha() => format.AlphaSizeInBits() != 0;
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> uses packed color channels.
@@ -160,7 +163,7 @@ public static class PixelFormatExtensions
         ///   which can affect how pixel data is accessed and processed.
         ///   Use this property to determine if special handling is required for reading or writing pixel values.
         /// </remarks>
-        public bool IsPacked => format is R8G8_B8G8_UNorm or G8R8_G8B8_UNorm;
+        public bool IsPacked() => format is R8G8_B8G8_UNorm or G8R8_G8B8_UNorm;
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> is a video format.
@@ -170,42 +173,39 @@ public static class PixelFormatExtensions
         ///   This property helps identify formats that may have specific requirements or optimizations,
         ///   and may not be suitable for rendering by the 3D pipeline.
         /// </remarks>
-        public bool IsVideoFormat
+        public bool IsVideoFormat()
         {
-            get
-            {
 #if DIRECTX11_1
-                switch (format)
-                {
-                    case PixelFormat.AYUV:
-                    case PixelFormat.Y410:
-                    case PixelFormat.Y416:
-                    case PixelFormat.NV12:
-                    case PixelFormat.P010:
-                    case PixelFormat.P016:
-                    case PixelFormat.YUY2:
-                    case PixelFormat.Y210:
-                    case PixelFormat.Y216:
-                    case PixelFormat.NV11:
-                        // These video formats can be used with the 3D pipeline through special view mappings
-                        return true;
+            switch (format)
+            {
+                case PixelFormat.AYUV:
+                case PixelFormat.Y410:
+                case PixelFormat.Y416:
+                case PixelFormat.NV12:
+                case PixelFormat.P010:
+                case PixelFormat.P016:
+                case PixelFormat.YUY2:
+                case PixelFormat.Y210:
+                case PixelFormat.Y216:
+                case PixelFormat.NV11:
+                    // These video formats can be used with the 3D pipeline through special view mappings
+                    return true;
 
-                    case PixelFormat.Opaque420:
-                    case PixelFormat.AI44:
-                    case PixelFormat.IA44:
-                    case PixelFormat.P8:
-                    case PixelFormat.A8P8:
-                        // These are limited use video formats not usable in any way by the 3D pipeline
-                        return true;
+                case PixelFormat.Opaque420:
+                case PixelFormat.AI44:
+                case PixelFormat.IA44:
+                case PixelFormat.P8:
+                case PixelFormat.A8P8:
+                    // These are limited use video formats not usable in any way by the 3D pipeline
+                    return true;
 
-                    default:
-                        return false;
-                }
-#else
-                // !DXGI_1_2_FORMATS
-                return false;
-#endif
+                default:
+                    return false;
             }
+#else
+            // !DXGI_1_2_FORMATS
+            return false;
+#endif
         }
 
         /// <summary>
@@ -217,7 +217,7 @@ public static class PixelFormatExtensions
         ///   These kind of formats are typically used for Textures and Images that are displayed on screen,
         ///   but not for Render Targets or Buffers involved in intermediate rendering calculations.
         /// </remarks>
-        public bool IsSRgb => srgbFormats[GetIndex(format)];
+        public bool IsSRgb() => srgbFormats[GetIndex(format)];
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> is an HDR format
@@ -228,7 +228,7 @@ public static class PixelFormatExtensions
         ///   These formats are typically used in high-dynamic-range rendering scenarios,
         ///   such as when rendering scenes with significant contrast between light and dark areas.
         /// </remarks>
-        public bool IsHDR => hdrFormats[GetIndex(format)];
+        public bool IsHDR() => hdrFormats[GetIndex(format)];
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> is a typeless format.
@@ -239,7 +239,7 @@ public static class PixelFormatExtensions
         ///   as different types depending on the context, such as when creating
         ///   a resource that can be viewed in multiple ways.
         /// </remarks>
-        public bool IsTypeless => typelessFormats[GetIndex(format)];
+        public bool IsTypeless() => typelessFormats[GetIndex(format)];
 
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> has an equivalent sRGB format.
@@ -251,8 +251,8 @@ public static class PixelFormatExtensions
         /// <exception cref="ArgumentException">
         ///   The provided pixel format is already an sRGB format.
         /// </exception>
-        public bool HasSRgbEquivalent
-            => format.IsSRgb
+        public bool HasSRgbEquivalent()
+            => format.IsSRgb()
                 ? throw new ArgumentException($"'{format}' is already an sRGB pixel format", nameof(format))
                 : sRgbConversion.ContainsKey(format);
 
@@ -266,8 +266,8 @@ public static class PixelFormatExtensions
         /// <exception cref="ArgumentException">
         ///   The provided pixel format is not an sRGB format.
         /// </exception>
-        public bool HasNonSRgbEquivalent
-            => !format.IsSRgb
+        public bool HasNonSRgbEquivalent()
+            => !format.IsSRgb()
                 ? throw new ArgumentException($"'{format}' is not a sRGB format", nameof(format))
                 : sRgbConversion.ContainsKey(format);
 
@@ -278,7 +278,7 @@ public static class PixelFormatExtensions
         ///   The equivalent sRGB format if it exists, or the provided pixel format otherwise.
         /// </returns>
         public PixelFormat ToSRgb()
-            => format.IsSRgb || !sRgbConversion.TryGetValue(format, out var srgbFormat)
+            => format.IsSRgb() || !sRgbConversion.TryGetValue(format, out var srgbFormat)
                 ? format
                 : srgbFormat;
 
@@ -289,7 +289,7 @@ public static class PixelFormatExtensions
         ///   The equivalent non-sRGB format if it exists, or the provided pixel format otherwise.
         /// </returns>
         public PixelFormat ToNonSRgb()
-            => !format.IsSRgb || !sRgbConversion.TryGetValue(format, out var nonSrgbFormat)
+            => !format.IsSRgb() || !sRgbConversion.TryGetValue(format, out var nonSrgbFormat)
                 ? format
                 : nonSrgbFormat;
 
@@ -316,7 +316,7 @@ public static class PixelFormatExtensions
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> has its components in the RGBA order.
         /// </summary>
-        public bool IsRgbaOrder => format switch
+        public bool IsRgbaOrder() => format switch
         {
             R32G32B32A32_Typeless or R32G32B32A32_Float or R32G32B32A32_UInt or R32G32B32A32_SInt or
             R32G32B32_Typeless or R32G32B32_Float or R32G32B32_UInt or R32G32B32_SInt or
@@ -333,7 +333,7 @@ public static class PixelFormatExtensions
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> has its components in the BGRA order.
         /// </summary>
-        public bool IsBgraOrder => format switch
+        public bool IsBgraOrder() => format switch
         {
             B8G8R8A8_UNorm or B8G8R8X8_UNorm or B8G8R8A8_Typeless or B8G8R8A8_UNorm_SRgb or B8G8R8X8_Typeless or B8G8R8X8_UNorm_SRgb => true,
             _ => false,

--- a/sources/engine/Stride/Graphics/PixelFormatExtensions.cs
+++ b/sources/engine/Stride/Graphics/PixelFormatExtensions.cs
@@ -173,7 +173,7 @@ public static class PixelFormatExtensions
         ///   This property helps identify formats that may have specific requirements or optimizations,
         ///   and may not be suitable for rendering by the 3D pipeline.
         /// </remarks>
-        public bool IsVideoFormat()
+        public bool IsVideo()
         {
 #if DIRECTX11_1
             switch (format)
@@ -316,7 +316,7 @@ public static class PixelFormatExtensions
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> has its components in the RGBA order.
         /// </summary>
-        public bool IsRgbaOrder() => format switch
+        public bool IsRGBAOrder() => format switch
         {
             R32G32B32A32_Typeless or R32G32B32A32_Float or R32G32B32A32_UInt or R32G32B32A32_SInt or
             R32G32B32_Typeless or R32G32B32_Float or R32G32B32_UInt or R32G32B32_SInt or
@@ -333,7 +333,7 @@ public static class PixelFormatExtensions
         /// <summary>
         ///   Gets a value indicating if the <see cref="PixelFormat"/> has its components in the BGRA order.
         /// </summary>
-        public bool IsBgraOrder() => format switch
+        public bool IsBGRAOrder() => format switch
         {
             B8G8R8A8_UNorm or B8G8R8X8_UNorm or B8G8R8A8_Typeless or B8G8R8A8_UNorm_SRgb or B8G8R8X8_Typeless or B8G8R8X8_UNorm_SRgb => true,
             _ => false,

--- a/sources/tests/tools/Stride.TextureConverter.Tests/TexLibraryTest.cs
+++ b/sources/tests/tools/Stride.TextureConverter.Tests/TexLibraryTest.cs
@@ -66,9 +66,9 @@ namespace Stride.TextureConverter.Tests
 
         public static void SwitchChannelsTest(TexImage image, ITexLibrary library)
         {
-            var isInRgbaOrder = image.Format.IsRgbaOrder;
+            var isInRgbaOrder = image.Format.IsRgbaOrder();
             library.Execute(image, new SwitchingBRChannelsRequest());
-            Assert.True(image.Format.IsRgbaOrder != isInRgbaOrder);
+            Assert.True(image.Format.IsRgbaOrder() != isInRgbaOrder);
 
             //Console.WriteLine("SwitchChannelsTest_" + image.Name + "." + TestTools.ComputeSHA1(image.Data, image.DataSize));
             Assert.Equal(TestTools.GetInstance().Checksum["SwitchChannelsTest_" + image.Name], TestTools.ComputeSHA1(image.Data, image.DataSize));
@@ -84,7 +84,7 @@ namespace Stride.TextureConverter.Tests
 
         public static void DecompressTest(TexImage image, ITexLibrary library)
         {
-            Assert.True(image.Format.IsCompressed);
+            Assert.True(image.Format.IsCompressed());
             library.Execute(image, new DecompressingRequest(false));
             Assert.True(image.Format == PixelFormat.R8G8B8A8_UNorm);
             Assert.Equal(TestTools.GetInstance().Checksum["DecompressTest_" + image.Name], TestTools.ComputeSHA1(image.Data, image.DataSize));
@@ -93,7 +93,7 @@ namespace Stride.TextureConverter.Tests
 
         public static void CompressTest(TexImage image, ITexLibrary library, PixelFormat format)
         {
-            Assert.True(!image.Format.IsCompressed);
+            Assert.True(!image.Format.IsCompressed());
             library.Execute(image, new CompressingRequest(format));
 
             Assert.True(image.Format == format);
@@ -104,7 +104,7 @@ namespace Stride.TextureConverter.Tests
         public static void GenerateMipMapTest(TexImage image, ITexLibrary library, Filter.MipMapGeneration filter)
         {
             Assert.True(image.MipmapCount == 1);
-            if (image.Format.IsCompressed) library.Execute(image, new DecompressingRequest(false));
+            if (image.Format.IsCompressed()) library.Execute(image, new DecompressingRequest(false));
             library.Execute(image, new MipMapsGenerationRequest(filter));
             Assert.True(image.MipmapCount > 1);
             Assert.Equal(TestTools.GetInstance().Checksum["GenerateMipMapTest_" + filter + "_" + image.Name], TestTools.ComputeSHA1(image.Data, image.DataSize));

--- a/sources/tests/tools/Stride.TextureConverter.Tests/TexLibraryTest.cs
+++ b/sources/tests/tools/Stride.TextureConverter.Tests/TexLibraryTest.cs
@@ -66,9 +66,9 @@ namespace Stride.TextureConverter.Tests
 
         public static void SwitchChannelsTest(TexImage image, ITexLibrary library)
         {
-            var isInRgbaOrder = image.Format.IsRgbaOrder();
+            var isInRgbaOrder = image.Format.IsRGBAOrder();
             library.Execute(image, new SwitchingBRChannelsRequest());
-            Assert.True(image.Format.IsRgbaOrder() != isInRgbaOrder);
+            Assert.True(image.Format.IsRGBAOrder() != isInRgbaOrder);
 
             //Console.WriteLine("SwitchChannelsTest_" + image.Name + "." + TestTools.ComputeSHA1(image.Data, image.DataSize));
             Assert.Equal(TestTools.GetInstance().Checksum["SwitchChannelsTest_" + image.Name], TestTools.ComputeSHA1(image.Data, image.DataSize));

--- a/sources/tests/tools/Stride.TextureConverter.Tests/TextureToolTest.cs
+++ b/sources/tests/tools/Stride.TextureConverter.Tests/TextureToolTest.cs
@@ -245,12 +245,12 @@ namespace Stride.TextureConverter.Tests
         public void SwitchChannelTest(string file)
         {
             var image = texTool.Load(Module.PathToInputImages + file);
-            var isInBgraOrder = image.Format.IsBgraOrder;
+            var isInBgraOrder = image.Format.IsBgraOrder();
 
             texTool.SwitchChannel(image);
             image.Update();
 
-            Assert.True(isInBgraOrder != image.Format.IsBgraOrder);
+            Assert.True(isInBgraOrder != image.Format.IsBgraOrder());
 
             Assert.Equal(TestTools.GetInstance().Checksum["TextureTool_SwitchChannel_" + image.Name], TestTools.ComputeSHA1(image.Data, image.DataSize));
             //Console.WriteLine("TextureTool_SwitchChannel_" + image.Name + "." + TestTools.ComputeSHA1(image.Data, image.DataSize));

--- a/sources/tests/tools/Stride.TextureConverter.Tests/TextureToolTest.cs
+++ b/sources/tests/tools/Stride.TextureConverter.Tests/TextureToolTest.cs
@@ -245,12 +245,12 @@ namespace Stride.TextureConverter.Tests
         public void SwitchChannelTest(string file)
         {
             var image = texTool.Load(Module.PathToInputImages + file);
-            var isInBgraOrder = image.Format.IsBgraOrder();
+            var isInBgraOrder = image.Format.IsBGRAOrder();
 
             texTool.SwitchChannel(image);
             image.Update();
 
-            Assert.True(isInBgraOrder != image.Format.IsBgraOrder());
+            Assert.True(isInBgraOrder != image.Format.IsBGRAOrder());
 
             Assert.Equal(TestTools.GetInstance().Checksum["TextureTool_SwitchChannel_" + image.Name], TestTools.ComputeSHA1(image.Data, image.DataSize));
             //Console.WriteLine("TextureTool_SwitchChannel_" + image.Name + "." + TestTools.ComputeSHA1(image.Data, image.DataSize));

--- a/sources/tools/Stride.TextureConverter/Backend/Requests/DecompressingRequest.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Requests/DecompressingRequest.cs
@@ -24,7 +24,7 @@ namespace Stride.TextureConverter.Requests
         /// <param name="pixelFormat">Input pixel format.</param>
         public DecompressingRequest(bool isSRgb, PixelFormat pixelFormat = PixelFormat.None)
         {
-            if (pixelFormat.IsHDR)
+            if (pixelFormat.IsHDR())
                 DecompressedFormat = PixelFormat.R16G16B16A16_Float;
             else
                 DecompressedFormat = isSRgb ? PixelFormat.R8G8B8A8_UNorm_SRgb : PixelFormat.R8G8B8A8_UNorm;

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/DxtTexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/DxtTexLib.cs
@@ -290,12 +290,12 @@ namespace Stride.TextureConverter.TexLibraries
             UpdateImage(image, libraryData);
 
             var alphaSize = DDSHeader.GetAlphaDepth(loader.FilePath);
-            image.OriginalAlphaDepth = alphaSize != -1 ? alphaSize : image.Format.AlphaSizeInBits;
+            image.OriginalAlphaDepth = alphaSize != -1 ? alphaSize : image.Format.AlphaSizeInBits();
         }
 
         private static void ChangeDxtImageType(DxtTextureLibraryData libraryData, DXGI_FORMAT dxgiFormat)
         {
-            if (((PixelFormat)libraryData.Metadata.format).SizeInBits != ((PixelFormat)dxgiFormat).SizeInBits)
+            if (((PixelFormat)libraryData.Metadata.format).SizeInBits() != ((PixelFormat)dxgiFormat).SizeInBits())
                 throw new ArgumentException("Impossible to change image data format. The two formats '{0}' and '{1}' are not compatibles.".ToFormat(libraryData.Metadata.format, dxgiFormat));
 
             libraryData.Metadata.format = dxgiFormat;
@@ -320,7 +320,7 @@ namespace Stride.TextureConverter.TexLibraries
             ScratchImage scratchImage = new ScratchImage();
 
             HRESULT hr;
-            if (request.Format.IsCompressed)
+            if (request.Format.IsCompressed())
             {
                 var topImage = libraryData.DxtImages[0];
                 if (topImage.Width % 4 != 0 || topImage.Height % 4 != 0)
@@ -422,7 +422,7 @@ namespace Stride.TextureConverter.TexLibraries
         private void Convert(TexImage image, DxtTextureLibraryData libraryData, ConvertingRequest request)
         {
             // TODO: temp if request format is SRGB we force it to non-srgb to perform the conversion. Will not work if texture input is SRGB
-            var outputFormat = request.Format.IsSRgb ? request.Format.ToNonSRgb() : request.Format;
+            var outputFormat = request.Format.IsSRgb() ? request.Format.ToNonSRgb() : request.Format;
 
             Log.Verbose($"Converting texture from {(PixelFormat)libraryData.Metadata.format} to {outputFormat}");
 
@@ -461,7 +461,7 @@ namespace Stride.TextureConverter.TexLibraries
             Log.Verbose("Decompressing texture ...");
 
             // determine the output format to avoid any sRGB/RGB conversions (only decompression, no conversion)
-            var outputFormat = !((PixelFormat)libraryData.Metadata.format).IsSRgb ? request.DecompressedFormat.ToNonSRgb() : request.DecompressedFormat.ToSRgb();
+            var outputFormat = !((PixelFormat)libraryData.Metadata.format).IsSRgb() ? request.DecompressedFormat.ToNonSRgb() : request.DecompressedFormat.ToSRgb();
 
             var scratchImage = new ScratchImage();
             var hr = Utilities.Decompress(libraryData.DxtImages, libraryData.DxtImages.Length, ref libraryData.Metadata, (DXGI_FORMAT)outputFormat, scratchImage);
@@ -784,7 +784,7 @@ namespace Stride.TextureConverter.TexLibraries
             image.MipmapCount = libraryData.Metadata.MipLevels;
             image.ArraySize = libraryData.Metadata.ArraySize;
             image.SlicePitch = libraryData.DxtImages[0].SlicePitch;
-            image.OriginalAlphaDepth = Math.Min(image.OriginalAlphaDepth, image.Format.AlphaSizeInBits);
+            image.OriginalAlphaDepth = Math.Min(image.OriginalAlphaDepth, image.Format.AlphaSizeInBits());
         }
 
 

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/FITexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/FITexLib.cs
@@ -380,7 +380,7 @@ namespace Stride.TextureConverter.TexLibraries
                 FreeImage.Unload(redChannel);
             }
 
-            if (image.Format.IsBgraOrder())
+            if (image.Format.IsBGRAOrder())
                 image.Format = Graphics.PixelFormat.R8G8B8A8_UNorm;
             else
                 image.Format = Graphics.PixelFormat.B8G8R8A8_UNorm;
@@ -506,7 +506,7 @@ namespace Stride.TextureConverter.TexLibraries
                 throw new TextureToolsException("Not implemented.");
             }
 
-            if (!image.Format.IsBgraOrder())
+            if (!image.Format.IsBGRAOrder())
             {
                 SwitchChannels(image, libraryData, new SwitchingBRChannelsRequest());
             }

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/FITexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/FITexLib.cs
@@ -55,7 +55,7 @@ namespace Stride.TextureConverter.TexLibraries
 
         public void StartLibrary(TexImage image)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Error("FreeImage can't process compressed texture.");
                 throw new TextureToolsException("FreeImage can't process compressed texture.");
@@ -380,7 +380,7 @@ namespace Stride.TextureConverter.TexLibraries
                 FreeImage.Unload(redChannel);
             }
 
-            if (image.Format.IsBgraOrder)
+            if (image.Format.IsBgraOrder())
                 image.Format = Graphics.PixelFormat.R8G8B8A8_UNorm;
             else
                 image.Format = Graphics.PixelFormat.B8G8R8A8_UNorm;
@@ -506,7 +506,7 @@ namespace Stride.TextureConverter.TexLibraries
                 throw new TextureToolsException("Not implemented.");
             }
 
-            if (!image.Format.IsBgraOrder)
+            if (!image.Format.IsBgraOrder())
             {
                 SwitchChannels(image, libraryData, new SwitchingBRChannelsRequest());
             }

--- a/sources/tools/Stride.TextureConverter/Backend/TexLibraries/PvrttTexLib.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/TexLibraries/PvrttTexLib.cs
@@ -916,7 +916,7 @@ namespace Stride.TextureConverter.TexLibraries
 
         private EPVRTColourSpace RetrieveNativeColorSpace(Stride.Graphics.PixelFormat format)
         {
-            return format.IsSRgb ? EPVRTColourSpace.SRgb : EPVRTColourSpace.Linear;
+            return format.IsSRgb() ? EPVRTColourSpace.SRgb : EPVRTColourSpace.Linear;
         }
     }
 }

--- a/sources/tools/Stride.TextureConverter/Backend/Tools.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Tools.cs
@@ -61,7 +61,7 @@ namespace Stride.TextureConverter
         /// </returns>
         public static bool IsInSameChannelOrder(PixelFormat format1, PixelFormat format2)
         {
-            return format1.IsBgraOrder() && format2.IsBgraOrder() || format1.IsRgbaOrder() && format2.IsRgbaOrder();
+            return format1.IsBGRAOrder() && format2.IsBGRAOrder() || format1.IsRGBAOrder() && format2.IsRGBAOrder();
         }
     }
 }

--- a/sources/tools/Stride.TextureConverter/Backend/Tools.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Tools.cs
@@ -25,9 +25,9 @@ namespace Stride.TextureConverter
             int widthCount = width;
             int heightCount = height;
 
-            int bpp = fmt.SizeInBits;
+            int bpp = fmt.SizeInBits();
 
-            if (fmt.IsCompressed)
+            if (fmt.IsCompressed())
             {
                 widthCount = Math.Max(1, (width + 3) / 4);
                 heightCount = Math.Max(1, (height + 3) / 4);
@@ -35,7 +35,7 @@ namespace Stride.TextureConverter
 
                 slicePitch = rowPitch * heightCount;
             }
-            else if (fmt.IsPacked)
+            else if (fmt.IsPacked())
             {
                 rowPitch = ((width + 1) >> 1) * 4;
 
@@ -44,7 +44,7 @@ namespace Stride.TextureConverter
             else
             {
                 if (bpp == 0)
-                    bpp = fmt.SizeInBits;
+                    bpp = fmt.SizeInBits();
 
                 rowPitch = (width * bpp + 7) / 8;
                 slicePitch = rowPitch * height;
@@ -61,7 +61,7 @@ namespace Stride.TextureConverter
         /// </returns>
         public static bool IsInSameChannelOrder(PixelFormat format1, PixelFormat format2)
         {
-            return format1.IsBgraOrder && format2.IsBgraOrder || format1.IsRgbaOrder && format2.IsRgbaOrder;
+            return format1.IsBgraOrder() && format2.IsBgraOrder() || format1.IsRgbaOrder() && format2.IsRgbaOrder();
         }
     }
 }

--- a/sources/tools/Stride.TextureConverter/Frontend/TexImage.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/TexImage.cs
@@ -373,7 +373,7 @@ namespace Stride.TextureConverter
         public int GetAlphaDepth()
         {
             // TODO: Improve this function so that it checks that actual data (will probably need to add the region to check as parameter)
-            int alphaDepth = Format.AlphaSizeInBits;
+            int alphaDepth = Format.AlphaSizeInBits();
             if (OriginalAlphaDepth == -1)
                 return alphaDepth;
 

--- a/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
@@ -390,7 +390,7 @@ namespace Stride.TextureConverter
         /// <param name="isSRgb">Indicate is the image to decompress is an sRGB image</param>
         public void Decompress(TexImage image, bool isSRgb)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 ExecuteRequest(image, new DecompressingRequest(isSRgb, image.Format));
             }
@@ -427,10 +427,10 @@ namespace Stride.TextureConverter
 
             var request = new ExportRequest(fileName, minimumMipMapSize);
 
-            if (FindLibrary(image, request) == null && image.Format.IsCompressed)
+            if (FindLibrary(image, request) == null && image.Format.IsCompressed())
             {
                 Log.Warning("No library can export this texture with the actual compression format. We will try to decompress it first.");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             ExecuteRequest(image, request);
@@ -458,17 +458,17 @@ namespace Stride.TextureConverter
                 throw new TextureToolsException("The minimup Mipmap size can't be negative. Put 0 or 1 for a complete Mipmap chain.");
             }
 
-            if (image.Format != format && format.IsCompressed && !image.Format.IsCompressed)
+            if (image.Format != format && format.IsCompressed() && !image.Format.IsCompressed())
             {
                 TexImage workingImage = (TexImage)image.Clone();
                 Compress(workingImage, format);
                 ExecuteRequest(workingImage, new ExportRequest(fileName, minimumMipMapSize));
                 workingImage.Dispose();
             }
-            else if (image.Format != format && format.IsCompressed)
+            else if (image.Format != format && format.IsCompressed())
             {
                 TexImage workingImage = (TexImage)image.Clone();
-                Decompress(workingImage, image.Format.IsSRgb);
+                Decompress(workingImage, image.Format.IsSRgb());
                 Compress(workingImage, format);
                 ExecuteRequest(workingImage, new ExportRequest(fileName, minimumMipMapSize));
                 workingImage.Dispose();
@@ -490,10 +490,10 @@ namespace Stride.TextureConverter
         /// <param name="image">The image.</param>
         public void SwitchChannel(TexImage image)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't switch channels of a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             ExecuteRequest(image, new SwitchingBRChannelsRequest());
@@ -513,10 +513,10 @@ namespace Stride.TextureConverter
         {
             if (image.Format == format) return;
 
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't compress an already compressed texture. It will be decompressed first..");
-                Decompress(image, format.IsSRgb);
+                Decompress(image, format.IsSRgb());
             }
 
             var request = new CompressingRequest(format, quality);
@@ -531,10 +531,10 @@ namespace Stride.TextureConverter
         /// <param name="colorKey">The color key.</param>
         public void ColorKey(TexImage image, Color colorKey)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't compress an already compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             if (image.Format != PixelFormat.R8G8B8A8_UNorm && image.Format != PixelFormat.B8G8R8A8_UNorm
@@ -558,10 +558,10 @@ namespace Stride.TextureConverter
         /// <param name="filter">The filter.</param>
         public void GenerateMipMaps(TexImage image, Filter.MipMapGeneration filter)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't generate mipmaps for a compressed texture. It will be decompressed first.");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             ExecuteRequest(image, new MipMapsGenerationRequest(filter));
@@ -592,10 +592,10 @@ namespace Stride.TextureConverter
                 return;
             }
 
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't resize a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             ExecuteRequest(image, new FixedRescalingRequest(width, height, filter));
@@ -627,10 +627,10 @@ namespace Stride.TextureConverter
                 return;
             }
 
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't rescale a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             ExecuteRequest(image, new FactorRescalingRequest(widthFactor, heightFactor, filter));
@@ -651,10 +651,10 @@ namespace Stride.TextureConverter
                 throw new TextureToolsException("The amplitude must be a positive float.");
             }
 
-            if (heightMap.Format.IsCompressed)
+            if (heightMap.Format.IsCompressed())
             {
                 Log.Warning("You can't generate a normal map from a compressed height hmap. It will be decompressed first..");
-                Decompress(heightMap, heightMap.Format.IsSRgb);
+                Decompress(heightMap, heightMap.Format.IsSRgb());
             }
 
             var request = new NormalMapGenerationRequest(amplitude);
@@ -671,10 +671,10 @@ namespace Stride.TextureConverter
         /// <param name="image">The image.</param>
         public void PreMultiplyAlpha(TexImage image)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't premultiply alpha on a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             ExecuteRequest(image, new PreMultiplyAlphaRequest());
@@ -687,7 +687,7 @@ namespace Stride.TextureConverter
         /// <returns>The <see cref="TexImage"/> containing the alpha component as rgb color. Note: it is the user responsibility to dispose the returned image.</returns>
         public unsafe TexImage CreateImageFromAlphaComponent(TexImage texImage)
         {
-            if (texImage.Dimension != TexImage.TextureDimension.Texture2D || texImage.Format.IsCompressed)
+            if (texImage.Dimension != TexImage.TextureDimension.Texture2D || texImage.Format.IsCompressed())
                 throw new NotImplementedException();
 
             var alphaImage = (TexImage)texImage.Clone(true);
@@ -761,8 +761,8 @@ namespace Stride.TextureConverter
 
             // check that we support the format
             var format = texture.Format;
-            var pixelSize = format.SizeInBytes;
-            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder || format.IsBgraOrder || pixelSize != 4))
+            var pixelSize = format.SizeInBytes();
+            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder() || format.IsBgraOrder() || pixelSize != 4))
             {
                 var guessedAlphaLevel = alphaDepth > 0 ? AlphaLevels.InterpolatedAlpha : AlphaLevels.NoAlpha;
                 logger?.Debug($"Unable to find alpha levels for texture type {format}. Returning default alpha level '{guessedAlphaLevel}'.");
@@ -780,7 +780,7 @@ namespace Stride.TextureConverter
 
             if (tranparencyColor.HasValue) // specific case when using a transparency color
             {
-                var transparencyValue = format.IsRgbaOrder ? tranparencyColor.Value.ToRgba() : tranparencyColor.Value.ToBgra();
+                var transparencyValue = format.IsRgbaOrder() ? tranparencyColor.Value.ToRgba() : tranparencyColor.Value.ToBgra();
 
                 for (int y = 0; y < region.Height; ++y)
                 {
@@ -837,7 +837,7 @@ namespace Stride.TextureConverter
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
             var format = texture.Format;
-            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder || format.IsBgraOrder || format.SizeInBytes != 4))
+            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder() || format.IsBgraOrder() || format.SizeInBytes() != 4))
                 throw new NotImplementedException();
 
             // check that the pixel is inside the texture
@@ -849,7 +849,7 @@ namespace Stride.TextureConverter
             var stride = texture.RowPitch / 4;
 
             var pixelColorInt = ptr[stride*pixel.Y + pixel.X];
-            var pixelColor = format.IsRgbaOrder ? Color.FromRgba(pixelColorInt) : Color.FromBgra(pixelColorInt);
+            var pixelColor = format.IsRgbaOrder() ? Color.FromRgba(pixelColorInt) : Color.FromBgra(pixelColorInt);
 
             return pixelColor;
         }
@@ -868,12 +868,12 @@ namespace Stride.TextureConverter
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
             var format = texture.Format;
-            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder || format.IsBgraOrder || format.SizeInBytes != 4))
+            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder() || format.IsBgraOrder() || format.SizeInBytes() != 4))
                 throw new NotImplementedException();
 
             // adjust the separator color the mask depending on the color format.
             var separator = (uint)(separatorColor ?? Color.Transparent).ToRgba();
-            if (texture.Format.IsBgraOrder)
+            if (texture.Format.IsBgraOrder())
             {
                 separator = RgbaToBgra(separator);
                 separatorMask = RgbaToBgra(separatorMask);
@@ -968,7 +968,7 @@ namespace Stride.TextureConverter
         /// <returns>The extracted region <see cref="TexImage"/>. Note: it is the user responsibility to dispose the returned image.</returns>
         public unsafe Image CreateImageFromRegion(TexImage texImage, Rectangle region)
         {
-            if (texImage.Dimension != TexImage.TextureDimension.Texture2D || texImage.Format.IsCompressed)
+            if (texImage.Dimension != TexImage.TextureDimension.Texture2D || texImage.Format.IsCompressed())
                 throw new NotImplementedException();
 
             Log.Info("Extracting region and exporting to Stride Image ...");
@@ -1043,10 +1043,10 @@ namespace Stride.TextureConverter
                 throw new TextureToolsException("The gamma must be a positive float.");
             }
 
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't correct gamme on a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             var request = new GammaCorrectionRequest(gamma);
@@ -1062,10 +1062,10 @@ namespace Stride.TextureConverter
         /// <param name="orientation">The orientation <see cref="Orientation.Flip"/>.</param>
         public void Flip(TexImage image, Orientation orientation)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't flip a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             var request = new FlippingRequest(orientation);
@@ -1081,10 +1081,10 @@ namespace Stride.TextureConverter
         /// <param name="orientation">The orientation <see cref="Orientation.Flip"/>.</param>
         public void FlipSub(TexImage image, int index, Orientation orientation)
         {
-            if (image.Format.IsCompressed)
+            if (image.Format.IsCompressed())
             {
                 Log.Warning("You can't flip a compressed texture. It will be decompressed first..");
-                Decompress(image, image.Format.IsSRgb);
+                Decompress(image, image.Format.IsSRgb());
             }
 
             var request = new FlippingSubRequest(index, orientation);
@@ -1173,9 +1173,9 @@ namespace Stride.TextureConverter
 
             var request = new AtlasExtractionRequest(name, minimumMipmapSize);
 
-            if (atlas.Format.IsCompressed)
+            if (atlas.Format.IsCompressed())
             {
-                Decompress(atlas, atlas.Format.IsSRgb);
+                Decompress(atlas, atlas.Format.IsSRgb());
             }
 
             ExecuteRequest(atlas, request);
@@ -1235,10 +1235,10 @@ namespace Stride.TextureConverter
 
             var request = new AtlasExtractionRequest(minimumMipmapSize);
 
-            if (atlas.Format.IsCompressed)
+            if (atlas.Format.IsCompressed())
             {
                 Log.Warning("You can't extract a texture from a compressed atlas. The atlas will be decompressed first..");
-                Decompress(atlas, atlas.Format.IsSRgb);
+                Decompress(atlas, atlas.Format.IsSRgb());
             }
 
             ExecuteRequest(atlas, request);
@@ -1264,9 +1264,9 @@ namespace Stride.TextureConverter
 
             var request = new ArrayExtractionRequest(minimumMipmapSize);
 
-            if (array.Format.IsCompressed)
+            if (array.Format.IsCompressed())
             {
-                Decompress(array, array.Format.IsSRgb);
+                Decompress(array, array.Format.IsSRgb());
             }
 
             ExecuteRequest(array, request);
@@ -1410,14 +1410,14 @@ namespace Stride.TextureConverter
             if (candidate.Format != model.Format)
             {
                 Log.Warning("The given texture format isn't correct. The texture will be converted..");
-                if (model.Format.IsCompressed)
+                if (model.Format.IsCompressed())
                 {
-                    if (candidate.Format.IsCompressed) Decompress(candidate, candidate.Format.IsSRgb);
+                    if (candidate.Format.IsCompressed()) Decompress(candidate, candidate.Format.IsSRgb());
                     Compress(candidate, model.Format);
                 }
                 else
                 {
-                    Decompress(candidate, candidate.Format.IsSRgb);
+                    Decompress(candidate, candidate.Format.IsSRgb());
                     if (candidate.Format != model.Format) Compress(candidate, model.Format);
                 }
             }
@@ -1442,7 +1442,7 @@ namespace Stride.TextureConverter
                 ITexLibrary library;
                 if ((library = FindLibrary(image, request)) != null)
                 {
-                    if (image.Format.IsBgraOrder && !library.SupportBGRAOrder())
+                    if (image.Format.IsBgraOrder() && !library.SupportBGRAOrder())
                     {
                         SwitchChannel(image);
                     }
@@ -1487,7 +1487,7 @@ namespace Stride.TextureConverter
                     }
 
                     // Both libraries for intermediate processing were found, preceeding with the request
-                    if (image.Format.IsBgraOrder && !library.SupportBGRAOrder())
+                    if (image.Format.IsBgraOrder() && !library.SupportBGRAOrder())
                     {
                         SwitchChannel(image);
                     }

--- a/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
+++ b/sources/tools/Stride.TextureConverter/Frontend/TextureTool.cs
@@ -762,7 +762,7 @@ namespace Stride.TextureConverter
             // check that we support the format
             var format = texture.Format;
             var pixelSize = format.SizeInBytes();
-            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder() || format.IsBgraOrder() || pixelSize != 4))
+            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRGBAOrder() || format.IsBGRAOrder() || pixelSize != 4))
             {
                 var guessedAlphaLevel = alphaDepth > 0 ? AlphaLevels.InterpolatedAlpha : AlphaLevels.NoAlpha;
                 logger?.Debug($"Unable to find alpha levels for texture type {format}. Returning default alpha level '{guessedAlphaLevel}'.");
@@ -780,7 +780,7 @@ namespace Stride.TextureConverter
 
             if (tranparencyColor.HasValue) // specific case when using a transparency color
             {
-                var transparencyValue = format.IsRgbaOrder() ? tranparencyColor.Value.ToRgba() : tranparencyColor.Value.ToBgra();
+                var transparencyValue = format.IsRGBAOrder() ? tranparencyColor.Value.ToRgba() : tranparencyColor.Value.ToBgra();
 
                 for (int y = 0; y < region.Height; ++y)
                 {
@@ -837,7 +837,7 @@ namespace Stride.TextureConverter
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
             var format = texture.Format;
-            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder() || format.IsBgraOrder() || format.SizeInBytes() != 4))
+            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRGBAOrder() || format.IsBGRAOrder() || format.SizeInBytes() != 4))
                 throw new NotImplementedException();
 
             // check that the pixel is inside the texture
@@ -849,7 +849,7 @@ namespace Stride.TextureConverter
             var stride = texture.RowPitch / 4;
 
             var pixelColorInt = ptr[stride*pixel.Y + pixel.X];
-            var pixelColor = format.IsRgbaOrder() ? Color.FromRgba(pixelColorInt) : Color.FromBgra(pixelColorInt);
+            var pixelColor = format.IsRGBAOrder() ? Color.FromRgba(pixelColorInt) : Color.FromBgra(pixelColorInt);
 
             return pixelColor;
         }
@@ -868,12 +868,12 @@ namespace Stride.TextureConverter
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
             var format = texture.Format;
-            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRgbaOrder() || format.IsBgraOrder() || format.SizeInBytes() != 4))
+            if (texture.Dimension != TexImage.TextureDimension.Texture2D || !(format.IsRGBAOrder() || format.IsBGRAOrder() || format.SizeInBytes() != 4))
                 throw new NotImplementedException();
 
             // adjust the separator color the mask depending on the color format.
             var separator = (uint)(separatorColor ?? Color.Transparent).ToRgba();
-            if (texture.Format.IsBgraOrder())
+            if (texture.Format.IsBGRAOrder())
             {
                 separator = RgbaToBgra(separator);
                 separatorMask = RgbaToBgra(separatorMask);
@@ -1442,7 +1442,7 @@ namespace Stride.TextureConverter
                 ITexLibrary library;
                 if ((library = FindLibrary(image, request)) != null)
                 {
-                    if (image.Format.IsBgraOrder() && !library.SupportBGRAOrder())
+                    if (image.Format.IsBGRAOrder() && !library.SupportBGRAOrder())
                     {
                         SwitchChannel(image);
                     }
@@ -1487,7 +1487,7 @@ namespace Stride.TextureConverter
                     }
 
                     // Both libraries for intermediate processing were found, preceeding with the request
-                    if (image.Format.IsBgraOrder() && !library.SupportBGRAOrder())
+                    if (image.Format.IsBGRAOrder() && !library.SupportBGRAOrder())
                     {
                         SwitchChannel(image);
                     }


### PR DESCRIPTION
# PR Details
Users shouldn't have to fix syntactic issues when upgrading versions, rolling back related changes.
Feel free to setup an upgrader if you want to keep your changes in @Ethereal77 and I'll close this PR. 
Also, are there any other breaking changes in the public API @Ethereal77 ?

## Related Issue

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
