### PR TITLE
Ci main refactor + new `/test` chatops bot

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,20 @@ We welcome code contributions via pull requests. Issues tagged with **[`good fir
 
 You can help us translate Stride; check out our [Localization Guide](https://doc.stride3d.net/latest/en/contributors/engine/localization.html).
 
+## Triggering CI tests on a PR
+
+Most CI runs automatically on PR commits. Two suites — editor screenshots and samples
+screenshots — only run on demand because they're slow and drift-prone. A bot listens for
+`/test` comments to dispatch them. Comment `/test help` on any PR for the full command list.
+
+Quick examples:
+- `/test editor samples` — run both screenshot suites
+- `/test linux-game` — re-run a specific main-CI suite (useful for transient failures)
+- `/test windows-game-vulkan` — re-run a specific graphics-API variant
+
+Bot definition: [`.github/workflows/pr-test-chatops.yml`](workflows/pr-test-chatops.yml).
+Only repo collaborators can trigger.
+
 ## Earn Money by Contributing
 
 If you are a developer with solid experience in C#, rendering techniques, or game development, we want to hire you! We have allocated funds from supporters on [Open Collective](https://opencollective.com/stride3d) and can pay for work on certain projects. [More information is available here](https://doc.stride3d.net/latest/en/contributors/engine/bug-bounties.html).

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,23 +1,6 @@
 name: Build Android Runtime
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-android.yml'
-      - 'build/Stride.Android.slnf'
-      # - 'deps/**'
-      # - 'sources/core/**'
-      # - 'sources/engine/**'
-      # - 'sources/native/**'
-      # - 'sources/shaders/**'
-      # - 'sources/shared/**'
-      # - 'sources/sdk/**'
-      - '!**/.all-contributorsrc'
-      - '!**/.editorconfig'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!crowdin.yml'
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build-type:
@@ -42,7 +25,6 @@ jobs:
   # Build Stride Runtime for Android
   #
   Android-Runtime:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false }}
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/build-assembly-processor.yml
+++ b/.github/workflows/build-assembly-processor.yml
@@ -1,19 +1,6 @@
 name: Build Assembly Processor
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-assembly-processor.yml'
-      - 'build/Stride.AssemblyProcessor.sln'
-      - 'sources/core/Stride.Core/**'
-      - 'sources/core/Stride.Core.AssemblyProcessor/**'
-      - 'sources/core/Stride.Core.AssemblyProcessor.Tests/**'
-      - '!**/.all-contributorsrc'
-      - '!**/.editorconfig'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!crowdin.yml'
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build-type:
@@ -38,7 +25,6 @@ jobs:
   # Build Assembly Processor
   #
   Assembly-Processor:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false }}
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,23 +1,6 @@
 name: Build iOS Runtime
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-ios.yml'
-      - 'build/Stride.iOS.slnf'
-      - 'deps/**'
-      - 'sources/core/**'
-      - 'sources/engine/**'
-      - 'sources/native/**'
-      - 'sources/shaders/**'
-      - 'sources/shared/**'
-      - 'sources/sdk/**'
-      - '!**/.all-contributorsrc'
-      - '!**/.editorconfig'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!crowdin.yml'
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build-type:
@@ -42,7 +25,6 @@ jobs:
   # Build Stride Runtime for iOS
   #
   iOS-Runtime:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false }}
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 concurrency:
-  group: build-ios-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: build-ios-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/build-linux-runtime.yml
+++ b/.github/workflows/build-linux-runtime.yml
@@ -1,23 +1,6 @@
 name: Build Linux Runtime
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-linux-runtime.yml'
-      - 'build/Stride.Runtime.slnf'
-      - 'deps/**'
-      - 'sources/core/**'
-      - 'sources/engine/**'
-      - 'sources/native/**'
-      - 'sources/shaders/**'
-      - 'sources/shared/**'
-      - 'sources/sdk/**'
-      - '!**/.all-contributorsrc'
-      - '!**/.editorconfig'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!crowdin.yml'
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build-type:
@@ -42,7 +25,6 @@ jobs:
   # Build Stride Runtime for Linux
   #
   Linux-Runtime:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false }}
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/build-windows-full.yml
+++ b/.github/workflows/build-windows-full.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 concurrency:
-  group: build-windows-full-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: build-windows-full-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/build-windows-full.yml
+++ b/.github/workflows/build-windows-full.yml
@@ -1,18 +1,6 @@
 name: Build Windows (Full)
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-windows-full.yml'
-      - 'build/Stride.sln'
-      - 'deps/**'
-      - 'sources/**'
-      - '!**/.all-contributorsrc'
-      - '!**/.editorconfig'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!crowdin.yml'
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build-type:
@@ -37,7 +25,6 @@ jobs:
   # Build Stride for Windows
   #
   Windows:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false }}
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/build-windows-runtime.yml
+++ b/.github/workflows/build-windows-runtime.yml
@@ -1,23 +1,6 @@
 name: Build Windows Runtime
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-windows-runtime.yml'
-      - 'build/Stride.Runtime.slnf'
-      - 'deps/**'
-      - 'sources/core/**'
-      - 'sources/engine/**'
-      - 'sources/native/**'
-      - 'sources/shaders/**'
-      - 'sources/shared/**'
-      - 'sources/sdk/**'
-      - '!**/.all-contributorsrc'
-      - '!**/.editorconfig'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!crowdin.yml'
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build-type:
@@ -53,7 +36,6 @@ jobs:
   # Build Stride Runtime for Windows
   #
   Windows-Runtime:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false }}
     name: Build (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}, ${{ github.event.inputs.graphics-api || inputs.graphics-api || 'Direct3D11' }})
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,6 @@ on:
       - '!crowdin.yml'
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
-  # Chatops bot dispatches this for tests-only re-runs against PR merge refs.
-  repository_dispatch:
-    types: [test-main-ci]
 
 permissions:
   checks: write
@@ -41,8 +38,8 @@ concurrency:
 
 jobs:
   # Per-area path-filter outputs drive the per-job `if:` conditions below.
-  # Defaults to 'true' for non-pull_request triggers (workflow_dispatch, repository_dispatch,
-  # push to master) so those run everything regardless of which files changed.
+  # Defaults to 'true' for non-pull_request triggers (workflow_dispatch, push to master)
+  # so those run everything regardless of which files changed.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -158,7 +155,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Windows-Runtime-D3D11'].result != 'failure'
       && needs['Windows-Runtime-D3D11'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-game-api-neutral.yml
@@ -172,7 +169,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Windows-Runtime-D3D11'].result != 'failure'
       && needs['Windows-Runtime-D3D11'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-simple.yml
@@ -185,7 +182,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Windows-Runtime-D3D11'].result != 'failure'
       && needs['Windows-Runtime-D3D11'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-game.yml
@@ -199,7 +196,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Windows-Runtime-D3D12'].result != 'failure'
       && needs['Windows-Runtime-D3D12'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-game.yml
@@ -213,7 +210,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Windows-Runtime-Vulkan'].result != 'failure'
       && needs['Windows-Runtime-Vulkan'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-game.yml
@@ -227,7 +224,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Linux-Runtime'].result != 'failure'
       && needs['Linux-Runtime'].result != 'cancelled'
     uses: ./.github/workflows/test-linux-simple.yml
@@ -240,7 +237,7 @@ jobs:
     if: |
       always()
       && github.event.pull_request.draft != true
-      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs.changes.outputs.runtime == 'true'
       && needs['Linux-Runtime'].result != 'failure'
       && needs['Linux-Runtime'].result != 'cancelled'
     uses: ./.github/workflows/test-linux-game.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,98 +27,222 @@ on:
       - '!crowdin.yml'
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
+  # Chatops bot dispatches this for tests-only re-runs against PR merge refs.
+  repository_dispatch:
+    types: [test-main-ci]
 
 permissions:
   checks: write
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ### Misc. ###
+  # Per-area path-filter outputs drive the per-job `if:` conditions below.
+  # Defaults to 'true' for non-pull_request triggers (workflow_dispatch, repository_dispatch,
+  # push to master) so those run everything regardless of which files changed.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.filter.outputs.runtime || 'true' }}
+      ios: ${{ steps.filter.outputs.ios || 'true' }}
+      full: ${{ steps.filter.outputs.full || 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            runtime:
+              - 'sources/engine/**'
+              - 'sources/core/**'
+              - 'sources/shaders/**'
+              - 'sources/native/**'
+              - 'sources/shared/**'
+              - 'sources/sdk/**'
+              - 'sources/assets/**'
+              - 'deps/**'
+              - 'build/Stride.Runtime.slnf'
+            ios:
+              - 'sources/engine/**'
+              - 'sources/core/**'
+              - 'sources/native/**'
+              - 'sources/shared/**'
+              - 'sources/sdk/**'
+              - 'deps/**'
+              - 'build/Stride.iOS.slnf'
+            full:
+              - 'sources/**'
+              - 'deps/**'
+              - 'build/Stride.sln'
+
+  ### Misc ###
   Assembly-Processor:
-    strategy:
-      matrix:
-        build-type: [Release]
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true' || needs.changes.outputs.full == 'true'
     uses: ./.github/workflows/build-assembly-processor.yml
     secrets: inherit
     with:
-      build-type: ${{ matrix.build-type }}
+      build-type: Release
 
   VS-Package:
-    strategy:
-      matrix:
-        build-type: [Debug] # Release has a bug and cannot build
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
     uses: ./.github/workflows/build-vs-package.yml
     secrets: inherit
     with:
-      build-type: ${{ matrix.build-type }}
+      build-type: Debug   # Release has a bug and cannot build
 
   ### Runtimes ###
-  # Android-Runtime:
-  #   strategy:
-  #     matrix:
-  #       build-type: [Release]
-  #   uses: ./.github/workflows/build-android.yml
-  #   secrets: inherit
-  #   with:
-  #     build-type: ${{ matrix.build-type }}
-
   iOS-Runtime:
-    strategy:
-      matrix:
-        build-type: [Release]
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     uses: ./.github/workflows/build-ios.yml
     secrets: inherit
     with:
-      build-type: ${{ matrix.build-type }}
+      build-type: Release
 
   Linux-Runtime:
-    strategy:
-      matrix:
-        build-type: [Release]
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
     uses: ./.github/workflows/build-linux-runtime.yml
     secrets: inherit
     with:
-      build-type: ${{ matrix.build-type }}
+      build-type: Release
 
-  Windows-Runtime:
-    strategy:
-      matrix:
-        build-type: [Release]
-        graphics-api: [Direct3D11, Direct3D12, Vulkan]
+  Windows-Runtime-D3D11:
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
     uses: ./.github/workflows/build-windows-runtime.yml
     secrets: inherit
     with:
-      build-type: ${{ matrix.build-type }}
-      graphics-api: ${{ matrix.graphics-api }}
+      build-type: Release
+      graphics-api: Direct3D11
+
+  Windows-Runtime-D3D12:
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
+    uses: ./.github/workflows/build-windows-runtime.yml
+    secrets: inherit
+    with:
+      build-type: Release
+      graphics-api: Direct3D12
+
+  Windows-Runtime-Vulkan:
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
+    uses: ./.github/workflows/build-windows-runtime.yml
+    secrets: inherit
+    with:
+      build-type: Release
+      graphics-api: Vulkan
+
+  ### Full Windows build (engine + editor + assets + samples) ###
+  Windows-Full:
+    needs: changes
+    if: github.event.pull_request.draft != true && needs.changes.outputs.full == 'true'
+    uses: ./.github/workflows/build-windows-full.yml
+    secrets: inherit
+    with:
+      build-type: Debug
 
   ### Tests ###
+  # Game tests where the picked graphics API doesn't materially affect outcomes
+  # (physics, audio, asset, engine logic). One run with D3D11 is sufficient.
+  Windows-Tests-Game-ApiNeutral:
+    needs: [changes, Windows-Runtime-D3D11]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Windows-Runtime-D3D11'].result != 'failure'
+      && needs['Windows-Runtime-D3D11'].result != 'cancelled'
+    uses: ./.github/workflows/test-windows-game-api-neutral.yml
+    secrets: inherit
+    with:
+      build-type: Debug
+
+  # Tests-Simple smoke-tests non-graphics paths; pinned to D3D11 build as the gate.
   Windows-Tests-Simple:
-    needs: Windows-Runtime
+    needs: [changes, Windows-Runtime-D3D11]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Windows-Runtime-D3D11'].result != 'failure'
+      && needs['Windows-Runtime-D3D11'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-simple.yml
     secrets: inherit
     with:
       build-type: Debug
 
-  Windows-Tests-Game:
-    needs: Windows-Runtime
+  Windows-Tests-Game-D3D11:
+    needs: [changes, Windows-Runtime-D3D11]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Windows-Runtime-D3D11'].result != 'failure'
+      && needs['Windows-Runtime-D3D11'].result != 'cancelled'
     uses: ./.github/workflows/test-windows-game.yml
     secrets: inherit
     with:
       build-type: Debug
+      graphics-api: Direct3D11
+
+  Windows-Tests-Game-D3D12:
+    needs: [changes, Windows-Runtime-D3D12]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Windows-Runtime-D3D12'].result != 'failure'
+      && needs['Windows-Runtime-D3D12'].result != 'cancelled'
+    uses: ./.github/workflows/test-windows-game.yml
+    secrets: inherit
+    with:
+      build-type: Debug
+      graphics-api: Direct3D12
+
+  Windows-Tests-Game-Vulkan:
+    needs: [changes, Windows-Runtime-Vulkan]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Windows-Runtime-Vulkan'].result != 'failure'
+      && needs['Windows-Runtime-Vulkan'].result != 'cancelled'
+    uses: ./.github/workflows/test-windows-game.yml
+    secrets: inherit
+    with:
+      build-type: Debug
+      graphics-api: Vulkan
 
   Linux-Tests-Simple:
-    needs: Linux-Runtime
+    needs: [changes, Linux-Runtime]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Linux-Runtime'].result != 'failure'
+      && needs['Linux-Runtime'].result != 'cancelled'
     uses: ./.github/workflows/test-linux-simple.yml
     secrets: inherit
     with:
       build-type: Debug
 
   Linux-Tests-Game:
-    needs: Linux-Runtime
+    needs: [changes, Linux-Runtime]
+    if: |
+      always()
+      && github.event.pull_request.draft != true
+      && (github.event_name == 'repository_dispatch' || needs.changes.outputs.runtime == 'true')
+      && needs['Linux-Runtime'].result != 'failure'
+      && needs['Linux-Runtime'].result != 'cancelled'
     uses: ./.github/workflows/test-linux-game.yml
     secrets: inherit
     with:

--- a/.github/workflows/pr-test-chatops-results.yml
+++ b/.github/workflows/pr-test-chatops-results.yml
@@ -1,0 +1,138 @@
+name: PR test chatops (results)
+
+# Companion to pr-test-chatops.yml. Two responsibilities:
+#   1. Flip the `chatops/<suite>` commit status on the PR head SHA (from pending → success/failure)
+#      as each individual run completes. SHA is read from a hidden marker in the dispatcher body.
+#   2. Once ALL runs referenced by a single dispatcher comment are done, post one summary comment
+#      pinging the original /test author. Idempotent via a marker appended to the dispatcher body.
+#
+# Deployment: see pr-test-chatops.yml header — uses the same App ID variable + private-key secret.
+
+on:
+  workflow_run:
+    workflows:
+      - "Test GameStudio (Screenshots)"
+      - "Test Samples (Screenshots)"
+      - "Test Windows (Game)"
+      - "Test Windows (Game ApiNeutral)"
+      - "Test Windows (Simple)"
+      - "Test Linux Game (Vulkan)"
+      - "Test Linux (Simple)"
+    types: [completed]
+
+jobs:
+  results:
+    if: github.event.workflow_run.event == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CHATOPS_APP_ID }}
+          private-key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
+
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const RESULTS_MARKER = '<!-- chatops-results-posted -->';
+            const runUrl = context.payload.workflow_run.html_url;
+
+            // Find the bot dispatcher comment that references this run URL.
+            // Iterates recently-updated open PRs; for Stride volumes this is fine.
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', per_page: 100, sort: 'updated', direction: 'desc',
+            });
+
+            for (const pr of prs) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr.number, per_page: 100,
+              });
+
+              const dispatcher = comments.find(c =>
+                c.user && c.user.type === 'Bot' &&
+                /\/test` dispatched:/.test(c.body || '') &&
+                (c.body || '').includes(runUrl)
+              );
+              if (!dispatcher) continue;
+
+              if ((dispatcher.body || '').includes(RESULTS_MARKER)) {
+                core.info(`Dispatcher ${dispatcher.id} already has results posted; skipping.`);
+                return;
+              }
+
+              // Parse "- `suite`: <run-url>" lines from the dispatcher body.
+              const re = /^- `([^`]+)`: (https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/actions\/runs\/(\d+))/gm;
+              const suites = [];
+              let m;
+              while ((m = re.exec(dispatcher.body)) !== null) {
+                suites.push({ name: m[1], url: m[2], runId: parseInt(m[3]) });
+              }
+              if (suites.length === 0) {
+                core.warning(`No parseable suite lines in dispatcher ${dispatcher.id}; skipping.`);
+                return;
+              }
+
+              const statuses = await Promise.all(suites.map(s =>
+                github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner, repo: context.repo.repo, run_id: s.runId,
+                }).then(({ data }) => ({ ...s, status: data.status, conclusion: data.conclusion }))
+                  .catch(() => ({ ...s, status: 'unknown', conclusion: null }))
+              ));
+
+              // Flip the per-suite commit status for the run that just completed (regardless of
+              // whether the others are done yet). SHA is captured from the dispatcher body so
+              // statuses land on the commit /test was issued against, even if the PR head moved.
+              const shaMatch = (dispatcher.body || '').match(/<!-- chatops-pr-head-sha:([a-f0-9]+) -->/);
+              const prHeadSha = shaMatch ? shaMatch[1] : null;
+              const completedRunId = context.payload.workflow_run.id;
+              const completed = statuses.find(s => s.runId === completedRunId);
+              if (prHeadSha && completed && completed.status === 'completed') {
+                const stateFor = c => c === 'success' ? 'success' : (c === 'failure' ? 'failure' : 'error');
+                try {
+                  await github.rest.repos.createCommitStatus({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    sha: prHeadSha,
+                    state: stateFor(completed.conclusion),
+                    context: `chatops/${completed.name}`,
+                    description: completed.conclusion || 'completed',
+                    target_url: completed.url,
+                  });
+                } catch (e) {
+                  core.warning(`Failed to update status for ${completed.name}: ${e.message}`);
+                }
+              }
+
+              const pending = statuses.filter(s => s.status !== 'completed');
+              if (pending.length > 0) {
+                core.info(`${pending.length}/${statuses.length} runs still pending; skipping post.`);
+                return;
+              }
+
+              // Author mention from the dispatcher body header (`@user — ...`).
+              const mentionMatch = (dispatcher.body || '').match(/^@(\S+)/);
+              const userMention = mentionMatch ? `@${mentionMatch[1]} — ` : '';
+
+              const icon = c => c === 'success' ? '✅' : (c === 'cancelled' ? '⚠️' : '❌');
+              const lines = statuses.map(s => `- ${icon(s.conclusion)} \`${s.name}\`: ${s.url}`);
+              const allGreen = statuses.every(s => s.conclusion === 'success');
+              const summary = allGreen ? 'all green' : 'some failed';
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `${userMention}\`/test\` complete (${summary}):\n${lines.join('\n')}`,
+              });
+
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: dispatcher.id,
+                body: dispatcher.body + `\n\n${RESULTS_MARKER}`,
+              });
+
+              return;
+            }
+
+            core.info(`No matching dispatcher comment found for run ${runUrl}.`);

