### PR TITLE
fix: Finalize array support in Quantum

### DIFF
--- a/sources/assets/Stride.Core.Assets/CollectionIdGenerator.cs
+++ b/sources/assets/Stride.Core.Assets/CollectionIdGenerator.cs
@@ -110,6 +110,12 @@ public class CollectionIdGenerator : DataVisitorBase
 
     private bool ShouldGenerateItemIdCollection(object collection)
     {
+        // Arrays do not support Collection Ids right now;
+        // a bunch of blockers in AssetPropertyGraph.ReconcileWithBaseNode around the expectations
+        // that add/remove work on this type of collection
+        if (collection is Array)
+            return false;
+
         // Do not generate for value types (collections that are struct) or null
         if (collection?.GetType().IsValueType != false)
             return false;

--- a/sources/core/Stride.Core.Design/Extensions/TypeDescriptorExtensions.cs
+++ b/sources/core/Stride.Core.Design/Extensions/TypeDescriptorExtensions.cs
@@ -136,7 +136,8 @@ public static class TypeDescriptorExtensions
     /// <summary>
     /// Attempts to return the type of inner values of an <see cref="ITypeDescriptor"/>, if it represents an enumerable type. If the given type descriptor is
     /// a <see cref="CollectionDescriptor"/>, this method will return its <see cref="CollectionDescriptor.ElementType"/> property. If the given type descriptor
-    /// is a <see cref="DictionaryDescriptor"/>, this method will return its <see cref="DictionaryDescriptor.ValueType"/>. Otherwise, it will return the
+    /// is a <see cref="DictionaryDescriptor"/>, this method will return its <see cref="DictionaryDescriptor.ValueType"/>. If the given type descriptor
+    /// is a <see cref="ArrayDescriptor"/>, this method will return its <see cref="ArrayDescriptor.ElementType"/>. Otherwise, it will return the
     /// <see cref="ITypeDescriptor.Type"/> property.
     /// </summary>
     /// <param name="typeDescriptor">The type descriptor.</param>
@@ -145,11 +146,8 @@ public static class TypeDescriptorExtensions
     {
         var type = typeDescriptor.Type;
 
-        if (typeDescriptor is CollectionDescriptor collectionDescriptor)
-            type = collectionDescriptor.ElementType;
-
-        if (typeDescriptor is DictionaryDescriptor dictionaryDescriptor)
-            type = dictionaryDescriptor.ValueType;
+        if (typeDescriptor is CollectionBaseDescriptor collectionDescriptor)
+            type = collectionDescriptor.ValueType;
 
         return type;
     }

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/ArrayDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/ArrayDescriptor.cs
@@ -8,7 +8,7 @@ namespace Stride.Core.Reflection;
 /// <summary>
 /// A descriptor for an array.
 /// </summary>
-public class ArrayDescriptor : ObjectDescriptor
+public class ArrayDescriptor : CollectionBaseDescriptor
 {
     public ArrayDescriptor(ITypeDescriptorFactory factory, Type type, bool emitDefaultValues, IMemberNamingConvention namingConvention)
         : base(factory, type, emitDefaultValues, namingConvention)
@@ -51,7 +51,7 @@ public class ArrayDescriptor : ObjectDescriptor
         return ((Array)array).GetValue(index);
     }
 
-    public void SetValue(object array, int index, object value)
+    public void SetValue(object array, int index, object? value)
     {
         ((Array)array).SetValue(value, index);
     }
@@ -64,5 +64,32 @@ public class ArrayDescriptor : ObjectDescriptor
     public int GetLength(object array)
     {
         return ((Array)array).Length;
+    }
+
+    public override object? GetValue(object collection, object index)
+    {
+        return GetValue(collection, (int)index);
+    }
+
+    public override void SetValue(object collection, object index, object? value)
+    {
+        SetValue(collection, (int)index, value);
+    }
+
+    public override Type ValueType => ElementType;
+
+    public override IEnumerable<object> EnumerateKeys(object collection)
+    {
+        return Enumerable.Range(0, GetLength(collection)).Cast<object>();
+    }
+
+    public override bool IsKeyValid(object? key)
+    {
+        return key is int i && i >= 0;
+    }
+
+    public override bool ContainsKey(object collection, object? key)
+    {
+        return key is int i && i >= 0 && i < GetLength(collection);
     }
 }

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/CollectionBaseDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/CollectionBaseDescriptor.cs
@@ -34,7 +34,7 @@ public abstract class CollectionBaseDescriptor : ObjectDescriptor
     /// Validates whether the type of this key would be valid
     /// </summary>
     /// <remarks>
