### PR TITLE
fix: Stride.Samples.Tests missing package reference

### DIFF
--- a/samples/Tests/Stride.Samples.Tests.csproj
+++ b/samples/Tests/Stride.Samples.Tests.csproj
@@ -13,6 +13,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# PR Details
Can't build `Stride.Samples.Tests`, https://github.com/stride3d/stride/blob/master/samples/Tests/SampleTestFixture.cs#L35 reports missing reference to Microsoft.Build when building the solution

## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**