### PR TITLE
feat: Open event routing for multi-user interfaces

### DIFF
--- a/sources/engine/Stride.UI/KeyEventArgs.cs
+++ b/sources/engine/Stride.UI/KeyEventArgs.cs
@@ -13,11 +13,11 @@ namespace Stride.UI
         /// <summary>
         /// The key that triggered the event.
         /// </summary>
-        public Keys Key { get; internal set; }
+        public Keys Key { get; init; }
 
         /// <summary>
         /// A reference to the input system that can be used to check the status of the other keys.
         /// </summary>
-        public InputManager Input { get; internal set; }
+        public InputManager Input { get; init; }
     }
 }

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.Picking.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.Picking.cs
@@ -170,7 +170,14 @@ namespace Stride.Rendering.UI
                 // TODO: add the pointer type to the event args?
                 var touchEvent = new TouchEventArgs
                 {
-                    Action = TouchAction.Down,
+                    Action = pointerEvent.EventType switch
+                    {
+                        PointerEventType.Pressed => TouchAction.Down,
+                        PointerEventType.Moved => TouchAction.Move,
+                        PointerEventType.Released => TouchAction.Up,
+                        PointerEventType.Canceled => TouchAction.Move,
+                        _ => throw new ArgumentOutOfRangeException()
+                    },
                     Timestamp = time,
                     ScreenPosition = currentTouchPosition,
                     ScreenTranslation = pointerEvent.DeltaPosition,
@@ -181,13 +188,10 @@ namespace Stride.Rendering.UI
                 switch (pointerEvent.EventType)
                 {
                     case PointerEventType.Pressed:
-                        touchEvent.Action = TouchAction.Down;
                         currentTouchedElement?.RaiseTouchDownEvent(touchEvent);
                         break;
 
                     case PointerEventType.Released:
-                        touchEvent.Action = TouchAction.Up;
-
                         // generate enter/leave events if we passed from an element to another without move events
                         if (currentTouchedElement != lastTouchedElement)
                             ThrowEnterAndLeaveTouchEvents(currentTouchedElement, lastTouchedElement, touchEvent);
@@ -197,8 +201,6 @@ namespace Stride.Rendering.UI
                         break;
 
                     case PointerEventType.Moved:
-                        touchEvent.Action = TouchAction.Move;
-
                         // first notify the move event (even if the touched element changed in between it is still coherent in one of its parents)
                         currentTouchedElement?.RaiseTouchMoveEvent(touchEvent);
 
@@ -208,8 +210,6 @@ namespace Stride.Rendering.UI
                         break;
 
                     case PointerEventType.Canceled:
-                        touchEvent.Action = TouchAction.Move;
-
                         // generate enter/leave events if we passed from an element to another without move events
                         if (currentTouchedElement != lastTouchedElement)
                             ThrowEnterAndLeaveTouchEvents(currentTouchedElement, lastTouchedElement, touchEvent);

--- a/sources/engine/Stride.UI/TextEventArgs.cs
+++ b/sources/engine/Stride.UI/TextEventArgs.cs
@@ -9,26 +9,26 @@ namespace Stride.UI
     /// <summary>
     /// The arguments associated with a <see cref="TextInputEvent"/>
     /// </summary>
-    internal class TextEventArgs : RoutedEventArgs
+    public class TextEventArgs : RoutedEventArgs
     {
         /// <summary>
         /// The text that was entered
         /// </summary>
-        public string Text { get; internal set; }
+        public string Text { get; init; }
         
         /// <summary>
         /// The type of text input event
         /// </summary>
-        public TextInputEventType Type { get; internal set; }
+        public TextInputEventType Type { get; init; }
 
         /// <summary>
         /// Start of the current composition being edited
         /// </summary>
-        public int CompositionStart { get; internal set; }
+        public int CompositionStart { get; init; }
 
         /// <summary>
         /// Length of the current part of the composition being edited
         /// </summary>
-        public int CompositionLength { get; internal set; }
+        public int CompositionLength { get; init; }
     }
 }

--- a/sources/engine/Stride.UI/TouchEventArgs.cs
+++ b/sources/engine/Stride.UI/TouchEventArgs.cs
@@ -15,31 +15,31 @@ namespace Stride.UI
         /// <summary>
         /// Gets the time when this event occurred.
         /// </summary>
-        public TimeSpan Timestamp { get; internal set; }
+        public TimeSpan Timestamp { get; init; }
         
         /// <summary>
         /// Gets the action that occurred.
         /// </summary>
-        public TouchAction Action { get; internal set; }
+        public TouchAction Action { get; init; }
 
         /// <summary>
         /// Gets the position of the touch on the screen. Position is normalized between [0,1]. (0,0) is the left top corner, (1,1) is the right bottom corner.
         /// </summary>
-        public Vector2 ScreenPosition { get; internal set; }
+        public Vector2 ScreenPosition { get; init; }
 
         /// <summary>
         /// Gets the translation of the touch on the screen since last triggered event (in normalized units). (1,1) represent a translation of the top left corner to the bottom right corner.
         /// </summary>
-        public Vector2 ScreenTranslation { get; internal set; }
+        public Vector2 ScreenTranslation { get; init; }
 
         /// <summary>
         /// Gets the position of the touch in the UI virtual world space.
         /// </summary>
-        public Vector3 WorldPosition { get; internal set; }
+        public Vector3 WorldPosition { get; init; }
 
         /// <summary>
         /// Gets the translation of the touch in the UI virtual world space.
         /// </summary>
-        public Vector3 WorldTranslation { get; internal set; }
+        public Vector3 WorldTranslation { get; init; }
     }
 }

