### PR TITLE
core: drop MicroThreading dep from Stride.Core.Serialization

### DIFF
--- a/sources/assets/Stride.Core.Assets.CompilerApp/Stride.Core.Assets.CompilerApp.csproj
+++ b/sources/assets/Stride.Core.Assets.CompilerApp/Stride.Core.Assets.CompilerApp.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\engine\Stride.BepuPhysics\Stride.BepuPhysics\Stride.BepuPhysics.csproj" />
     <ProjectReference Include="..\..\engine\Stride.SpriteStudio.Offline\Stride.SpriteStudio.Offline.csproj" />
     <ProjectReference Include="..\..\engine\Stride.UI\Stride.UI.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <Import Project="..\..\shared\Stride.NuGetResolver.Targets\Stride.NuGetResolver.Targets.projitems" Label="Shared" />
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Editor/Sdk/Sdk.targets" />

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Stride.Core.BuildEngine.Common.csproj
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Stride.Core.BuildEngine.Common.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Stride.Core.Design\Stride.Core.Design.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Editor/Sdk/Sdk.targets" />
 </Project>

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Stride.Core.Mathematics\Stride.Core.Mathematics.csproj" />
     <ProjectReference Include="..\Stride.Core.Serialization\Stride.Core.Serialization.csproj" />
+    <ProjectReference Include="..\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
     <ProjectReference Include="..\Stride.Core.Yaml\Stride.Core.Yaml.csproj" />
   </ItemGroup>
 

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Stride.Core.Diagnostics;
 using Stride.Core.IO;
-using Stride.Core.MicroThreading;
 using Stride.Core.Reflection;
 using Stride.Core.Streaming;
 
@@ -157,59 +156,6 @@ public sealed partial class ContentManager : IContentManager
             }
             return true;
         }
-    }
-
-    /// <summary>
-    /// Reloads a content asynchronously. If possible, same recursively referenced objects are reused.
-    /// </summary>
-    /// <param name="obj">The object to reload.</param>
-    /// <param name="newUrl">The url of the new object to load. This allows to replace an asset by another one, or to handle renamed content.</param>
-    /// <param name="settings">The loader settings.</param>
-    /// <returns>A task that completes when the content has been reloaded. The result of the task is True if it could be reloaded, false otherwise.</returns>
-    /// <exception cref="System.InvalidOperationException">Content not loaded through this ContentManager.</exception>
-    public Task<bool> ReloadAsync(object obj, string? newUrl = null, ContentManagerLoaderSettings? settings = null)
-    {
-        return ScheduleAsync(() => Reload(obj, newUrl, settings));
-    }
-
-    /// <summary>
-    /// Loads an asset from the specified URL asynchronously.
-    /// </summary>
-    /// <typeparam name="T">The content type.</typeparam>
-    /// <param name="url">The URL to load from.</param>
-    /// <param name="settings">The settings. If null, fallback to <see cref="ContentManagerLoaderSettings.Default" />.</param>
-    /// <remarks>If the asset is already loaded, it just increases the reference count of the asset and return the same instance.</remarks>
-    /// <returns>The loaded content.</returns>
-    public Task<T> LoadAsync<T>(string url, ContentManagerLoaderSettings? settings = null) where T : class
-    {
-        return ScheduleAsync(() => Load<T>(url, settings));
-    }
-
-    /// <summary>
-    /// Loads an asset from the specified URL asynchronously.
-    /// </summary>
-    /// <param name="type">The type.</param>
-    /// <param name="url">The URL.</param>
-    /// <param name="settings">The settings.</param>
-    /// <remarks>If the asset is already loaded, it just increases the reference count of the asset and return the same instance.</remarks>
-    /// <returns>The loaded content.</returns>
-    public Task<object> LoadAsync(Type type, string url, ContentManagerLoaderSettings? settings = null)
-    {
-        return ScheduleAsync(() => Load(type, url, settings));
-    }
-
-    private static Task<T> ScheduleAsync<T>(Func<T> action)
-    {
-        var microThread = Scheduler.CurrentMicroThread;
-        return Task.Factory.StartNew(() =>
-        {
-            var initialContext = SynchronizationContext.Current;
-            // This synchronization context gives access to any MicroThreadLocal values. The database to use might actually be micro thread local.
-            SynchronizationContext.SetSynchronizationContext(new MicrothreadProxySynchronizationContext(microThread));
-            var result = action();
-            SynchronizationContext.SetSynchronizationContext(initialContext);
-            return result;
-        });
     }
 
     /// <summary>

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/IContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/IContentManager.cs
@@ -35,15 +35,6 @@ public interface IContentManager
     T Load<T>(string url, ContentManagerLoaderSettings? settings = null) where T : class;
 
     /// <summary>
