### PR TITLE
[Editor] Change TransformationGizmo Update to be synchronous and change entity duplication behavior

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameEntityTransformService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameEntityTransformService.cs
@@ -5,11 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Stride.Core.BuildEngine;
-using Stride.Core;
-using Stride.Core.Annotations;
-using Stride.Core.Extensions;
-using Stride.Core.Mathematics;
 using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Services;
 using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewModels;
 using Stride.Assets.Presentation.AssetEditors.GameEditor;
@@ -17,8 +12,14 @@ using Stride.Assets.Presentation.AssetEditors.GameEditor.Game;
 using Stride.Assets.Presentation.AssetEditors.GameEditor.Services;
 using Stride.Assets.Presentation.AssetEditors.Gizmos;
 using Stride.Assets.Presentation.SceneEditor;
+using Stride.Core;
+using Stride.Core.Annotations;
+using Stride.Core.BuildEngine;
+using Stride.Core.Extensions;
+using Stride.Core.Mathematics;
 using Stride.Editor.EditorGame.Game;
 using Stride.Engine;
+using Stride.Input;
 using Stride.Rendering;
 using Stride.Rendering.Compositing;
 
@@ -38,6 +39,12 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
         private TransformationSpace space;
         private double gizmoSize = 1.0f;
         private bool dynamicSnappingInUse = false;
+
+        private bool isEntityDuplicationInProgress = false;
+        private Entity entityDuplicationPreviousEntityWithGizmo;
+        private IReadOnlyCollection<Entity> entityDuplicationPreviousSelection;
+        private readonly Dictionary<Entity, Entity> entityDuplicationSrcToPreviewEntityMap = [];
+        private readonly Dictionary<AbsoluteId, Entity> entityDuplicationSrcIdToPreviewEntityMap = [];
 
         public EditorGameEntityTransformService([NotNull] EntityHierarchyEditorViewModel editor, [NotNull] IEditorGameController controller)
         {
@@ -98,7 +105,14 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             }
         }
 
-        public override IEnumerable<Type> Dependencies { get { yield return typeof(IEditorGameEntitySelectionService); } }
+        public override IEnumerable<Type> Dependencies
+        {
+            get
+            {
+                yield return typeof(IEditorGameEntitySelectionService);
+                yield return typeof(EditorGameModelSelectionService);
+            }
+        }
 
         Transformation IEditorGameTransformViewModelService.ActiveTransformation
         {
@@ -140,9 +154,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
         {
             EnsureNotDestroyed(nameof(EditorGameEntityTransformService));
 
-            var selectionService = Services.Get<IEditorGameEntitySelectionService>();
-            if (selectionService != null)
-                selectionService.SelectionUpdated -= UpdateModifiedEntitiesList;
+            OnDeactivate();
             return base.DisposeAsync();
         }
 
@@ -179,6 +191,9 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             TranslationGizmo = new TranslationGizmo();
             RotationGizmo = new RotationGizmo();
             ScaleGizmo = new ScaleGizmo();
+            TranslationGizmo.TransformationStarted += OnGizmoTransformationStarted;
+            ScaleGizmo.TransformationStarted += OnGizmoTransformationStarted;
+            RotationGizmo.TransformationStarted += OnGizmoTransformationStarted;
             TranslationGizmo.TransformationEnded += OnGizmoTransformationFinished;
             ScaleGizmo.TransformationEnded += OnGizmoTransformationFinished;
             RotationGizmo.TransformationEnded += OnGizmoTransformationFinished;
@@ -187,8 +202,6 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             transformationGizmos.Add(RotationGizmo);
             transformationGizmos.Add(ScaleGizmo);
 
-            Services.Get<IEditorGameEntitySelectionService>().SelectionUpdated += UpdateModifiedEntitiesList;
-
             // Initialize and add the Gizmo entities to the gizmo scene
             MicrothreadLocalDatabases.MountCommonDatabase();
 
@@ -196,9 +209,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             foreach (var gizmo in transformationGizmos)
                 gizmo.Initialize(game.Services, editorScene);
 
-            // Deactivate all transformation gizmo by default
-            foreach (var gizmo in transformationGizmos)
-                gizmo.IsEnabled = false;
+            OnActivate();
 
             // set the default active transformation gizmo
             ActiveTransformationGizmo = TranslationGizmo;
@@ -206,6 +217,40 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             // Start update script (with priority 1 so that it happens after UpdateModifiedEntitiesList is called -- which usually happens from a EditorGameComtroller.PostAction() which has a default priority 0)
             game.Script.AddTask(Update, 1);
             return Task.FromResult(true);
+        }
+
+        protected void OnActivate()
+        {
+            Services.Get<IEditorGameEntitySelectionService>().SelectionUpdated += UpdateModifiedEntitiesList;
+
+            // Deactivate all transformation gizmo by default
+            foreach (var gizmo in transformationGizmos)
+                gizmo.IsEnabled = false;
+        }
+
+        protected void OnDeactivate()
+        {
+            EntityWithGizmo = null;
+            foreach (var gizmo in transformationGizmos)
+            {
+                gizmo.CancelTransform();
+                gizmo.ModifiedEntities = [];
+                gizmo.IsEnabled = false;
+            }
+
+            isEntityDuplicationInProgress = false;
+            foreach (var (_, previewEntity) in entityDuplicationSrcToPreviewEntityMap)
+            {
+                // Detach from scene
+                previewEntity.SetParent(null);
+                previewEntity.Scene = null;
+            }
+            entityDuplicationSrcToPreviewEntityMap.Clear();
+            entityDuplicationSrcIdToPreviewEntityMap.Clear();
+
+            var selectionService = Services.Get<IEditorGameEntitySelectionService>();
+            if (selectionService != null)
+                selectionService.SelectionUpdated -= UpdateModifiedEntitiesList;
         }
 
         private async Task Update()
