### PR TITLE
Fix editor crash due to AssetViewModel.TypeDisplayName being null

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
@@ -192,7 +192,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// <summary>
         /// Gets the display name of the type of this asset.
         /// </summary>
-        public override string TypeDisplayName { get { var desc = DisplayAttribute.GetDisplay(AssetType); return desc != null ? desc.Name : AssetType.Name; } }
+        public override string TypeDisplayName { get { var desc = DisplayAttribute.GetDisplay(AssetType); return desc?.Name ?? AssetType.Name; } }
 
         /// <summary>
         /// Gets the dependencies of this asset.


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
Ensures `AssetViewModel.TypeDisplayName` uses object type name as fallback name if `[Display]` attribute `Name` property is not set.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3149

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->