-    /// For ints it also checks if its value is above 0
+    /// For ints it also checks if its value is greater than or equal to 0
     /// </remarks>
     public abstract bool IsKeyValid(object? key);
 

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/CollectionBaseDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/CollectionBaseDescriptor.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Yaml.Serialization;
+
+namespace Stride.Core.Reflection;
+
+public abstract class CollectionBaseDescriptor : ObjectDescriptor
+{
+    protected CollectionBaseDescriptor(ITypeDescriptorFactory factory, Type type, bool emitDefaultValues, IMemberNamingConvention namingConvention) : base(factory, type, emitDefaultValues, namingConvention)
+    {
+    }
+
+    /// <summary>
+    /// Returns the value at the key specified in the collection.
+    /// </summary>
+    /// <remarks> The key would be the integer index for list-like collections </remarks>
+    public abstract object? GetValue(object collection, object key);
+
+    /// <summary>
+    /// Sets the value at key to value in the collection provided.
+    /// </summary>
+    /// <remarks> The key would be the integer index for list-like collections </remarks>
+    public abstract void SetValue(object collection, object key, object? value);
+
+    /// <summary>
+    /// The type of value returned through <see cref="GetValue"/>
+    /// </summary>
+    public abstract Type ValueType { get; }
+
+    public abstract IEnumerable<object> EnumerateKeys(object collection);
+
+    /// <summary>
+    /// Validates whether the type of this key would be valid
+    /// </summary>
+    /// <remarks>
+    /// For ints it also checks if its value is above 0
+    /// </remarks>
+    public abstract bool IsKeyValid(object? key);
+
+    /// <summary>
+    /// Checks whether there is a value for this key
+    /// </summary>
+    public abstract bool ContainsKey(object collection, object? key);
+}

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/CollectionDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/CollectionDescriptor.cs
@@ -8,9 +8,9 @@ using Stride.Core.Yaml.Serialization;
 namespace Stride.Core.Reflection;
 
 /// <summary>
-/// Provides a descriptor for a <see cref="ICollection"/>.
+/// Provides a descriptor for a non-array <see cref="ICollection"/>. For arrays, use <see cref="ArrayDescriptor"/> instead.
 /// </summary>
-public abstract class CollectionDescriptor : ObjectDescriptor
+public abstract class CollectionDescriptor : CollectionBaseDescriptor
 {
     public CollectionDescriptor(ITypeDescriptorFactory factory, Type type, bool emitDefaultValues, IMemberNamingConvention namingConvention)
         : base(factory, type, emitDefaultValues, namingConvention)
@@ -102,16 +102,7 @@ public abstract class CollectionDescriptor : ObjectDescriptor
     /// </summary>
     /// <param name="collection">The collection.</param>
     /// <param name="index">The index.</param>
-    public abstract object? GetValue(object collection, object index);
-
-    /// <summary>
-    /// Returns the value matching the given index in the collection.
-    /// </summary>
-    /// <param name="collection">The collection.</param>
-    /// <param name="index">The index.</param>
     public abstract object? GetValue(object collection, int index);
-
-    public abstract void SetValue(object list, object index, object? value);
 
     /// <summary>
     /// Add to the collections of the same type than this descriptor.
@@ -154,4 +145,21 @@ public abstract class CollectionDescriptor : ObjectDescriptor
     /// <param name="collection">The collection.</param>
     /// <returns>The number of elements of a collection, -1 if it cannot determine the number of elements.</returns>
     public abstract int GetCollectionCount(object? collection);
+
+    public override Type ValueType => ElementType;
+
+    public override IEnumerable<object> EnumerateKeys(object collection)
+    {
+        return Enumerable.Range(0, GetCollectionCount(collection)).Cast<object>();
+    }
+
+    public override bool IsKeyValid(object? key)
+    {
+        return key is int i && i >= 0;
+    }
+
+    public override bool ContainsKey(object collection, object? key)
+    {
+        return key is int i && i >= 0 && i < GetCollectionCount(collection);
+    }
 }

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
@@ -10,7 +10,7 @@ namespace Stride.Core.Reflection;
 /// <summary>
 /// Provides a descriptor for a <see cref="IDictionary"/>.
 /// </summary>