--- a/.github/workflows/pr-test-chatops.yml
+++ b/.github/workflows/pr-test-chatops.yml
@@ -1,0 +1,215 @@
+name: PR test chatops
+
+# Lets PR commenters dispatch CI workflows on demand. Each dispatched suite lands a `chatops/<suite>`
+# pending commit status on the PR head; pr-test-chatops-results.yml flips it to success/failure
+# when the run completes and posts a summary comment.
+#
+# Authorization: only repo collaborators (OWNER / MEMBER / COLLABORATOR association) can trigger.
+# Tests run against the PR's virtual merge ref (refs/pull/<N>/merge) so same-repo and fork PRs work.
+#
+# === Deployment ===
+# Needs a GitHub App ("stride-chatops" by default) installed on the repo, with permissions:
+#   - Contents: read & write          (repository_dispatch)
+#   - Pull requests: read & write     (comments + reactions)
+#   - Actions: read                   (workflow-run lookups)
+#   - Commit statuses: read & write   (PR check rollup)
+# Then in repo Settings → Secrets and variables → Actions:
+#   - Variable CHATOPS_APP_ID             (the App's numeric ID)
+#   - Secret   CHATOPS_APP_PRIVATE_KEY    (the App's .pem private key, full contents)
+# The companion listener pr-test-chatops-results.yml uses the same App credentials.
+#
+# === Available commands === (post as a PR comment)
+#   /test help                         — show this list in-thread
+#   /test editor                       — Editor screenshot regression
+#   /test samples                      — Sample screenshot regression
+#   /test windows-game                 — All 4 Windows game-test variants (d3d11/d3d12/vulkan/api-neutral)
+#   /test windows-game-d3d11           — One specific Windows game-test API
+#   /test windows-game-d3d12
+#   /test windows-game-vulkan
+#   /test windows-game-api-neutral
+#   /test windows-simple               — Windows simple unit tests
+#   /test windows                      — windows-simple + all 4 windows-game variants
+#   /test linux                        — All Linux test variants
+#   /test linux-game
+#   /test linux-simple
+#   /test e2e                          — editor + samples (end-to-end screenshot suites)
+#
+# Multiple suites in one command: `/test editor samples linux-game`.
+
+on:
+  issue_comment:
+    types: [created]
+
+# Only the preflight "not configured" comment uses GITHUB_TOKEN; the actual /test dispatch
+# flow runs under the App token (which carries its own permissions).
+permissions:
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/test')
+    runs-on: ubuntu-latest
+    steps:
+      # Friendly fail on unconfigured forks: explain it in a PR comment rather than failing
+      # silently in the Actions tab. Uses the default GITHUB_TOKEN (write perms on issue_comment).
+      - if: vars.CHATOPS_APP_ID == ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `\`/test\` bot isn't configured on this repo. See the deployment notes at the top of \`.github/workflows/pr-test-chatops.yml\`.`,
+            });
+            core.setFailed('chatops not configured (CHATOPS_APP_ID variable unset)');
+
+      # Mint a stride-chatops App installation token. Using the App (rather than the default
+      # GITHUB_TOKEN) means dispatched workflow_runs propagate to downstream listeners — GitHub
+      # blocks workflow_run propagation when the dispatcher uses GITHUB_TOKEN. Also gives the
+      # bot its own identity (stride-chatops[bot]) instead of github-actions[bot].
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CHATOPS_APP_ID }}
+          private-key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
+
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const SUITES = {
+              'editor':                  { event: 'test-editor-screenshots',      workflow: 'test-windows-editor.yml' },
+              'samples':                 { event: 'test-samples-screenshots',     workflow: 'test-samples-screenshots.yml' },
+              'windows-game-d3d11':      { event: 'test-windows-game',            workflow: 'test-windows-game.yml',            payload: { 'graphics-api': 'Direct3D11' } },
+              'windows-game-d3d12':      { event: 'test-windows-game',            workflow: 'test-windows-game.yml',            payload: { 'graphics-api': 'Direct3D12' } },
+              'windows-game-vulkan':     { event: 'test-windows-game',            workflow: 'test-windows-game.yml',            payload: { 'graphics-api': 'Vulkan' } },
+              'windows-game-api-neutral':{ event: 'test-windows-game-api-neutral',workflow: 'test-windows-game-api-neutral.yml' },
+              'windows-simple':          { event: 'test-windows-simple',          workflow: 'test-windows-simple.yml' },
+              'linux-game':              { event: 'test-linux-game',              workflow: 'test-linux-game.yml' },
+              'linux-simple':            { event: 'test-linux-simple',            workflow: 'test-linux-simple.yml' },
+            };
+            // Aliases expand recursively (windows → windows-game → windows-game-d3d11, ...).
+            const ALIASES = {
+              'windows-game':    ['windows-game-d3d11', 'windows-game-d3d12', 'windows-game-vulkan', 'windows-game-api-neutral'],
+              'windows':         ['windows-simple', 'windows-game'],
+              'linux':           ['linux-simple', 'linux-game'],
+              'e2e':             ['editor', 'samples'],
+            };
+
+            const author = context.payload.comment.user.login;
+            const body = (context.payload.comment.body || '').trim();
+            const m = body.match(/^\/test\b\s*(.*)$/i);
+            if (!m) return;
+            const args = (m[1] || '').toLowerCase().split(/\s+/).filter(Boolean);
+
+            const post = (text) => github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: text,
+            });
+
+            // /test help — cheat sheet in-thread
+            if (args.length === 1 && args[0] === 'help') {
+              const lines = [
+                'Available test triggers:',
+                ...Object.keys(SUITES).map(k => `- \`/test ${k}\``),
+                '',
+                'Aliases (expand to multiple suites):',
+                ...Object.entries(ALIASES).map(([k, v]) => `- \`/test ${k}\` → ${v.map(s => '`' + s + '`').join(', ')}`),
+                '',
+                'Combine suites: `/test editor samples linux-game`',
+              ];
+              await post(lines.join('\n'));
+              return;
+            }
+
+            // Expand aliases recursively (cycle-safe), validate against SUITES.
+            const expanded = [];
+            const unknown = [];
+            const expand = (name, seen = new Set()) => {
+              if (seen.has(name)) return;
+              seen.add(name);
+              if (ALIASES[name]) ALIASES[name].forEach(c => expand(c, seen));
+              else if (SUITES[name]) expanded.push(name);
+              else unknown.push(name);
+            };
+            for (const a of args) expand(a);
+            const requested = [...new Set(expanded)];
+
+            if (requested.length === 0 || unknown.length > 0) {
+              await post(`@${author} unknown or empty suite. \`/test help\` for the list.${unknown.length ? ` (unknown: ${unknown.map(u => '`' + u + '`').join(', ')})` : ''}`);
+              return;
+            }
+
+            // Authorize: collaborators only
+            const assoc = context.payload.comment.author_association;
+            if (!['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc)) {
+              await post(`@${author} \`/test\` requires repo collaborator access.`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: context.payload.comment.id, content: 'rocket',
+            });
+
+            const lines = [];
+            for (const suite of requested) {
+              const cfg = SUITES[suite];
+              try {
+                const dispatchAt = new Date();
+                await github.rest.repos.createDispatchEvent({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  event_type: cfg.event,
+                  client_payload: { pr_number: pr.number, pr_head_sha: pr.head.sha, dispatched_by: author, ...(cfg.payload || {}) },
+                });
+
+                // Poll for the run we just kicked off so we can post a link comment.
+                // createDispatchEvent returns 204 with no run id; this is the documented workaround.
+                let run = null;
+                for (let i = 0; i < 10; i++) {
+                  await new Promise(r => setTimeout(r, 2000));
+                  const { data } = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    workflow_id: cfg.workflow, event: 'repository_dispatch', per_page: 5,
+                  });
+                  run = (data.workflow_runs || []).find(r => new Date(r.created_at) >= dispatchAt);
+                  if (run) break;
+                }
+                // Format matched by pr-test-chatops-results.yml — keep "`<suite>`: <run-url>" shape stable.
+                lines.push(run
+                  ? `- \`${suite}\`: ${run.html_url}`
+                  : `- \`${suite}\`: dispatched (run link will appear in Checks tab — couldn't capture within 20s)`);
+
+                // Pending commit status — listener flips to success/failure on completion. Only
+                // create it when we have a run URL to link to; otherwise the status would be
+                // stuck pending (the listener has no way to match it back).
+                if (run) {
+                  try {
+                    await github.rest.repos.createCommitStatus({
+                      owner: context.repo.owner, repo: context.repo.repo,
+                      sha: pr.head.sha,
+                      state: 'pending',
+                      context: `chatops/${suite}`,
+                      description: 'Dispatched, awaiting completion',
+                      target_url: run.html_url,
+                    });
+                  } catch (e) {
+                    core.warning(`Failed to set pending status for ${suite}: ${e.message}`);
+                  }
+                }
+              } catch (e) {
+                lines.push(`- \`${suite}\`: failed to dispatch — ${e.message}`);
+              }
+            }
+            // This comment is also load-bearing state for pr-test-chatops-results.yml — it parses
+            // the @author header (for the completion ping), the per-suite run URLs (to detect
+            // "all runs done"), and the hidden chatops-pr-head-sha marker (so status checks land
+            // on the right SHA even if the user pushes more commits). Don't drop the comment just
+            // because the 🚀 reaction + commit statuses already convey "/test was accepted".
+            await post(`@${author} — \`/test\` dispatched:\n${lines.join('\n')}\n\n<!-- chatops-pr-head-sha:${pr.head.sha} -->`);