-    /// Loads content from the specified URL asynchronously.
-    /// </summary>
-    /// <typeparam name="T">The content type.</typeparam>
-    /// <param name="url">The URL to load from.</param>
-    /// <param name="settings">The settings. If null, fallback to <see cref="ContentManagerLoaderSettings.Default"/>.</param>
-    /// <returns></returns>
-    Task<T> LoadAsync<T>(string url, ContentManagerLoaderSettings? settings = null) where T : class;
-
-    /// <summary>
     /// Gets a previously loaded asset from its URL.
     /// </summary>
     /// <typeparam name="T">The type of asset to retrieve.</typeparam>

--- a/sources/core/Stride.Core.Serialization/Serialization/UrlReferenceContentManagerExtenstions.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/UrlReferenceContentManagerExtenstions.cs
@@ -58,23 +58,6 @@ public static class UrlReferenceContentManagerExtenstions
     }
 
     /// <summary>
-    /// Loads content from the specified URL asynchronously.
-    /// </summary>
-    /// <typeparam name="T">The content type.</typeparam>
-    /// <param name="content">The <see cref="IContentManager"/>.</param>
-    /// <param name="urlReference">The URL to load from.</param>
-    /// <param name="settings">The settings. If null, fallback to <see cref="ContentManagerLoaderSettings.Default"/>.</param>
-    /// <returns>The loaded content.</returns>
-    /// <exception cref="ArgumentNullException">If <paramref name="urlReference"/> is <c>null</c> or <c>empty</c>. Or <paramref name="content"/> is <c>null</c>.</exception>
-    public static Task<T> LoadAsync<T>(this IContentManager content, UrlReference<T> urlReference, ContentManagerLoaderSettings? settings = null)
-        where T : class
-    {
-        CheckArguments(content, urlReference);
-
-        return content.LoadAsync<T>(urlReference.Url, settings);
-    }
-
-    /// <summary>
     /// Gets a previously loaded asset from its URL.
     /// </summary>
     /// <typeparam name="T">The type of asset to retrieve.</typeparam>

--- a/sources/core/Stride.Core.Serialization/Stride.Core.Serialization.csproj
+++ b/sources/core/Stride.Core.Serialization/Stride.Core.Serialization.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
     <ProjectReference Include="..\Stride.Core.IO\Stride.Core.IO.csproj" />
   </ItemGroup>
 

--- a/sources/core/Stride.Core.Tests/Stride.Core.Tests.Android.csproj
+++ b/sources/core/Stride.Core.Tests/Stride.Core.Tests.Android.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />
     <ProjectReference Include="..\Stride.Core.Serialization\Stride.Core.Serialization.csproj" />
+    <ProjectReference Include="..\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets" />
 </Project>

--- a/sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj
+++ b/sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />
+    <ProjectReference Include="..\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
     <ProjectReference Include="..\Stride.Core.Serialization\Stride.Core.Serialization.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets" />