-public class DictionaryDescriptor : ObjectDescriptor
+public class DictionaryDescriptor : CollectionBaseDescriptor
 {
     private static readonly List<string> ListOfMembersToRemove = ["Comparer", "Keys", "Values", "Capacity"];
 
@@ -86,7 +86,7 @@ public class DictionaryDescriptor : ObjectDescriptor
     /// Gets the type of the value.
     /// </summary>
     /// <value>The type of the value.</value>
-    public Type ValueType { get; }
+    public override Type ValueType { get; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this instance is pure dictionary.
@@ -123,7 +123,7 @@ public class DictionaryDescriptor : ObjectDescriptor
     /// <param name="key">The key.</param>
     /// <param name="value">The value.</param>
     /// <exception cref="InvalidOperationException">No Add() method found on dictionary [{0}].ToFormat(Type)</exception>
-    public void SetValue(object dictionary, object key, object? value)
+    public override void SetValue(object dictionary, object key, object? value)
     {
         ArgumentNullException.ThrowIfNull(dictionary);
         setValueMethod(dictionary, key, value);
@@ -158,7 +158,7 @@ public class DictionaryDescriptor : ObjectDescriptor
     /// </summary>
     /// <param name="dictionary">The dictionary.</param>
     /// <param name="key">The key.</param>
-    public bool ContainsKey(object dictionary, object key)
+    public override bool ContainsKey(object dictionary, object key)
     {
         ArgumentNullException.ThrowIfNull(dictionary);
         return containsKeyMethod.Invoke(dictionary, key);
@@ -199,7 +199,7 @@ public class DictionaryDescriptor : ObjectDescriptor
     /// </summary>
     /// <param name="dictionary">The dictionary.</param>
     /// <param name="key">The key.</param>
-    public object? GetValue(object dictionary, object key)
+    public override object? GetValue(object dictionary, object key)
     {
         ArgumentNullException.ThrowIfNull(dictionary);
         return getValueMethod.Invoke(dictionary, key);
@@ -241,5 +241,18 @@ public class DictionaryDescriptor : ObjectDescriptor
         }
 
         return base.PrepareMember(member, metadataClassMemberInfo);
+    }
+
+    public override IEnumerable<object> EnumerateKeys(object collection)
+    {
+        foreach (var key in GetKeys(collection))
+        {
+            yield return key;
+        }
+    }
+
+    public override bool IsKeyValid(object? key)
+    {
+        return KeyType.IsInstanceOfType(key);
     }
 }

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
@@ -158,10 +158,10 @@ public class DictionaryDescriptor : CollectionBaseDescriptor
     /// </summary>
     /// <param name="dictionary">The dictionary.</param>
     /// <param name="key">The key.</param>
-    public override bool ContainsKey(object dictionary, object key)
+    public override bool ContainsKey(object dictionary, object? key)
     {
         ArgumentNullException.ThrowIfNull(dictionary);
-        return containsKeyMethod.Invoke(dictionary, key);
+        return key is not null && containsKeyMethod.Invoke(dictionary, key);
     }
 
     /// <summary>

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/SetDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/SetDescriptor.cs
@@ -180,6 +180,8 @@ public class SetDescriptor : CollectionDescriptor
         }
     }
 
+    public override Type ValueType => ElementType;
+
     /// <summary>
     /// Determines whether the specified type is a .NET set.
     /// </summary>
@@ -211,5 +213,25 @@ public class SetDescriptor : CollectionDescriptor
         }
 
         return base.PrepareMember(member, metadataClassMemberInfo);
+    }
+
+    public override IEnumerable<object> EnumerateKeys(object coll)
+    {
+        var enumerable = coll as System.Collections.IEnumerable;
+        var enumerator = enumerable.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            yield return enumerator.Current;
+        }
+    }
+
+    public override bool IsKeyValid(object? key)
+    {
+        return ElementType.IsInstanceOfType(key);
+    }
+
+    public override bool ContainsKey(object collection, object? key)
+    {
+        return Contains(collection, key);
     }
 }

