### PR TITLE
feat: Add Yes/No to all for batch asset import

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -630,7 +630,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     {
                         var message = Tr._p("Message", "Source file '{0}' is not inside of your project's resource folders, do you want to copy it?").ToFormat(file.FullPath);
 
-                        var copyResult = await Dialogs.MessageBoxAsync(message, files.Count > 1 && i != files.Count - 1 ? copyPromptWithToAllButtons : dialogDefaultButtons, MessageBoxImage.Warning);
+                        var copyResult = await Dialogs.MessageBoxAsync(message, i != files.Count - 1 ? copyPromptWithToAllButtons : dialogDefaultButtons, MessageBoxImage.Warning);
 
                         if (copyResult is DialogClosed or DialogNo)
                         {
@@ -667,7 +667,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                             {
                                 var message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(finalPath);
 
-                                var copyResult = await Dialogs.MessageBoxAsync(message, files.Count > 1 && i != files.Count - 1 ? overwritePromptWithToAllButtons : dialogDefaultButtons, MessageBoxImage.Warning);
+                                var copyResult = await Dialogs.MessageBoxAsync(message, i != files.Count - 1 ? overwritePromptWithToAllButtons : dialogDefaultButtons, MessageBoxImage.Warning);
 
                                 overwriteAll = copyResult is DialogYesToAll;
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -547,7 +547,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         private async Task<string> GetAssetCopyDirectory(DirectoryBaseViewModel directory, UFile file)
         {
             var path = directory.Path;
-            var message = Tr._p("Message", "Do you want to place the resource in the default location ?");
+            var message = Tr._p("Message", "Do you want to place the resource in the default location?");
             var finalPath = Path.GetFullPath(Path.Combine(directory.Package.Package.ResourceFolders[0], path, file.GetFileName()));
             var pathResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (pathResult == MessageBoxResult.No)
@@ -589,26 +589,22 @@ namespace Stride.Core.Assets.Editor.ViewModel
             const int DialogNoToAll = 4;
 
             var newAssets = new List<AssetViewModel>();
-            IReadOnlyList<DialogButtonInfo> copyPromptButtons = DialogHelper.CreateButtons(files is not null && files.Count > 1 ?
+            IReadOnlyList<DialogButtonInfo> copyPromptWithToAllButtons = DialogHelper.CreateButtons(
             [
                 Tr._p("Button", "Yes"),
                 Tr._p("Button", "No"),
                 Tr._p("Button", "Yes to all"),
                 Tr._p("Button", "No to all")
-            ]
-            :
-            [
-                Tr._p("Button", "Yes"),
-                Tr._p("Button", "No")
             ], 1, 2);
 
-            IReadOnlyList<DialogButtonInfo> overwritePromptButtons = DialogHelper.CreateButtons(files is not null && files.Count > 1 ?
+            IReadOnlyList<DialogButtonInfo> overwritePromptWithToAllButtons = DialogHelper.CreateButtons(
             [
                 Tr._p("Button", "Yes"),
                 Tr._p("Button", "No"),
                 Tr._p("Button", "Yes to all")
-            ]
-            :
+            ], 1, 2);
+
+            IReadOnlyList<DialogButtonInfo> dialogDefaultButtons = DialogHelper.CreateButtons(
             [
                 Tr._p("Button", "Yes"),
                 Tr._p("Button", "No")
@@ -634,7 +630,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     {
                         var message = Tr._p("Message", "Source file '{0}' is not inside of your project's resource folders, do you want to copy it?").ToFormat(file.FullPath);
 
-                        var copyResult = await Dialogs.MessageBoxAsync(message, copyPromptButtons, MessageBoxImage.Warning);
+                        var copyResult = await Dialogs.MessageBoxAsync(message, files.Count > 1 && i != files.Count - 1 ? copyPromptWithToAllButtons : dialogDefaultButtons, MessageBoxImage.Warning);
 
                         if (copyResult is DialogClosed or DialogNo)
                         {
@@ -671,7 +667,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                             {
                                 var message = Tr._p("Message", "The file '{0}' already exists, it will get overwritten if you continue, do you really want to proceed?").ToFormat(finalPath);
 
-                                var copyResult = await Dialogs.MessageBoxAsync(message, overwritePromptButtons, MessageBoxImage.Warning);
+                                var copyResult = await Dialogs.MessageBoxAsync(message, files.Count > 1 && i != files.Count - 1 ? overwritePromptWithToAllButtons : dialogDefaultButtons, MessageBoxImage.Warning);
 
                                 overwriteAll = copyResult is DialogYesToAll;
 
@@ -691,7 +687,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     }
                     catch (Exception ex)
                     {
-                        var message = Tr._p("Message", $"An error occurred while copying the asset to the resources folder : {ex.Message}");
+                        var message = Tr._p("Message", "An error occurred while copying the asset to the resources folder: {0}").ToFormat(ex.Message);
                         await Dialogs.MessageBoxAsync(message, MessageBoxButton.OK, MessageBoxImage.Error);
                         return newAssets;
                     }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -547,7 +547,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         private async Task<string> GetAssetCopyDirectory(DirectoryBaseViewModel directory, UFile file)
         {
             var path = directory.Path;
-            var message = Tr._p("Message", "Do you want to place the resource in the default location?");
+            var message = Tr._p("Message", "Do you want to place the resource in the default location ?");
             var finalPath = Path.GetFullPath(Path.Combine(directory.Package.Package.ResourceFolders[0], path, file.GetFileName()));
             var pathResult = await Dialogs.MessageBoxAsync(message, MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (pathResult == MessageBoxResult.No)

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -671,9 +671,14 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
                                 overwriteAll = copyResult is DialogYesToAll;
 
-                                if (copyResult is DialogClosed or DialogNo)
+                                if (copyResult is DialogClosed)
                                 {
                                     return newAssets;
+                                }
+
+                                if (copyResult is DialogNo)
+                                {
+                                    continue;
                                 }
                             }
                             File.Copy(file.FullPath, finalPath, true);


### PR DESCRIPTION
# PR Details

This change modifies the asset import to help with the flow of importing more than one item at a time. Importing multiple assets into Stride can be a bit of a pain, especially coming from Unity where drag and drop handles asset source copying for you.

While Stride does support multiple asset imports, it can very quickly add up as you're prompted with a dialogue box to copy the object to resources for every single asset, an additional one for the location (if choosing yes), and lastly, one more potential box if it already exists in that location.

Depending on the number of assets, this can quickly become a hassle to have to click 3+ times per asset just to get them imported.

The intent of this is to allow a user to pick once and handle it for all assets, or individually if still desired.

When picking a different location to copy the resources to, this makes the assumption (if you hit yes to all) that you want everything copied to that location. Otherwise, hitting Yes will prompt per asset as it currently does.

## Related Issue

#2916 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

There is currently a failure around BuildResult and an assembly reference in SampleTestFixture, but since this is mentioned in another PR, I don't believe its related to these changes. 
