### PR TITLE
Fix recent project version picker

### DIFF
--- a/sources/launcher/Stride.Launcher.Tests/MainViewXamlTests.cs
+++ b/sources/launcher/Stride.Launcher.Tests/MainViewXamlTests.cs
@@ -1,0 +1,39 @@
+using System.Xml.Linq;
+using Xunit;
+
+namespace Stride.Launcher.Tests;
+
+public sealed class MainViewXamlTests
+{
+    [Fact]
+    public void RecentProjectOpenWithMenu_PassesSelectedVersionToCommand()
+    {
+        var xaml = XDocument.Load(FindMainViewPath());
+        XNamespace avalonia = "https://github.com/avaloniaui";
+
+        var openWithButton = Assert.Single(
+            xaml.Descendants(avalonia + "Button"),
+            element =>
+                (string?)element.Attribute("Command")
+                == "{Binding $parent[ScrollViewer].((vm:RecentProjectViewModel)DataContext).OpenWithCommand}");
+
+        Assert.Equal("{Binding}", (string?)openWithButton.Attribute("CommandParameter"));
+    }
+
+    private static string FindMainViewPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var path = Path.Combine(directory.FullName, "sources", "launcher", "Stride.Launcher", "Views", "MainView.axaml");
+            if (File.Exists(path))
+            {
+                return path;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not find MainView.axaml.");
+    }
+}

--- a/sources/launcher/Stride.Launcher/Views/MainView.axaml
+++ b/sources/launcher/Stride.Launcher/Views/MainView.axaml
@@ -581,6 +581,7 @@
                                             <DataTemplate DataType="{x:Type vm:StrideVersionViewModel}">
                                               <Button Content="{Binding DisplayName, StringFormat={x:Static l:Strings.OpenProjectWithVersion}}"
                                                       Command="{Binding $parent[ScrollViewer].((vm:RecentProjectViewModel)DataContext).OpenWithCommand}"
+                                                      CommandParameter="{Binding}"
                                                       HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" />
                                             </DataTemplate>
                                           </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- pass the selected compatible Stride version into the recent-project `OpenWithCommand`
- add a XAML regression test so the version-picker button keeps its command parameter

## Why
The recent-project menu renders entries such as `Open with {version}`, but the button did not pass the clicked version to `RecentProjectViewModel.OpenWithCommand`. The command therefore received `null` and fell back to the project's recorded version instead of the selected menu item.

Part of #2744.

## Tests
- `C:\hades\.dotnet-10.0.300\dotnet.exe test sources\launcher\Stride.Launcher.Tests\Stride.Launcher.Tests.csproj -v minimal`
- `C:\hades\.dotnet-10.0.300\dotnet.exe format sources\launcher\Stride.Launcher.Tests\Stride.Launcher.Tests.csproj whitespace --verify-no-changes --no-restore --include sources\launcher\Stride.Launcher.Tests\MainViewXamlTests.cs -v minimal`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`