### PR TITLE
build: per-checkout NuGet version suffix (disambiguates parallel work…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ project.lock.json
 
 # Auto-generated local developer settings (Stride.Platform.props bootstrap)
 /build/Stride.Local.props
+
+# Auto-generated per-checkout by Stride.WorktreeVersion.targets (per-checkout NuGet version suffix)
+/sources/shared/SharedAssemblyInfo.Worktree.cs

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
@@ -35,6 +35,7 @@
   <Import Project="Stride.AssemblyProcessor.targets" />
   <Import Project="Stride.CodeAnalysis.targets" />
   <Import Project="Stride.PackageInfo.targets" />
+  <Import Project="$(StrideRoot)sources\targets\Stride.WorktreeVersion.targets" Condition="'$(_StrideWorktreeVersionTargetsImported)' != 'true'" />
 
   <!-- ================================================================ -->
   <!-- Disable ValidateExecutableReferences -->

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.PackageInfo.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.PackageInfo.targets
@@ -30,4 +30,17 @@
     <None Include="$(MSBuildThisFileDirectory)../nuget-icon.png" Pack="true" PackagePath="" Visible="false"/>
   </ItemGroup>
 
+  <!-- Per-checkout NuGet version suffix (producer side). StrideWorktreeSuffix is resolved by
+       StrideEnsureWorktreeVersion in Stride.WorktreeVersion.targets — empty on CI, package
+       builds, and the primary checkout; "-devN" on additional checkouts. Append it to
+       PackageVersion before the pack pipeline reads it so the .nupkg matches the suffix the
+       consumer-side StrideVersion.NuGetVersion const is compiled with. -->
+  <Target Name="StrideAppendWorktreeVersion"
+          DependsOnTargets="StrideEnsureWorktreeVersion"
+          BeforeTargets="GenerateNuspec">
+    <PropertyGroup Condition="'$(StrideWorktreeSuffix)' != '' And !$(PackageVersion.EndsWith('$(StrideWorktreeSuffix)'))">
+      <PackageVersion>$(PackageVersion)$(StrideWorktreeSuffix)</PackageVersion>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/sources/targets/Stride.WorktreeVersion.targets
+++ b/sources/targets/Stride.WorktreeVersion.targets
@@ -1,0 +1,260 @@
+<!-- Per-checkout NuGet version suffix.
+
+     Multiple checkouts of Stride on one machine (git worktrees or independent clones) all
+     auto-pack first-party packages at the same version and clobber each other in the shared
+     %LocalAppData%/Stride/NugetDev feed and the global NuGet cache. This file gives each
+     checkout a distinct suffix so they stop colliding.
+
+     A per-machine ledger at <LocalApplicationData>/Stride/worktree-ids.txt maps each checkout
+     path to a token: the first checkout to register is "(primary)" (no suffix, builds 4.4.0.1
+     unchanged), the rest are "dev1", "dev2", ... The token feeds NuGetVersionSuffix on both
+     ends — the .nupkg version (producer, via StrideAppendWorktreeVersion in
+     Stride.PackageInfo.targets) and the StrideVersion.NuGetVersion const baked into
+     Stride.Assets.dll (consumer, via the SharedAssemblyInfo.cs -> SharedAssemblyInfo.Worktree.cs
+     swap below).
+
+     Disabled on CI and package builds: there the suffix stays empty and builds are unchanged. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_StrideWorktreeVersionTargetsImported>true</_StrideWorktreeVersionTargetsImported>
+    <!-- RoslynCodeTaskFactory compiles the inline task at UsingTask registration, not lazily on
+         first use — so gating only the target would still pay the ~1-2s compile on every CI
+         build. This gate goes on the UsingTask itself. It reads env vars only, so it is valid at
+         import time (unlike StridePackageBuild, which the target condition adds at run time). -->
+    <_StrideWorktreeVersionEnabled Condition="'$(_StrideWorktreeVersionEnabled)' == ''">true</_StrideWorktreeVersionEnabled>
+    <_StrideWorktreeVersionEnabled Condition="'$(CI)' == 'true' Or '$(GITHUB_ACTIONS)' == 'true' Or '$(TF_BUILD)' == 'true' Or '$(StrideSkipWorktreeVersion)' == 'true'">false</_StrideWorktreeVersionEnabled>
+  </PropertyGroup>
+
+  <UsingTask Condition="'$(_StrideWorktreeVersionEnabled)' == 'true'" TaskName="ResolveStrideWorktreeVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <Code Type="Class" Language="cs">
+        <![CDATA[
+        using System;
+        using System.Collections.Generic;
+        using System.IO;
+        using System.Text.RegularExpressions;
+        using System.Threading;
+        using Microsoft.Build.Framework;
+        using Microsoft.Build.Utilities;
+
+        public class ResolveStrideWorktreeVersion : Task
+        {
+            [Required] public string StrideRoot { get; set; }
+
+            // Explicit override (StrideWorktreeId property/env var); wins over the ledger when set.
+            public string OverrideId { get; set; }
+
+            // Ledger location override (StrideWorktreeLedger property); defaults to
+            // LocalApplicationData/Stride/worktree-ids.txt.
+            public string LedgerPath { get; set; }
+
+            [Required] public string SourceVersionFile { get; set; }
+            [Required] public string GeneratedVersionFile { get; set; }
+
+            [Output] public string WorktreeSuffix { get; set; }
+
+            public override bool Execute()
+            {
+                WorktreeSuffix = string.Empty;
+                try
+                {
+                    string root = NormalizePath(StrideRoot);
+                    string ledgerPath = !string.IsNullOrWhiteSpace(LedgerPath)
+                        ? LedgerPath
+                        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Stride", "worktree-ids.txt");
+                    Directory.CreateDirectory(Path.GetDirectoryName(ledgerPath));
+
+                    for (int attempt = 0; attempt < 300; attempt++)
+                    {
+                        try
+                        {
+                            // FileShare.None on a sibling lock file serializes the first-build race
+                            // across MSBuild's parallel project nodes (cross-process, cross-platform).
+                            using (new FileStream(ledgerPath + ".lock", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+                            {
+                                string token = !string.IsNullOrWhiteSpace(OverrideId)
+                                    ? OverrideId.Trim()
+                                    : ResolveOrRegister(ledgerPath, root);
+
+                                WorktreeSuffix = TokenToSuffix(token);
+
+                                if (WorktreeSuffix.Length != 0)
+                                    WriteGeneratedFile(WorktreeSuffix);
+                                else if (File.Exists(GeneratedVersionFile))
+                                    File.Delete(GeneratedVersionFile);
+                            }
+                            return true;
+                        }
+                        catch (IOException)
+                        {
+                            Thread.Sleep(5);
+                        }
+                    }
+                    throw new IOException("Timed out acquiring the Stride worktree ledger lock at " + ledgerPath);
+                }
+                catch (Exception e)
+                {
+                    Log.LogWarning("Stride worktree version resolution skipped: " + e.Message);
+                    WorktreeSuffix = string.Empty;
+                    return true;
+                }
+            }
+
+            private string ResolveOrRegister(string ledgerPath, string root)
+            {
+                var lines = File.Exists(ledgerPath)
+                    ? new List<string>(File.ReadAllLines(ledgerPath))
+                    : new List<string>();
+
+                // Steady state: already registered — return the existing token, no pruning.
+                foreach (string line in lines)
+                {
+                    string token, dir;
+                    if (TryParseLine(line, out token, out dir)
+                        && NormalizePath(dir).Equals(root, PathComparison))
+                        return token;
+                }
+
+                // Not registered: drop entries whose folder is gone, then allocate the lowest free
+                // slot (treating "(primary)" as slot 0). So deleting dev1 while dev2 is taken
+                // frees dev1 for the next checkout, instead of climbing to dev3 indefinitely.
+                // UNC entries (\\server\share\...) are kept regardless — a transient network
+                // failure makes Directory.Exists return false, which would silently delete a
+                // perfectly valid entry.
+                var kept = new List<string>(lines.Count);
+                var liveDevNumbers = new HashSet<int>();
+                bool primaryLive = false;
+                foreach (string line in lines)
+                {
+                    string token, dir;
+                    if (!TryParseLine(line, out token, out dir))
+                    {
+                        kept.Add(line);
+                        continue;
+                    }
+                    string normalizedDir = NormalizePath(dir);
+                    bool isUnc = normalizedDir.StartsWith("\\\\", StringComparison.Ordinal)
+                              || normalizedDir.StartsWith("//", StringComparison.Ordinal);
+                    if (!isUnc && !Directory.Exists(normalizedDir))
+                    {
+                        Log.LogMessage(MessageImportance.High,
+                            "Pruning stale Stride worktree ledger entry: '" + token + "' -> '" + dir + "'");
+                        continue;
+                    }
+                    kept.Add(line);
+                    if (token.Equals("(primary)", StringComparison.OrdinalIgnoreCase))
+                        primaryLive = true;
+                    else
+                    {
+                        Match m = Regex.Match(token, "^dev([0-9]+)$");
+                        if (m.Success)
+                            liveDevNumbers.Add(int.Parse(m.Groups[1].Value));
+                    }
+                }
+
+                string newToken;
+                if (!primaryLive)
+                {
+                    newToken = "(primary)";
+                }
+                else
+                {
+                    int n = 1;
+                    while (liveDevNumbers.Contains(n)) n++;
+                    newToken = "dev" + n;
+                }
+
+                if (kept.Count == 0)
+                    kept.Add("# Stride checkout version-suffix ledger. The primary checkout has no suffix.");
+                kept.Add(newToken + " = " + root);
+                File.WriteAllLines(ledgerPath, kept);
+                Log.LogMessage(MessageImportance.High,
+                    "Registered this checkout in the Stride worktree ledger as '" + newToken + "' (" + ledgerPath + ")");
+                return newToken;
+            }
+
+            private void WriteGeneratedFile(string suffix)
+            {
+                string source = File.ReadAllText(SourceVersionFile);
+                string patched = Regex.Replace(source, "NuGetVersionSuffix = \"[^\"]*\";",
+                    m => "NuGetVersionSuffix = \"" + suffix + "\";");
+                if (!File.Exists(GeneratedVersionFile) || File.ReadAllText(GeneratedVersionFile) != patched)
+                    File.WriteAllText(GeneratedVersionFile, patched);
+            }
+
+            // Windows file paths are case-insensitive; Linux is case-sensitive; macOS depends on
+            // the volume (case-insensitive HFS+/default APFS, case-sensitive APFS). On macOS the
+            // FS reports paths in their stored casing either way, so Ordinal still matches the
+            // same checkout across builds — and Ordinal correctly distinguishes truly-distinct
+            // case-sensitive checkouts on Linux (where OrdinalIgnoreCase would falsely merge
+            // `/work/stride` and `/work/Stride` and silently clobber both).
+            private static readonly StringComparison PathComparison =
+                Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            private static string NormalizePath(string p)
+                => Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            private static string TokenToSuffix(string token)
+            {
+                if (string.IsNullOrWhiteSpace(token))
+                    return string.Empty;
+                token = token.Trim();
+                if (token.Equals("(primary)", StringComparison.OrdinalIgnoreCase))
+                    return string.Empty;
+                return token[0] == '-' ? token : "-" + token;
+            }
+
+            private static bool TryParseLine(string line, out string token, out string dir)
+            {
+                token = null;
+                dir = null;
+                if (string.IsNullOrWhiteSpace(line))
+                    return false;
+                string t = line.Trim();
+                if (t[0] == '#')
+                    return false;
+                int eq = t.IndexOf('=');
+                if (eq <= 0)
+                    return false;
+                token = t.Substring(0, eq).Trim();
+                dir = t.Substring(eq + 1).Trim();
+                return token.Length != 0 && dir.Length != 0;
+            }
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Auto path (dev builds): resolve the suffix, then swap SharedAssemblyInfo.cs ->
+       SharedAssemblyInfo.Worktree.cs so the consumer-side StrideVersion.NuGetVersion const is
+       compiled with the suffix. Gated off on CI and package builds. The lock inside the task
+       plus this target running before CoreCompile means no project ever compiles the generated
+       file while another is still writing it. -->
+  <Target Name="StrideEnsureWorktreeVersion"
+          Condition="'$(_StrideWorktreeVersionEnabled)' == 'true' And '$(StridePackageBuild)' != 'true'"
+          BeforeTargets="PrepareResources">
+    <ResolveStrideWorktreeVersion
+        StrideRoot="$(StrideRoot)"
+        OverrideId="$(StrideWorktreeId)"
+        LedgerPath="$(StrideWorktreeLedger)"
+        SourceVersionFile="$(StrideRoot)sources\shared\SharedAssemblyInfo.cs"
+        GeneratedVersionFile="$(StrideRoot)sources\shared\SharedAssemblyInfo.Worktree.cs">
+      <Output TaskParameter="WorktreeSuffix" PropertyName="StrideWorktreeSuffix" />
+    </ResolveStrideWorktreeVersion>
+    <ItemGroup Condition="'$(StrideWorktreeSuffix)' != ''">
+      <_StrideWorktreeSharedAssemblyFile Include="@(Compile)" Condition="'%(Compile.FullPath)' == '$([System.IO.Path]::GetFullPath(`$(StrideRoot)sources\shared\SharedAssemblyInfo.cs`))'" />
+      <Compile Remove="@(_StrideWorktreeSharedAssemblyFile)" />
+      <Compile Include="@(_StrideWorktreeSharedAssemblyFile->'$(StrideRoot)sources\shared\SharedAssemblyInfo.Worktree.cs')" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Explicit path: `dotnet msbuild -t:StrideRegisterWorktree` registers the checkout in the
+       ledger (or reports its token) without a full build — handy from a worktree-setup script.
+       Reuses StrideEnsureWorktreeVersion so the task is invoked from one place; a no-op on CI. -->
+  <Target Name="StrideRegisterWorktree" DependsOnTargets="StrideEnsureWorktreeVersion">
+    <Message Importance="high" Text="Stride worktree version suffix for $(StrideRoot): '$(StrideWorktreeSuffix)' (empty = primary checkout, no suffix)" />
+  </Target>
+
+</Project>

--- a/sources/targets/Stride.targets
+++ b/sources/targets/Stride.targets
@@ -43,6 +43,8 @@
   <Import Project="$(MSBuildThisFileDirectory)Stride.GraphicsApi.PackageReference.targets"/>
   <Import Project="$(MSBuildThisFileDirectory)Stride.GraphicsApi.Dev.targets"/>
 
+  <Import Project="$(MSBuildThisFileDirectory)Stride.WorktreeVersion.targets" Condition="'$(_StrideWorktreeVersionTargetsImported)' != 'true'"/>
+
   <!-- If it exists, replace SharedAssemblyInfo.cs with the Package one (which contain NuGet and git versions) -->
   <Target Name="StrideReplaceVersionInfo" Condition="'$(StridePackageBuild)' == 'true'" BeforeTargets="PrepareResources">
     <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\shared\SharedAssemblyInfo.NuGet.cs')" Text="File SharedAssemblyInfo.NuGet.cs doesn't seem to have been generated. Please make sure Stride.build PackageEnvironment target has been run succesfully."/>


### PR DESCRIPTION
## Problem

Multiple Stride checkouts on one machine (git worktrees / separate clones) all auto-pack first-party packages at same version (i.e. `4.4.0.1`) and clobber each other in the shared `%LocalAppData%/Stride/NugetDev` feed and the NuGet global cache.

## Proposal

A per-machine ledger at `<LocalAppData>/Stride/worktree-ids.txt` assigns each checkout a token — the first to register is `(primary)` (no suffix, builds `4.4.0.1` exactly as today), the rest get `dev1`, `dev2`, …
You can also register it yourself to anything custom.

The token feeds `NuGetVersionSuffix` on both ends:

- **Producer**: appended to `PackageVersion` before the pack pipeline.
- **Consumer**: regex-patched into a generated `SharedAssemblyInfo.Worktree.cs` swapped in for `SharedAssemblyInfo.cs` at compile time, so the `StrideVersion.NuGetVersion` const matches the `.nupkg`.

Resolution runs via an inline `RoslynCodeTaskFactory` task; the steady-state cost is very low (once loaded after first call).

## CI / package builds

Gated off via `$(CI)` / `$(GITHUB_ACTIONS)` / `$(TF_BUILD)`. The gate is on the `<UsingTask>` element itself, so `RoslynCodeTaskFactory` never compiles the task on CI.

## Notes

- Stale entries (folder gone) are pruned before a new registration; freed slots are reused (`dev1` deleted while `dev2` is taken → next checkout becomes `dev1`, not `dev3`).
- Path casing: `OrdinalIgnoreCase` on Windows, `Ordinal` on Linux/macOS.
- UNC entries are skipped from pruning — a network glitch can't silently delete a real entry.
- `StrideWorktreeId` env var / MSBuild property overrides the ledger.
- `dotnet msbuild -t:StrideRegisterWorktree` registers a checkout explicitly without a build.

## Alternative considered

Going the other way: have each locally-created sample remember which Stride checkout created it (a back-reference in the project), and at build time resolve packages directly from that checkout's outputs — bypassing the shared NuGet feed/cache entirely. No version mechanics, no ledger, no CI gate.

Rejected because it ties the sample to a specific folder on disk: moving or renaming the checkout breaks the sample, and it doesn't help externally-distributed samples (GitHub clones, tutorials, samples shared between devs).
Also it forces us to maintain a completely different system with its own class of bugs.