### PR TITLE
Fix compiling small textures

### DIFF
--- a/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
+++ b/sources/tools/Stride.TextureConverter/Backend/Wrappers/DxtNetWrapper.cs
@@ -931,7 +931,11 @@ namespace Stride.TextureConverter.DxtWrapper
                 int headerSize = sizeof(DDSHeaderDX9);  // 128byte
                 byte[] buffer = new byte[headerSize];
                 DDSHeaderDX9 header;
-                fileStream.ReadExactly(buffer, 0, headerSize);
+                int readCount = fileStream.Read(buffer, 0, headerSize);
+                if (readCount != headerSize)
+                {
+                    return -1;
+                }
                 fixed (byte* ptr = buffer)
                 {
                     DDSHeaderDX9* headerPtr = &header;


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Prevent GetAlphaDepth from throwing EndOfStreamException when reading image files that are less than the DDSHeader size (eg. 1x1 pixel image file) by exiting gracefully, since files are not guaranteed to be at least 128 bytes.
This exception causes AssetCompiler from failing to build if small images are in your game project.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Caused by #3076

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->