--- a/sources/engine/Stride.UI/UIElement.Events.cs
+++ b/sources/engine/Stride.UI/UIElement.Events.cs
@@ -14,40 +14,40 @@ namespace Stride.UI
     {
         #region Routed Events
 
-        private static readonly RoutedEvent<TouchEventArgs> PreviewTouchDownEvent =
+        public static readonly RoutedEvent<TouchEventArgs> PreviewTouchDownEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("PreviewTouchDown", RoutingStrategy.Tunnel, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> PreviewTouchMoveEvent =
+        public static readonly RoutedEvent<TouchEventArgs> PreviewTouchMoveEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("PreviewTouchMove", RoutingStrategy.Tunnel, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> PreviewTouchUpEvent =
+        public static readonly RoutedEvent<TouchEventArgs> PreviewTouchUpEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("PreviewTouchUp", RoutingStrategy.Tunnel, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> TouchDownEvent =
+        public static readonly RoutedEvent<TouchEventArgs> TouchDownEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("TouchDown", RoutingStrategy.Bubble, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> TouchEnterEvent =
+        public static readonly RoutedEvent<TouchEventArgs> TouchEnterEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("TouchEnter", RoutingStrategy.Direct, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> TouchLeaveEvent =
+        public static readonly RoutedEvent<TouchEventArgs> TouchLeaveEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("TouchLeave", RoutingStrategy.Direct, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> TouchMoveEvent =
+        public static readonly RoutedEvent<TouchEventArgs> TouchMoveEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("TouchMove", RoutingStrategy.Bubble, typeof(UIElement));
 
-        private static readonly RoutedEvent<TouchEventArgs> TouchUpEvent =
+        public static readonly RoutedEvent<TouchEventArgs> TouchUpEvent =
             EventManager.RegisterRoutedEvent<TouchEventArgs>("TouchUp", RoutingStrategy.Bubble, typeof(UIElement));
 
-        private static readonly RoutedEvent<KeyEventArgs> KeyPressedEvent =
+        public static readonly RoutedEvent<KeyEventArgs> KeyPressedEvent =
             EventManager.RegisterRoutedEvent<KeyEventArgs>("KeyPressed", RoutingStrategy.Bubble, typeof(UIElement));
 
-        private static readonly RoutedEvent<KeyEventArgs> KeyDownEvent =
+        public static readonly RoutedEvent<KeyEventArgs> KeyDownEvent =
             EventManager.RegisterRoutedEvent<KeyEventArgs>("KeyDown", RoutingStrategy.Bubble, typeof(UIElement));
 
-        private static readonly RoutedEvent<KeyEventArgs> KeyReleasedEvent =
+        public static readonly RoutedEvent<KeyEventArgs> KeyReleasedEvent =
             EventManager.RegisterRoutedEvent<KeyEventArgs>("KeyReleased", RoutingStrategy.Bubble, typeof(UIElement));
 
-        private static readonly RoutedEvent<TextEventArgs> TextInputEvent =
+        public static readonly RoutedEvent<TextEventArgs> TextInputEvent =
             EventManager.RegisterRoutedEvent<TextEventArgs>("TextInput", RoutingStrategy.Bubble, typeof(UIElement));
 
         #endregion


### PR DESCRIPTION
# PR Details
`UIElement.RaiseEvent` is public, but events themselves cannot be created by users as the properties for those have internal setters.
This is essential for simulating multiple input methods on different UIs within the same game instance, for splitscreen multiplayer for example.

## Related Issue
I think we mentioned this once but I don't remember where.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->