### PR TITLE
chore: Update BepuPhysics to 2.5.0-beta.28

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <!-- Runtime dependencies -->
   <ItemGroup>
-    <PackageVersion Include="BepuPhysics" Version="2.5.0-beta.27" />
+    <PackageVersion Include="BepuPhysics" Version="2.5.0-beta.28" />
     <PackageVersion Include="DotRecast.Core" Version="2025.2.1" />
     <PackageVersion Include="DotRecast.Detour" Version="2025.2.1" />
     <PackageVersion Include="DotRecast.Recast" Version="2025.2.1" />


### PR DESCRIPTION
## Summary

  Update Bepu from `2.5.0-beta.27` to `2.5.0-beta.28`

  ### Bug fixes in beta.28
  - Sweep function incorrectly categorized shapes as triangles
  - Multiple `Triangle.Id` related bugs corrected
  - Fixed coordinate axis confusion (z vs w)
  - `VolumeConstraint` and `AreaConstraint` stability problems resolved

  ### Types of changes

  - [ ] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Docs change / refactoring / dependency upgrade
  - [ ] Other (describe below)

  ### Checklist

  - [x] I have built and run the editor to try this change out