--- a/sources/core/Stride.Core.Tests/Stride.Core.Tests.iOS.csproj
+++ b/sources/core/Stride.Core.Tests/Stride.Core.Tests.iOS.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />
+    <ProjectReference Include="..\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
     <ProjectReference Include="..\Stride.Core.Serialization\Stride.Core.Serialization.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets" />

--- a/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
+++ b/sources/editor/Stride.Assets.Presentation/Stride.Assets.Presentation.csproj
@@ -69,6 +69,7 @@
     <ProjectReference Include="..\Stride.Core.Assets.Editor\Stride.Core.Assets.Editor.csproj" />
     <ProjectReference Include="..\Stride.Editor\Stride.Editor.csproj" />
     <ProjectReference Include="..\Stride.Samples.Templates\Stride.Samples.Templates.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/sources/editor/Stride.Editor/Stride.Editor.csproj
+++ b/sources/editor/Stride.Editor/Stride.Editor.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\..\engine\Stride.Video\Stride.Video.csproj" />
     <ProjectReference Include="..\..\tools\Stride.TextureConverter\Stride.TextureConverter.csproj" />
     <ProjectReference Include="..\Stride.Core.Assets.Editor\Stride.Core.Assets.Editor.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="Themes\Generic.xaml">

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Stride.BepuPhysics.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Stride.BepuPhysics.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Stride.Engine\Stride.Engine.csproj" />
+    <ProjectReference Include="..\..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sources/engine/Stride.Debugger/Stride.Debugger.csproj
+++ b/sources/engine/Stride.Debugger/Stride.Debugger.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stride.Assets\Stride.Assets.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Editor/Sdk/Sdk.targets" />
 </Project>

--- a/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.Android.csproj
+++ b/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.Android.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />
     <ProjectReference Include="..\Stride.Graphics.Regression\Stride.Graphics.Regression.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="XunitAttributes.cs" />

