### PR TITLE
Fire tracking remove events after mutation

### DIFF
--- a/sources/core/Stride.Core.Tests/Collections/FastTrackingCollectionTests.cs
+++ b/sources/core/Stride.Core.Tests/Collections/FastTrackingCollectionTests.cs
@@ -44,12 +44,14 @@ public class FastTrackingCollectionTests
     {
         var collection = new FastTrackingCollection<string> { "test" };
         var eventRaised = false;
+        var itemRemovedBeforeEvent = false;
         FastTrackingCollectionChangedEventArgs capturedArgs = default;
 
         FastTrackingCollection<string>.FastEventHandler<FastTrackingCollectionChangedEventArgs> handler =
             (object sender, ref FastTrackingCollectionChangedEventArgs e) =>
         {
             eventRaised = true;
+            itemRemovedBeforeEvent = !collection.Contains("test");
             capturedArgs = e;
         };
         collection.CollectionChanged += handler;
@@ -60,6 +62,7 @@ public class FastTrackingCollectionTests
         Assert.Equal(NotifyCollectionChangedAction.Remove, capturedArgs.Action);
         Assert.Equal("test", capturedArgs.Item);
         Assert.Equal(0, capturedArgs.Index);
+        Assert.True(itemRemovedBeforeEvent);
     }
 
     [Fact]
@@ -68,6 +71,7 @@ public class FastTrackingCollectionTests
         var collection = new FastTrackingCollection<int> { 1, 2, 3 };
         var removeCount = 0;
         var removedItems = new List<int>();
+        var removedItemsWereGone = new List<bool>();
 
         FastTrackingCollection<int>.FastEventHandler<FastTrackingCollectionChangedEventArgs> handler =
             (object sender, ref FastTrackingCollectionChangedEventArgs e) =>
@@ -76,6 +80,7 @@ public class FastTrackingCollectionTests
             {
                 removeCount++;
                 removedItems.Add((int)e.Item!);
+                removedItemsWereGone.Add(!collection.Contains((int)e.Item!));
             }
         };
         collection.CollectionChanged += handler;
@@ -84,6 +89,7 @@ public class FastTrackingCollectionTests
 
         Assert.Equal(3, removeCount);
         Assert.Equal(new[] { 3, 2, 1 }, removedItems); // Reverse order
+        Assert.Equal(new[] { true, true, true }, removedItemsWereGone);
         Assert.Empty(collection);
     }
 

--- a/sources/core/Stride.Core.Tests/Collections/TrackingCollectionTests.cs
+++ b/sources/core/Stride.Core.Tests/Collections/TrackingCollectionTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Specialized;
+using Stride.Core.Collections;
+using Xunit;
+
+namespace Stride.Core.Tests.Collections;
+
+public class TrackingCollectionTests
+{
+    [Fact]
+    public void Remove_RaisesCollectionChangedAfterItemRemoved()
+    {
+        var collection = new TrackingCollection<int> { 1 };
+        var itemRemovedBeforeEvent = false;
+
+        collection.CollectionChanged += (sender, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+                itemRemovedBeforeEvent = !collection.Contains(1);
+        };
+
+        collection.RemoveAt(0);
+
+        Assert.True(itemRemovedBeforeEvent);
+    }
+
+    [Fact]
+    public void Clear_RaisesCollectionChangedAfterItemsRemoved()
+    {
+        var collection = new TrackingCollection<int> { 1, 2, 3 };
+        var removedItemsWereGone = new List<bool>();
+
+        collection.CollectionChanged += (sender, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+                removedItemsWereGone.Add(!collection.Contains((int)args.Item!));
+        };
+
+        collection.Clear();
+
+        Assert.Equal(new[] { true, true, true }, removedItemsWereGone);
+    }
+}

