### PR TITLE
feat: Include asset name when logging asset-related issues

### DIFF
--- a/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
+++ b/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
@@ -99,6 +99,20 @@ public class AssetLogMessage : LogMessage
 
     public int Character { get; set; }
 
+    public override string Text
+    {
+        get
+        {
+            if (AssetReference?.Location != null)
+                return $"{AssetReference.Location}({Line + 1},{Character + 1}): {base.Text}";
+            return base.Text;
+        }
+        set
+        {
+            base.Text = value;
+        }
+    }
+
     /// <summary>
     /// Gets or sets the message code.
     /// </summary>

--- a/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
+++ b/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
@@ -142,13 +142,4 @@ public class AssetLogMessage : LogMessage
     /// </summary>
     /// <value>The related.</value>
     public List<IReference> Related { get; }
-
-    public override string ToString()
-    {
-        var result = base.ToString();
-        if (AssetReference?.Location != null)
-            result = $"{AssetReference.Location}({Line + 1},{Character + 1}): {result}";
-
-        return result;
-    }
 }

--- a/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
+++ b/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
@@ -22,13 +22,12 @@ public class AssetLogMessage : LogMessage
     /// <param name="messageCode">The message code.</param>
     /// <exception cref="ArgumentNullException">asset</exception>
     public AssetLogMessage(Package? package, IReference? assetReference, LogMessageType type, AssetMessageCode messageCode)
+        : base(null, type, AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString())
     {
         Package = package;
         AssetReference = assetReference;
-        Type = type;
         MessageCode = messageCode;
         Related = [];
-        Text = AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString();
     }
 
     /// <summary>
@@ -41,14 +40,12 @@ public class AssetLogMessage : LogMessage
     /// <param name="arguments">The arguments.</param>
     /// <exception cref="ArgumentNullException">asset</exception>
     public AssetLogMessage(Package? package, IReference? assetReference, LogMessageType type, AssetMessageCode messageCode, params object?[] arguments)
+        : base(null, type, string.Format(AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString(), arguments))
     {
         Package = package;
         AssetReference = assetReference;
-        Type = type;
         MessageCode = messageCode;
         Related = [];
-        var message = AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString();
-        Text = string.Format(message, arguments);
     }
 
     /// <summary>
@@ -59,12 +56,11 @@ public class AssetLogMessage : LogMessage
     /// <param name="type">The type.</param>
     /// <exception cref="ArgumentNullException">asset</exception>
     public AssetLogMessage(Package? package, IReference? assetReference, LogMessageType type, string text)
+        : base(null, type, text)
     {
         Package = package;
         AssetReference = assetReference;
-        Type = type;
         Related = [];
-        Text = text;
     }
 
     public static AssetLogMessage From(Package? package, IReference? assetReference, ILogMessage logMessage, string assetPath, int line = 0, int character = 0)
@@ -106,10 +102,6 @@ public class AssetLogMessage : LogMessage
             if (AssetReference?.Location != null)
                 return $"{AssetReference.Location}({Line + 1},{Character + 1}): {base.Text}";
             return base.Text;
-        }
-        set
-        {
-            base.Text = value;
         }
     }
 

--- a/sources/core/Stride.Core/Diagnostics/ILogMessage.cs
+++ b/sources/core/Stride.Core/Diagnostics/ILogMessage.cs
@@ -27,7 +27,7 @@ public interface ILogMessage
     /// Gets or sets the text.
     /// </summary>
     /// <value>The text.</value>
-    string Text { get; set; }
+    string Text { get; }
 
     /// <summary>
     /// Gets or sets the exception info.

--- a/sources/core/Stride.Core/Diagnostics/LogMessage.cs
+++ b/sources/core/Stride.Core/Diagnostics/LogMessage.cs
@@ -67,7 +67,7 @@ public class LogMessage : ILogMessage
     /// Gets or sets the text.
     /// </summary>
     /// <value>The text.</value>
-    public virtual string Text { get; set; } = string.Empty;
+    public virtual string Text { get; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the exception.

--- a/sources/core/Stride.Core/Diagnostics/ProfilingMessage.cs
+++ b/sources/core/Stride.Core/Diagnostics/ProfilingMessage.cs
@@ -67,7 +67,6 @@ public class ProfilingMessage : LogMessage
     public override string Text
     {
         get => Message?.ToString() ?? string.Empty;
-        set => Message = value != null ? new ProfilingEventMessage(value) : null;
     }
 
     /// <summary>


### PR DESCRIPTION
# PR Details
The different log display do not `ToString()` log messages they receive, instead they extract the `LogType` and `Text`, this PR ensures that the `Text` for AssetLogMessage includes the asset location.
<img width="942" height="700" alt="image" src="https://github.com/user-attachments/assets/321a5aaa-0d31-4d58-b6ae-37d80114ed68" />

The different logger omit certain information depending on the filters, so using `ToString` or introducing a `ToStringShort()` and `ToStringLong` did not feel like the best way to go about solving this.


## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**