### PR TITLE
sdk: auto-detect StrideNativeBuildMode

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -89,7 +89,6 @@ jobs:
       - name: Build
         run: |
           dotnet build build\Stride.Android.slnf `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
             -p:StridePlatforms=Android `

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Build
         run: |
           dotnet build build\Stride.iOS.slnf `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/build-linux-runtime.yml
+++ b/.github/workflows/build-linux-runtime.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Build
         run: |
           dotnet build build\Stride.Runtime.slnf `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/build-windows-full.yml
+++ b/.github/workflows/build-windows-full.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Build
         run: |
           dotnet build build\Stride.sln `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/build-windows-runtime.yml
+++ b/.github/workflows/build-windows-runtime.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Build
         run: |
           dotnet build build\Stride.Runtime.slnf `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/check-parallel-build.yml
+++ b/.github/workflows/check-parallel-build.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           dotnet build build\Stride.sln `
             -bl:parallel-audit.binlog `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:StrideSkipUnitTests=true `

--- a/.github/workflows/test-linux-game.yml
+++ b/.github/workflows/test-linux-game.yml
@@ -59,7 +59,6 @@ jobs:
         run: |
           dotnet build build\Stride.Tests.Game.GPU.slnf `
             -p:StrideTestRuntimeIdentifier=linux-x64 `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
@@ -70,7 +69,6 @@ jobs:
         run: |
           dotnet build build\Stride.Tests.Game.Linux.slnf `
             -p:StrideTestRuntimeIdentifier=linux-x64 `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/test-linux-simple.yml
+++ b/.github/workflows/test-linux-simple.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           dotnet build build\Stride.Tests.Simple.Linux.slnf `
             -p:StrideTestRuntimeIdentifier=linux-x64 `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/test-samples-screenshots.yml
+++ b/.github/workflows/test-samples-screenshots.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Build harness assembly (packs Stride.Games.AutoTesting into bin/packages)
         run: |
           dotnet build sources\engine\Stride.Games.AutoTesting\Stride.Games.AutoTesting.csproj `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || 'Debug' }} `
             -p:StrideGraphicsApi=${{ matrix.graphics-api }} `
@@ -117,7 +116,6 @@ jobs:
       - name: Build test project
         run: |
           dotnet build samples\Tests\Stride.Samples.Tests.csproj `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || 'Debug' }} `
             -p:StrideGraphicsApi=${{ matrix.graphics-api }} `

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -54,7 +54,6 @@ jobs:
         run: |
           dotnet build build\Stride.Tests.Game.slnf `
             -p:StrideTestRuntimeIdentifier=win-x64 `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
@@ -153,7 +152,6 @@ jobs:
         run: |
           dotnet build build\Stride.Tests.Game.GPU.slnf `
             -p:StrideTestRuntimeIdentifier=win-x64 `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/.github/workflows/test-windows-simple.yml
+++ b/.github/workflows/test-windows-simple.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           dotnet build build\Stride.Tests.Simple.slnf `
             -p:StrideTestRuntimeIdentifier=win-x64 `
-            -p:StrideNativeBuildMode=Clang `
             -nr:false `
             -v:m -p:WarningLevel=0 `
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `

--- a/build/test-linux-gpu.ps1
+++ b/build/test-linux-gpu.ps1
@@ -47,7 +47,6 @@ foreach ($proj in $testProjects) {
 
 Write-Host "=== Step 2: Build (targeting Linux/Vulkan) ===" -ForegroundColor Cyan
 dotnet build build\Stride.Tests.Game.GPU.slnf `
-    -p:StrideNativeBuildMode=Clang `
     -nr:false `
     -v:m -p:WarningLevel=0 `
     -p:Configuration=Debug `

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.NativeBuildMode.props
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.NativeBuildMode.props
@@ -1,41 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
-    Stride Native Build Mode Configuration
-
-    Manages which toolchain is used for native C++ compilation and linking.
-
-    Build Modes:
-    - Msvc (default on Windows): Uses clang for compilation and MSVC linker for linking (Windows only)
-                                 Requires Visual Studio or MSVC toolset
-                                 Default for Windows builds to preserve existing behavior
-
-    - Clang:                     Uses clang for compilation and LLVM LLD for linking
-                                 Works on Windows, Linux, macOS, iOS, Android
-                                 RECOMMENDED: Cross-platform, no MSVC dependency
-                                 Default for non-Windows platforms
-
-    Usage:
-    1. Command line:
-       dotnet build /p:StrideNativeBuildMode=Clang
-
-    2. Environment variable:
-       set StrideNativeBuildMode=Clang
-
-    3. In .csproj/.props file:
-       <StrideNativeBuildMode>Clang</StrideNativeBuildMode>
-
-    4. User configuration file:
-       %APPDATA%\Stride\Stride.Build.props or similar
+    Native build mode: MSVC (clang + MSVC linker, Windows only) or Clang (clang + LLD, all platforms).
+    Override via -p:StrideNativeBuildMode=Clang|MSVC, env var, or property.
   -->
 
   <PropertyGroup>