--- a/sources/core/Stride.Core.Tests/Collections/TrackingDictionaryTests.cs
+++ b/sources/core/Stride.Core.Tests/Collections/TrackingDictionaryTests.cs
@@ -35,10 +35,14 @@ public class TrackingDictionaryTests
     {
         var dict = new TrackingDictionary<string, int> { { "key1", 10 } };
         TrackingCollectionChangedEventArgs? eventArgs = null;
+        var keyRemovedBeforeEvent = false;
         dict.CollectionChanged += (sender, args) =>
         {
             if (args.Action == NotifyCollectionChangedAction.Remove)
+            {
                 eventArgs = args;
+                keyRemovedBeforeEvent = !dict.ContainsKey("key1");
+            }
         };
 
         var result = dict.Remove("key1");
@@ -49,6 +53,33 @@ public class TrackingDictionaryTests
         Assert.Equal(NotifyCollectionChangedAction.Remove, eventArgs.Action);
         Assert.Equal("key1", eventArgs.Key);
         Assert.Equal(10, eventArgs.Item);
+        Assert.True(keyRemovedBeforeEvent);
+    }
+
+    [Fact]
+    public void Remove_KeyValuePair_RemovesItemAndTriggersEvent()
+    {
+        var dict = new TrackingDictionary<string, int> { { "key1", 10 } };
+        TrackingCollectionChangedEventArgs? eventArgs = null;
+        var keyRemovedBeforeEvent = false;
+        dict.CollectionChanged += (sender, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+            {
+                eventArgs = args;
+                keyRemovedBeforeEvent = !dict.ContainsKey("key1");
+            }
+        };
+
+        var result = dict.Remove(new KeyValuePair<string, int>("key1", 10));
+
+        Assert.True(result);
+        Assert.Empty(dict);
+        Assert.NotNull(eventArgs);
+        Assert.Equal(NotifyCollectionChangedAction.Remove, eventArgs.Action);
+        Assert.Equal("key1", eventArgs.Key);
+        Assert.Equal(10, eventArgs.Item);
+        Assert.True(keyRemovedBeforeEvent);
     }
 
     [Fact]
@@ -161,16 +192,21 @@ public class TrackingDictionaryTests
             { "key2", 20 }
         };
         var removeCount = 0;
+        var removedKeysWereGone = new List<bool>();
         dict.CollectionChanged += (sender, args) =>
         {
             if (args.Action == NotifyCollectionChangedAction.Remove)
+            {
                 removeCount++;
+                removedKeysWereGone.Add(!dict.ContainsKey((string)args.Key!));
+            }
         };
 
         dict.Clear();
 
         Assert.Empty(dict);
         Assert.Equal(2, removeCount);
+        Assert.Equal(new[] { true, true }, removedKeysWereGone);
     }
 
     [Fact]

--- a/sources/core/Stride.Core/Collections/FastTrackingCollection.cs
+++ b/sources/core/Stride.Core/Collections/FastTrackingCollection.cs
@@ -47,20 +47,38 @@ public class FastTrackingCollection<T> : FastCollection<T>
     /// <inheritdoc/>
     protected override void RemoveItem(int index)
     {
+        var item = this[index];
+        base.RemoveItem(index);
+
         var collectionChanged = itemRemoved;
         if (collectionChanged != null)
         {
-            var e = new FastTrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, this[index], null, index, true);
+            var e = new FastTrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, null, index, true);
             collectionChanged(this, ref e);
         }
-        base.RemoveItem(index);
     }
 
     /// <inheritdoc/>
     protected override void ClearItems()
     {
-        ClearItemsEvents();
+        var collectionChanged = itemRemoved;
+        if (collectionChanged == null)
+        {
+            base.ClearItems();
+            return;
+        }
+
+        var removedItems = new List<(T Item, int Index)>(Count);
+        for (var i = Count - 1; i >= 0; --i)
+            removedItems.Add((this[i], i));
+
         base.ClearItems();
+
+        foreach (var removedItem in removedItems)
+        {
+            var e = new FastTrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItem.Item, null, removedItem.Index, true);
+            collectionChanged(this, ref e);
+        }
     }
 
     protected void ClearItemsEvents()

