### PR TITLE
fix: YAML, Add deserialization Handler for DeletedKeyWithId

### DIFF
--- a/sources/assets/Stride.Core.Assets/Yaml/KeyWithIdSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/KeyWithIdSerializer.cs
@@ -38,6 +38,9 @@ public class KeyWithIdSerializer : ItemIdSerializerBase
         if (keySerializer is not ScalarSerializerBase scalarKeySerializer)
             throw new InvalidOperationException("Non-scalar key not yet supported!");
 
+        if (keyString.Length == 0)
+            return Activator.CreateInstance(typeof(DeletedKeyWithId<>).MakeGenericType(keyType), id);
+
         var context = new ObjectContext(objectContext.SerializerContext, null, keyDescriptor);
         var key = scalarKeySerializer.ConvertFrom(ref context, new Scalar(keyString));
         var result = Activator.CreateInstance(typeof(KeyWithId<>).MakeGenericType(keyType), id, key);


### PR DESCRIPTION
# PR Details
Some definition to ensure the rest makes sense, here's how an entry for an item in a collection looks like in YAML:
```
Materials:
    4f2a44a83ccd0b9a1d6f8d3f5f0772d2~0: d9db4834-f7ce-4f6a-be87-d54732302ec3:Ground Material
```
`4f2a44a83ccd0b9a1d6f8d3f5f0772d2~0` is a `KeyWithId`, `4f2a44a83ccd0b9a1d6f8d3f5f0772d2` would be the Id, while `0` is the key.

Deserializing a collections whose items defined on the base prefab have been removed would lead to a warning when loading in a project;
```
FormatException: The input string '' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Int32.Parse(String s, IFormatProvider provider)
   at Stride.Core.Yaml.Serialization.Serializers.PrimitiveSerializer.ConvertFrom(ObjectContext& context, Scalar scalar) in I:\stride\sources\core\Stride.Core.Yaml\Serialization\Serializers\PrimitiveSerializer.cs:line 133
   at Stride.Core.Yaml.KeyWithIdSerializer.ConvertFrom(ObjectContext& objectContext, Scalar fromScalar) in I:\stride\sources\assets\Stride.Core.Assets\Yaml\KeyWithIdSerializer.cs:line 42
```
It's fairly easy to repro;
- Create a prefab with a model
- Add the prefab to a scene
- Enable the material toggle on the model component of the prefab you added in the scene
- Open the prefab itself and enable the material toggle on that prefab's model component

This is how the two yaml look like after this operation:
Base:
```
Materials:
    4f2a44a83ccd0b9a1d6f8d3f5f0772d2~0: d9db4834-f7ce-4f6a-be87-d54732302ec3:Ground Material
```
Derived:
```
Materials:
    4313c8fdf0379e96de405f63ca8da803*~0: d9db4834-f7ce-4f6a-be87-d54732302ec3:Ground Material
    4f2a44a83ccd0b9a1d6f8d3f5f0772d2~: ~(Deleted)
```

We might naively think that the deleted entry on the derived one doesn't make a ton of sense, but remember that we started by changing the derived one before changing the base one. Given that specificity, index 0 on the derived one should not inherit any changes from index #0 on its base. That would break user expectations as something overriden on derived should never be affected by changes on the base.

What's going on: `KeyWithIdSerializer.ConvertFrom()` calls `PrimitiveSerializer.ConvertFrom()` which in turn throws as the keyString provided is empty here
https://github.com/stride3d/stride/blob/137215cb0befe25761fc23f6db1570f235b974d9/sources/assets/Stride.Core.Assets/Yaml/KeyWithIdSerializer.cs#L40-L43

The ConvertTo method of this same class does not output a key when the value is a removal;
https://github.com/stride3d/stride/blob/137215cb0befe25761fc23f6db1570f235b974d9/sources/assets/Stride.Core.Assets/Yaml/KeyWithIdSerializer.cs#L66-L71

Looks like that particular implementation wasn't entirely finished, so I added in logic in `ConvertFrom` to mirror `ConvertTo`'s behavior.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->