### PR TITLE
fix: Update Transformation Tooltip gizmo to have transparent background property so hit registration matches highlighting

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Views/EntityHierarchyEditorView.xaml
@@ -30,9 +30,6 @@
         <Setter Property="Width" Value="28"/>
         <Setter Property="Height" Value="28"/>
         <Setter Property="Padding" Value="0"/>
-        <Setter Property="ToolTip" Value="{Binding Converter={sd:EnumToTooltip}}"/>
-        <Setter Property="sd:ToolTipHelper.Status" Value="{Binding Editor.Status, Source={x:Static sd:SessionViewModel.Instance}}"/>
-        <Setter Property="ToolTipService.ShowOnDisabled" Value="True"/>
       </Style>
 
       <Style x:Key="EnumListBox" BasedOn="{StaticResource {x:Type ListBox}}" TargetType="ListBox">
@@ -47,7 +44,8 @@
         <Setter Property="ItemTemplate">
           <Setter.Value>
             <DataTemplate>
-              <Border Width="28" Height="28">
+              <Border Width="28" Height="28"
+                      Background="Transparent" ToolTip="{Binding Converter={sd:EnumToTooltip}}" sd:ToolTipHelper.Status="{Binding Editor.Status, Source={x:Static sd:SessionViewModel.Instance}}" ToolTipService.ShowOnDisabled="True">
                 <Image Width="16" Height="16" Source="{Binding Converter={sd:EnumToResource}}" />
               </Border>
             </DataTemplate>


### PR DESCRIPTION
# PR Details

The hover highlight and tooltip for the transform gizmos are not consistent as the tooltip will only occur when directly over the actual icon itself, while the highlight occurs when on the button.

Example:
![InitialTooltipIssue](https://github.com/user-attachments/assets/5fa39738-1b9e-4ef0-9359-92a9b59e7b42)

The tooltip was attached to the Border element inside the DataTemplate, causing a mismatch where hovering over the ListBoxItem's padding area triggered the highlight but didn't show the tooltip. This change moves the tooltip from the Border element into the ListBoxItem container style so that it applies to the entire item.

With change:

![InitialTooltipFixedf](https://github.com/user-attachments/assets/5daf7ad4-3d85-4b3a-bee0-cfa8c86a6c04)

## Related Issue

#3054 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->