### PR TITLE
fix: Multi stage and render-group UI input

### DIFF
--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.Picking.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.Picking.cs
@@ -39,8 +39,6 @@ namespace Stride.Rendering.UI
         {
             // clear the list of compacted pointer events of time frame
             compactedPointerEvents.Clear();
-            // Drain the UI-side pointer event buffer; events have now been consumed by this Draw.
-            uiSystem?.ClearPendingPointerEvents();
         }
 
         partial void PickingPrepare()

--- a/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
+++ b/sources/engine/Stride.UI/Rendering/UI/UIRenderFeature.cs
@@ -274,6 +274,14 @@ namespace Stride.Rendering.UI
             }
         }
 
+        public override void Flush(RenderDrawContext context)
+        {
+            base.Flush(context);
+
+            // Drain the UI-side event buffer; must be done in flush given that Draw() can be called more than once depending on UI render group and stages
+            uiSystem?.ClearPendingPointerEvents();
+        }
+
         private void RecursiveDrawWithClipping(RenderDrawContext context, UIElement element, ref Matrix worldViewProj, SamplerState samplerState)
         {
             // if the element is not visible, we also remove all its children


### PR DESCRIPTION
# PR Details
Commit https://github.com/stride3d/stride/commit/2ef8bf6724057046ee5fcea238055d4e40a6c8d0 introduced an issue for users who split different UI component to run through different render stages. To render after post effects for example.

The first call to `Draw()` get the appropriate set of UI inputs, but further calls covering the next set of render groups will work off of an empty input buffer.

## Related Issue
None reported

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**