### PR TITLE
refactor: Remove unused package references from project files

### DIFF
--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" />
     <ProjectReference Include="..\Stride.Audio\Stride.Audio.csproj" />
     <ProjectReference Include="..\Stride.Rendering\Stride.Rendering.csproj" />
     <ProjectReference Include="..\Stride.VirtualReality\Stride.VirtualReality.csproj" />

--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -38,7 +38,6 @@
     </ProjectReference>
     <ProjectReference Include="..\..\shaders\Stride.Shaders.Effects\Stride.Shaders.Effects.csproj" />
     <ProjectReference Include="..\Stride\Stride.csproj" />
-    <PackageReference Include="System.Memory" />
     <PackageReference Include="WinPixEventRuntime" Condition="'$(TargetFramework)' == '$(StrideFramework)'" />
     <!-- PrivateAssets="compile": native bindings stay out of consumer compile graphs (analyzer perf);
          consumers calling GraphicsMarshal interop add their own PackageReference. -->

--- a/sources/tools/Stride.Graphics.RenderDocPlugin/Stride.Graphics.RenderDocPlugin.csproj
+++ b/sources/tools/Stride.Graphics.RenderDocPlugin/Stride.Graphics.RenderDocPlugin.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\engine\Stride.Graphics\Stride.Graphics.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry" />
     <PackageReference Include="Silk.NET.Direct3D11" Condition="'$(TargetFramework)' == '$(StrideFramework)' Or '$(TargetFramework)' == '$(StrideFrameworkUWP)'" />
     <PackageReference Include="Silk.NET.Direct3D12" Condition="'$(TargetFramework)' == '$(StrideFramework)' Or '$(TargetFramework)' == '$(StrideFrameworkUWP)'" />
   </ItemGroup>


### PR DESCRIPTION
# PR Details

Removed `System.Threading.Tasks.Dataflow` from Stride.Engine.csproj, `System.Memory` from Stride.Graphics.csproj, and `Microsoft.Win32.Registry` from Stride.Graphics.RenderDocPlugin.csproj to clean up unnecessary dependencies, they might be linked through other projects. This removes also some warnings from the Stride build and Stride Docs build.

Comment from Kryptos-FR: I think there are many other instances of such unnecessary dependencies. However, some might still be necessary on certain platforms.

Comment from Vaclav: Yes. These were specifially showing up to be pruned in Stride Docs build and I don't know if we can actually remove them.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

n/a

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->