### PR TITLE
fix: Prevent Game Studio crash when creating prefab from entities with ModelNodeLinkComponent

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/ValueConverters/EntityComponentToTransformLinkInfo.cs
+++ b/sources/editor/Stride.Assets.Presentation/ValueConverters/EntityComponentToTransformLinkInfo.cs
@@ -19,7 +19,7 @@ namespace Stride.Assets.Presentation.ValueConverters
             if (string.IsNullOrEmpty(modelNodeLinkComponent?.NodeName))
                 return DependencyProperty.UnsetValue;
 
-            if (modelNodeLinkComponent.Target != null && !string.IsNullOrEmpty(modelNodeLinkComponent.NodeName))
+            if (modelNodeLinkComponent.Target?.Entity != null && !string.IsNullOrEmpty(modelNodeLinkComponent.NodeName))
             {
                 var entity = modelNodeLinkComponent.Target.Entity;
                 return $"{entity.Name}.{modelNodeLinkComponent.NodeName}";

--- a/sources/engine/Stride.Engine/Engine/ModelComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/ModelComponent.cs
@@ -124,6 +124,9 @@ namespace Stride.Engine
 
         private void CheckSkeleton()
         {
+            if (model is null)
+                return;
+                
             if (modelViewHierarchyDirty || meshInfos.Count != model.Meshes.Count)
             {
                 ModelUpdated();


### PR DESCRIPTION
# PR Details

Fixes two NullReferenceException crashes that occur when creating a prefab from a selection that contains entities with a ModelNodeLinkComponent bound to a skeleton node.

## Related Issue

fix #3165

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist



- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->