### PR TITLE
Parallel build

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           dotnet build build\Stride.Android.slnf `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Android `
             -p:StrideSkipUnitTests=true `

--- a/.github/workflows/build-assembly-processor.yml
+++ b/.github/workflows/build-assembly-processor.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build
         run: |
           dotnet build build\Stride.AssemblyProcessor.sln `
-            -restore -m:1 -nr:false `
+            -restore -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StrideSkipUnitTests=true `

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           dotnet build build\Stride.iOS.slnf `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=iOS `

--- a/.github/workflows/build-linux-runtime.yml
+++ b/.github/workflows/build-linux-runtime.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           dotnet build build\Stride.Runtime.slnf `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Linux `

--- a/.github/workflows/build-vs-package.yml
+++ b/.github/workflows/build-vs-package.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build
         run: |
           msbuild build\Stride.VisualStudio.sln `
-            -restore -m:1 -nr:false `
+            -restore -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StrideSkipUnitTests=true `

--- a/.github/workflows/build-windows-full.yml
+++ b/.github/workflows/build-windows-full.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           dotnet build build\Stride.sln `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Windows `

--- a/.github/workflows/build-windows-runtime.yml
+++ b/.github/workflows/build-windows-runtime.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           dotnet build build\Stride.Runtime.slnf `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Windows `

--- a/.github/workflows/test-linux-game.yml
+++ b/.github/workflows/test-linux-game.yml
@@ -64,7 +64,7 @@ jobs:
           dotnet build build\Stride.Tests.Game.GPU.slnf `
             -p:StrideTestRuntimeIdentifier=linux-x64 `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatform=Linux `
@@ -75,7 +75,7 @@ jobs:
           dotnet build build\Stride.Tests.Game.Linux.slnf `
             -p:StrideTestRuntimeIdentifier=linux-x64 `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatform=Linux `

--- a/.github/workflows/test-linux-simple.yml
+++ b/.github/workflows/test-linux-simple.yml
@@ -43,7 +43,7 @@ jobs:
           dotnet build build\Stride.Tests.Simple.Linux.slnf `
             -p:StrideTestRuntimeIdentifier=linux-x64 `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatform=Linux `

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -59,7 +59,7 @@ jobs:
           dotnet build build\Stride.Tests.Game.slnf `
             -p:StrideTestRuntimeIdentifier=win-x64 `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Windows `
@@ -157,7 +157,7 @@ jobs:
           dotnet build build\Stride.Tests.Game.GPU.slnf `
             -p:StrideTestRuntimeIdentifier=win-x64 `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Windows `

--- a/.github/workflows/test-windows-simple.yml
+++ b/.github/workflows/test-windows-simple.yml
@@ -42,7 +42,7 @@ jobs:
           dotnet build build\Stride.Tests.Simple.slnf `
             -p:StrideTestRuntimeIdentifier=win-x64 `
             -p:StrideNativeBuildMode=Clang `
-            -m:1 -nr:false `
+            -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Windows `

--- a/build/test-linux-gpu.ps1
+++ b/build/test-linux-gpu.ps1
@@ -48,7 +48,7 @@ foreach ($proj in $testProjects) {
 Write-Host "=== Step 2: Build (targeting Linux/Vulkan) ===" -ForegroundColor Cyan
 dotnet build build\Stride.Tests.Game.GPU.slnf `
     -p:StrideNativeBuildMode=Clang `
-    -m:1 -nr:false `
+    -nr:false `
     -v:m -p:WarningLevel=0 `
     -p:Configuration=Debug `
     -p:StridePlatform=Linux `

--- a/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props
+++ b/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props
@@ -12,6 +12,12 @@
     <!-- Mark as test project for dotnet test -->
     <IsTestProject>true</IsTestProject>
 
+    <!-- Test projects don't need to produce NuGet packages. Local property only — do NOT
+         let it propagate to referenced projects (e.g. Stride.Core.Assets.CompilerApp), which
+         still need their own .nupkg in bin\packages\ for the test's AssetCompiler run. The
+         ProjectReference metadata below adds this to GlobalPropertiesToRemove to be sure. -->
+    <StrideSkipAutoPack>true</StrideSkipAutoPack>
+
     <!-- Tests are executables (for asset compilation, native libs, etc.) -->
     <OutputType>WinExe</OutputType>
     <StrideIsExecutable>true</StrideIsExecutable>

