### PR TITLE
fix: Platformer2D sample, enable alpha cutoff.

### DIFF
--- a/samples/Templates/Platformer2D/Platformer2D/Assets/MainScene.sdscene
+++ b/samples/Templates/Platformer2D/Platformer2D/Assets/MainScene.sdscene
@@ -553,6 +553,7 @@ Hierarchy:
                         SpriteProvider: !SpriteFromSheet
                             Sheet: c805102c-bb90-4d52-9429-dc7e873a001c:Sprites/knight_sheet
                         Color: {R: 1.0, G: 1.0, B: 1.0, A: 1.0}
+                        IsAlphaCutoff: true
                         Sampler: PointClamp
                     1aae5b7c99a80425dad5a895b79aca36: !CharacterComponent
                         Id: 6c53052b-df5e-4b94-9a69-5d71f11000e2
@@ -575,7 +576,6 @@ Hierarchy:
                                 LocalRotation: {X: 0.0, Y: 0.0, Z: 0.0, W: 1.0}
                     c6a4e0b10f6435cda498bfaa02311444: !Platformer2D.Player.PlayerController,Platformer2D
                         Id: 61d3db51-dd47-4c05-971d-15dc8b6cb6dc
-                        spriteSheet: null
                         CharacterComponent: ref!! 6c53052b-df5e-4b94-9a69-5d71f11000e2
                         Sprite: ref!! 9eb91181-85f7-4026-9827-4f687df669d9
         -   Entity:


### PR DESCRIPTION
# PR Details

Fixes https://github.com/stride3d/stride/issues/3097.

Before:
<img src="https://private-user-images.githubusercontent.com/187624379/567442622-895a3c38-82e3-445d-bbf9-2c01033b017f.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzQyMDc5MzgsIm5iZiI6MTc3NDIwNzYzOCwicGF0aCI6Ii8xODc2MjQzNzkvNTY3NDQyNjIyLTg5NWEzYzM4LTgyZTMtNDQ1ZC1iYmY5LTJjMDEwMzNiMDE3Zi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMzIyJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDMyMlQxOTI3MThaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02Yzc4MjViOTIwY2RlZDg5ZjY5MjNlYjgyYzA4ODViZGQ2ODFhM2NiYzc0ZWQ1MTg5MjExNzI4ODMxMTliNzk0JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.s76lTLX0WAV_qv3uttCRnVa68sLo_SqEf3_BJymMsEU"/>

After:
<img width="170" height="96" alt="image" src="https://github.com/user-attachments/assets/6a6fe1f2-2d9f-469f-8714-fe5a3b16305a" />


## Related Issue
https://github.com/stride3d/stride/issues/3097

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
N/A.

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**