### PR TITLE
feat: Prefer loading projects with *.sdpkg above other executables

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -496,10 +496,20 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
         private void AutoSelectCurrentProject()
         {
-            var currentProject = LocalPackages.OfType<ProjectViewModel>().FirstOrDefault(x => x.Type == ProjectType.Executable && x.Platform == PlatformType.Windows) ?? LocalPackages.FirstOrDefault();
-            if (currentProject != null)
+            var executableProjects = LocalPackages
+                .OfType<ProjectViewModel>()
+                .Where(x => x.Type == ProjectType.Executable && x.Platform == PlatformType.Windows);
+            
+            PackageViewModel selectedProject = executableProjects
+                // Prefer solutions with an existing *.sdpkg
+                .FirstOrDefault(x => x.PackageContainer is SolutionProject { IsImplicitProject: false });
+
+            selectedProject ??= executableProjects.FirstOrDefault();
+            selectedProject ??= LocalPackages.FirstOrDefault();
+
+            if (selectedProject != null)
             {
-                SetCurrentProject(currentProject);
+                SetCurrentProject(selectedProject);
             }
         }
 


### PR DESCRIPTION
# PR Details
Users may have other unrelated executable in their solution, this PR ensures that the gamestudio will prefer projects with an existing sdpkg over others when selecting the current project.

## Related Issue
None logged

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
