### PR TITLE
[GameStudio] FIX for #3172 - Make correct Entity rotation on offsetted subscene

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -363,7 +363,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                     Scale = entity.Transform.Scale,
                     Translation = entity.Transform.Position,
                     Rotation = entity.Transform.Rotation,
-                    InverseParentMatrix = entity.Transform.Parent != null ? Matrix.Invert(entity.Transform.Parent.WorldMatrix) : Matrix.Identity
+                    InverseParentMatrix = inverseParent
                 };
             }
         }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -192,10 +192,20 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                     worldMatrix.TranslationVector = AnchorEntity.Transform.WorldMatrix.TranslationVector;
                     break;
                 case TransformationSpace.ObjectSpace:
-                    var parentMatrix = Matrix.Identity;
+                    Matrix parentMatrix;
                     if (AnchorEntity.GetParent() != null)
+                    {
                         parentMatrix = AnchorEntity.TransformValue.Parent.WorldMatrix;
-
+                    }
+                    else
+                    {
+                        // Root entity in subscene — use Scene.Offset as parent matrix
+                        var scene = AnchorEntity.Scene;
+                        parentMatrix = (scene != null && scene.Offset != Vector3.Zero)
+                            ? Matrix.Translation(scene.Offset)
+                            : Matrix.Identity;
+                    }
+                    
                     // We don't use the entity's "WorldMatrix" because its scale could be zero, which would break the gizmo.
                     worldMatrix = Matrix.RotationQuaternion(AnchorEntity.Transform.Rotation) *
                                   Matrix.Translation(AnchorEntity.Transform.Position) *
@@ -334,6 +344,19 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             {
                 // Ensure world matrix is computed
                 entity.Transform.UpdateWorldMatrix();
+
+                Matrix inverseParent;
+                if (entity.Transform.Parent != null)
+                {
+                    inverseParent = Matrix.Invert(entity.Transform.Parent.WorldMatrix);
+                }
+                else
+                {
+                    var scene = entity.Scene;
+                    inverseParent = (scene != null && scene.Offset != Vector3.Zero)
+                        ? Matrix.Invert(Matrix.Translation(scene.Offset))
+                        : Matrix.Identity;
+                }
 
                 InitialTransformations[entity] = new InitialTransformation
                 {


### PR DESCRIPTION
# PR Details

PR fixes incorrect rotation of Entity placed on offsetted subscene

## Related Issue

fix #3172

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->