### PR TITLE
Revert "Rendering: Added missing override in ShadowMap shaders"

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapFilterDefault.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapFilterDefault.sdsl
@@ -10,12 +10,12 @@ namespace Stride.Rendering.Shadows
         /// <summary>
         /// Calculate the shadow factor based on the shadow map texture, the position, a sampler
         /// </summary>
-        override float FilterShadow(float2 position, float positionDepth)
+        float FilterShadow(float2 position, float positionDepth)
         {
             return ShadowMapTexture.SampleCmpLevelZero(LinearClampCompareLessEqualSampler, position, positionDepth);
         }
         
-        override float FilterThickness(float3 pixelPositionWS,
+        float FilterThickness(float3 pixelPositionWS,
                               float3 meshNormalWS,
                               float2 depthRanges,
                               float4x4 worldToShadowCascadeUV,    // Transforms from world space to shadow cascade UV.

--- a/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapFilterPcf.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapFilterPcf.sdsl
@@ -98,7 +98,7 @@ namespace Stride.Rendering.Shadows
             return ShadowMapTexture.SampleCmpLevelZero(LinearClampCompareLessEqualSampler, position, positionDepth);
         }
 
-        override float FilterShadow(float2 position, float positionDepth)
+        float FilterShadow(float2 position, float positionDepth)
         {
             float shadow = 0.0f;
 
@@ -234,7 +234,7 @@ namespace Stride.Rendering.Shadows
             return(thickness / normalizationFactor);
         }
 
-        override float FilterThickness(float3 pixelPositionWS,
+        float FilterThickness(float3 pixelPositionWS,
                               float3 meshNormalWS,
                               float2 depthRanges,
                               float4x4 worldToShadowCascadeUV,    // Transforms from world space to shadow cascade UV.

--- a/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapFilterVsm.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Shadows/ShadowMapFilterVsm.sdsl
@@ -13,7 +13,7 @@ namespace Stride.Rendering.Shadows
             float MinVariance;
         };
 
-        override float FilterShadow(float2 position, float shadowMapDistance)
+        float FilterShadow(float2 position, float shadowMapDistance)
         {
             float2 moments = (float2)ShadowMapTexture.SampleLevel(LinearBorderSampler, position, 0.0);
             float variance = moments.y - moments.x * moments.x;


### PR DESCRIPTION
This reverts commit 26db1ae49be212a492558484f740cb57cf117c12.

# PR Details
Crashes the compilation of shadowmap sampling with `Error:  E0213: There is no need for the override keyword when overriding the method declaration ...`

## Related Issue


## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