--- a/sources/core/Stride.Core.Reflection/TypeDescriptors/SetDescriptor.cs
+++ b/sources/core/Stride.Core.Reflection/TypeDescriptors/SetDescriptor.cs
@@ -217,11 +217,9 @@ public class SetDescriptor : CollectionDescriptor
 
     public override IEnumerable<object> EnumerateKeys(object coll)
     {
-        var enumerable = coll as System.Collections.IEnumerable;
-        var enumerator = enumerable.GetEnumerator();
-        while (enumerator.MoveNext())
+        foreach (var obj in (System.Collections.IEnumerable)coll)
         {
-            yield return enumerator.Current;
+            yield return obj;
         }
     }
 

--- a/sources/core/Stride.Core.Yaml.Tests/DescriptorTests.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/DescriptorTests.cs
@@ -197,6 +197,16 @@ public class DescriptorTests
         Assert.Equal(0, descriptor.Count);
         Assert.True(descriptor.IsPureCollection);
         Assert.Equal(typeof(string), descriptor.ElementType);
+        Assert.True(descriptor.IsKeyValid(0));
+        Assert.False(descriptor.IsKeyValid(-1));
+
+        var testObj = new List<string>();
+        testObj.Add("zero");
+        testObj.Add("one");
+        testObj.Add("two");
+
+        TestCollectionBaseDescriptorWithWrite(descriptor, testObj, [(0, "zero"), (1, "one"), (2, "two")], 0, "0");
+        Assert.False(descriptor.ContainsKey(testObj, new InvalidKeyTester()));
 
         descriptor = new ListDescriptor(factory, typeof(NonPureCollection), false,
             new DefaultNamingConvention());
@@ -229,6 +239,16 @@ public class DescriptorTests
         Assert.True(descriptor.IsPureDictionary);
         Assert.Equal(typeof(int), descriptor.KeyType);
         Assert.Equal(typeof(string), descriptor.ValueType);
+        Assert.True(descriptor.IsKeyValid(0));
+        Assert.True(descriptor.IsKeyValid(-1));
+
+        var testObj = new Dictionary<int, string>();
+        testObj.Add(0, "zero");
+        testObj.Add(1, "one");
+        testObj.Add(2, "two");
+
+        TestCollectionBaseDescriptorWithWrite(descriptor, testObj, [(0, "zero"), (1, "one"), (2, "two")], 3, "three");
+        Assert.Throws<InvalidCastException>(() => descriptor.ContainsKey(testObj, new InvalidKeyTester()));
 
         descriptor = new DictionaryDescriptor(factory, typeof(NonPureDictionary), false,
             new DefaultNamingConvention());
@@ -240,6 +260,47 @@ public class DescriptorTests
     }
 
     [Fact]
+    public void TestSetDescriptor()
+    {
+        var attributeRegistry = new AttributeRegistry();
+        var factory = new TypeDescriptorFactory(attributeRegistry);
+        var descriptor = new SetDescriptor(factory, typeof(HashSet<string>), false,
+            new DefaultNamingConvention());
+        descriptor.Initialize(new DefaultKeyComparer());
+
+        Assert.Equal(0, descriptor.Count);
+        Assert.True(descriptor.IsPureCollection);
+        Assert.Equal(typeof(string), descriptor.ValueType);
+        Assert.False(descriptor.IsKeyValid(0));
+        Assert.False(descriptor.IsKeyValid(-1));
+
+        var testObj = new HashSet<string>();
+        testObj.Add("zero");
+        testObj.Add("one");
+        testObj.Add("two");
+
+        TestCollectionBaseDescriptorWithWrite(descriptor, testObj, testObj.Select((v) => (v, v)).ToArray(), "three", "three");
+        Assert.Throws<InvalidCastException>(() => descriptor.ContainsKey(testObj, new InvalidKeyTester()));
+    }
+
+    private void TestCollectionBaseDescriptorWithWrite<TKey, TVal>(CollectionBaseDescriptor descriptor, object testObj, (TKey index, TVal value)[] content, TKey newIndex, TVal newVal)
+    {
+        Assert.False(descriptor.IsKeyValid(null));
+        Assert.False(descriptor.IsKeyValid(new object()));
+
+        Assert.Equal(content.Select(x => x.index).Order().ToArray(), descriptor.EnumerateKeys(testObj).Order().Cast<TKey>().ToArray());
+        Assert.True(descriptor.ContainsKey(testObj, content[0].index));
+        Assert.Equal(content[0].value, descriptor.GetValue(testObj, content[0].index));
+
+        Assert.False(descriptor.ContainsKey(testObj, null));
+
+        descriptor.SetValue(testObj, newIndex, newVal);
+        Assert.Equal(newVal, descriptor.GetValue(testObj, newIndex));
+    }
+
+    private struct InvalidKeyTester;
+
+    [Fact]
     public void TestArrayDescriptor()
     {
         var attributeRegistry = new AttributeRegistry();
@@ -249,6 +310,12 @@ public class DescriptorTests
 
         Assert.Equal(0, descriptor.Count);
         Assert.Equal(typeof(int), descriptor.ElementType);
+        Assert.True(descriptor.IsKeyValid(0));
+        Assert.False(descriptor.IsKeyValid(-1));
+
+        var testObj = new int[] { 2, 1, 0 };
+        TestCollectionBaseDescriptorWithWrite(descriptor, testObj, [(2, 0), (1, 1), (0, 2)], 0, 0);
+        Assert.False(descriptor.ContainsKey(testObj, new InvalidKeyTester()));
     }
 
     public enum MyEnum