--- a/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets
@@ -70,7 +70,9 @@
     <ProjectReference Include="$(StrideRoot)sources\assets\Stride.Core.Assets.CompilerApp\Stride.Core.Assets.CompilerApp.csproj">
       <Private>false</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <GlobalPropertiesToRemove>TargetFramework</GlobalPropertiesToRemove>
+      <!-- Strip test-project-only properties so CompilerApp still packs its .nupkg
+           (needed at AssetCompiler time for the test's package graph resolution). -->
+      <GlobalPropertiesToRemove>TargetFramework;StrideSkipAutoPack</GlobalPropertiesToRemove>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
     </ProjectReference>
   </ItemGroup>

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
@@ -228,7 +228,6 @@
     <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
              Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''"
              BuildInParallel="$(BuildInParallel)"
-             Targets="Build;Pack"
              RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;StrideGraphicsApi">
     </MSBuild>
   </Target>

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
@@ -89,10 +89,13 @@
   <!-- ================================================================ -->
   <!-- Stride.Core.CompilerServices Roslyn Analyzer -->
   <!-- ================================================================ -->
+  <!-- Stride.Core.CompilerServices is single-TF (netstandard2.0), so an explicit
+       SetTargetFramework is redundant — and harmful: it forces TargetFramework into the
+       consumer-ref dispatch globals, producing a cache key distinct from the slnf-direct
+       outer dispatch (which has no TF global). Both then race on obj/. -->
   <ItemGroup Condition="!$(MSBuildProjectName.StartsWith('Stride.Core.CompilerServices'))">
     <ProjectReference Include="$(StrideRoot)sources\core\Stride.Core.CompilerServices\Stride.Core.CompilerServices.csproj"
                       OutputItemType="Analyzer"
-                      SetTargetFramework="TargetFramework=netstandard2.0"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Dependencies.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Dependencies.targets
@@ -32,11 +32,43 @@
   <!-- ================================================================ -->
 
   <!-- List dependency files from .ssdeps -->
+  <!-- When the current build targets a specific StrideGraphicsApi, drop candidate paths whose
+       parent directory is a non-current API folder. Otherwise a non-API-dependent middle project
+       (say Stride.Engine, built with default API=Direct3D11) re-exports its CopyLocal'd
+       Stride.Graphics.ssdeps through the reference graph, and the direct API-dependent reference
+       also provides one — both land on the same filename in the output folder and race. -->
   <Target Name="_StrideListDepsFiles" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <_StrideDepsFile Include="@(ReferencePath->'%(RootDir)%(Directory)%(Filename).ssdeps')" Condition="'%(ReferencePath.CopyLocal)' != 'false' And Exists('%(RootDir)%(Directory)%(Filename).ssdeps')"/>
       <_StrideDepsFile Include="@(ReferenceDependencyPaths->'%(RootDir)%(Directory)%(Filename).ssdeps')" Condition="'%(ReferenceDependencyPaths.CopyLocal)' != 'false' And Exists('%(RootDir)%(Directory)%(Filename).ssdeps')"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(StrideGraphicsApi)' != ''">
+      <_StrideDepsFile Remove="@(_StrideDepsFile)" Condition="$([System.String]::Copy('%(Identity)').Contains('\Direct3D11\')) And '$(StrideGraphicsApi)' != 'Direct3D11'" />
+      <_StrideDepsFile Remove="@(_StrideDepsFile)" Condition="$([System.String]::Copy('%(Identity)').Contains('\Direct3D12\')) And '$(StrideGraphicsApi)' != 'Direct3D12'" />
+      <_StrideDepsFile Remove="@(_StrideDepsFile)" Condition="$([System.String]::Copy('%(Identity)').Contains('\Vulkan\')) And '$(StrideGraphicsApi)' != 'Vulkan'" />
+      <_StrideDepsFile Remove="@(_StrideDepsFile)" Condition="$([System.String]::Copy('%(Identity)').Contains('\OpenGL\')) And '$(StrideGraphicsApi)' != 'OpenGL'" />
+      <_StrideDepsFile Remove="@(_StrideDepsFile)" Condition="$([System.String]::Copy('%(Identity)').Contains('\OpenGLES\')) And '$(StrideGraphicsApi)' != 'OpenGLES'" />
+    </ItemGroup>
+    <ItemGroup>
       <None Include="@(_StrideDepsFile)" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Filter transitive CopyToOutput items coming from non-API-dependent project references.
+       They would otherwise pull the default-API variant (e.g. Direct3D11) of API-dependent
+       side files (Stride.Graphics.ssdeps, Stride.VirtualReality.ssdeps, and the native libs
+       they manifest) through the reference graph, colliding in the consumer's output folder
+       with the direct API-dependent reference's correct variant. -->
+  <Target Name="_StrideFilterTransitiveCopyToOutputDirectoryItems"
+          BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory;_CopyOutOfDateSourceItemsToOutputDirectoryAlways"
+          DependsOnTargets="GetCopyToOutputDirectoryItems"
+          Condition="'$(StrideGraphicsApi)' != ''">
+    <ItemGroup>
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy('%(Identity)').Contains('\Direct3D11\')) And '$(StrideGraphicsApi)' != 'Direct3D11'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy('%(Identity)').Contains('\Direct3D12\')) And '$(StrideGraphicsApi)' != 'Direct3D12'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy('%(Identity)').Contains('\Vulkan\')) And '$(StrideGraphicsApi)' != 'Vulkan'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy('%(Identity)').Contains('\OpenGL\')) And '$(StrideGraphicsApi)' != 'OpenGL'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy('%(Identity)').Contains('\OpenGLES\')) And '$(StrideGraphicsApi)' != 'OpenGLES'" />
     </ItemGroup>
   </Target>
 

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.GraphicsApi.InnerBuild.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.GraphicsApi.InnerBuild.targets
@@ -29,7 +29,8 @@
   <!-- ================================================================ -->
   <Target Name="_StrideQueryGraphicsApis" Returns="@(_StrideGraphicsApisItemsInternal)" Condition="'$(StrideProjectType)' != 'Cpp'">
     <ItemGroup Condition="'$(StrideGraphicsApis)' != ''">
-      <_StrideGraphicsApisItemsInternal Include="$(StrideGraphicsApis)" TargetFramework="$(TargetFramework)" StrideGraphicsApiDependent="$(StrideGraphicsApiDependent)" />
+      <!-- Unescape first so a command-line '%3B' separator survives as real item splits. -->
+      <_StrideGraphicsApisItemsInternal Include="$([MSBuild]::Unescape($(StrideGraphicsApis)))" TargetFramework="$(TargetFramework)" StrideGraphicsApiDependent="$(StrideGraphicsApiDependent)" />
     </ItemGroup>
     <ItemGroup Condition="'$(StrideGraphicsApis)' == ''">
       <_StrideGraphicsApisItemsInternal Include="$(StrideGraphicsApi)" TargetFramework="$(TargetFramework)" StrideGraphicsApiDependent="$(StrideGraphicsApiDependent)" />
@@ -59,12 +60,14 @@
       </_InnerBuildProjects>
     </ItemGroup>
 
-    <!-- Graphics-API-dependent: query each TFM for its graphics APIs -->
+    <!-- Graphics-API-dependent: query each TFM for its graphics APIs. Don't strip
+         StrideGraphicsApi here — doing so would create a distinct project-instance cache
+         entry with no StrideGraphicsApi, which later Build dispatches from transitive callers
+         would race against the with-SGA entry created by DispatchToInnerBuilds. -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Condition="'$(StrideGraphicsApiDependent)' == 'true'"
              BuildInParallel="$(BuildInParallel)"
              Properties="TargetFramework=%(_TargetFrameworkNormalized.Identity)"
-             RemoveProperties="StrideGraphicsApi"
              Targets="_StrideQueryGraphicsApis">
       <Output ItemName="_StrideGraphicsApisItems" TaskParameter="TargetOutputs" />
     </MSBuild>
@@ -82,44 +85,72 @@
   <!-- ================================================================ -->
   <!-- Project reference Graphics API propagation                       -->
   <!-- ================================================================ -->
-  <!-- Detects if referenced projects are StrideGraphicsApiDependent
-       and injects StrideGraphicsApi into their SetTargetFramework.
-       For non-dependent references, removes StrideGraphicsApi to
-       prevent unnecessary rebuilds. -->
-  <Target Name="_StrideQueryGraphicsApiDependent" Returns="@(_StrideGraphicsApiDependentItemsInternal)" Condition="'$(StrideProjectType)' != 'Cpp'">
-    <ItemGroup>
-      <_StrideGraphicsApiDependentItemsInternal Include="stride_fake_graphics_api" StrideGraphicsApiDependent="$(StrideGraphicsApiDependent)" />
-    </ItemGroup>
+  <!-- For each ProjectReference, route StrideGraphicsApi based on whether the *target*
+       project is API-dep (matched by filename, so transitive refs auto-promoted by the
+       .NET SDK from project.assets.json classify correctly — they don't carry any per-ref
+       metadata we could use). Keep in sync with projects that set
+       StrideGraphicsApiDependent=true. -->
+  <PropertyGroup>
+    <!-- Semicolon-delimited list of API-dep projects that are referenced by other projects
+         (and therefore need consumer-side SGA routing). Surrounded by ; for substring-safe
+         .Contains(';%(Filename);') lookup (so ';Stride.Graphics;' never matches
+         ';Stride.Graphics.Regression;'). Leaf API-dep projects (e.g., Stride.*.Tests.*)
+         are intentionally excluded — they declare StrideGraphicsApiDependent=true for their
+         own per-API output paths but nothing references them, so no routing is needed.
+         Consistency enforced by _StrideValidateGraphicsApiDependentProjectList below. -->
+    <_StrideGraphicsApiDependentProjectList>;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.Graphics;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.Games;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.Input;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.VirtualReality;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.Video;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.Graphics.Regression;</_StrideGraphicsApiDependentProjectList>
+    <_StrideGraphicsApiDependentProjectList>$(_StrideGraphicsApiDependentProjectList)Stride.Graphics.RenderDocPlugin;</_StrideGraphicsApiDependentProjectList>
+    <!-- Current API for this evaluation. In an API-dep inner build this is the dispatched
+         API (set via global from _ComputeTargetFrameworkItems); in a non-API-dep build it
+         falls back to the first entry of StrideGraphicsApis so A(API-dep)→B(non-API-dep)→
+         C(API-dep) chains still route with a valid API. -->
+    <_StrideGraphicsApiCurrent>$(StrideGraphicsApi)</_StrideGraphicsApiCurrent>
+    <_StrideGraphicsApiCurrent Condition="'$(_StrideGraphicsApiCurrent)' == '' And '$(StrideGraphicsApis)' != ''">$([MSBuild]::Unescape($(StrideGraphicsApis)).Split(';', StringSplitOptions.RemoveEmptyEntries)[0])</_StrideGraphicsApiCurrent>
+    <!-- TFMs where Stride.Graphics.targets disables per-API dispatch (single inner build,
+         no StrideGraphicsApi in cache key). Consumer refs at these TFMs must NOT add
+         StrideGraphicsApi, or they'd diverge from the callee's own outer→inner dispatch. -->
+    <_StrideGraphicsApiDependentDisabledAtCurrentTF Condition="'$(TargetFramework)' == '$(StrideFrameworkiOS)' Or '$(TargetFramework)' == '$(StrideFrameworkAndroid)' Or '$(TargetFramework)' == '$(StrideFrameworkUWP)'">true</_StrideGraphicsApiDependentDisabledAtCurrentTF>
+  </PropertyGroup>
+
+  <!-- Consistency checks on the _StrideGraphicsApiDependentProjectList. Skipped on TFMs where Stride.Graphics.targets
+       overrides StrideGraphicsApiDependent (iOS/Android/UWP) since the flag's in-memory value
+       no longer matches the user's csproj declaration. -->
+  <Target Name="_StrideValidateGraphicsApiDependentProjectList" BeforeTargets="Build"
+          Condition="'$(_StrideGraphicsApiDependentDisabledAtCurrentTF)' != 'true'">
+    <!-- If I'm in the list, my csproj must declare the flag. Catches incomplete SDK list edits. -->
+    <Error Condition="$(_StrideGraphicsApiDependentProjectList.Contains(';$(MSBuildProjectName);')) And '$(StrideGraphicsApiDependent)' != 'true'"
+           Text="$(MSBuildProjectName) is listed in _StrideGraphicsApiDependentProjectList (Stride.GraphicsApi.InnerBuild.targets) but its csproj doesn't set &lt;StrideGraphicsApiDependent&gt;true&lt;/StrideGraphicsApiDependent&gt;. Either add the flag or remove from the list." />
+    <!-- If I directly reference an API-dep project (by inspecting its csproj content), that
+         project must be in the list. Catches new API-dep libraries that nobody registered.
+         Only scans direct refs (no transitive), so leaf test projects don't false-alarm. -->
+    <Error Condition="'%(ProjectReference.FullPath)' != '' And $([System.IO.File]::ReadAllText('%(ProjectReference.FullPath)').Contains('&lt;StrideGraphicsApiDependent&gt;true&lt;/StrideGraphicsApiDependent&gt;')) And !$(_StrideGraphicsApiDependentProjectList.Contains(';%(ProjectReference.Filename);'))"
+           Text="$(MSBuildProjectName) directly references %(ProjectReference.Filename) which sets &lt;StrideGraphicsApiDependent&gt;true&lt;/StrideGraphicsApiDependent&gt;, but %(ProjectReference.Filename) is not in _StrideGraphicsApiDependentProjectList (Stride.GraphicsApi.InnerBuild.targets). Add it there so consumer refs don't race under parallel build." />
   </Target>
 
-  <Target Name="_StrideProjectReferenceGraphicsApiDependent" BeforeTargets="PrepareProjectReferences">
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             BuildInParallel="$(BuildInParallel)"
-             Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework);"
-             RemoveProperties="StrideGraphicsApi"
-             Targets="_StrideQueryGraphicsApiDependent"
-             SkipNonexistentTargets="true">
-      <Output ItemName="_StrideGraphicsApiDependentItems" TaskParameter="TargetOutputs" />
-    </MSBuild>
-    <PropertyGroup>
-      <!-- Transmit current graphics API. This is useful in case we have transitions such as:
-           Direct3D12 -> ProjectWithoutGraphicsApi -> Direct3D12
-           otherwise it would try to build 3rd project twice (due to the reference from ProjectWithoutGraphicsApi). -->
-      <_StrideGraphicsApiCurrent>$(StrideGraphicsApi)</_StrideGraphicsApiCurrent>
-      <!-- Fallback in case the project without graphics API is the project initiating the build. -->
-      <_StrideGraphicsApiCurrent Condition="'$(_StrideGraphicsApiCurrent)' == '' And '$(StrideGraphicsApis)' != ''">$(StrideGraphicsApis.Split(';', StringSplitOptions.RemoveEmptyEntries)[0])</_StrideGraphicsApiCurrent>
-      <_StrideGraphicsApiCurrent Condition="'$(_StrideGraphicsApiCurrent)' == ''">$(StrideDefaultGraphicsApi)</_StrideGraphicsApiCurrent>
-      <_StrideGraphicsApiCurrent Condition="'$(_StrideGraphicsApiCurrent)' == ''">Direct3D11</_StrideGraphicsApiCurrent>
-    </PropertyGroup>
+  <!-- Runs at target time so _MSBuildProjectReferenceExistent is fully populated (direct
+       refs, SDK-auto-added refs, AND transitive refs from project.assets.json).
+       AdditionalProperties is the cache-key-contributing channel: the MSBuild task engine
+       reads it from item metadata automatically at dispatch time. SetTargetFramework also
+       works but has a side effect of setting SkipGetTargetFrameworkProperties=true, which
+       bypasses TFM negotiation and breaks cases like Games[net10.0-windows]→Graphics[net10.0]. -->
+  <Target Name="_StrideAnnotateProjectReferences" BeforeTargets="_GetProjectReferenceTargetFrameworkProperties;PrepareProjectReferences"
+          Condition="'$(_StrideGraphicsApiCurrent)' != '' And '$(_StrideGraphicsApiDependentDisabledAtCurrentTF)' != 'true'">
     <ItemGroup>
-      <_MSBuildProjectReferenceExistent Remove="@(_StrideGraphicsApiDependentItems->'%(OriginalItemSpec)')" />
-      <_MSBuildProjectReferenceExistent Include="@(_StrideGraphicsApiDependentItems->'%(OriginalItemSpec)')" Condition="'%(_StrideGraphicsApiDependentItems.StrideGraphicsApiDependent)' != 'true'" />
-      <_MSBuildProjectReferenceExistent Include="@(_StrideGraphicsApiDependentItems->'%(OriginalItemSpec)')" Condition="'%(_StrideGraphicsApiDependentItems.StrideGraphicsApiDependent)' == 'true'">
-        <StrideGraphicsApiDependent>%(_StrideGraphicsApiDependentItems.StrideGraphicsApiDependent)</StrideGraphicsApiDependent>
-        <StrideGraphicsApi>$(_StrideGraphicsApiCurrent)</StrideGraphicsApi>
-        <SetTargetFramework>%(_StrideGraphicsApiDependentItems.SetTargetFramework);StrideGraphicsApi=$(_StrideGraphicsApiCurrent)</SetTargetFramework>
+      <!-- API-dep ref: pass the current API so consumer and callee share a per-API cache entry. -->
+      <_MSBuildProjectReferenceExistent Update="@(_MSBuildProjectReferenceExistent)"
+                                        Condition="$(_StrideGraphicsApiDependentProjectList.Contains(';%(Filename);'))">
+        <AdditionalProperties>%(_MSBuildProjectReferenceExistent.AdditionalProperties);StrideGraphicsApi=$(_StrideGraphicsApiCurrent)</AdditionalProperties>
       </_MSBuildProjectReferenceExistent>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.StrideGraphicsApiDependent)' != 'true'">