@@ -228,19 +273,19 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
                         // Activate transformation snapping
                         if (game.Input.IsKeyPressed(SceneEditorSettings.TranslationGizmo.GetValue()))
                         {
-                            await editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = Transformation.Translation);
+                            editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = Transformation.Translation);
                         }
 
                         // Activate rotation snapping
                         if (game.Input.IsKeyPressed(SceneEditorSettings.RotationGizmo.GetValue()))
                         {
-                            await editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = Transformation.Rotation);
+                            editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = Transformation.Rotation);
                         }
 
                         // Activate scale snapping
                         if (game.Input.IsKeyPressed(SceneEditorSettings.ScaleGizmo.GetValue()))
                         {
-                            await editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = Transformation.Scale);
+                            editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = Transformation.Scale);
                         }
 
                         // Toggle between different snapping methods
@@ -248,19 +293,23 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
                         {
                             var current = activeTransformation;
                             var next = (int)(current + 1) % Enum.GetValues<Transformation>().Length;
-                            await editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = (Transformation)next);
+                            editor.Dispatcher.InvokeAsync(() => editor.Transform.ActiveTransformation = (Transformation)next);
+                        }
+
+                        if (game.Input.IsKeyPressed(Keys.Escape)
+                            && activeTransformationGizmo is not null
+                            && activeTransformationGizmo.IsTransformationInProgress)
+                        {
+                            activeTransformationGizmo.CancelTransform();
                         }
                     }
 
-                    IEnumerable<Task> tasks;
-                    lock (transformationGizmos)
+                    foreach (var x in transformationGizmos)
                     {
-                        tasks = transformationGizmos.Select(x => x.Update());
+                        x.Update();
                     }
 
-                    IsControllingMouse = activeTransformationGizmo != null && activeTransformationGizmo.IsUnderMouse() && IsMouseAvailable;
-
-                    await Task.WhenAll(tasks);
+                    IsControllingMouse = activeTransformationGizmo != null && activeTransformationGizmo.IsEnabled && activeTransformationGizmo.IsUnderMouse() && IsMouseAvailable;
                 }
 
                 await game.Script.NextFrame();
@@ -300,12 +349,17 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
 
         private void UpdateModifiedEntitiesList(object sender, [NotNull] EntitySelectionEventArgs e)
         {
+            if (!IsActive || isEntityDuplicationInProgress)
+            {
+                return;
+            }
             EntityWithGizmo = e.NewSelection.LastOrDefault();
-            if (ActiveTransformationGizmo != null && EntityWithGizmo == null)
+            if (ActiveTransformationGizmo != null && !ActiveTransformationGizmo.IsTransformationInProgress && EntityWithGizmo == null)
             {
                 // Reset the transformation axes if the selection is cleared.
                 ActiveTransformationGizmo.ClearTransformationAxes();
             }
+
             var modifiedEntities = new List<Entity>();
             modifiedEntities.AddRange(e.NewSelection);
 
@@ -317,13 +371,86 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             }
         }
 