--- a/sources/presentation/Stride.Core.Presentation.Quantum/Presenters/ItemNodePresenter.cs
+++ b/sources/presentation/Stride.Core.Presentation.Quantum/Presenters/ItemNodePresenter.cs
@@ -17,20 +17,10 @@ public class ItemNodePresenter : NodePresenterBase
         ArgumentNullException.ThrowIfNull(factory);
         ArgumentNullException.ThrowIfNull(parent);
         Container = container ?? throw new ArgumentNullException(nameof(container));
-        Descriptor = TypeDescriptorFactory.Default.Find(container.Descriptor.GetInnerCollectionType());
+        var innerCollectionType = container.Descriptor.GetInnerCollectionType();
+        Descriptor = TypeDescriptorFactory.Default.Find(innerCollectionType);
         OwnerCollection = parent;
-        if (container.Descriptor is CollectionDescriptor collectionDescriptor)
-        {
-            Type = collectionDescriptor.ElementType;
-        }
-        else if (container.Descriptor is DictionaryDescriptor dictionaryDescriptor)
-        {
-            Type = dictionaryDescriptor.ValueType;
-        }
-        else if (container.Descriptor is ArrayDescriptor arrayDescriptor)
-        {
-            Type = arrayDescriptor.ElementType;
-        }
+        Type = innerCollectionType;
         Index = index;
         Name = index.ToString();
         Order = index.IsInt ? (int?)index.Int : null; // So items are sorted by index instead of string

