### PR TITLE
Add `Stride.Core.CompilerServices` to the solution filters (.slnf)

### DIFF
--- a/build/Stride.Android.slnf
+++ b/build/Stride.Android.slnf
@@ -7,6 +7,7 @@
       "..\\sources\\core\\Stride.Core.Mathematics\\Stride.Core.Mathematics.csproj",
       "..\\sources\\core\\Stride.Core.MicroThreading\\Stride.Core.MicroThreading.csproj",
       "..\\sources\\core\\Stride.Core.Serialization\\Stride.Core.Serialization.csproj",
+      "..\\sources\\core\\Stride.Core.CompilerServices\\Stride.Core.CompilerServices.csproj",
       "..\\sources\\engine\\Stride\\Stride.csproj",
       "..\\sources\\engine\\Stride.Audio\\Stride.Audio.csproj",
       "..\\sources\\engine\\Stride.Engine\\Stride.Engine.csproj",

--- a/build/Stride.Runtime.slnf
+++ b/build/Stride.Runtime.slnf
@@ -7,6 +7,7 @@
       "..\\sources\\core\\Stride.Core.MicroThreading\\Stride.Core.MicroThreading.csproj",
       "..\\sources\\core\\Stride.Core.Serialization\\Stride.Core.Serialization.csproj",
       "..\\sources\\core\\Stride.Core\\Stride.Core.csproj",
+      "..\\sources\\core\\Stride.Core.CompilerServices\\Stride.Core.CompilerServices.csproj",
       "..\\sources\\engine\\Stride.Audio\\Stride.Audio.csproj",
       "..\\sources\\engine\\Stride.Engine\\Stride.Engine.csproj",
       "..\\sources\\engine\\Stride.Games\\Stride.Games.csproj",

--- a/build/Stride.iOS.slnf
+++ b/build/Stride.iOS.slnf
@@ -7,6 +7,7 @@
       "..\\sources\\core\\Stride.Core.Mathematics\\Stride.Core.Mathematics.csproj",
       "..\\sources\\core\\Stride.Core.MicroThreading\\Stride.Core.MicroThreading.csproj",
       "..\\sources\\core\\Stride.Core.Serialization\\Stride.Core.Serialization.csproj",
+      "..\\sources\\core\\Stride.Core.CompilerServices\\Stride.Core.CompilerServices.csproj",
       "..\\sources\\engine\\Stride\\Stride.csproj",
       "..\\sources\\engine\\Stride.Audio\\Stride.Audio.csproj",
       "..\\sources\\engine\\Stride.Engine\\Stride.Engine.csproj",


### PR DESCRIPTION
# PR Details

`Stride.Core` packs the analyzers DLL (`Stride.Core.CompilerServices`) directly from the bin folder. From the `.csproj`:
```xml
<None Include="...\Stride.Core.CompilerServices\bin\$(Configuration)\netstandard2.0\Stride.Core.CompilerServices.dll"
      Pack="true" PackagePath="analyzers/dotnet/cs" />
```
That means `Stride.Core.CompilerServices.dll` must already exist on disk when `Stride.Core` is packed.

Building the full solution `Stride.sln` succeeds because it has `Stride.Core.CompilerServices` in its build graph, and when the SDK targets reference that project it automatically builds it first. However, `Stride.Runtime.slnf` omitted it, and then `Stride.Core` later failed when it tried to pack the analyzer DLL from disk.

This PR adds the `Stride.Core.CompilerServices` project to the `Stride.Runtime.snlf` to fix this. It also adds it to the `Stride.Android.slnf` and `Stride.iOS.slnf` for the same reasons.

## Related Issue

No issue. Commented on Discord.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