--- a/sources/core/Stride.Core/Collections/TrackingCollection.cs
+++ b/sources/core/Stride.Core/Collections/TrackingCollection.cs
@@ -43,15 +43,30 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
     /// <inheritdoc/>
     protected override void RemoveItem(int index)
     {
-        itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, this[index], null, index, true));
+        var item = this[index];
         base.RemoveItem(index);
+        itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, null, index, true));
     }
 
     /// <inheritdoc/>
     protected override void ClearItems()
     {
-        ClearItemsEvents();
+        // Note: Changing CollectionChanged is not thread-safe
+        var collectionChanged = itemRemoved;
+        if (collectionChanged == null)
+        {
+            base.ClearItems();
+            return;
+        }
+
+        var removedItems = new List<(T Item, int Index)>(Count);
+        for (var i = Count - 1; i >= 0; --i)
+            removedItems.Add((this[i], i));
+
         base.ClearItems();
+
+        foreach (var removedItem in removedItems)
+            collectionChanged(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItem.Item, null, removedItem.Index, true));
     }
 
     protected void ClearItemsEvents()

--- a/sources/core/Stride.Core/Collections/TrackingDictionary.cs
+++ b/sources/core/Stride.Core/Collections/TrackingDictionary.cs
@@ -74,7 +74,12 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
     {
         var collectionChanged = itemRemoved;
         if (collectionChanged != null && innerDictionary.TryGetValue(key, out var dictValue))
-            collectionChanged(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, key, dictValue, null, true));
+        {
+            var removed = innerDictionary.Remove(key);
+            if (removed)
+                collectionChanged(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, key, dictValue, null, true));
+            return removed;
+        }
 
         return innerDictionary.Remove(key);
     }
@@ -171,7 +176,12 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
     {
         var collectionChanged = itemRemoved;
         if (collectionChanged != null && innerDictionary.Contains(item))
-            return innerDictionary.Remove(item.Key);
+        {
+            var removed = ((IDictionary<TKey, TValue>)innerDictionary).Remove(item);
+            if (removed)
+                collectionChanged(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item.Key, item.Value, null, true));
+            return removed;
+        }
 
         return ((IDictionary<TKey, TValue>)innerDictionary).Remove(item);
     }


### PR DESCRIPTION
Closes #3171.

`TrackingCollection`, `FastTrackingCollection`, and `TrackingDictionary` all exposed remove notifications before the backing collection had actually changed. That made `CollectionChanged` handlers observe stale state during `Remove`, `RemoveAt`, and clear-driven remove notifications.

This updates remove notifications so handlers observe post-removal state while keeping the existing payloads and remove event ordering:

- `TrackingCollection.RemoveItem` stores the removed item, removes it, then fires `Remove`.
- `FastTrackingCollection.RemoveItem` does the same for fast event args.
- `TrackingCollection.ClearItems` and `FastTrackingCollection.ClearItems` snapshot remove payloads, clear the collection, then raise remove events in the existing reverse order.
- `TrackingDictionary.Remove(TKey)` removes before firing.
- `TrackingDictionary.Remove(KeyValuePair<TKey,TValue>)` now also raises the remove event when it removes an item.

`SetItem` behavior is intentionally unchanged because its existing remove/add notifications are marked `CollectionChanged=false`, and the issue calls replace semantics out as a separate breaking-change question.

Local validation:

- `dotnet restore sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj`
- `dotnet test sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj --filter "FullyQualifiedName~TrackingCollectionTests|FullyQualifiedName~FastTrackingCollectionTests|FullyQualifiedName~TrackingDictionaryTests" --no-restore --nologo` -> 27 passed
- `git diff --cached --check`

Notes:

- The local checkout was sparse/blobless, so I added `sources/tests/xunit.runner.stride` to the sparse checkout to make the test project compile locally.
- Push used `GIT_LFS_SKIP_PUSH=1` because this commit does not modify LFS files, and the local partial clone reported an unrelated missing promisor object for an existing FFmpeg LFS blob during the default LFS pre-push scan.