### PR TITLE
fix: null checking in IndexBufferBinding equals operator

### DIFF
--- a/sources/engine/Stride.Graphics/IndexBufferBinding.cs
+++ b/sources/engine/Stride.Graphics/IndexBufferBinding.cs
@@ -87,7 +87,7 @@ namespace Stride.Graphics
 
         public static bool operator ==(IndexBufferBinding left, IndexBufferBinding right)
         {
-            if (left is null && right is null)
+            if (ReferenceEquals(left, right))
                 return true;
 
             return left?.Equals(right) ?? false;


### PR DESCRIPTION
# PR Details

The `==` would throw on null arrguments causing a crash in MeshRenderFeature if no index buffer was set in the draw data.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**