### PR TITLE
fix: clear stale pixels around font atlas glyphs to prevent bleeding

### DIFF
--- a/sources/engine/Stride.Graphics/Font/FontCacheManager.cs
+++ b/sources/engine/Stride.Graphics/Font/FontCacheManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 using Stride.Core;
@@ -82,12 +83,48 @@ namespace Stride.Graphics.Font
                         throw new InvalidOperationException("The rendered character is too big for the cache texture");
                 }
             }
-            // updload the bitmap on the texture (if the size in the bitmap is not null)
+            // Upload the bitmap to the atlas texture, with a 1px transparent border extending
+            // beyond the allocated region to clear any stale pixels from previously freed glyphs.
+            // This overlaps into neighbors' transparent borders (which are also zeroed), so no
+            // glyph data is corrupted. Prevents bilinear filtering artifacts when scaling fonts.
             if (character.Bitmap.Rows != 0 && character.Bitmap.Width != 0)
             {
-                var dataBox = new DataBox(character.Bitmap.Buffer, character.Bitmap.Pitch, character.Bitmap.Pitch * character.Bitmap.Rows);
-                var region = new ResourceRegion(character.Glyph.Subrect.Left, character.Glyph.Subrect.Top, 0, character.Glyph.Subrect.Right, character.Glyph.Subrect.Bottom, 1);
-                commandList.UpdateSubResource(cacheTextures[0], 0, dataBox, region);
+                var texW = cacheTextures[0].ViewWidth;
+                var texH = cacheTextures[0].ViewHeight;
+
+                // Expand the upload region by 1px on each side, clamped to texture bounds
+                int left = Math.Max(0, character.Glyph.Subrect.Left - 1);
+                int top = Math.Max(0, character.Glyph.Subrect.Top - 1);
+                int right = Math.Min(texW, character.Glyph.Subrect.Right + 1);
+                int bottom = Math.Min(texH, character.Glyph.Subrect.Bottom + 1);
+                int expandedW = right - left;
+                int expandedH = bottom - top;
+
+                // Build expanded buffer: zero-filled, with the glyph bitmap copied into the center
+                var expandedSize = expandedW * expandedH;
+                var expandedBuffer = ArrayPool<byte>.Shared.Rent(expandedSize);
+                Array.Clear(expandedBuffer, 0, expandedSize);
+                int offsetX = character.Glyph.Subrect.Left - left;
+                int offsetY = character.Glyph.Subrect.Top - top;
+                unsafe
+                {
+                    var src = (byte*)character.Bitmap.Buffer;
+                    for (int y = 0; y < character.Bitmap.Rows; y++)
+                    {
+                        var srcRow = src + y * character.Bitmap.Pitch;
+                        var dstOffset = (y + offsetY) * expandedW + offsetX;
+                        for (int x = 0; x < character.Bitmap.Width; x++)
+                            expandedBuffer[dstOffset + x] = srcRow[x];
+                    }
+
+                    fixed (byte* pExpanded = expandedBuffer)
+                    {
+                        var dataBox = new DataBox((nint)pExpanded, expandedW, expandedSize);
+                        var region = new ResourceRegion(left, top, 0, right, bottom, 1);
+                        commandList.UpdateSubResource(cacheTextures[0], 0, dataBox, region);
+                    }
+                }
+                ArrayPool<byte>.Shared.Return(expandedBuffer);
             }
 
             // update the glyph data


### PR DESCRIPTION
# PR Details

Close up of the issue:
<img width="1108" height="147" alt="image" src="https://github.com/user-attachments/assets/06021d37-6bf4-4138-8586-9fd015a810bb" />

When rendering dynamic font scaled up, some nearby glyphs on texture atlas were bleeding.
Glyph have a 1 pixel border, so a total 2 pixels between glyph data if you include the border of neighbors glyphs (1 + 1).
This give a padding of 2 pixel which is enough to avoid bilinear filtering bleeding.

However, if a glyph is unallocated, texture is not explicitly cleared and the new glyph can overwrite in the middle of other old glyphs. So instead of usual 2 pixel border we have only 1 pixel between glyph data in texture and this results in bilinear bleeding.

The fix consists of always clearing 1 extra pixel when uploading a glyph (basically a 2 pixel border).
This is correct because:
- if neighbor is a valid glyph, the extra pixel will overwrite neighbors' glyph borders.
- if overwriting on top of old glyph, it will create enough border (2 pixel) to avoid bilinear filtering issues
- of course we clip around corner/side of textures to not write data outside the texture boundaries


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