-        private void OnGizmoTransformationFinished(object sender, EventArgs e)
+        private void OnGizmoTransformationStarted(object sender, EventArgs e)
         {
-            var transformations = new Dictionary<AbsoluteId, TransformationTRS>();
-            foreach (var item in Selection.GetSelectedRootIds())
+            isEntityDuplicationInProgress = game.Input.IsKeyDown(Keys.LeftCtrl) || game.Input.IsKeyDown(Keys.RightCtrl);
+            if (isEntityDuplicationInProgress)
             {
-                var entity = (Entity)controller.FindGameSidePart(item);
-                transformations.Add(item, new TransformationTRS(entity.Transform));
+                // Duplication occurs in the editor so we should make the gizmo update proxy entities
+                // until the editor returns the duplicated entities
+                entityDuplicationPreviousEntityWithGizmo = EntityWithGizmo;
+                entityDuplicationPreviousSelection = ActiveTransformationGizmo?.ModifiedEntities ?? [];
+                entityDuplicationSrcToPreviewEntityMap.Clear();
+                foreach (var id in Selection.GetSelectedRootIds())
+                {
+                    var entity = (Entity)controller.FindGameSidePart(id);
+                    var previewEntity = BuildDuplicationPreviewEntity(entity);
+
+                    entityDuplicationSrcToPreviewEntityMap[entity] = previewEntity;
+                    entityDuplicationSrcIdToPreviewEntityMap[id] = previewEntity;
+                }
+                ActiveTransformationGizmo.RemapModifyingEntities(entityDuplicationSrcToPreviewEntityMap);
+                if (EntityWithGizmo is not null
+                    && entityDuplicationSrcToPreviewEntityMap.TryGetValue(EntityWithGizmo, out var anchorProxyEntity))
+                {
+                    EntityWithGizmo = anchorProxyEntity;
+                }
+
+                var modelSelectionService = Services.Get<EditorGameModelSelectionService>();
+                modelSelectionService?.ChangeSelection(entityDuplicationSrcIdToPreviewEntityMap.Values.ToList());
+            }
+        }
+
+        private void OnGizmoTransformationFinished(object sender, TransformationEndedEventArgs e)
+        {
+            if (isEntityDuplicationInProgress)
+            {
+                var newTransformations = new Dictionary<AbsoluteId, TransformationTRS?>();
+                foreach (var (srcId, previewEntity) in entityDuplicationSrcIdToPreviewEntityMap)
+                {
+                    newTransformations.Add(srcId, new TransformationTRS(previewEntity.Transform));
+                    // Detach from scene
+                    previewEntity.SetParent(null);
+                    previewEntity.Scene = null;
+                }
+                entityDuplicationSrcIdToPreviewEntityMap.Clear();
+                entityDuplicationSrcToPreviewEntityMap.Clear();
+
+                if (e.IsCanceled)
+                {
+                    // Reselect previous entities
+                    ActiveTransformationGizmo?.ModifiedEntities = entityDuplicationPreviousSelection;
+                    EntityWithGizmo = entityDuplicationPreviousEntityWithGizmo;
+                    var modelSelectionService = Services.Get<EditorGameModelSelectionService>();
+                    modelSelectionService?.ChangeSelection(entityDuplicationPreviousSelection);
+                }
+                else
+                {
+                    // Clear preview entities selection (which will select the duplicated entities after the editor finishes actual duplication)
+                    ActiveTransformationGizmo?.ModifiedEntities = [];
+                    EntityWithGizmo = null;
+                    var modelSelectionService = Services.Get<EditorGameModelSelectionService>();
+                    modelSelectionService?.ChangeSelection([]);
+                    // Confirm duplication
+                    editor.Dispatcher.InvokeAsync(() => editor.DuplicateEntities(newTransformations));
+                }
+
+                isEntityDuplicationInProgress = false;
+                entityDuplicationPreviousEntityWithGizmo = null;
+                entityDuplicationPreviousSelection = null;
+                return;
+            }
+
+            if (e.IsCanceled)
+            {
+                return;
+            }
+
+            var transformations = new Dictionary<AbsoluteId, TransformationTRS>();
+            foreach (var id in Selection.GetSelectedRootIds())
+            {
+                var entity = (Entity)controller.FindGameSidePart(id);
+                transformations.Add(id, new TransformationTRS(entity.Transform));
             }
 
             InvokeTransformationFinished(transformations);
@@ -361,6 +488,22 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
                         throw new ArgumentOutOfRangeException(nameof(transformation));
                 }
             });
+        }
+
+        private static Entity BuildDuplicationPreviewEntity(Entity srcEntity)
+        {
+            var dupePreviewEntity = srcEntity.Clone();
+            dupePreviewEntity.Name = $"Duplication {dupePreviewEntity.Name}";
+            var parentEntity = srcEntity.GetParent();
+            if (parentEntity is not null)
+            {
+                dupePreviewEntity.SetParent(parentEntity);
+            }
+            else
+            {
+                dupePreviewEntity.Scene = srcEntity.Scene;
+            }
+            return dupePreviewEntity;
         }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameModelSelectionService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameModelSelectionService.cs
@@ -102,6 +102,22 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             });
         }
 