--- a/sources/engine/Stride.Engine/Engine/ContentManagerAsyncExtensions.cs
+++ b/sources/engine/Stride.Engine/Engine/ContentManagerAsyncExtensions.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Stride.Core.MicroThreading;
+
+namespace Stride.Core.Serialization.Contents;
+
+/// <summary>
+/// Async Load/Reload helpers for <see cref="ContentManager"/> that propagate the calling MicroThread's
+/// synchronization context onto the task — required for code paths that rely on MicroThreadLocal values
+/// (e.g. selecting the active database).
+/// </summary>
+public static class ContentManagerAsyncExtensions
+{
+    /// <summary>
+    /// Reloads a previously loaded asset asynchronously.
+    /// </summary>
+    /// <param name="contentManager">The content manager.</param>
+    /// <param name="obj">The object to reload.</param>
+    /// <param name="newUrl">The url of the new object to load. This allows to replace an asset by another one, or to handle renamed content.</param>
+    /// <param name="settings">The loader settings.</param>
+    /// <returns>A task that completes when the content has been reloaded. The result of the task is True if it could be reloaded, false otherwise.</returns>
+    /// <exception cref="System.InvalidOperationException">Content not loaded through this ContentManager.</exception>
+    public static Task<bool> ReloadAsync(this ContentManager contentManager, object obj, string? newUrl = null, ContentManagerLoaderSettings? settings = null)
+    {
+        return ScheduleAsync(() => contentManager.Reload(obj, newUrl, settings));
+    }
+
+    /// <summary>
+    /// Loads an asset from the specified URL asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The content type.</typeparam>
+    /// <param name="contentManager">The content manager.</param>
+    /// <param name="url">The URL to load from.</param>
+    /// <param name="settings">The settings. If null, fallback to <see cref="ContentManagerLoaderSettings.Default" />.</param>
+    /// <remarks>If the asset is already loaded, it just increases the reference count of the asset and return the same instance.</remarks>
+    /// <returns>The loaded content.</returns>
+    public static Task<T> LoadAsync<T>(this IContentManager contentManager, string url, ContentManagerLoaderSettings? settings = null) where T : class
+    {
+        return ScheduleAsync(() => contentManager.Load<T>(url, settings));
+    }
+
+    /// <summary>
+    /// Loads content from the specified <see cref="UrlReference{T}"/> asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The content type.</typeparam>
+    /// <param name="content">The <see cref="IContentManager"/>.</param>
+    /// <param name="urlReference">The URL to load from.</param>
+    /// <param name="settings">The settings. If null, fallback to <see cref="ContentManagerLoaderSettings.Default"/>.</param>
+    /// <returns>The loaded content.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="urlReference"/> is <c>null</c> or <c>empty</c>. Or <paramref name="content"/> is <c>null</c>.</exception>
+    public static Task<T> LoadAsync<T>(this IContentManager content, UrlReference<T> urlReference, ContentManagerLoaderSettings? settings = null)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        if (urlReference?.IsEmpty != false)
+            throw new ArgumentNullException(nameof(urlReference));
+
+        return content.LoadAsync<T>(urlReference.Url, settings);
+    }
+
+    /// <summary>
+    /// Loads an asset from the specified URL asynchronously.
+    /// </summary>
+    /// <param name="contentManager">The content manager.</param>
+    /// <param name="type">The type.</param>
+    /// <param name="url">The URL.</param>
+    /// <param name="settings">The settings.</param>
+    /// <remarks>If the asset is already loaded, it just increases the reference count of the asset and return the same instance.</remarks>
+    /// <returns>The loaded content.</returns>
+    public static Task<object> LoadAsync(this ContentManager contentManager, Type type, string url, ContentManagerLoaderSettings? settings = null)
+    {
+        return ScheduleAsync(() => contentManager.Load(type, url, settings));
+    }
+
+    private static Task<T> ScheduleAsync<T>(Func<T> action)
+    {
+        var microThread = Scheduler.CurrentMicroThread;
+        return Task.Factory.StartNew(() =>
+        {
+            var initialContext = SynchronizationContext.Current;
+            // This synchronization context gives access to any MicroThreadLocal values. The database to use might actually be micro thread local.
+            SynchronizationContext.SetSynchronizationContext(new MicrothreadProxySynchronizationContext(microThread));
+            var result = action();
+            SynchronizationContext.SetSynchronizationContext(initialContext);
+            return result;
+        });
+    }
+}

--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Stride.Rendering\Stride.Rendering.csproj" />
     <ProjectReference Include="..\Stride.VirtualReality\Stride.VirtualReality.csproj" />
     <ProjectReference Include="..\..\shaders\Stride.Shaders.Compilers\Stride.Shaders.Compilers.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets" />
 </Project>

--- a/sources/engine/Stride.Navigation.Tests/Stride.Navigation.Tests.Windows.csproj
+++ b/sources/engine/Stride.Navigation.Tests/Stride.Navigation.Tests.Windows.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />
     <ProjectReference Include="..\Stride.Navigation\Stride.Navigation.csproj" />
     <ProjectReference Include="..\Stride.Graphics.Regression\Stride.Graphics.Regression.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="XunitAttributes.cs" />

--- a/sources/engine/Stride.Physics/Stride.Physics.csproj
+++ b/sources/engine/Stride.Physics/Stride.Physics.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />
+    <ProjectReference Include="..\..\core\Stride.Core.MicroThreading\Stride.Core.MicroThreading.csproj" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Move `ContentManager.LoadAsync` / `ReloadAsync` to extension methods (`ContentManagerAsyncExtensions` in `Stride.Engine`) so `Stride.Core.Serialization` no longer depends on `Stride.Core.MicroThreading`.

`IContentManager.LoadAsync<T>` is removed from the interface and replaced by an extension.

The 12 projects that use MicroThreading types directly now reference `Stride.Core.MicroThreading` explicitly (was transitive via Serialization).

For user code, no changes needed (as long as `Stride.Engine` is referenced).
