### PR TITLE
fix: TransformComponent.SetWorld rotation multiplication order

### DIFF
--- a/sources/engine/Stride.Engine.Tests/TestTransformComponent.cs
+++ b/sources/engine/Stride.Engine.Tests/TestTransformComponent.cs
@@ -78,5 +78,26 @@ namespace Stride.Engine.Tests
             Assert.Equal(Vector3.Zero, pos);
             Assert.Equal(Quaternion.Identity, rot);
         }
+
+        [Fact]
+        public void TestSetWorldTransformationNested()
+        {
+            var scene = new Scene();
+            var parent = new Entity { Scene = scene }.Transform;
+            var child = new Entity { Transform = { Parent = parent } }.Transform;
+            var targetPosition = new Vector3(2, 2, 2);
+            var targetRotation = Quaternion.RotationY(MathF.PI * 0.1f);
+
+            parent.Position = new Vector3(1, 1, 1);
+            parent.Rotation = Quaternion.RotationX(MathF.PI * 0.05f);
+
+            child.UpdateWorldMatrix();
+            child.SetWorld(targetPosition, targetRotation);
+            child.UpdateWorldMatrix();
+
+            child.GetWorldTransformation(out var position, out var rotation, out _);
+            Assert.Equal(targetPosition, position);
+            Assert.Equal(targetRotation, rotation);
+        }
     }
 }

--- a/sources/engine/Stride.Engine/Engine/EntityTransformExtensions.cs
+++ b/sources/engine/Stride.Engine/Engine/EntityTransformExtensions.cs
@@ -278,7 +278,7 @@ namespace Stride.Engine
             Vector3.Transform(ref position, ref worldMatrixInv, out position);
             
             worldMatrix.Decompose(out _, out Quaternion parentRot, out _);
-            rotation = Quaternion.Invert(parentRot) * rotation;
+            rotation = rotation * Quaternion.Invert(parentRot);
             
             transformComponent.Position = position;
             transformComponent.Rotation = rotation;
@@ -335,7 +335,7 @@ namespace Stride.Engine
             }
 
             transformComponent.Parent.WorldMatrix.Decompose(out _, out Quaternion parentRot, out _);
-            transformComponent.Rotation = Quaternion.Invert(parentRot) * rotation;
+            transformComponent.Rotation = rotation * Quaternion.Invert(parentRot);
         }
     }
 }


### PR DESCRIPTION
# PR Details

`TransformComponent.SetWorld` has a wrong multiplication order of the quaternions. It first applied the new world rotation, then undid the parent world rotation. In some cases this works, e.g. rotating along the same axis, but not in general.

Added a test which reproduced the issue and then passes with the issue fixed.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Could be breaking if someone relied on the wrong behavior.

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
