### PR TITLE
fix: Add Assimp "LimitBoneWeights" aiPostProcessSteps

### DIFF
--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -165,12 +165,13 @@ namespace Stride.Importer.ThreeD
             var scene = assimp.ImportFileExWithProperties(inputFilename, importFlags, null, propStore);
 
             postProcessFlags |= aiPostProcessSteps.aiProcess_CalcTangentSpace
-                               | aiPostProcessSteps.aiProcess_Triangulate
-                               | aiPostProcessSteps.aiProcess_GenNormals
-                               | aiPostProcessSteps.aiProcess_SortByPType
-                               | aiPostProcessSteps.aiProcess_FlipWindingOrder
-                               | aiPostProcessSteps.aiProcess_FlipUVs
-                               | aiPostProcessSteps.aiProcess_GlobalScale;
+                                | aiPostProcessSteps.aiProcess_Triangulate
+                                | aiPostProcessSteps.aiProcess_GenNormals
+                                | aiPostProcessSteps.aiProcess_SortByPType
+                                | aiPostProcessSteps.aiProcess_FlipWindingOrder
+                                | aiPostProcessSteps.aiProcess_FlipUVs
+                                | aiPostProcessSteps.aiProcess_GlobalScale
+                                | aiPostProcessSteps.aiProcess_LimitBoneWeights;
 
             scene = assimp.ApplyPostProcessing(scene, (uint)postProcessFlags);
             assimp.ReleasePropertyStore(propStore);


### PR DESCRIPTION
# fix: Add aiProcess_LimitBoneWeights to Assimp post-processing flags
 
When importing animated models, we got a lot of warn about bones excess weights bones per vertex at compile time, it was slowing down the build process and log reading.
 
This fix adds `aiProcess_LimitBoneWeights` to the Assimp post-processing step. This flag caps bone influences per vertex to 4 during import, which is the standard hardware limit and what Stride's runtime expects. The compiler no longer needs to deal with excess influences, eliminating the warnings and reducing build time on large projects.
 
## Related Issue
<!-- N/A or link if one exists -->
 
## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
 