### PR TITLE
feat: Support external GPL color palettes in color picker

### DIFF
--- a/samples/Tests/Tests.sln
+++ b/samples/Tests/Tests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2026
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11612.150
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stride.Samples.Tests", "Stride.Samples.Tests.csproj", "{AA6F38A3-8A04-42AE-A19C-9B0123EC1589}"
 EndProject

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/ColorPaletteViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/ColorPaletteViewModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Collections.Generic;
+using System.IO;
 
 using Stride.Core.Mathematics;
 
@@ -8,17 +9,44 @@ namespace Stride.Core.Assets.Editor.ViewModel
 {
     public static class ColorPaletteViewModel
     {
-        public static Dictionary<string, Color3> Colors = new Dictionary<string, Color3>
+        public const string PaletteFileName = "ColorPalette.gpl";
+
+        public static readonly Dictionary<string, Color3> DefaultColors = new Dictionary<string, Color3>
         {
-            { "Silver", new Color3(0.98695203f, 0.981576133f, 0.960581067f) },
+            { "Silver",    new Color3(0.98695203f, 0.981576133f, 0.960581067f) },
             { "Aluminium", new Color3(0.959559115f, 0.963518888f, 0.964957682f) },
-            { "Gold", new Color3(1.0f, 0.88565079f, 0.609162496f) },
-            { "Copper", new Color3(0.979292159f, 0.814900815f, 0.754550145f) },
-            { "Chromium", new Color3(0.761787833f, 0.765888197f, 0.764724015f) },
-            { "Nickel", new Color3(0.827766422f, 0.797984931f, 0.74652364f) },
-            { "Titanium", new Color3(0.756946965f, 0.727607463f, 0.695207239f) },
-            { "Cobalt", new Color3(0.829103572f, 0.824958926f, 0.812750243f) },
-            { "Platimium", new Color3(0.834934076f, 0.814845027f, 0.783999116f) },
+            { "Gold",      new Color3(1.0f,         0.88565079f,  0.609162496f) },
+            { "Copper",    new Color3(0.979292159f, 0.814900815f, 0.754550145f) },
+            { "Chromium",  new Color3(0.761787833f, 0.765888197f, 0.764724015f) },
+            { "Nickel",    new Color3(0.827766422f, 0.797984931f, 0.74652364f)  },
+            { "Titanium",  new Color3(0.756946965f, 0.727607463f, 0.695207239f) },
+            { "Cobalt",    new Color3(0.829103572f, 0.824958926f, 0.812750243f) },
+            { "Platinum",  new Color3(0.834934076f, 0.814845027f, 0.783999116f) }, // Fixed typo: was "Platimium"
         };
+
+        private static Dictionary<string, Color3>? _colors;
+        public static Dictionary<string, Color3> Colors
+        {
+            get
+            {
+                if (_colors is null)
+                    _colors = LoadColors();
+
+                return _colors;
+            }
+        }
+
+        public static void Reload() => _colors = null;
+
+        private static Dictionary<string, Color3> LoadColors()
+        {
+            var palettePath = Path.Combine(
+                Path.GetDirectoryName(typeof(ColorPaletteViewModel).Assembly.Location) ?? string.Empty,
+                PaletteFileName);
+
+            var parsed = GplPaletteParser.TryParse(palettePath);
+
+            return parsed ?? DefaultColors;
+        }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/GplPaletteParser.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/GplPaletteParser.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Stride.Core.Mathematics;
+
+namespace Stride.Core.Assets.Editor.ViewModel
+{
+    public static class GplPaletteParser
+    {
+        public static Dictionary<string, Color3>? TryParse(string filePath)
+        {
+            if (!File.Exists(filePath))
+                return null;
+
+            var colors = new Dictionary<string, Color3>();
+
+            try
+            {
+                var lines = File.ReadAllLines(filePath);
+
+                if (lines.Length == 0 || !lines[0].Trim().Equals("GIMP Palette", StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                int index = 1;
+                int unnamedIndex = 1;
+
+                for (; index < lines.Length; index++)
+                {
+                    var line = lines[index].Trim();
+
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#") || line.StartsWith("Name:") || line.StartsWith("Columns:"))
+                        continue;
+
+                    var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    if (parts.Length < 3)
+                        continue;
+
+                    if (!byte.TryParse(parts[0], out byte r) ||
+                        !byte.TryParse(parts[1], out byte g) ||
+                        !byte.TryParse(parts[2], out byte b))
+                        continue;
+
+                    var name = parts.Length >= 4
+                        ? string.Join(" ", parts, 3, parts.Length - 3).Trim()
+                        : $"Color {unnamedIndex++}";
+
+                    var key = name;
+                    int suffix = 2;
+                    while (colors.ContainsKey(key))
+                        key = $"{name} {suffix++}";
+
+                    colors[key] = new Color3(r / 255f, g / 255f, b / 255f);
+                }
+
+                return colors.Count > 0 ? colors : null;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
C## What this does
Users can now drop a `ColorPalette.gpl` file next to the Stride editor 
executable to customize the color picker palette without recompiling.

## How to use
1. Download any `.gpl` palette from [Lospec](https://lospec.com/palette-list)
2. Rename it to `ColorPalette.gpl`
3. Place it next to the GameStudio executable
4. Restart the editor — your palette will load automatically

If no file is found, the original default palette is used as fallback.

## Changes
- Added `GplPaletteParser.cs` — parses standard GIMP `.gpl` files
- Updated `ColorPaletteViewModel.cs` — lazy-loads from file, falls back to defaults
- Fixed typo: `"Platimium"` → `"Platinum"`

#3064