--- a/sources/presentation/Stride.Core.Quantum/BoxedNode.cs
+++ b/sources/presentation/Stride.Core.Quantum/BoxedNode.cs
@@ -35,13 +35,9 @@ public class BoxedNode : ObjectNode
     {
         if (index.TryGetValue(out var indexValue))
         {
-            if (Descriptor is CollectionDescriptor collectionDescriptor)
+            if (Descriptor is CollectionBaseDescriptor collectionDescriptor)
             {
                 collectionDescriptor.SetValue(Value, indexValue, newValue);
-            }
-            else if (Descriptor is DictionaryDescriptor dictionaryDescriptor)
-            {
-                dictionaryDescriptor.SetValue(Value, index, newValue);
             }
             else
             {

--- a/sources/presentation/Stride.Core.Quantum/DefaultNodeBuilder.cs
+++ b/sources/presentation/Stride.Core.Quantum/DefaultNodeBuilder.cs
@@ -138,9 +138,9 @@ internal class DefaultNodeBuilder : DataVisitorBase, INodeBuilder
         }
 
         var descriptor = TypeDescriptorFactory.Find(value?.GetType());
-        if (descriptor is CollectionDescriptor or DictionaryDescriptor)
+        if (descriptor is CollectionBaseDescriptor collection)
         {
-            var valueType = GetElementValueType(descriptor);
+            var valueType = collection.ValueType;
             return !PrimitiveTypeFilter.IsPrimitiveType(valueType) ? Reference.CreateReference(value, type, NodeIndex.Empty, false) : null;
         }
 
@@ -165,12 +165,6 @@ internal class DefaultNodeBuilder : DataVisitorBase, INodeBuilder
     private static bool IsCollection(Type type)
     {
         return typeof(ICollection).IsAssignableFrom(type);
-    }
-
-    private static Type? GetElementValueType(ITypeDescriptor descriptor)
-    {
-        var collectionDescriptor = descriptor as CollectionDescriptor;
-        return descriptor is DictionaryDescriptor dictionaryDescriptor ? dictionaryDescriptor.ValueType : collectionDescriptor?.ElementType;
     }
 
     private class DefaultPrimitiveFilter : IPrimitiveTypeFilter

--- a/sources/presentation/Stride.Core.Quantum/DynamicNode.cs
+++ b/sources/presentation/Stride.Core.Quantum/DynamicNode.cs
@@ -182,32 +182,10 @@ public abstract class DynamicNode : DynamicObject, IEnumerable
         {
             var value = node.Retrieve();
             var descriptor = node.Descriptor;
-            if (descriptor is CollectionDescriptor collectionDescriptor)
+            if (descriptor is CollectionBaseDescriptor collectionDescriptor)
             {
-                if (descriptor is SetDescriptor setDescriptor)
-                {
-                    if (setDescriptor.Contains(value, index.Value))
-                    {
-                        return true;
-                    }
-                }
-                else
-                {
-                    if (index.IsInt
-                        && index.Int >= 0
-                        && index.Int < collectionDescriptor.GetCollectionCount(value))
-                    {
-                        return true;
-                    }
-                }
-            }
-            else if (descriptor is DictionaryDescriptor dictionaryDescriptor)
-            {
-                if (dictionaryDescriptor.KeyType.IsInstanceOfType(index.Value)
-                    && dictionaryDescriptor.ContainsKey(value, index.Value))
-                {
+                if (collectionDescriptor.ContainsKey(value, index.Value))
                     return true;
-                }
             }
         }
         return false;
@@ -221,21 +199,11 @@ public abstract class DynamicNode : DynamicObject, IEnumerable
             return reference != null;
         }
 
-        if (node.Descriptor is CollectionDescriptor collectionDescriptor)
+        if (node.Descriptor is CollectionBaseDescriptor collectionBaseDescriptor)
         {
-            if (node.Descriptor.Category == DescriptorCategory.Set)
-            {
-                return collectionDescriptor.ElementType.IsInstanceOfType(index.Value);
-            }
-            else
-            {
-                return index.IsInt && index.Int >= 0;
-            }
+            return collectionBaseDescriptor.IsKeyValid(index.Value);
         }
-        else if (node.Descriptor is DictionaryDescriptor dictionaryDescriptor)
-        {
-            return dictionaryDescriptor.KeyType.IsInstanceOfType(index.Value);
-        }
+
         return false;
     }
 

--- a/sources/presentation/Stride.Core.Quantum/GraphNodeBase.cs
+++ b/sources/presentation/Stride.Core.Quantum/GraphNodeBase.cs
@@ -64,32 +64,11 @@ public abstract class GraphNodeBase : IInitializingGraphNode
 
     public static IEnumerable<NodeIndex>? GetIndices(IGraphNode node)
     {
-        if (node.Descriptor is CollectionDescriptor collectionDescriptor)
+        if (node.Descriptor is CollectionBaseDescriptor collectionDescriptor)
         {
-            if (node.Descriptor.Category == DescriptorCategory.Set)
-            {
-                var enumerator = (node.Retrieve() as IEnumerable).GetEnumerator();
-                NodeIndex[] valueArr = new NodeIndex[collectionDescriptor.GetCollectionCount(node.Retrieve())];
-                int i = 0;
-                while (enumerator.MoveNext())
-                {
-                    valueArr[i++] = new NodeIndex(enumerator.Current);
-                }
-                return valueArr;
-            }
-            else
-            {
-                return Enumerable.Range(0, collectionDescriptor.GetCollectionCount(node.Retrieve())).Select(x => new NodeIndex(x));
-            }
+            return collectionDescriptor.EnumerateKeys(node.Retrieve()).Select(x => new NodeIndex(x));
         }
-        else if (node.Descriptor is DictionaryDescriptor dictionaryDescriptor)
-        {
-            return dictionaryDescriptor.GetKeys(node.Retrieve()).Cast<object>().Select(x => new NodeIndex(x));
-        }
-        else if (node.Descriptor is ArrayDescriptor arrayDescriptor)
-        {
-            return Enumerable.Range(0, arrayDescriptor.GetLength(node.Retrieve())).Select(x => new NodeIndex(x));
-        }
+
         return null;
     }
 

