### PR TITLE
[Tests] fix: Paths are case sensitive on Linux

### DIFF
--- a/sources/engine/Stride.Assets.Tests/Stride.Assets.Tests.csproj
+++ b/sources/engine/Stride.Assets.Tests/Stride.Assets.Tests.csproj
@@ -26,7 +26,7 @@
     <Compile Include="TexturePackerTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\data\tests\factory\factory.fbx">
+    <Content Include="..\..\data\tests\Factory\factory.fbx">
       <Link>app_data\Stride.Assets.Tests\factory.fbx</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -34,7 +34,7 @@
       <Link>app_data\Stride.Assets.Tests\knight.fbx</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\data\tests\factory\TX-Factory_Ground.dds">
+    <Content Include="..\..\data\tests\Factory\TX-Factory_Ground.dds">
       <Link>app_data\Stride.Assets.Tests\TX-Factory_Ground.dds</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
# PR Details

A minor fix related to testing that adjusts the case sensitivity of paths for Linux/Unix systems

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix 


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**