--- a/.github/workflows/test-linux-game.yml
+++ b/.github/workflows/test-linux-game.yml
@@ -15,10 +15,13 @@ on:
       build-type:
         default: Debug
         type: string
+  repository_dispatch:
+    # Fired by chatops bot. Payload: { pr_number, dispatched_by }.
+    types: [test-linux-game]
 
 
 concurrency:
-  group: test-linux-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: test-linux-game-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -33,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
@@ -107,6 +111,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
@@ -182,6 +187,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/test-linux-simple.yml
+++ b/.github/workflows/test-linux-simple.yml
@@ -15,10 +15,13 @@ on:
       build-type:
         default: Debug
         type: string
+  repository_dispatch:
+    # Fired by chatops bot. Payload: { pr_number, dispatched_by }.
+    types: [test-linux-simple]
 
 
 concurrency:
-  group: test-linux-simple-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: test-linux-simple-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -31,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
@@ -61,6 +65,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/test-samples-screenshots.yml
+++ b/.github/workflows/test-samples-screenshots.yml
@@ -19,7 +19,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # LPIPS comparator falls back to Claude vision for borderline drift; without ANTHROPIC_API_KEY
+  # (typical on forks) flaky frames would surface as false drift. Skip cleanly when missing.
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has-api-key: ${{ steps.check.outputs.has-api-key }}
+    steps:
+      - id: check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "has-api-key=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-api-key=false" >> $GITHUB_OUTPUT
+            echo "::notice::ANTHROPIC_API_KEY not set; skipping samples screenshot suite. Set it under repo Settings → Secrets → Actions to enable."
+          fi
+
   Run:
