### PR TITLE
feat(ui): add RenderOrder property for UI component stacking

### DIFF
--- a/sources/engine/Stride.UI/Engine/UIComponent.cs
+++ b/sources/engine/Stride.UI/Engine/UIComponent.cs
@@ -130,6 +130,15 @@ namespace Stride.Engine
         public RenderGroup RenderGroup { get; set; }
 
         /// <summary>
+        /// Gets or sets the render order of this UI component. Components with a lower value
+        /// are rendered first (behind), higher values are rendered on top.
+        /// </summary>
+        [DataMember(90)]
+        [Display("Render Order")]
+        [DefaultValue(0)]
+        public int RenderOrder { get; set; }
+
+        /// <summary>
         /// A fixed size UI component with height of 1 will be this much of the vertical resolution on screen
         /// </summary>
         [DataMemberIgnore]

--- a/sources/engine/Stride.UI/Rendering/UI/RenderUIElement.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/RenderUIElement.cs
@@ -37,6 +37,7 @@ namespace Stride.Rendering.UI
         public bool IsBillboard;
         public bool SnapText;
         public bool IsFixedSize;
+        public int RenderOrder;
 
         /// <summary>
         /// Last registered position of teh mouse

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
@@ -100,6 +100,9 @@ namespace Stride.Rendering.UI
                 uiElementStates.Add(new UIElementState(renderElement));
             }
 
+            // sort by RenderOrder so components with lower value are drawn first (behind)
+            uiElementStates.Sort(static (a, b) => a.RenderObject.RenderOrder.CompareTo(b.RenderObject.RenderOrder));
+
             // evaluate the current draw time (game instance is null for thumbnails)
             var drawTime = game != null ? game.DrawTime : new GameTime();
 

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderProcessor.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderProcessor.cs
@@ -52,6 +52,7 @@ namespace Stride.Rendering.UI
                 renderUIElement.IsBillboard = uiComponent.IsBillboard;
                 renderUIElement.SnapText = uiComponent.SnapText;
                 renderUIElement.IsFixedSize = uiComponent.IsFixedSize;
+                renderUIElement.RenderOrder = uiComponent.RenderOrder;
 
                 if (renderUIElement.RenderGroup != uiComponent.RenderGroup)
                 {


### PR DESCRIPTION
# PR Details

Add `RenderOrder` property to `UIComponent` to control draw order of overlapping UI components. Lower values are rendered first (behind), higher values render on top. Default is `0`, preserving existing behavior.

## Related Issue

None.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation. PR: https://github.com/stride3d/stride-docs/pull/490
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**