### PR TITLE
docs: add default value remarks to CollidableComponent

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -261,7 +261,7 @@ public abstract class CollidableComponent : EntityComponent
 
     internal void TryUpdateFeatures()
     {
-#warning Norbo: Some of the callsites for this method may not require a full reconstruction of the body ? Something we should validate
+        #warning Norbo: Some of the callsites for this method may not require a full reconstruction of the body ? Something we should validate
         if (Simulation is not null)
             ReAttach(Simulation);
         else if (Processor is not null) // We may have to fall back to this when 'Collider.TryAttach' failed previously; when this collidable didn't have any collider before

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -101,6 +101,7 @@ public abstract class CollidableComponent : EntityComponent
     /// If the contact is trying to make a bounce happen at 240hz,
     /// but the integrator timestep is only 60hz,
     /// the unrepresentable motion will get damped out and the body won't bounce as much.
+    /// <para>Defaults to <c>30</c>.</para>
     /// </remarks>
     [Display(category: CategoryForces)]
     public float SpringFrequency
@@ -119,6 +120,9 @@ public abstract class CollidableComponent : EntityComponent
     /// <summary>
     /// The amount of energy/velocity lost when this collidable bounces off
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>3</c>.
+    /// </remarks>
     [Display(category: CategoryForces)]
     public float SpringDampingRatio
     {
@@ -133,6 +137,12 @@ public abstract class CollidableComponent : EntityComponent
         }
     }
 
+    /// <summary>
+    /// The friction coefficient applied when this collidable slides against another surface.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>1</c>.
+    /// </remarks>
     [Display(category: CategoryForces)]
     public float FrictionCoefficient
     {
@@ -147,6 +157,9 @@ public abstract class CollidableComponent : EntityComponent
     /// <summary>
     /// The maximum speed this object will exit out of the collision when overlapping another collidable
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>1000</c>.
+    /// </remarks>
     [Display(category: CategoryForces)]
     public float MaximumRecoveryVelocity
     {
@@ -248,7 +261,7 @@ public abstract class CollidableComponent : EntityComponent
 
     internal void TryUpdateFeatures()
     {
-        #warning Norbo: Some of the callsites for this method may not require a full reconstruction of the body ? Something we should validate
+#warning Norbo: Some of the callsites for this method may not require a full reconstruction of the body ? Something we should validate
         if (Simulation is not null)
             ReAttach(Simulation);
         else if (Processor is not null) // We may have to fall back to this when 'Collider.TryAttach' failed previously; when this collidable didn't have any collider before


### PR DESCRIPTION
# PR Details

Added and updated <remarks> XML comments for SpringFrequency, SpringDampingRatio, FrictionCoefficient, and MaximumRecoveryVelocity to indicate their default values. No changes to logic or behavior.

These changes update documentation comments to clarify property defaults, improving code clarity and API usability.

The pull request enhances the XML documentation for various physics properties.
- CollidableComponent.cs: Added <remarks> XML comments for property defaults on SpringFrequency, SpringDampingRatio, FrictionCoefficient, and MaximumRecoveryVelocity.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->