### PR TITLE
fix: Recompile spritesheet asset and thumbnail when source file is changed

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/Thumbnails/SpriteSheetThumbnailCompiler.cs
+++ b/sources/editor/Stride.Assets.Presentation/Thumbnails/SpriteSheetThumbnailCompiler.cs
@@ -1,9 +1,12 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Collections.Generic;
+using System.IO;
 using Stride.Core.Assets;
 using Stride.Core.Assets.Compiler;
 using Stride.Core.BuildEngine;
+using Stride.Core.Serialization.Contents;
 using Stride.Core.Mathematics;
 using Stride.Assets.Sprite;
 using Stride.Editor.Thumbnails;
@@ -46,6 +49,22 @@ namespace Stride.Assets.Presentation.Thumbnails
             public SpriteSheetThumbnailCommand(ThumbnailCompilerContext context, AssetItem assetItem, IAssetFinder assetFinder, string url, ThumbnailCommandParameters parameters)
                 : base(context, assetItem, assetFinder, url, parameters)
             {
+            }
+
+            public override IEnumerable<ObjectUrl> GetInputFiles()
+            {
+                foreach (var input in base.GetInputFiles())
+                    yield return input;
+
+                var spriteSheet = (SpriteSheetAsset)Parameters.Asset;
+                if (spriteSheet?.Sprites == null)
+                    yield break;
+
+                foreach (var sprite in spriteSheet.Sprites)
+                {
+                    if (sprite.Source != null && File.Exists(sprite.Source))
+                        yield return new ObjectUrl(UrlType.File, sprite.Source);
+                }
             }
 
             protected override void RenderSprites(RenderDrawContext context)

--- a/sources/engine/Stride.Assets/Sprite/SpriteSheetAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Sprite/SpriteSheetAssetCompiler.cs
@@ -131,6 +131,27 @@ namespace Stride.Assets.Sprite
                 writer.Write(TextureSerializationData.Version);
             }
 
+            public override IEnumerable<ObjectUrl> GetInputFiles()
+            {
+                if (Parameters.SheetAsset.Packing.Enabled)
+                {
+                    // When packing, source images are read directly from disk
+                    foreach (var sprite in Parameters.SheetAsset.Sprites)
+                    {
+                        if (sprite.Source != null && File.Exists(sprite.Source))
+                            yield return new ObjectUrl(UrlType.File, sprite.Source);
+                    }
+                }
+                else
+                {
+                    // When not packing, textures are compiled by TextureConvertCommands so re-run when they change
+                    foreach (var textureUrl in Parameters.ImageToTextureUrl.Values)
+                    {
+                        yield return new ObjectUrl(UrlType.Content, textureUrl);
+                    }
+                }
+            }
+
             protected override Task<ResultStatus> DoCommandOverride(ICommandContext commandContext)
             {
                 var assetManager = new ContentManager(MicrothreadLocalDatabases.ProviderService);


### PR DESCRIPTION
# PR Details

Modifying a sprite source image (e.g. a PNG) without also modifying the .sdsprite asset file did not trigger recompilation of the SpriteSheet asset or its thumbnail. If you were to add a new sprite to the spritesheet, the thumbnail and spritesheet would update, but removing the sprite would then revert it back to the old one. The workaround was to manually clear the obj/stride cache, but that's very tedious when you're making minor tweaks to a sprite.

The Stride hash is computed from files/content declared via GetInputFiles() but neither SpriteSheetCommand nor SpriteSheetThumbnailCommand overrode GetInputFiles(), so changes to source PNG files were invisible. The actual .sdsheet asset file itself hadn't changed, so it skipped recompilation.

SpriteSheetAssetCompiler.cs:
Added GetInputFiles() to SpriteSheetCommand:
•	Packing disabled: Declares the intermediate compiled texture URLs as content dependencies. The prerequisite TextureConvertCommand already tracks the source PNG and re-runs when it changes; by depending on its output, SpriteSheetCommand detects the change transitively and also re-runs.
•	Packing enabled: The SpriteSheetCommand loads source PNGs from disk directly, so source files are declared as File inputs directly.

SpriteSheetThumbnailCompiler.cs:
Added GetInputFiles() to SpriteSheetThumbnailCommand, which always reads the sprite source PNG paths from the SpriteSheetAsset parameters and declares them as File inputs. The base implementation's inputs are preserved via base.GetInputFiles().

Now if you make a change to the underlying source it recompile the spritesheet _and_ the thumbnail, so you can immediately run the project and see the updated sprites without having to delete any files or folders.

## Related Issue

#791 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**