### PR TITLE
docs: Tweak PR template to notify users they should mark them as draft when it makes sense

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,3 +28,6 @@
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 - [ ] **I have built and run the editor to try this change out.**
+
+<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
+<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->


### PR DESCRIPTION
# PR Details
Easier for us to know whether a PR is actually ready. Discussion we had with Ethereal.

## Related Issue


## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