+      <!-- Non-API-dep ref: strip StrideGraphicsApi so different-API callers collapse to one
+           cache entry per (project, TF) instead of racing on a shared obj/ path. -->
+      <_MSBuildProjectReferenceExistent Update="@(_MSBuildProjectReferenceExistent)"
+                                        Condition="!$(_StrideGraphicsApiDependentProjectList.Contains(';%(Filename);'))">
         <GlobalPropertiesToRemove>%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);StrideGraphicsApi</GlobalPropertiesToRemove>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>


### PR DESCRIPTION
# PR Details

## Parallel MSBuild in CI

This PR re-enables parallel MSBuild (`-maxcpucount`) across the build and test workflows that had been pinned to `-m:1` as a workaround for race conditions.

In practice, CI builds seems **10–30% faster**.

### What changed

- **CI workflows**: dropped `-m:1` from build/test workflows (runtime, tests, platform builds) — they now run at full CPU parallelism by default like a normal `dotnet build`.
- **Stride.Build.Sdk**: fixed the underlying parallel-build races in `Stride.GraphicsApi.InnerBuild.targets` + `Stride.AssemblyProcessor.targets` + `Sdk.targets` so projects can be safely built in parallel regardless of whether you use single-API, multi-API, or platform-specific configurations.
- Adding a new graphics-API-dependent library now requires two coordinated edits: set `<StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>` in the csproj **and** register the project in the SDK's list (new). The SDK validates this at build time and errors with a clear message pointing to the missing part (if any).

### Verified

- Windows Runtime (Direct3D11 / Direct3D12 / Vulkan)
- Windows Full
- iOS / Linux / Assembly Processor / VS Package
- Windows Tests (Simple, Game Common, Game per-API)
- Linux Tests (Simple, Game Common, Game Vulkan)
- Multi-API builds (`-p:StrideGraphicsApis=Direct3D11;Direct3D12;Vulkan`)
- Release workflows (release.yml, release-launcher.yml, release-vspackage.yml) — unchanged since `msbuild /m` was already enabling parallelism


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->