+        public void ChangeSelection(IEnumerable<Entity> entities)
+        {
+            var recursiveSelection = new HashSet<Entity>(entities);
+            foreach (var childEntity in entities.SelectDeep(x => x.Transform.Children.Select(y => y.Entity)))
+            {
+                recursiveSelection.Add(childEntity);
+            }
+
+            editor.Controller.InvokeAsync(() =>
+            {
+                // update the selection on the gizmo entities.
+                selectedEntities.Clear();
+                selectedEntities.AddRange(recursiveSelection);
+            });
+        }
+
         class WireframeFilter : RenderStageFilter
         {
             private readonly HashSet<Entity> selectedEntities;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyEditorViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyEditorViewModel.cs
@@ -5,20 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
-using Stride.Core.Assets;
-using Stride.Core.Assets.Editor.Services;
-using Stride.Core.Assets.Editor.View.Behaviors;
-using Stride.Core.Assets.Editor.ViewModel;
-using Stride.Core;
-using Stride.Core.Annotations;
-using Stride.Core.Diagnostics;
-using Stride.Core.Extensions;
-using Stride.Core.Mathematics;
-using Stride.Core.Presentation.Commands;
-using Stride.Core.Presentation.Interop;
-using Stride.Core.Presentation.Services;
-using Stride.Core.Presentation.Windows;
-using Stride.Core.Translation;
 using Stride.Assets.Entities;
 using Stride.Assets.Presentation.AssetEditors.AssetCompositeGameEditor.ViewModels;
 using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.EntityFactories;
@@ -31,6 +17,21 @@ using Stride.Assets.Presentation.SceneEditor;
 using Stride.Assets.Presentation.View;
 using Stride.Assets.Presentation.ViewModel;
 using Stride.Assets.Presentation.ViewModel.CopyPasteProcessors;
+using Stride.Core;
+using Stride.Core.Annotations;
+using Stride.Core.Assets;
+using Stride.Core.Assets.Editor.Services;
+using Stride.Core.Assets.Editor.View.Behaviors;
+using Stride.Core.Assets.Editor.ViewModel;
+using Stride.Core.Assets.Editor.ViewModel.Progress;
+using Stride.Core.Diagnostics;
+using Stride.Core.Extensions;
+using Stride.Core.Mathematics;
+using Stride.Core.Presentation.Commands;
+using Stride.Core.Presentation.Interop;
+using Stride.Core.Presentation.Services;
+using Stride.Core.Presentation.Windows;
+using Stride.Core.Translation;
 using Stride.Engine;
 
 namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewModels
@@ -208,6 +209,81 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             SelectedItems.AddRange(duplicatedAssets);
 
             return duplicatedAssets;
+        }
+
+        [NotNull]
+        public async Task DuplicateEntities([NotNull] IReadOnlyDictionary<AbsoluteId, TransformationTRS?> transformations, bool selectDuplicatedEntites = true)
+        {
+            var dialogService = ServiceProvider.Get<IEditorDialogService>();
+
+            var logger = new LoggerResult();
+            var workProgress = new WorkProgressViewModel(ServiceProvider, logger)
+            {
+                Title = Tr._p("Title", "Duplicate entities"),
+                KeepOpen = KeepOpen.OnWarningsOrErrors,
+                IsIndeterminate = true,
+                IsCancellable = false,
+                Minimum = 0,
+                Maximum = 1,
+            };
+            dialogService.ShowProgressWindow(workProgress, minDelay: 500);
+
+            try
+            {
+                // save elements to copy and remove them from current selection.
+                var selectedEntityViewModels = new List<EntityViewModel>();
+                foreach (var (id, _) in transformations)
+                {
+                    var entityViewModel = (EntityViewModel)FindPartViewModel(id);
+                    if (entityViewModel is null)
+                    {
+                        logger.Error(string.Format(Tr._p("Log", "Entity {0} no longer exists."), id.ObjectId));  // Can occur if a user uses undo command in the middle of transforming
+                        return;
+                    }
+                    selectedEntityViewModels.Add(entityViewModel);
+                }
+                var entitiesToDuplicate = GetCommonRoots(selectedEntityViewModels);
+                if (entitiesToDuplicate.Count == 0)
+                    return;
+
+                workProgress.Maximum = entitiesToDuplicate.Count;
+                workProgress.UpdateProgressAsync(Tr._p("Message", "Duplicating entities..."), newProgressValue: 0);
+                if (selectDuplicatedEntites)
+                {
+                    SelectedItems.Clear();
+                }
+                // duplicate the elements
+                var duplicatedAssets = new Dictionary<EntityViewModel, EntityViewModel>();
+                using (var transaction = UndoRedoService.CreateTransaction())
+                {
+                    int count = 0;
+                    foreach (var entityViewModel in entitiesToDuplicate)
+                    {
+                        count++;
+                        workProgress.UpdateProgressAsync(string.Format(Tr._p("Message", "Duplicating entities {0}/{1}"), count, entitiesToDuplicate.Count), newProgressValue: count);
+                        await Task.Delay(1);    // HACK: required so the progress bar updates, since we're already in the UI thread
+
+                        var duplicatedEntity = entityViewModel.Duplicate(transformations);
+                        duplicatedAssets[entityViewModel] = duplicatedEntity;
+                    }
+
+                    UndoRedoService.SetName(transaction, "Duplicate entities");
+                }
+
+                if (selectDuplicatedEntites)
+                {
+                    // set selection to new copied elements.
+                    SelectedItems.AddRange(duplicatedAssets.Values);
+                }
+            }
+            catch (Exception e)
+            {
+                logger.Error(Tr._p("Log", "An exception occurred while duplicating entites."), e);
+            }
+            finally
+            {
+                await workProgress.NotifyWorkFinished(cancelled: false, logger.HasErrors);
+            }
         }
 
         [NotNull]

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityViewModel.cs
@@ -5,28 +5,27 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Stride.Core.Assets;
+using Stride.Assets.Entities;
+using Stride.Assets.Presentation.AssetEditors.AssetCompositeGameEditor.ViewModels;
+using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.EntityFactories;
+using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Services;
+using Stride.Assets.Presentation.AssetEditors.GameEditor;
+using Stride.Assets.Presentation.Quantum;
+using Stride.Assets.Presentation.ViewModel;
+using Stride.Core;
+using Stride.Core.Annotations;
 using Stride.Core.Assets.Analysis;
 using Stride.Core.Assets.Editor.Components.Properties;
 using Stride.Core.Assets.Editor.Quantum.NodePresenters;
 using Stride.Core.Assets.Editor.View.Behaviors;
 using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Assets.Quantum;
