### PR TITLE
fix: Swapped Front/Back Z-axis labels on view camera gizmo

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraOrientationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraOrientationGizmo.cs
@@ -41,8 +41,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             new FaceData("Left", "-X", new Vector3(0, -MathUtil.PiOverTwo, 0)),
             new FaceData("Top", "Y", new Vector3(-MathUtil.PiOverTwo, 0, 0)),
             new FaceData("Bottom", "-Y", new Vector3(MathUtil.PiOverTwo, 0, 0)),
-            new FaceData("Back", "-Z", Vector3.Zero),
-            new FaceData("Front", "Z", new Vector3(0, MathUtil.Pi, 0))
+            new FaceData("Back", "Z", Vector3.Zero),
+            new FaceData("Front", "-Z", new Vector3(0, MathUtil.Pi, 0))
         };
 
         /// <summary>

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraOrientationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/CameraOrientationGizmo.cs
@@ -41,8 +41,8 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             new FaceData("Left", "-X", new Vector3(0, -MathUtil.PiOverTwo, 0)),
             new FaceData("Top", "Y", new Vector3(-MathUtil.PiOverTwo, 0, 0)),
             new FaceData("Bottom", "-Y", new Vector3(MathUtil.PiOverTwo, 0, 0)),
-            new FaceData("Back", "Z", Vector3.Zero),
-            new FaceData("Front", "-Z", new Vector3(0, MathUtil.Pi, 0))
+            new FaceData("Front", "Z", Vector3.Zero),
+            new FaceData("Back", "-Z", new Vector3(0, MathUtil.Pi, 0))
         };
 
         /// <summary>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
The CameraOrientationGizmo displays incorrect axis labels for the Front and Back faces. The "Back" face (no rotation, at +Z) was labeled "-Z" and the "Front" face (180° Y rotation, at -Z) was labeled "Z". This swaps the two XYZComponent strings so they match their actual positions.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Fixes #3117](https://github.com/stride3d/stride/issues/3117)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->