### PR TITLE
Fix sample teardown hang: drain GPU before the window is destroyed

### DIFF
--- a/samples/Tests/Runner/ScreenshotRunner.cs
+++ b/samples/Tests/Runner/ScreenshotRunner.cs
@@ -360,7 +360,12 @@ public static class ScreenshotRunner
 
         if (!process.WaitForExit(TimeSpan.FromSeconds(timeoutSeconds)))
         {
-            try { process.Kill(entireProcessTree: true); } catch { }
+            // A hang here is almost always a teardown deadlock (the sample wrote done.json then
+            // failed to exit). Snapshot the hung process's thread stacks before killing it so the
+            // next CI occurrence ships the actual deadlock callstack as an artifact.
+            try { CaptureHangDump(process, Path.GetDirectoryName(logPath)!, log); } catch (Exception e) { log.WriteLine($"[runner] hang dump failed: {e.Message}"); }
+
+            try { process.Kill(entireProcessTree: true); } catch (Exception e) { log.WriteLine($"[runner] kill failed: {e.Message}"); }
             // Kill returns before the OS finishes tearing down the process and releasing its file
             // handles; without this WaitForExit the caller races the kernel and intermittently
             // fails to copy / overwrite files the killed process had open.
@@ -370,6 +375,85 @@ public static class ScreenshotRunner
         }
         return process.ExitCode == 0;
     }