-using Stride.Core;
-using Stride.Core.Annotations;
 using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
 using Stride.Core.Presentation.Commands;
 using Stride.Core.Presentation.Quantum;
 using Stride.Core.Presentation.Quantum.Presenters;
 using Stride.Core.Quantum;
-using Stride.Assets.Entities;
-using Stride.Assets.Presentation.AssetEditors.AssetCompositeGameEditor.ViewModels;
-using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.EntityFactories;
-using Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Services;
-using Stride.Assets.Presentation.AssetEditors.GameEditor.Services;
-using Stride.Assets.Presentation.Quantum;
-using Stride.Assets.Presentation.ViewModel;
 using Stride.Engine;
 
 namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewModels
@@ -371,11 +370,31 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             Editor.Controller.GetService<IEditorGameEntityCameraViewModelService>().CenterOnEntity(target, meshIndex);
         }
 
-        public EntityViewModel Duplicate()
+        public EntityViewModel Duplicate(IReadOnlyDictionary<AbsoluteId, TransformationTRS?> transformations = null)
         {
             var flags = SubHierarchyCloneFlags.GenerateNewIdsForIdentifiableObjects;
             var clonedHierarchy = EntityHierarchyPropertyGraph.CloneSubHierarchies(Asset.Session.AssetNodeContainer, Asset.Asset, AssetSideEntity.Id.Yield(), flags, out Dictionary<Guid, Guid> idRemapping);
             AssetPartsAnalysis.GenerateNewBaseInstanceIds(clonedHierarchy);
+
+            if (transformations?.Count > 0)
+            {
+                var absIdRemapping = new Dictionary<AbsoluteId, AbsoluteId>();
+                var clonedEntitiesById = clonedHierarchy.RootParts.BreadthFirst(x => x.Transform.Children.Select(y => y.Entity)).ToDictionary(x => x.Id);
+                foreach (var (srcId, transformData) in transformations)
+                {
+                    if (transformData is not TransformationTRS transformDataValue)
+                    {
+                        continue;
+                    }
+                    if (idRemapping.TryGetValue(srcId.ObjectId, out var destEntityId)
+                        && clonedEntitiesById.TryGetValue(destEntityId, out var clonedEntity))
+                    {
+                        clonedEntity.Transform.Position = transformDataValue.Position;
+                        clonedEntity.Transform.Rotation = transformDataValue.Rotation;
+                        clonedEntity.Transform.Scale = transformDataValue.Scale;
+                    }
+                }
+            }
 
             var addedRoot = clonedHierarchy.Parts[clonedHierarchy.RootParts.Single().Id];
             addedRoot.Folder = (Parent as EntityFolderViewModel)?.Path;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/RotationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/RotationGizmo.cs
@@ -147,7 +147,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 rotationAxes[axis].Get<ModelComponent>().Model.Materials[0] = isSelected ? ElementSelectedMaterial : axisMaterial;
             }
 
