### PR TITLE
fix: Crash when adding bepu's DebugRenderComponent in editor

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Debug/DebugRenderProcessor.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Debug/DebugRenderProcessor.cs
@@ -36,7 +36,7 @@ public class DebugRenderProcessor : EntityProcessor<DebugRenderComponent>
         get => _visible;
         set
         {
-            if (_sceneSystem.SceneInstance.GetProcessor<CollidableProcessor>() is { } proc)
+            if (_sceneSystem.SceneInstance.GetProcessor<CollidableProcessor>() is { } proc && _visibilityGroup is not null)
             {
                 if (_visible == value)
                     return;
@@ -66,7 +66,7 @@ public class DebugRenderProcessor : EntityProcessor<DebugRenderComponent>
     protected override void OnEntityComponentAdding(Entity entity, DebugRenderComponent component, DebugRenderComponent data)
     {
         base.OnEntityComponentAdding(entity, component, data);
-        if (_sceneSystem.SceneInstance.GetProcessor<CollidableProcessor>() is not null)
+        if (_sceneSystem?.SceneInstance?.GetProcessor<CollidableProcessor>() is not null && _visibilityGroup is not null)
             Visible = component.Visible;
         else if (component.Visible)
             _latent = true;
@@ -76,19 +76,9 @@ public class DebugRenderProcessor : EntityProcessor<DebugRenderComponent>
 
     protected override void OnSystemAdd()
     {
-        SinglePassWireframeRenderFeature wireframeRenderFeature;
-
         _shapeCacheSystem = Services.GetOrCreate<ShapeCacheSystem>();
         _game = Services.GetSafeServiceAs<IGame>();
         _sceneSystem = Services.GetSafeServiceAs<SceneSystem>();
-
-        if (_sceneSystem.GraphicsCompositor.RenderFeatures.OfType<SinglePassWireframeRenderFeature>().FirstOrDefault() is null)
-        {
-            wireframeRenderFeature = new();
-            _sceneSystem.GraphicsCompositor.RenderFeatures.Add(wireframeRenderFeature);
-        }
-
-        _visibilityGroup = _sceneSystem.SceneInstance.VisibilityGroups.First();
     }
 
     protected override void OnSystemRemove()
@@ -98,6 +88,18 @@ public class DebugRenderProcessor : EntityProcessor<DebugRenderComponent>
 
     public override void Draw(RenderContext context)
     {
+        if (_visibilityGroup is null)
+        {
+            if (_sceneSystem.SceneInstance.VisibilityGroups.Count == 0)
+                return;
+
+            _visibilityGroup = _sceneSystem.SceneInstance.VisibilityGroups.First();
+            if (_sceneSystem.GraphicsCompositor.RenderFeatures.OfType<SinglePassWireframeRenderFeature>().FirstOrDefault() is null)
+            {
+                _sceneSystem.GraphicsCompositor.RenderFeatures.Add(new SinglePassWireframeRenderFeature());
+            }
+        }
+
         if (_latent)
         {
             Visible = true;


### PR DESCRIPTION
# PR Details

Fixed an issue where adding the DebugRenderComponent directly in editor crashed the game.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