+
+    /// <summary>
+    /// Captures a heap process dump of a hung sample into the per-sample output dir so it rides along
+    /// with the uploaded artifacts. On Windows uses <c>MiniDumpWriteDump</c> (Windows' <c>createdump</c>
+    /// can only dump the current process); elsewhere uses the runtime's <c>createdump</c>, which still
+    /// takes a target pid. Best-effort: any failure is logged and swallowed.
+    /// </summary>
+    private static void CaptureHangDump(Process process, string outputDir, TextWriter log)
+    {
+        var dumpPath = Path.Combine(outputDir, "hang-dump.dmp");
+        log.WriteLine($"[runner] capturing hang dump of pid {process.Id} -> {dumpPath}");
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Prefer a full-memory dump (managed + native callstacks under SOS). If the full read
+            // fails — graphics processes can have mapped regions that aren't fully readable — fall
+            // back to a stacks dump (Normal + ThreadInfo + IndirectlyReferencedMemory + HandleData),
+            // which still carries every thread's native callstack, enough to pinpoint the deadlock.
+            if (!TryMiniDump(process, dumpPath, 0x2 | 0x4 | 0x1000, "full", log))
+                TryMiniDump(process, dumpPath, 0x0 | 0x1000 | 0x40 | 0x4, "stacks", log);
+            return;
+        }
+
+        var createdump = Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), "createdump");
+        if (!File.Exists(createdump))
+        {
+            log.WriteLine($"[runner] createdump not found at '{createdump}'; skipping hang dump");
+            return;
+        }
+        var psi = new ProcessStartInfo(createdump, $"--withheap --name \"{dumpPath}\" {process.Id}")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        using var dumper = Process.Start(psi);
+        if (dumper is null)
+        {
+            log.WriteLine("[runner] failed to start createdump");
+            return;
+        }
+        var stdout = dumper.StandardOutput.ReadToEnd();
+        var stderr = dumper.StandardError.ReadToEnd();
+        if (!dumper.WaitForExit(TimeSpan.FromSeconds(120)))
+        {
+            try { dumper.Kill(entireProcessTree: true); } catch { }
+            log.WriteLine("[runner] createdump timed out");
+            return;
+        }
+        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)) log.WriteLine($"[createdump] {line.TrimEnd()}");
+        foreach (var line in stderr.Split('\n', StringSplitOptions.RemoveEmptyEntries)) log.WriteLine($"[createdump:stderr] {line.TrimEnd()}");
+        log.WriteLine($"[runner] createdump exited {dumper.ExitCode}");
+    }
+
+    private static bool TryMiniDump(Process process, string dumpPath, int dumpType, string label, TextWriter log)
+    {
+        try
+        {
+            using var fs = new FileStream(dumpPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            if (MiniDumpWriteDump(process.Handle, (uint)process.Id, fs.SafeFileHandle.DangerousGetHandle(),
+                                  dumpType, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
+            {
+                log.WriteLine($"[runner] hang dump ({label}) written: {fs.Length} bytes");
+                return true;
+            }
+            log.WriteLine($"[runner] MiniDumpWriteDump ({label}) failed (win32 error {Marshal.GetLastWin32Error()})");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            log.WriteLine($"[runner] hang dump ({label}) threw: {ex.Message}");
+            return false;
+        }
+    }
+
+    [DllImport("Dbghelp.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MiniDumpWriteDump(IntPtr hProcess, uint processId, IntPtr hFile, int dumpType,
+                                                 IntPtr exceptionParam, IntPtr userStreamParam, IntPtr callbackParam);
 
     /// <summary>
     /// Regenerate one sample from its template into <paramref name="targetDir"/>, then copy the

--- a/samples/Tests/Templates/SampleAutoTesting.targets.template
+++ b/samples/Tests/Templates/SampleAutoTesting.targets.template
@@ -14,7 +14,7 @@
   </ItemGroup>
   <!-- Pin WARP for reproducible D3D11/D3D12 captures. -->
   <ItemGroup Condition="'$(StrideAutoTesting)' == 'true' And ('$(StrideGraphicsApi)' == 'Direct3D11' Or '$(StrideGraphicsApi)' == 'Direct3D12')">
-    <PackageReference Include="Microsoft.Direct3D.WARP" Version="1.0.18" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Direct3D.WARP" Version="1.0.20" GeneratePathProperty="true" />
     <Content Include="$(PkgMicrosoft_Direct3D_WARP)\build\native\bin\x64\d3d10warp.dll"
              Condition="'$(PkgMicrosoft_Direct3D_WARP)' != ''"
              Link="d3d10warp.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />

--- a/samples/Tests/Templates/SampleAutoTesting.targets.template
+++ b/samples/Tests/Templates/SampleAutoTesting.targets.template
@@ -19,4 +19,16 @@
              Condition="'$(PkgMicrosoft_Direct3D_WARP)' != ''"
              Link="d3d10warp.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
+  <!-- Pin the D3D12 runtime + debug layer (Agility SDK) so captures don't depend on the OS-serviced
+       D3D12. Side-loaded into a D3D12\ subfolder; GraphicsDevice activates it via ID3D12SDKConfiguration
+       before creating the device. D3D12 only — the Agility SDK does not cover D3D11. -->
+  <ItemGroup Condition="'$(StrideAutoTesting)' == 'true' And '$(StrideGraphicsApi)' == 'Direct3D12'">
+    <PackageReference Include="Microsoft.Direct3D.D3D12" Version="1.619.3" GeneratePathProperty="true" />
+    <Content Include="$(PkgMicrosoft_Direct3D_D3D12)\build\native\bin\x64\D3D12Core.dll"
+             Condition="'$(PkgMicrosoft_Direct3D_D3D12)' != ''"
+             Link="D3D12\D3D12Core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_Direct3D_D3D12)\build\native\bin\x64\d3d12SDKLayers.dll"
+             Condition="'$(PkgMicrosoft_Direct3D_D3D12)' != ''"
+             Link="D3D12\D3D12SDKLayers.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+  </ItemGroup>
 </Project>

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="DotRecast.Recast.Toolset" Version="2025.2.1" />
     <PackageVersion Include="FFmpeg.AutoGen" Version="7.1.1" />
     <PackageVersion Include="K4os.Compression.LZ4.Legacy" Version="1.3.6" />
-    <PackageVersion Include="Microsoft.Direct3D.WARP" Version="1.0.18" />
+    <PackageVersion Include="Microsoft.Direct3D.WARP" Version="1.0.20" />
     <PackageVersion Include="Microsoft.Direct3D.D3D12" Version="1.619.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0-preview.4" />

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="FFmpeg.AutoGen" Version="7.1.1" />
     <PackageVersion Include="K4os.Compression.LZ4.Legacy" Version="1.3.6" />
     <PackageVersion Include="Microsoft.Direct3D.WARP" Version="1.0.18" />
+    <PackageVersion Include="Microsoft.Direct3D.D3D12" Version="1.619.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0-preview.4" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />

--- a/sources/engine/Stride.Games.AutoTesting/ScreenshotTestRunner.cs
+++ b/sources/engine/Stride.Games.AutoTesting/ScreenshotTestRunner.cs
@@ -91,9 +91,14 @@ internal sealed class ScreenshotTestRunner
             return;
 
         // Skip back-buffer clamp so portrait samples don't get cropped on smaller host desktops.
-        // OnGameStarted fires before graphicsDeviceManager.CreateDevice, so the flag is in effect
+        // OnGameStarted fires before graphicsDeviceManager.CreateDevice, so the flags are in effect
         // by the time the swap chain is created.
-        ((GraphicsDeviceManager)game.GraphicsDeviceManager).SkipBackBufferClampToWindow = true;
+        var deviceManager = (GraphicsDeviceManager)game.GraphicsDeviceManager;
+        deviceManager.SkipBackBufferClampToWindow = true;
+
+        // Present without vsync: tests don't need display pacing, and compositor pacing is
+        // unreliable for hidden CI windows (throttled or unserviced presents slow the run).
+        deviceManager.SynchronizeWithVerticalRetrace = false;
 
         // The test fixture self-registers from a [ModuleInitializer] (see AutoTestingBootstrap.RegisterTest).
         var test = AutoTestingBootstrap.RegisteredTest;

--- a/sources/engine/Stride.Games.AutoTesting/ScreenshotTestRunner.cs
+++ b/sources/engine/Stride.Games.AutoTesting/ScreenshotTestRunner.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Engine;
 using Stride.Games;
@@ -62,6 +63,7 @@ internal sealed class ScreenshotTestRunner
     private const string ScreenshotsSubDir = "screenshots";
     private const string DoneFileName = "done.json";
     private const string ErrorLogName = "error.log";
+    private const int ErrorLoggedExitCode = 102;
 
     private readonly Game game;
     private readonly IScreenshotTest test;
@@ -99,6 +101,21 @@ internal sealed class ScreenshotTestRunner
         // Present without vsync: tests don't need display pacing, and compositor pacing is
         // unreliable for hidden CI windows (throttled or unserviced presents slow the run).
         deviceManager.SynchronizeWithVerticalRetrace = false;
+
+        // Fail the run if the engine logs an error, even when the game otherwise exits cleanly.
+        // Mapped to the exit code at process exit because some errors (e.g. a GPU drain timeout
+        // during teardown) happen after the test already set its exit code.
+        var errorLogged = false;
+        GlobalLogger.GlobalMessageLogged += message =>
+        {
+            if (message.Type >= LogMessageType.Error)
+                errorLogged = true;
+        };
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            if (errorLogged && Environment.ExitCode == 0)
+                Environment.ExitCode = ErrorLoggedExitCode;
+        };
 
         // The test fixture self-registers from a [ModuleInitializer] (see AutoTestingBootstrap.RegisterTest).
         var test = AutoTestingBootstrap.RegisteredTest;

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -191,6 +191,7 @@ namespace Stride.Games
                     {
                         if (Exiting)
                         {
+                            OnClosing(this, EventArgs.Empty);
                             Destroy();
                             return;
                         }

--- a/sources/engine/Stride.Games/GameBase.cs
+++ b/sources/engine/Stride.Games/GameBase.cs
@@ -374,6 +374,11 @@ namespace Stride.Games
                     // Setup the graphics device if it was not already setup.
                     SetupGraphicsDeviceEvents();
 
+                    // Drain pending GPU work before the window is destroyed: a queued flip-model
+                    // Present can only complete while its window is alive, and the device is
+                    // destroyed after the window on the exit path.
+                    Window.Closing += (_, _) => GraphicsDevice?.WaitForGpuIdle();
+
                     // Bind Graphics Context enabling initialize to use GL API eg. SetData to texture ...etc
                     BeginDraw();
 

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -157,6 +157,7 @@ namespace Stride.Games
                     {
                         if (Exiting)
                         {
+                            OnClosing(this, EventArgs.Empty);
                             Destroy();
                             return;
                         }

--- a/sources/engine/Stride.Games/WindowsStore/GameWindowUWP.cs
+++ b/sources/engine/Stride.Games/WindowsStore/GameWindowUWP.cs
@@ -396,6 +396,7 @@ namespace Stride.Games
                     coreWindow.Dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
                     if (Exiting)
                     {
+                        OnClosing(this, EventArgs.Empty);
                         Destroy();
                         break;
                     }

--- a/sources/engine/Stride.Graphics.Regression/Stride.Graphics.Regression.csproj
+++ b/sources/engine/Stride.Graphics.Regression/Stride.Graphics.Regression.csproj
@@ -41,16 +41,24 @@
     <PackageReference Include="Stride.Dependencies.Lavapipe" ExcludeAssets="native" PrivateAssets="native"
                       Condition="'$(StrideTargetFramework)' == '$(StrideFramework)' Or '$(StrideTargetFramework)' == '$(StrideFrameworkWindows)'" />
 
-    <!-- Pin WARP (software rasterizer) for reproducible D3D11/D3D12 test runs across CI and dev machines.
-         Side-loaded via d3d10warp.dll next to the test host .exe — same DLL covers both D3D11 and D3D12.
-         Skipped on Vulkan/Null builds so Linux outputs stay slim. Dev/test use only (no redistribution).
-         GeneratePathProperty is needed because the package uses build/native/ layout (C++ convention),
-         which NuGet does not auto-import into C# projects. -->
+    <!-- Pin software rendering to a fixed version side-loaded next to the test host exe instead of the
+         OS one, for reproducible captures across CI/dev: WARP (rasterizer, D3D11/D3D12) and the D3D12
+         Agility SDK (runtime + debug layer, D3D12 only, into D3D12\ and activated by GraphicsDevice via
+         ID3D12SDKConfiguration). GeneratePathProperty is needed because these native packages use a
+         build/native/ layout that NuGet doesn't auto-import into C# projects. -->
     <PackageReference Include="Microsoft.Direct3D.WARP" GeneratePathProperty="true"
                       Condition="'$(StrideGraphicsApi)' == 'Direct3D11' Or '$(StrideGraphicsApi)' == 'Direct3D12'" />
     <Content Include="$(PkgMicrosoft_Direct3D_WARP)\build\native\bin\x64\d3d10warp.dll"
              Condition="'$(PkgMicrosoft_Direct3D_WARP)' != ''"
              Link="d3d10warp.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <PackageReference Include="Microsoft.Direct3D.D3D12" GeneratePathProperty="true"
+                      Condition="'$(StrideGraphicsApi)' == 'Direct3D12'" />
+    <Content Include="$(PkgMicrosoft_Direct3D_D3D12)\build\native\bin\x64\D3D12Core.dll"
+             Condition="'$(PkgMicrosoft_Direct3D_D3D12)' != ''"
+             Link="D3D12\D3D12Core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_Direct3D_D3D12)\build\native\bin\x64\d3d12SDKLayers.dll"
+             Condition="'$(PkgMicrosoft_Direct3D_D3D12)' != ''"
+             Link="D3D12\D3D12SDKLayers.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
 
     <ProjectReference Include="..\..\tools\Stride.Graphics.RenderDocPlugin\Stride.Graphics.RenderDocPlugin.csproj" />
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -414,6 +414,10 @@ namespace Stride.Graphics
         /// <inheritdoc/>
         protected internal override void OnDestroyed(bool immediately = false)
         {
+            // Drain the GPU before releasing the swap-chain and its buffers: the last Present may
+            // still be in flight, and DXGI only tears the swap-chain down once it completes.
+            GraphicsDevice.WaitForGpuIdle();
+
             // Manually update Back-Buffer Texture
             backBuffer.OnDestroyed(immediately);
             backBuffer.LifetimeState = GraphicsResourceLifetimeState.Destroyed;

--- a/sources/engine/Stride.Graphics/Direct3D12/CommandList.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/CommandList.Direct3D12.cs
@@ -1115,11 +1115,13 @@ namespace Stride.Graphics
             else
             {
                 // Fallback: use D3D12 built-in event markers (visible in RenderDoc, NSight, etc.)
+                // Metadata 1 = PIX_EVENT_ANSI_VERSION, matching the ANSI payload — tools (and the
+                // debug layer's event accounting) can't decode the marker otherwise.
                 var maxBytes = System.Text.Encoding.ASCII.GetMaxByteCount(name.Length) + 1;
                 var nameBytes = stackalloc byte[maxBytes];
                 int written = System.Text.Encoding.ASCII.GetBytes(name, new Span<byte>(nameBytes, maxBytes));
                 nameBytes[written] = 0;
-                currentCommandList.NativeCommandList.BeginEvent(Metadata: 0, nameBytes, (uint)(written + 1));
+                currentCommandList.NativeCommandList.BeginEvent(Metadata: 1, nameBytes, (uint)(written + 1));
             }
         }
 

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.Fence.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.Fence.cs
@@ -118,8 +118,25 @@ public unsafe partial class GraphicsDevice
         /// </remarks>
         internal void WaitForFenceCPUInternal(ulong fenceValue)
         {
+            WaitForFenceCPUInternal(fenceValue, Timeout.Infinite);
+        }
+
+        /// <summary>
+        ///   Waits for the specified fence value to be signaled by a Command Queue, blocking
+        ///   the calling thread up to <paramref name="millisecondsTimeout"/>.
+        /// </summary>
+        /// <param name="fenceValue">The fence value to wait for.</param>
+        /// <param name="millisecondsTimeout">
+        ///   The maximum time to wait, or <see cref="Timeout.Infinite"/> to wait indefinitely.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the fence value was reached;
+        ///   <see langword="false"/> if the wait timed out.
+        /// </returns>
+        internal bool WaitForFenceCPUInternal(ulong fenceValue, int millisecondsTimeout)
+        {
             if (IsFenceCompleteInternal(fenceValue))
-                return;
+                return true;
 
             // TODO: D3D12: In case of concurrency, this lock could end up blocking too long a second thread with lower fenceValue than the first one
             lock (lockObject)
@@ -127,8 +144,15 @@ public unsafe partial class GraphicsDevice
                 var localFenceEvent = fenceEvent ??= new AutoResetEvent(initialState: false);
 
                 fence->SetEventOnCompletion(fenceValue, (void*) localFenceEvent.GetSafeWaitHandle().DangerousGetHandle());
-                localFenceEvent.WaitOne();
+                if (!localFenceEvent.WaitOne(millisecondsTimeout))
+                {
+                    // A late completion would still signal the abandoned event; replace it so the
+                    // next wait on this thread cannot wake up spuriously.
+                    fenceEvent = new AutoResetEvent(initialState: false);
+                    return false;
+                }
                 LastCompletedFence = fenceValue;
+                return true;
             }
         }
 

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
@@ -33,6 +33,11 @@ namespace Stride.Graphics
         private static object debugLayerLock = new();
         private static bool debugLayerLoaded = false;
 
+        // D3D12 Agility SDK redist shipped app-local under D3D12\ (Microsoft.Direct3D.D3D12 1.619.x).
+        private const uint AgilitySDKVersion = 619;
+        private static readonly Guid CLSID_D3D12SDKConfiguration = new(0x7cda6aca, 0xa03e, 0x49c8, 0x94, 0x58, 0x03, 0x34, 0xd2, 0x0e, 0x07, 0xce);
+        private static bool agilitySDKChecked;
+
         private ID3D12InfoQueue* nativeInfoQueue;
         private ID3D12InfoQueue1* nativeInfoQueue1;
         private uint debugMessageCallbackCookie;
@@ -418,6 +423,9 @@ namespace Stride.Graphics
             IsDeferred = true;
 
             var d3d12 = D3D12.GetApi();
+
+            // Opt into an app-local Agility SDK (if shipped) before the debug layer / device load D3D12Core.
+            TryActivateAgilitySDK(d3d12);
 
             // The Debug Layer must be initialized before creating the device
             if (IsDebugMode)
@@ -806,6 +814,40 @@ namespace Stride.Graphics
         /// </summary>
         /// <param name="pipelineStateDescription">A Pipeline State description that can be modified and adjusted.</param>
         private partial void AdjustDefaultPipelineStateDescription(ref PipelineStateDescription pipelineStateDescription) { }
+
+        /// <summary>
+        ///   Activates an app-local D3D12 Agility SDK (shipped under <c>D3D12\</c>) once per process,
+        ///   before any device or debug interface is created. No-op if the redist isn't present.
+        /// </summary>
+        private static void TryActivateAgilitySDK(D3D12 d3d12)
+        {
+            lock (debugLayerLock)
+            {
+                if (agilitySDKChecked)
+                    return;
+                agilitySDKChecked = true;
+
+                if (!System.IO.File.Exists(System.IO.Path.Combine(AppContext.BaseDirectory, "D3D12", "D3D12Core.dll")))
+                    return;
+
+                var clsid = CLSID_D3D12SDKConfiguration;
+                int hr = d3d12.GetInterface(ref clsid, out ComPtr<ID3D12SDKConfiguration> sdkConfig);
+                if (hr < 0 || sdkConfig.IsNull())
+                {
+                    Log.Warning($"[D3D12] Agility SDK present but ID3D12SDKConfiguration is unavailable (0x{hr:X8}); using system D3D12.");
+                    return;
+                }
+
+                // Path is relative to the exe and must end with a separator.
+                hr = sdkConfig.SetSDKVersion(AgilitySDKVersion, "D3D12\\");
+                sdkConfig.Release();
+
+                if (hr < 0)
+                    Log.Warning($"[D3D12] Agility SDK SetSDKVersion({AgilitySDKVersion}) failed (0x{hr:X8}); using system D3D12.");
+                else
+                    Log.Info($"[D3D12] Using app-local Agility SDK {AgilitySDKVersion}.");
+            }
+        }
 
         /// <summary>
         ///   Releases the platform-specific Graphics Device and all its associated resources.

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
@@ -854,8 +854,13 @@ namespace Stride.Graphics
         /// </summary>
         partial void WaitForGPUIdle()
         {
+            // Bounded: a queued Present can never complete once its window is destroyed, and a
+            // healthy queue drains well within this (hardware TDR caps command lists at ~2s).
+            const int GpuIdleTimeoutMs = 10_000;
+
             FrameFence.Signal(NativeCommandQueue, FrameFence.NextFenceValue);
-            FrameFence.WaitForFenceCPUInternal(FrameFence.NextFenceValue);
+            if (!FrameFence.WaitForFenceCPUInternal(FrameFence.NextFenceValue, GpuIdleTimeoutMs))
+                Log.Error($"[D3D12] GPU queue did not drain within {GpuIdleTimeoutMs / 1000}s; continuing teardown. A pending Present whose window was already destroyed can never complete.");
         }
 
         protected partial void DestroyPlatformDevice()


### PR DESCRIPTION
# PR Details

Sample screenshot runs occasionally hung forever on exit (~1 in 200 on hardware, near-always on CI WARP).

The window was destroyed before the GPU drain in the swap-chain presenter, and a queued `Present` can only complete while its window is alive, so the drain fence never signaled.

- **Games**: the exit path now raises `Closing` before destroying the window, and `GameBase` drains the GPU on `Window.Closing` (covers programmatic exit and user close on WinForms/SDL/UWP).
- **D3D12**: the teardown drain is bounded at 10s with a warning, so an orphaned Present degrades to a logged delay instead of a process that never exits.
- **Test infra**: hang-dump capture on sample teardown timeout, app-local Agility SDK pin + WARP bump, vsync disabled for screenshot runs.

Verified on local VM with WARP and 2 CPU: pre-fix hangs within 5 iterations, fixed runs many iterations clean.