-            overlaySphere.Get<ModelComponent>().Model.Materials[0] = TransformationStarted ? overlaySphereSelectedMaterial : overlaySphereDefaultMaterial;
+            overlaySphere.Get<ModelComponent>().Model.Materials[0] = IsTransformationInProgress ? overlaySphereSelectedMaterial : overlaySphereDefaultMaterial;
         }
 
         /// <summary>
@@ -223,9 +223,9 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             return Quaternion.RotationAxis(rotationAxis, rotationAngle);
         }
 
-        protected override void OnTransformationFinished()
+        protected override void OnTransformationFinished(bool wasCanceled)
         {
-            base.OnTransformationFinished();
+            base.OnTransformationFinished(wasCanceled);
 
             UpdateNotSelectedAxisVisibility(false);
         }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/ScaleGizmo.cs
@@ -148,9 +148,9 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             return entity;
         }
 
-        public override async Task Update()
+        public override void Update()
         {
-            await base.Update();
+            base.Update();
 
             UpdateDrawOrder();
         }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationEndedEventArgs.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationEndedEventArgs.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+namespace Stride.Assets.Presentation.AssetEditors.Gizmos;
+
+public struct TransformationEndedEventArgs
+{
+    public static TransformationEndedEventArgs Successful => new() { IsCanceled = false };
+    public static TransformationEndedEventArgs Canceled => new() { IsCanceled = true };
+
+    public bool IsCanceled { get; init; }
+}

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TransformationGizmo.cs
@@ -43,12 +43,15 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         public const RenderGroupMask TransformationGizmoGroupMask = RenderGroupMask.Group4;
 
         private bool transformationInitialized;
-        private bool duplicationDone;
 
+        /// <summary>
+        /// Event triggered when a gizmo transformation starts.
+        /// </summary>
+        public event EventHandler TransformationStarted;
         /// <summary>
         /// Event triggered when a gizmo transformation finishes.
         /// </summary>
-        public event EventHandler TransformationEnded;
+        public event EventHandler<TransformationEndedEventArgs> TransformationEnded;
 
         /// <summary>
         /// Gets the gizmo default scale in ratio of screen height ( 1 => full screen vertically )
@@ -58,7 +61,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         /// <summary>
         /// Returns whether the transformation has started or not
         /// </summary>
-        protected bool TransformationStarted { get; private set; }
+        public bool IsTransformationInProgress { get; private set; }
 
         /// <summary>
         /// The default material for the origin elements
@@ -89,7 +92,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         /// The value of the gizmo world matrix at the beginning of the transformation.
         /// </summary>
         protected Matrix StartWorldMatrix = Matrix.Identity;
-        
+
         /// <summary>
         /// The projection plane of the transformation.
         /// </summary>
@@ -129,7 +132,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         /// Gets or sets the entity modified by the gizmo.
         /// </summary>
         public IReadOnlyCollection<Entity> ModifiedEntities { get; set; }
