### PR TITLE
sdk/tests: filter runtimes/<rid> after GetCopyToOutputDirectoryItems

### DIFF
--- a/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets
@@ -91,19 +91,30 @@
        and flatten matching ones to the output root. This ensures only the target RID's
        native libs are copied, and they're placed flat for dlopen to find them. -->
   <Target Name="_StrideFilterAndFlattenRuntimes"
-          BeforeTargets="_CopyFilesMarkedCopyLocal;_CopySourceItemsToOutputDirectory"
+          BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory;_CopyOutOfDateSourceItemsToOutputDirectoryAlways;_CopyFilesMarkedCopyLocal"
+          DependsOnTargets="GetCopyToOutputDirectoryItems"
           Condition="'$(RuntimeIdentifier)' != ''">
     <ItemGroup>
-      <!-- Remove non-matching runtimes/ items -->
-      <None Remove="@(None)"
-          Condition="'%(None.CopyToOutputDirectory)' != '' And
-                     $([System.String]::Copy('%(None.Link)').Replace('/','\\').StartsWith('runtimes\')) And
-                     !$([System.String]::Copy('%(None.Link)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))" />
-      <!-- Flatten matching runtimes/ items to output root -->
-      <None Update="@(None)"
-          Condition="'%(None.CopyToOutputDirectory)' != '' And
-                     $([System.String]::Copy('%(None.Link)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))"
-          Link="%(Filename)%(Extension)" />
+      <!-- Filter source items (None / Content / etc. with CopyToOutputDirectory) -->
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)"
+          Condition="$([System.String]::Copy('%(_SourceItemsToCopyToOutputDirectory.TargetPath)').Replace('/','\\').StartsWith('runtimes\')) And
+                     !$([System.String]::Copy('%(_SourceItemsToCopyToOutputDirectory.TargetPath)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))" />
+      <_SourceItemsToCopyToOutputDirectory Update="@(_SourceItemsToCopyToOutputDirectory)"
+          Condition="$([System.String]::Copy('%(_SourceItemsToCopyToOutputDirectory.TargetPath)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))"
+          TargetPath="%(Filename)%(Extension)" />
+      <_SourceItemsToCopyToOutputDirectoryAlways Remove="@(_SourceItemsToCopyToOutputDirectoryAlways)"
+          Condition="$([System.String]::Copy('%(_SourceItemsToCopyToOutputDirectoryAlways.TargetPath)').Replace('/','\\').StartsWith('runtimes\')) And
+                     !$([System.String]::Copy('%(_SourceItemsToCopyToOutputDirectoryAlways.TargetPath)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))" />
+      <_SourceItemsToCopyToOutputDirectoryAlways Update="@(_SourceItemsToCopyToOutputDirectoryAlways)"
+          Condition="$([System.String]::Copy('%(_SourceItemsToCopyToOutputDirectoryAlways.TargetPath)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))"
+          TargetPath="%(Filename)%(Extension)" />
+      <!-- Filter ReferenceCopyLocalPaths (NuGet runtime assets + project-reference copies) -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+          Condition="$([System.String]::Copy('%(ReferenceCopyLocalPaths.DestinationSubPath)').Replace('/','\\').StartsWith('runtimes\')) And
+                     !$([System.String]::Copy('%(ReferenceCopyLocalPaths.DestinationSubPath)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))" />
+      <ReferenceCopyLocalPaths Update="@(ReferenceCopyLocalPaths)"
+          Condition="$([System.String]::Copy('%(ReferenceCopyLocalPaths.DestinationSubPath)').Replace('/','\\').StartsWith('runtimes\$(RuntimeIdentifier)\'))"
+          DestinationSubPath="%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Summary

When a test project is built with `-p:RuntimeIdentifier=<rid>`, only the target RID's native libs should land in the output, flattened at the bin root (so `DllImport` / `dlopen` find them without a `runtimes/<rid>/native/` subdir). Used by Linux GPU CI flows: `dotnet test -p:RuntimeIdentifier=linux-x64` gives a clean Linux test bin with no Windows/macOS DLL clutter and natives at lookup-ready paths.

The existing `_StrideFilterAndFlattenRuntimes` was incomplete: it only operated on items declared in the test project itself, so the bulk of natives — flowing in transitively from project references and NuGet runtime assets — bypassed the filter and all five RIDs' natives still ended up in `bin/.../runtimes/<rid>/native/...`.

This PR moves the filter past `GetCopyToOutputDirectoryItems` and covers both `_SourceItemsToCopyToOutputDirectory(Always)` and `ReferenceCopyLocalPaths`, matching the pattern already used by `_StrideFilterTransitiveCopyToOutputDirectoryItems` (for graphics-API filtering).
