### PR TITLE
perf: use ArrayPool for temporary buffers where useful

### DIFF
--- a/sources/tools/Stride.FreeImage/Classes/FreeImageStreamIO.cs
+++ b/sources/tools/Stride.FreeImage/Classes/FreeImageStreamIO.cs
@@ -35,6 +35,7 @@
 
 using System;
 using System.IO;
+using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 
@@ -86,7 +87,7 @@ namespace FreeImageAPI.IO
 			}
 			uint readCount = 0;
 			byte* ptr = (byte*)buffer;
-			byte[] bufferTemp = new byte[size];
+			byte[] bufferTemp = ArrayPool<byte>.Shared.Rent((int)size);
 			int read;
 			while (readCount < count)
 			{
@@ -102,6 +103,7 @@ namespace FreeImageAPI.IO
 				}
 				readCount++;
 			}
+			ArrayPool<byte>.Shared.Return(bufferTemp);
 			return readCount;
 		}
 
@@ -116,7 +118,7 @@ namespace FreeImageAPI.IO
 				return 0;
 			}
 			uint writeCount = 0;
-			byte[] bufferTemp = new byte[size];
+			byte[] bufferTemp = ArrayPool<byte>.Shared.Rent((int)size);
 			byte* ptr = (byte*)buffer;
 			while (writeCount < count)
 			{
@@ -134,6 +136,7 @@ namespace FreeImageAPI.IO
 				}
 				writeCount++;
 			}
+			ArrayPool<byte>.Shared.Return(bufferTemp);
 			return writeCount;
 		}
 


### PR DESCRIPTION
# PR Details

> Low priority

I noticed some unnecessary allocations in classes that deal with asset management. Usually these buffers are around the same size, so I opted for an array pool. 

These arrays are not read past their needed length, are not used after returning, and aren't large enough to allocate any arrays that aren't already allocated in the shared allocator, so array pools shouldn't cause any issues here.

note: also used ReadExactly instead of Read for a stream read as per CA2022.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (I ran all tests, but some unrelated tests were failing)
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->