--- a/sources/presentation/Stride.Core.Quantum/GraphNodePath.cs
+++ b/sources/presentation/Stride.Core.Quantum/GraphNodePath.cs
@@ -414,13 +414,9 @@ public sealed class GraphNodePath : IEnumerable<IGraphNode>, IEquatable<GraphNod
                     var index = itemPath.Index;
                     var enumerableReference = ((IObjectNode)node!).ItemReferences;
                     var descriptor = node.Descriptor;
-                    if (descriptor is CollectionDescriptor collectionDescriptor)
+                    if (descriptor is CollectionBaseDescriptor collectionDescriptor)
                     {
                         memberPath.Push(collectionDescriptor, index.Value);
-                    }
-                    else if (descriptor is DictionaryDescriptor dictionaryDescriptor)
-                    {
-                        memberPath.Push(dictionaryDescriptor, index.Value);
                     }
 
                     if (i != path.Count - 1)

--- a/sources/presentation/Stride.Core.Quantum/Internal/Content.cs
+++ b/sources/presentation/Stride.Core.Quantum/Internal/Content.cs
@@ -24,17 +24,9 @@ internal static class Content
 
         ArgumentNullException.ThrowIfNull(value);
 
-        if (descriptor is CollectionDescriptor collectionDescriptor)
+        if (descriptor is CollectionBaseDescriptor collectionBaseDescriptor)
         {
-            return collectionDescriptor.GetValue(value, indexValue);
-        }
-        else if (descriptor is DictionaryDescriptor dictionaryDescriptor)
-        {
-            return dictionaryDescriptor.GetValue(value, indexValue);
-        }
-        else if (descriptor is ArrayDescriptor arrayDescriptor)
-        {
-            return arrayDescriptor.GetValue(value, (int)indexValue);
+            return collectionBaseDescriptor.GetValue(value, indexValue);
         }
 
         // Try with the concrete type descriptor

--- a/sources/presentation/Stride.Core.Quantum/ObjectNode.cs
+++ b/sources/presentation/Stride.Core.Quantum/ObjectNode.cs
@@ -38,7 +38,7 @@ public class ObjectNode : GraphNodeBase, IInitializingObjectNode, IGraphNodeInte
 
     /// <inheritdoc/>
     [MemberNotNullWhen(true, nameof(Indices))]
-    public bool IsEnumerable => Descriptor is CollectionDescriptor || Descriptor is DictionaryDescriptor || Descriptor is ArrayDescriptor;
+    public bool IsEnumerable => Descriptor is CollectionBaseDescriptor;
 
     /// <inheritdoc/>
     [MemberNotNullWhen(true, nameof(ItemReferences))]
@@ -224,17 +224,9 @@ public class ObjectNode : GraphNodeBase, IInitializingObjectNode, IGraphNodeInte
             itemArgs = new ItemChangeEventArgs(this, index, ContentChangeType.CollectionUpdate, oldValue, newValue);
             NotifyItemChanging(itemArgs);
         }
-        if (Descriptor is CollectionDescriptor collectionDescriptor)
+        if (Descriptor is CollectionBaseDescriptor collectionDescriptor)
         {
-            collectionDescriptor.SetValue(Value, indexValue, ConvertValue(newValue, collectionDescriptor.ElementType));
-        }
-        else if (Descriptor is DictionaryDescriptor dictionaryDescriptor)
-        {
-            dictionaryDescriptor.SetValue(Value, indexValue, ConvertValue(newValue, dictionaryDescriptor.ValueType));
-        }
-        else if (Descriptor is ArrayDescriptor arrayDescriptor)
-        {
-            arrayDescriptor.SetValue(Value, (int)indexValue, ConvertValue(newValue, arrayDescriptor.ElementType));
+            collectionDescriptor.SetValue(Value, indexValue, ConvertValue(newValue, collectionDescriptor.ValueType));
         }
         else
         {


### PR DESCRIPTION
# PR Details
Arrays previously had limited support in the gamestudio, asset types could not be assigned to one of its slots for example. This PR fixes that.

Note that this PR does not affect collection id support for arrays; derived arrays still won't inherit appropriately as it requires rewriting some of the internal logic called through `AssetPropertyGraph.ReconcileWithBaseNode` that work with the expectation that one can remove and add to the collection.

Also note that some of these changes refactor some of the reflection logic around collection types to move type-specific logic to their own implementation. Let me know if this is a pain on your side @Kryptos-FR and we'll see what I can do to help you out.

## Related Issue
Fixes #2386

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