+    needs: preflight
+    if: needs.preflight.outputs.has-api-key == 'true'
     name: Capture & compare all samples (${{ matrix.graphics-api }}, ${{ github.event.inputs.build-type || 'Debug' }})
     # Single job per graphics API: the harness + orchestrator + comparator are sample-agnostic, so a
     # matrix-per-sample would build the engine 15× for the same artifacts. Sequential capture

--- a/.github/workflows/test-samples-screenshots.yml
+++ b/.github/workflows/test-samples-screenshots.yml
@@ -10,12 +10,14 @@ on:
         options:
           - Debug
           - Release
+  repository_dispatch:
+    types: [test-samples-screenshots]
   schedule:
     # Daily at 04:37 UTC — offset off top-of-hour to avoid GitHub Actions cron load spikes.
     - cron: '37 4 * * *'
 
 concurrency:
-  group: test-samples-screenshots-${{ github.ref }}
+  group: test-samples-screenshots-${{ github.event.client_payload.pr_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -63,6 +65,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/test-windows-editor.yml
+++ b/.github/workflows/test-windows-editor.yml
@@ -20,7 +20,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Editor drift is non-deterministic enough that the LPIPS comparator relies on Claude vision
+  # as a fallback for borderline cases. Without ANTHROPIC_API_KEY (typical on forks), most flaky
+  # runs would report drift. Skip the suite cleanly so forks don't see misleading failures.
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has-api-key: ${{ steps.check.outputs.has-api-key }}
+    steps:
+      - id: check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "has-api-key=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-api-key=false" >> $GITHUB_OUTPUT
+            echo "::notice::ANTHROPIC_API_KEY not set; skipping editor screenshot suite. Set it under repo Settings → Secrets → Actions to enable."
+          fi
+
   Run:
+    needs: preflight
+    if: needs.preflight.outputs.has-api-key == 'true'
     name: Editor screenshots (${{ github.event.inputs.build-type || 'Debug' }})
     runs-on: windows-2025-vs2026
     env:

--- a/.github/workflows/test-windows-editor.yml
+++ b/.github/workflows/test-windows-editor.yml
@@ -1,4 +1,4 @@
-name: Test GameStudio (Editor Screenshots)
+name: Test GameStudio (Screenshots)
 
 on:
   workflow_dispatch:
@@ -10,13 +10,16 @@ on:
         options:
           - Debug
           - Release
+  repository_dispatch:
+    # Fired by chatops bot. Payload: { pr_number, dispatched_by }.
+    types: [test-editor-screenshots]
   schedule:
     # Daily at 05:17 UTC — offset off top-of-hour to avoid GitHub Actions cron load spikes;
     # gap from test-samples-screenshots (04:37) so they don't compete for runners.
     - cron: '17 5 * * *'
 
 concurrency:
-  group: test-windows-editor-${{ github.ref }}
+  group: test-windows-editor-${{ github.event.client_payload.pr_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -52,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/test-windows-game-api-neutral.yml
+++ b/.github/workflows/test-windows-game-api-neutral.yml
@@ -1,0 +1,70 @@
+name: Test Windows (Game ApiNeutral)
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        description: Build
+        default: Debug
+        type: choice
+        options:
+          - Debug
+          - Release
+  workflow_call:
+    inputs:
+      build-type:
+        default: Debug
+        type: string
+
+concurrency:
+  group: test-windows-game-api-neutral-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  cancel-in-progress: true
+
+jobs:
+  Game-ApiNeutral:
+    name: Test Game ApiNeutral (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
+    runs-on: windows-2025-vs2026
+    env:
+      STRIDE_GRAPHICS_SOFTWARE_RENDERING: "1"
+      STRIDE_TESTS_RENDERDOC: "error"
+      STRIDE_MAX_PARALLELISM: "8"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Disable WER dialogs
+        run: reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting" /v DontShowUI /t REG_DWORD /d 1 /f
+      - name: Build
+        run: |
+          dotnet build build\Stride.Tests.Game.slnf `
+            -p:StrideTestRuntimeIdentifier=win-x64 `
+            -nr:false `
+            -v:m -p:WarningLevel=0 `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
+            -p:StridePlatforms=Windows `
+            -p:StrideGraphicsApis=Direct3D11
+      - name: Test
+        run: |
+          dotnet test build\Stride.Tests.Game.slnf `
+            --no-build `
+            --logger:trx --results-directory TestResults `
+            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+      - name: Publish Test Report
+        if: always()
+        uses: phoenix-actions/test-reporting@v15
+        with:
+          name: 'Test Report: Windows Game ApiNeutral'
+          path: TestResults/*.trx
+          reporter: dotnet-trx
+          output-to: step-summary
+          list-tests: 'failed'
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-game-api-neutral
+          path: tests/local/
+          if-no-files-found: ignore

--- a/.github/workflows/test-windows-game-api-neutral.yml
+++ b/.github/workflows/test-windows-game-api-neutral.yml
@@ -15,9 +15,11 @@ on:
       build-type:
         default: Debug
         type: string
+  repository_dispatch:
+    types: [test-windows-game-api-neutral]
 
 concurrency:
-  group: test-windows-game-api-neutral-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: test-windows-game-api-neutral-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -32,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -24,66 +24,19 @@ on:
       build-type:
         default: Debug
         type: string
+      graphics-api:
+        default: ''
+        type: string
 
 
 concurrency:
-  group: test-windows-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: test-windows-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}-${{ github.event.inputs.graphics-api || inputs.graphics-api || 'all' }}
   cancel-in-progress: true
 
 jobs:
   #
-  # Game tests - API-independent projects (run once)
-  #
-  Game-Common:
-    name: Test Game Common (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
-    runs-on: windows-2025-vs2026
-    env:
-      STRIDE_GRAPHICS_SOFTWARE_RENDERING: "1"
-      STRIDE_TESTS_RENDERDOC: "error"
-      STRIDE_MAX_PARALLELISM: "8"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-      - name: Disable WER dialogs
-        run: reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting" /v DontShowUI /t REG_DWORD /d 1 /f
-      - name: Build
-        run: |
-          dotnet build build\Stride.Tests.Game.slnf `
-            -p:StrideTestRuntimeIdentifier=win-x64 `
-            -nr:false `
-            -v:m -p:WarningLevel=0 `
-            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} `
-            -p:StridePlatforms=Windows `
-            -p:StrideGraphicsApis=Direct3D11
-      - name: Test
-        run: |
-          dotnet test build\Stride.Tests.Game.slnf `
-            --no-build `
-            --logger:trx --results-directory TestResults `
-            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
-      - name: Publish Test Report
-        if: always()
-        uses: phoenix-actions/test-reporting@v15
-        with:
-          name: 'Test Report: Windows Game Common'
-          path: TestResults/*.trx
-          reporter: dotnet-trx
-          output-to: step-summary
-          list-tests: 'failed'
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-artifacts-game-common
-          path: tests/local/
-          if-no-files-found: ignore
-
-  #
-  # Game tests - Graphics API-dependent projects (run per API)
+  # Game tests - Graphics API-dependent projects (run per API).
+  # API-independent tests live in test-windows-game-common.yml so they run once.
   #
   Game-GraphicsApi:
     name: Test Game ${{ matrix.graphics-api }} (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
@@ -91,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graphics-api: ${{ github.event.inputs.graphics-api != '' && fromJson(format('["{0}"]', github.event.inputs.graphics-api)) || fromJson('["Direct3D11","Direct3D12","Vulkan"]') }}
+        graphics-api: ${{ (github.event.inputs.graphics-api || inputs.graphics-api) != '' && fromJson(format('["{0}"]', github.event.inputs.graphics-api || inputs.graphics-api)) || fromJson('["Direct3D11","Direct3D12","Vulkan"]') }}
     env:
       STRIDE_GRAPHICS_SOFTWARE_RENDERING: "1"
       STRIDE_TESTS_RENDERDOC: "error"

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -27,16 +27,19 @@ on:
       graphics-api:
         default: ''
         type: string
+  repository_dispatch:
+    # Fired by chatops bot. Payload: { pr_number, graphics-api, dispatched_by }.
+    types: [test-windows-game]
 
 
 concurrency:
-  group: test-windows-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}-${{ github.event.inputs.graphics-api || inputs.graphics-api || 'all' }}
+  group: test-windows-game-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}-${{ github.event.client_payload['graphics-api'] || github.event.inputs.graphics-api || inputs.graphics-api || 'all' }}
   cancel-in-progress: true
 
 jobs:
   #
   # Game tests - Graphics API-dependent projects (run per API).
-  # API-independent tests live in test-windows-game-common.yml so they run once.
+  # API-independent tests live in test-windows-game-api-neutral.yml so they run once.
   #
   Game-GraphicsApi:
     name: Test Game ${{ matrix.graphics-api }} (${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }})
@@ -44,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graphics-api: ${{ (github.event.inputs.graphics-api || inputs.graphics-api) != '' && fromJson(format('["{0}"]', github.event.inputs.graphics-api || inputs.graphics-api)) || fromJson('["Direct3D11","Direct3D12","Vulkan"]') }}
+        graphics-api: ${{ (github.event.client_payload['graphics-api'] || github.event.inputs.graphics-api || inputs.graphics-api) != '' && fromJson(format('["{0}"]', github.event.client_payload['graphics-api'] || github.event.inputs.graphics-api || inputs.graphics-api)) || fromJson('["Direct3D11","Direct3D12","Vulkan"]') }}
     env:
       STRIDE_GRAPHICS_SOFTWARE_RENDERING: "1"
       STRIDE_TESTS_RENDERDOC: "error"
@@ -59,6 +62,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          # Chatops dispatch passes a PR number; check out its merge ref so we test the
+          # post-merge state (works uniformly for same-repo and fork PRs).
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/test-windows-simple.yml
+++ b/.github/workflows/test-windows-simple.yml
@@ -15,10 +15,13 @@ on:
       build-type:
         default: Debug
         type: string
+  repository_dispatch:
+    # Fired by chatops bot. Payload: { pr_number, dispatched_by }.
+    types: [test-windows-simple]
 
 
 concurrency:
-  group: test-windows-simple-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  group: test-windows-simple-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -30,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ github.event.client_payload.pr_number && format('refs/pull/{0}/merge', github.event.client_payload.pr_number) || github.ref }}
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'


### PR DESCRIPTION
# PR Details

CI refactor + new `/test` chatops bot

Four commits, each independently mergeable but they land best together.

- **`ci: drop duplicate pull_request triggers from build-*`**
   `build-ios.yml`, `build-linux-runtime.yml`, `build-windows-runtime.yml` were each firing twice per PR (standalone + via `main.yml`'s `workflow_call`). Drops the standalone trigger; saves ~15–25 min of duplicate compute per PR.
- **`ci/main: explicit per-API jobs + path-filter gating`**
   replaces the matrix with explicit per-API jobs (`Windows-Runtime-{D3D11,D3D12,Vulkan}`, `Windows-Tests-Game-{D3D11,D3D12,Vulkan}`, etc.), so each can be re-run, required, or chatops-targeted individually. Adds `dorny/paths-filter` to skip irrelevant jobs on docs-only / scoped PRs. Adds `Windows-Tests-Game-ApiNeutral` so non-graphics-API tests (physics/audio/asset/engine logic) run once instead of per-API. Heavy jobs skip on draft PRs.
- **`ci: skip screenshots without ANTHROPIC_API_KEY`**
   editor/samples screenshot suites use Claude vision as LPIPS fallback; without the key (typical on forks) flaky frames surface as false drift. Adds a preflight that skips cleanly with a notice when the secret is absent.
- **`ci: PR-comment chatops bot (/test ...)`**
   a GitHub-App-backed bot that dispatches selected suites on collaborator comments.
   `/test help` lists commands.
   I did some tests there: https://github.com/xen2/stride/pull/4