-        
+
         protected TransformationGizmo()
         {
             RenderGroup = TransformationGizmoGroup;
@@ -138,7 +141,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         protected override Entity Create()
         {
             base.Create();
-            
+
             DefaultOriginMaterial = CreateEmissiveColorMaterial(Color.White);
             ElementSelectedMaterial = CreateEmissiveColorMaterial(Color.Gold);
             TransparentElementSelectedMaterial = CreateEmissiveColorMaterial(Color.Gold.WithAlpha(86));
@@ -166,7 +169,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         {
             return TransformationAxes != GizmoTransformationAxes.None;
         }
-        
+
         /// <summary>
         /// Gets the world matrix of the gizmo
         /// </summary>
@@ -259,23 +262,27 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             if (Game.EditorServices.Get<IEditorGameCameraService>().IsMoving)
                 return;
 
-            if (duplicationDone)
+            if (IsTransformationInProgress)
                 return;
 
             UpdateTransformationAxis();
         }
 
+        /// <summary>
+        /// Update which axes are hovered over by the mouse.
+        /// </summary>
         protected abstract void UpdateTransformationAxis();
 
         protected abstract InitialTransformation CalculateTransformation();
 
-        protected virtual void OnTransformationFinished()
+        protected virtual void OnTransformationFinished(bool wasCanceled)
         {
-            duplicationDone = false;
+            IsTransformationInProgress = false;
             if (InitialTransformations.Count > 0)
             {
                 InitialTransformations.Clear();
-                TransformationEnded?.Invoke(this, EventArgs.Empty);
+                var eventArgs = wasCanceled ? TransformationEndedEventArgs.Canceled : TransformationEndedEventArgs.Successful;
+                TransformationEnded?.Invoke(this, eventArgs);
             }
         }
 
@@ -326,7 +333,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
         protected virtual void OnTransformationStarted(Vector2 mouseDragPixel)
         {
-            TransformationStarted = true;
+            IsTransformationInProgress = true;
 
             // keep in memory all initial transformation states
             InitialTransformations.Clear();
@@ -346,24 +353,51 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
         }
 
         /// <summary>
+        /// Cancel any in-progress transform.
+        /// </summary>
+        public void CancelTransform()
+        {
+            if (!IsTransformationInProgress)
+            {
+                return;
+            }
+
+            // Revert transforms
+            foreach (var (entity, initTransform) in InitialTransformations)
+            {
+                entity.Transform.Scale = initTransform.Scale;
+                entity.Transform.Position = initTransform.Translation;
+                entity.Transform.Rotation = initTransform.Rotation;
+            }
+            ClearTransformationAxes();
+            OnTransformationFinished(wasCanceled: true);
+            transformationInitialized = false;
+        }
+
+        /// <summary>
         /// Update the transformation of the selected entity. The transformation applied depends on the current TransformationAxes.
         /// For all types of transformations, we calculate the change between the start click position and the current mouse position instead of working with delta changes.
         /// This ensures that when the user returns to start click position the transformation is as it was at the beginning of the transformation.
         /// The transformation direction is either horizontal (left->right) or vertical (bottom->top) and is determined at the beginning of the gesture depending on the user move direction.
         /// </summary>
-        private async Task TransformSceneEntityBase()
+        private void TransformSceneEntityBase()
         {
-            if (!Input.IsKeyDown(Keys.LeftCtrl) && !Input.IsKeyDown(Keys.RightCtrl))
-                duplicationDone = false;
-
             // skip the update if no transformation is currently performed
-            if (!IsEnabled || AnchorEntity == null || TransformationAxes == GizmoTransformationAxes.None || !Input.IsMouseButtonDown(MouseButton.Left))
+            if (!IsEnabled || AnchorEntity == null)
+            {
+                return;
+            }
+            bool isMouseDown = Input.IsMouseButtonDown(MouseButton.Left);
+            if (!IsTransformationInProgress && (TransformationAxes == GizmoTransformationAxes.None || !isMouseDown))
+            {
+                return;
+            }
+            if (IsTransformationInProgress && !isMouseDown)
             {
                 if (transformationInitialized)
-                    OnTransformationFinished();
+                    OnTransformationFinished(wasCanceled: false);
 
                 transformationInitialized = false;
-                TransformationStarted = false;
                 return;
             }
 
@@ -378,7 +412,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             var mouseDrag = mousePosition - StartMousePosition;
 
             // start the transformation only if user has dragged from a given amount of pixel. Determine direction of the transformation.
-            if (!TransformationStarted)
+            if (!IsTransformationInProgress)
             {
                 // ensure that the mouse cursor has been moved enough
                 var screenSize = new Vector2(GraphicsDevice.Presenter.BackBuffer.Width, GraphicsDevice.Presenter.BackBuffer.Height);
@@ -393,16 +427,10 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 if (currentTransformation.IsIdentity())
                     return;
 
-                // check if Ctrl is pressed and initiate a duplication in this case.
-                if (ModifiedEntities.Count > 0 && !duplicationDone && Input.IsKeyDown(Keys.LeftCtrl) || Input.IsKeyDown(Keys.RightCtrl))
-                {
-                    duplicationDone = true;
-                    await Game.EditorServices.Get<IEditorGameEntitySelectionService>().DuplicateSelection();
-                }
-
                 OnTransformationStarted(mouseDragPixel);
+                TransformationStarted?.Invoke(this, EventArgs.Empty);
             }
-            
+
             // determine the transformation to apply
             var transformation = CalculateTransformation();
 
@@ -411,7 +439,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             {
                 var initialTransfo = InitialTransformations[entity];
                 var entityTransfo = entity.Transform;
-                
+
                 if (initialTransfo.InverseParentMatrix == Matrix.Zero)
                 {
                     // This usually occurs when at least one axis is scaled to zero (because the matrix inversion
@@ -431,7 +459,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
                 // calculate the gizmo to parent space matrix
                 Matrix gizmoToParentMatrix;
                 Matrix.Multiply(ref StartWorldMatrix, ref initialTransfo.InverseParentMatrix, out gizmoToParentMatrix);
-                
+
                 // the scale
                 entityTransfo.Scale = initialTransfo.Scale * transformation.Scale;
 
@@ -452,7 +480,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             }
         }
 
-        public virtual async Task Update()
+        public virtual void Update()
         {
             if (!IsEnabled)
                 return;
@@ -460,7 +488,7 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             UpdateShape();
             UpdateTransformationAxisBase();
             UpdateColors();
-            await TransformSceneEntityBase();
+            TransformSceneEntityBase();
             UpdateTransformation();
         }
 
@@ -473,8 +501,31 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
 
         public void ClearTransformationAxes()
         {
-            if (!duplicationDone)
-                TransformationAxes = GizmoTransformationAxes.None;
+            TransformationAxes = GizmoTransformationAxes.None;
+        }
+
+        public void RemapModifyingEntities(Dictionary<Entity, Entity> remapEntities)
+        {
+            if (!IsTransformationInProgress)
+            {
+                throw new InvalidOperationException($"Transform is not in-progress.");
+            }
+
+            var newModifyEntities = new List<Entity>();
+            foreach (var (srcEntity, destEntity) in remapEntities)
+            {
+                if (InitialTransformations.Remove(srcEntity, out var initTransform))
+                {
+                    InitialTransformations[destEntity] = initTransform;
+                    newModifyEntities.Add(destEntity);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Entity '{srcEntity.Name ?? srcEntity.Id.ToString()}' was not being modified.");
+                }
+            }
+
+            ModifiedEntities = newModifyEntities;
         }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TranslationGizmo.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/Gizmos/TranslationGizmo.cs
@@ -150,9 +150,9 @@ namespace Stride.Assets.Presentation.AssetEditors.Gizmos
             return entity;
         }
 
-        public override async Task Update()
+        public override void Update()
         {
-            await base.Update();
+            base.Update();
 
             UpdateDrawOrder();
         }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
This serves as a bit of prep work leading to #3183.

The purpose of this PR is to remove the async part of `TransformationGizmo.Update`.
The only two places where async is used is:
1. Keyboard shortcut to change the transform gizmo mode (translate/rotate/scale via `W`/`E`/`R` keys)
2. Hold `Ctrl` -> Drag gizmo to duplicate entities (note: an existing quirk is you must focus in the scene before `Ctrl` key down is detected, which is not fixed in this PR).

My changes and reasoning:
1. No longer await UI invoke. This is an example of `game -> editor -> game`, which relies on the `editor -> game` return to set update the transform gizmo mode (refer to Related Issue section for a bit more context).
It now just treats it as a fire-and-forget request to the editor, which will 'eventually' update the mode back to the game thread.
I'm not really sure if there is a cleaner solution, other than either 'predicting' the mode change (ie. update directly as well), or block the gizmo until the editor 'confirms' the request.

2. Moved the entity duplication logic out of the transform gizmo and into EditorGameEntityTransformService.
This makes the transform gizmo reusable for other things which may or may not have 'duplication' logic (eg. spline tool).
Another change, which might be more debatable, is now the initial duplication is only done on the game side (temp cloned entities), then at the end of the transform the request is sent to the editor.
Doing it this way also means there is only **one** undo/redo transaction, whereas the previous behavior had two transactions (1st transaction on the drag start to generate entities in place, then a 2nd transaction for the position update), ie. you had to undo twice to actually remove the duplicated objects.
One other quirk is when duplicating a large number of entities (eg. use 3rd Person Platformer template and duplicate the entire 'Platform' folder via `Ctrl` + drag), the original behavior has a large initial freeze since it clones at the start.
This change makes the large freeze occur at the end of the transform (along with a progress bar popup if longer than 500ms), however this does introduce a different quirk where the preview entities disappear then the real objects are added afterwards.

3. (New functionality) There is also now the ability to hit Escape key to cancel the transform when you're in the middle of transforming (no transaction goes the editor).

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Prep work for #3183

Regarding further context for change 1:
There is a bit of concern with the current architecture of the 'game services', which may need additional thoughts on.
The issue is the back and forth marshaling between 'WPF UI thread' (ie. where the asset/quantum data live) and the 'game thread' (ie. live scene editor).

There are some 'game services' that contain both the game scene data and the 'view model'/UI thread data (ie. implement `IEditorGameService` and `IEditorGameViewModelService` as a single class), and can end up doing things like `'game thread' -> await InvokeAsync to 'UI thread' -> InvokeAsync to 'game thread'`, which is exactly what the gizmo code was doing.

Regarding further context for change 2:
The future goal is to change classes that inherit `EditorGameMouseServiceBase` to only have sync update methods, so they can ultimately be bundled through some 'edit mode' class and updated in some specified order (and optionally enabled/disabled depending on the mode), rather than the free-for-all approach that's happening now (they will still have the option to register an independent task via ScriptSystem if they need it).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Not sure if doc change is required or not, `TranslationGizmo`/`ScaleGizmo`/`RotationGizmo` are public, however these gizmos are part of `Stride.Assets.Presentation`, which the general user cannot accidentally stumble into due to the lack of proper plugin integration.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->