-    <!-- Check if we're building on Windows OS -->
-    <_IsWindowsBuildForWindows Condition="$([MSBuild]::IsOSPlatform('Windows'))">true</_IsWindowsBuildForWindows>
-    <_IsWindowsBuildForWindows Condition="'$(_IsWindowsBuildForWindows)' == ''">false</_IsWindowsBuildForWindows>
-
-    <!-- Default to MSVC only for Windows builds on Windows platform, otherwise use Clang -->
-    <StrideNativeBuildMode Condition="'$(StrideNativeBuildMode)' == '' And '$(_IsWindowsBuildForWindows)' == 'true'">Msvc</StrideNativeBuildMode>
+    <!-- MSVC when targeting Windows (or unset) AND the VS C++ tools are loaded in the current shell, Clang otherwise. -->
+    <StrideNativeBuildMode Condition="'$(StrideNativeBuildMode)' == '' And ('$(StridePlatform)' == '' Or '$(StridePlatform)' == 'Windows') And '$(VCINSTALLDIR)' != ''">MSVC</StrideNativeBuildMode>
     <StrideNativeBuildMode Condition="'$(StrideNativeBuildMode)' == ''">Clang</StrideNativeBuildMode>
   </PropertyGroup>
 
@@ -44,14 +16,14 @@
     <StrideNativeBuildModeClang Condition="'$(StrideNativeBuildMode)' == 'Clang'">true</StrideNativeBuildModeClang>
     <StrideNativeBuildModeClang Condition="'$(StrideNativeBuildMode)' != 'Clang'">false</StrideNativeBuildModeClang>
 
-    <StrideNativeBuildModeMsvc Condition="'$(StrideNativeBuildMode)' == 'Msvc'">true</StrideNativeBuildModeMsvc>
-    <StrideNativeBuildModeMsvc Condition="'$(StrideNativeBuildMode)' != 'Msvc'">false</StrideNativeBuildModeMsvc>
+    <StrideNativeBuildModeMSVC Condition="'$(StrideNativeBuildMode)' == 'MSVC'">true</StrideNativeBuildModeMSVC>
+    <StrideNativeBuildModeMSVC Condition="'$(StrideNativeBuildMode)' != 'MSVC'">false</StrideNativeBuildModeMSVC>
   </PropertyGroup>
 
   <!-- Diagnostic target to inform user of build mode -->
   <Target Name="_StrideNativeBuildModeInfo" BeforeTargets="Build" Condition="'$(StrideNativeOutputName)' != ''">
-    <Message Text="[Stride] Native build mode: $(StrideNativeBuildMode) (platform: $(_IsWindowsBuildForWindows))" Importance="normal" />
-    <Message Text="[Stride] To override: dotnet build /p:StrideNativeBuildMode=Clang|Msvc" Importance="low" />
+    <Message Text="[Stride] Native build mode: $(StrideNativeBuildMode)" Importance="normal" />
+    <Message Text="[Stride] To override: dotnet build /p:StrideNativeBuildMode=Clang|MSVC" Importance="low" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Pick MSVC only when targeting Windows AND the VS C++ tools are loaded
(VCINSTALLDIR set), Clang otherwise.

- Plain `dotnet build` from a regular shell on Windows now works out of the box
- Cross-compile from Windows host (Linux/Android/iOS targets) auto-uses Clang
- Drops the now-redundant `-p:StrideNativeBuildMode=Clang` from many CI workflows (release.yml keeps it, it runs msbuild.exe
  with VS env active)

Note: we'll have to check if MSVC mode is really necessary still at all.