### PR TITLE
 Declare TargetFrameworks explicitly (drop the StrideRuntime indirection)

### DIFF
--- a/build/tools/ParallelBuildAuditor/ParallelBuildAuditor.csproj
+++ b/build/tools/ParallelBuildAuditor/ParallelBuildAuditor.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Stride.Tools.ParallelBuildAuditor</RootNamespace>
     <AssemblyName>ParallelBuildAuditor</AssemblyName>
-    <StrideRuntime>false</StrideRuntime>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <StrideCodeAnalysis>false</StrideCodeAnalysis>
   </PropertyGroup>

--- a/build/tools/Stride.CompareGold/Stride.CompareGold.csproj
+++ b/build/tools/Stride.CompareGold/Stride.CompareGold.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Opt out of Stride SDK -->
-    <StrideRuntime>false</StrideRuntime>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <StrideCodeAnalysis>false</StrideCodeAnalysis>
     <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>

--- a/docs/build/SDK-GUIDE.md
+++ b/docs/build/SDK-GUIDE.md
@@ -47,7 +47,7 @@ All Stride projects import the SDK files directly from source:
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
 
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets" />
@@ -172,7 +172,7 @@ dotnet build sources/sdk/Stride.Build.Sdk.slnx
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
   </PropertyGroup>
   <ItemGroup>
@@ -199,12 +199,17 @@ dotnet build sources/sdk/Stride.Build.Sdk.slnx
 ```xml
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
+  <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stride.Core\Stride.Core.csproj" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets" />
 </Project>
 ```
+
+A test that must run on multiple platforms imports `Stride.Build.Sdk.MultiPlatform.Tests` instead and declares `<TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>` (the `…MacOS` variant to also build `net10.0-macos`). That set is computed from `$(StrideTestPlatforms)` — see [Property Evaluation Order](#property-evaluation-order).
 
 ---
 
@@ -218,8 +223,8 @@ sources/sdk/
 |       +-- Sdk.props                          # Entry point (before project file)
 |       +-- Sdk.targets                        # Entry point (after project file)
 |       +-- Stride.Frameworks.props            # Framework constants (net10.0, net10.0-android, ...)
-|       +-- Stride.Frameworks.targets          # StrideRuntime -> TargetFrameworks expansion
-|       +-- Stride.Platform.props              # Platform detection, output paths
+|       +-- Stride.Frameworks.targets          # Per-TFM StrideTargetFramework/StridePlatform re-derivation
+|       +-- Stride.Platform.props              # Platform detection, output paths, runtime TargetFrameworks sets
 |       +-- Stride.Platform.targets            # Platform-specific compiler defines
 |       +-- Stride.Graphics.props              # Default graphics APIs per platform
 |       +-- Stride.Graphics.targets            # Graphics API defines and UI framework
@@ -278,16 +283,18 @@ Phase 3: Stride.Build.Sdk/Sdk/Sdk.targets     <-- AFTER project file
 
 ```xml
 <!-- Sdk.props: Set defaults (user hasn't defined anything yet) -->
-<StrideRuntime Condition="'$(StrideRuntime)' == ''">false</StrideRuntime>
+<StrideCodeAnalysis Condition="'$(StrideCodeAnalysis)' == ''">false</StrideCodeAnalysis>
 
 <!-- .csproj: Override defaults -->
-<StrideRuntime>true</StrideRuntime>
+<StrideCodeAnalysis>true</StrideCodeAnalysis>
 
 <!-- Sdk.targets: Act on final value (user's value is visible) -->
-<PropertyGroup Condition="'$(StrideRuntime)' == 'true'">
-  <TargetFrameworks>net10.0;net10.0-android;net10.0-ios</TargetFrameworks>
+<PropertyGroup Condition="'$(StrideCodeAnalysis)' == 'true'">
+  <EnableNETAnalyzers>true</EnableNETAnalyzers>
 </PropertyGroup>
 ```
+
+> Framework selection is the exception that proves the rule: because consuming a user flag in `.targets` is awkward, runtime/test projects instead **declare `<TargetFrameworks>` explicitly** from a set the SDK precomputes at props time (`StrideRuntimeTargetFrameworks` / `StrideTestTargetFrameworks`), so there is no user flag to consume late.
 
 ### Rules of thumb
 
@@ -299,7 +306,7 @@ Phase 3: Stride.Build.Sdk/Sdk/Sdk.targets     <-- AFTER project file
 
 The old build system used `<Import Project="..\..\targets\Stride.Core.props" />` placed *after* setting properties in the .csproj. This allowed properties to be visible during the import, but required users to carefully order their property definitions before the import — a fragile pattern. The SDK approach standardizes the evaluation order, eliminating this class of bugs.
 
-The old system had a critical bug where `StrideRuntime` was checked in the `.props` phase (before the user's .csproj defined it), causing multi-targeting to silently fail unless the property was set before the import or passed on the command line. The SDK fixes this by checking `StrideRuntime` in `.targets`.
+The old system had a critical bug where a user flag (the former `StrideRuntime`) was checked in the `.props` phase before the user's .csproj defined it, causing multi-targeting to silently fail unless the property was set before the import or passed on the command line. The SDK avoids this entirely: the runtime/test framework sets are precomputed in `.props` from `$(StridePlatforms)`, and each project declares `<TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>` directly — so there is no late-consumed user flag at all.
 
 ### Full import order
 
@@ -317,7 +324,7 @@ YourProject.csproj
 Stride.Build.Sdk/Sdk/Sdk.targets (top)
   +-- Microsoft.NET.Sdk/Sdk.targets (base .NET SDK)
   +-- Stride.Platform.targets       (platform defines, mobile properties)
-  +-- Stride.Frameworks.targets     (StrideRuntime -> TargetFrameworks)
+  +-- Stride.Frameworks.targets     (per-TFM StrideTargetFramework/StridePlatform)
   +-- Stride.Graphics.targets       (API defines, UI framework)
   +-- Stride.GraphicsApi.InnerBuild.targets (multi-API dispatch)
   +-- Stride.Dependencies.targets   (native .ssdeps system)
@@ -382,7 +389,7 @@ Stride.Build.Sdk/Sdk/Sdk.targets (top)
 
 | Property | Purpose | Set by |
 |----------|---------|--------|
-| `StrideRuntime` | Enable multi-platform targeting (generates `TargetFrameworks`) | Project (.csproj) |
+| `StrideRuntimeTargetFrameworks` | SDK-computed runtime TFM set; a runtime project sets `<TargetFrameworks>` to this (or the `…Windows`/`…MacOS` variant) | SDK (Stride.Platform.props) |
 | `StrideAssemblyProcessor` | Enable IL post-processing (serialization, module init) | Project (.csproj) |
 | `StrideAssemblyProcessorOptions` | Processor flags (e.g., `--serialization --auto-module-initializer`) | Project (.csproj) |
 | `StrideCodeAnalysis` | Enable code analysis rules | Project (.csproj) |
@@ -576,11 +583,11 @@ Separating `Stride.Build.Sdk.Editor` prevents engine runtime projects from accid
 
 ### No `Stride.Build.Sdk.Runtime` package
 
-Initially considered, but unnecessary. Runtime projects use `Stride.Build.Sdk` directly with `StrideRuntime=true` in their .csproj. The SDK expands this into the correct `TargetFrameworks` in the targets phase.
+Initially considered, but unnecessary. Runtime projects use `Stride.Build.Sdk` directly and declare `<TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>` — a set the SDK precomputes in `Stride.Platform.props` from the active platforms.
 
 ### Evaluation timing: defaults in props, logic in targets
 
-All user-configurable properties (`StrideRuntime`, `StrideAssemblyProcessor`, etc.) get default values in `Sdk.props` and are checked in `Sdk.targets`. This is the standard MSBuild SDK pattern and avoids the evaluation-order bugs present in the old system.
+All user-configurable flags (`StrideAssemblyProcessor`, `StrideCodeAnalysis`, etc.) get default values in `Sdk.props` and are checked in `Sdk.targets`. This is the standard MSBuild SDK pattern and avoids the evaluation-order bugs present in the old system. (Framework selection sidesteps it differently — see the note under [Correct patterns](#correct-patterns).)
 
 ### No `build/` convention files
 
@@ -620,7 +627,7 @@ The property is likely being read in `Sdk.props` (too early). Move the logic to 
 
 ### Multi-targeting not working
 
-Ensure `StrideRuntime=true` is set in the .csproj. The SDK expands this in `Sdk.targets` (not `Sdk.props`) because it needs to see the user's value.
+Ensure the .csproj declares `<TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>` (or the `…Windows`/`…MacOS` variant; tests use `$(StrideTestTargetFrameworks)`). The set is computed in `Stride.Platform.props` from `$(StridePlatforms)`, so pass `-p:StridePlatforms=Windows;Android` (etc.) to target other platforms.
 
 ### Assembly processor not running
 

--- a/sources/assets/Stride.Core.Assets.Quantum.Tests/Stride.Core.Assets.Quantum.Tests.csproj
+++ b/sources/assets/Stride.Core.Assets.Quantum.Tests/Stride.Core.Assets.Quantum.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/sources/assets/Stride.Core.Assets.Tests/Stride.Core.Assets.Tests.csproj
+++ b/sources/assets/Stride.Core.Assets.Tests/Stride.Core.Assets.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/sources/buildengine/Stride.Core.BuildEngine.Tests/Stride.Core.BuildEngine.Tests.csproj
+++ b/sources/buildengine/Stride.Core.BuildEngine.Tests/Stride.Core.BuildEngine.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>

--- a/sources/core/Stride.Core.CompilerServices.Tests/Stride.Core.CompilerServices.Tests.csproj
+++ b/sources/core/Stride.Core.CompilerServices.Tests/Stride.Core.CompilerServices.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/sources/core/Stride.Core.Design.Tests/Stride.Core.Design.Tests.csproj
+++ b/sources/core/Stride.Core.Design.Tests/Stride.Core.Design.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/sources/core/Stride.Core.IO/Stride.Core.IO.csproj
+++ b/sources/core/Stride.Core.IO/Stride.Core.IO.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/core/Stride.Core.Mathematics.Tests/Stride.Core.Mathematics.Tests.csproj
+++ b/sources/core/Stride.Core.Mathematics.Tests/Stride.Core.Mathematics.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/sources/core/Stride.Core.Mathematics/Stride.Core.Mathematics.csproj
+++ b/sources/core/Stride.Core.Mathematics/Stride.Core.Mathematics.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StridePublicApi>true</StridePublicApi>
   </PropertyGroup>
 

--- a/sources/core/Stride.Core.MicroThreading/Stride.Core.MicroThreading.csproj
+++ b/sources/core/Stride.Core.MicroThreading/Stride.Core.MicroThreading.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/core/Stride.Core.Reflection/Stride.Core.Reflection.csproj
+++ b/sources/core/Stride.Core.Reflection/Stride.Core.Reflection.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/core/Stride.Core.Serialization/Stride.Core.Serialization.csproj
+++ b/sources/core/Stride.Core.Serialization/Stride.Core.Serialization.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj
+++ b/sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/sources/core/Stride.Core.Yaml.Tests/Stride.Core.Yaml.Tests.csproj
+++ b/sources/core/Stride.Core.Yaml.Tests/Stride.Core.Yaml.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/sources/core/Stride.Core/Stride.Core.csproj
+++ b/sources/core/Stride.Core/Stride.Core.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/sources/engine/Stride.Audio.Tests/Stride.Audio.Tests.csproj
+++ b/sources/engine/Stride.Audio.Tests/Stride.Audio.Tests.csproj
@@ -1,13 +1,14 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworksMacOS)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Audio.Tests</AssemblyName>
     <RootNamespace>Stride.Audio.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>
     <StrideCompileAssets>true</StrideCompileAssets>
     <StrideGraphicsRegression>true</StrideGraphicsRegression>
-    <!-- net10.0-macos to test AVFoundation -->
-    <StrideExplicitMacOSRuntime>true</StrideExplicitMacOSRuntime>
     <!-- Force msbuild to check to rebuild this assembly instead of letting VS IDE guess -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>

--- a/sources/engine/Stride.Audio/Stride.Audio.csproj
+++ b/sources/engine/Stride.Audio/Stride.Audio.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrideNativeOutputName>libstrideaudio</StrideNativeOutputName>
-    <StrideRuntime>true</StrideRuntime>
-    <!-- net10.0-macos for AVFoundation audio extraction (gated by STRIDE_VIDEO_AVFOUNDATION). -->
-    <StrideExplicitMacOSRuntime>true</StrideExplicitMacOSRuntime>
+    <!-- Includes net10.0-macos for AVFoundation audio extraction (gated by STRIDE_VIDEO_AVFOUNDATION). -->
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworksMacOS)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
   </PropertyGroup>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Debug/Stride.BepuPhysics.Debug.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Debug/Stride.BepuPhysics.Debug.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Stride.BepuPhysics.Debug</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Navigation/Stride.BepuPhysics.Navigation.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Navigation/Stride.BepuPhysics.Navigation.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Soft/Stride.BepuPhysics.Soft.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics.Soft/Stride.BepuPhysics.Soft.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics._2D/Stride.BepuPhysics._2D.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics._2D/Stride.BepuPhysics._2D.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Stride.BepuPhysics.csproj
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Stride.BepuPhysics.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>

--- a/sources/engine/Stride.Engine.NoAssets.Tests/Stride.Engine.NoAssets.Tests.csproj
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/Stride.Engine.NoAssets.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Engine.NoAssets.Tests</AssemblyName>
     <RootNamespace>Stride.Engine.Tests</RootNamespace>
     <StrideCompileAssets>false</StrideCompileAssets>

--- a/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.csproj
+++ b/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Engine.Tests</AssemblyName>
     <RootNamespace>Stride.Engine.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Stride</RootNamespace>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--parameter-key --auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>

--- a/sources/engine/Stride.Games.AutoTesting/Stride.Games.AutoTesting.csproj
+++ b/sources/engine/Stride.Games.AutoTesting/Stride.Games.AutoTesting.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>

--- a/sources/engine/Stride.Games/Stride.Games.csproj
+++ b/sources/engine/Stride.Games/Stride.Games.csproj
@@ -2,8 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
-    <StrideExplicitWindowsRuntime>true</StrideExplicitWindowsRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworksWindows)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer</StrideAssemblyProcessorOptions>

--- a/sources/engine/Stride.Graphics.Regression/Stride.Graphics.Regression.csproj
+++ b/sources/engine/Stride.Graphics.Regression/Stride.Graphics.Regression.csproj
@@ -5,7 +5,7 @@
     <!-- This is a test helper library, not a test project. xunit.runner.visualstudio sets
          IsTestProject=true which breaks StrideGraphicsApiDependent output paths. -->
     <IsTestProject>false</IsTestProject>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideCompilerTargetsEnable Condition="'$(StridePackageBuild)' == 'true'">false</StrideCompilerTargetsEnable>

--- a/sources/engine/Stride.Graphics.Tests.10_0/Stride.Graphics.Tests.10_0.csproj
+++ b/sources/engine/Stride.Graphics.Tests.10_0/Stride.Graphics.Tests.10_0.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Graphics.Tests.10_0</AssemblyName>
     <RootNamespace>Stride.Graphics.Tests</RootNamespace>
     <AndroidResgenNamespace>Stride.Graphics.Tests</AndroidResgenNamespace>

--- a/sources/engine/Stride.Graphics.Tests.11_0/Stride.Graphics.Tests.11_0.csproj
+++ b/sources/engine/Stride.Graphics.Tests.11_0/Stride.Graphics.Tests.11_0.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Graphics.Tests.11_0</AssemblyName>
     <RootNamespace>Stride.Graphics.Tests</RootNamespace>
     <AndroidResgenNamespace>Stride.Graphics.Tests</AndroidResgenNamespace>

--- a/sources/engine/Stride.Graphics.Tests/Stride.Graphics.Tests.csproj
+++ b/sources/engine/Stride.Graphics.Tests/Stride.Graphics.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Graphics.Tests</AssemblyName>
     <RootNamespace>Stride.Graphics.Tests</RootNamespace>
     <StrideCompileAssets>true</StrideCompileAssets>

--- a/sources/engine/Stride.Graphics/Stride.Graphics.csproj
+++ b/sources/engine/Stride.Graphics/Stride.Graphics.csproj
@@ -2,12 +2,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworksMacOS)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePackAssets>true</StridePackAssets>
     <StrideAssetAssembly>true</StrideAssetAssembly>
-    <StrideExplicitMacOSRuntime>true</StrideExplicitMacOSRuntime>
     <DefineConstants>$(DefineConstants);STRIDE_GRAPHICS_NO_DESCRIPTOR_COPIES</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(StrideGraphicsApi)' == 'Vulkan' ">

--- a/sources/engine/Stride.Input.Tests/Stride.Input.Tests.csproj
+++ b/sources/engine/Stride.Input.Tests/Stride.Input.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Input.Tests</AssemblyName>
     <RootNamespace>Stride.Input.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/sources/engine/Stride.Input/Stride.Input.csproj
+++ b/sources/engine/Stride.Input/Stride.Input.csproj
@@ -2,8 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
-    <StrideExplicitWindowsRuntime>true</StrideExplicitWindowsRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworksWindows)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>

--- a/sources/engine/Stride.Native/Stride.Native.csproj
+++ b/sources/engine/Stride.Native/Stride.Native.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--serialization --parameter-key</StrideAssemblyProcessorOptions>
   </PropertyGroup>

--- a/sources/engine/Stride.Navigation.Tests/Stride.Navigation.Tests.csproj
+++ b/sources/engine/Stride.Navigation.Tests/Stride.Navigation.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Navigation.Tests</AssemblyName>
     <RootNamespace>Stride.Navigation.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/sources/engine/Stride.Navigation/Stride.Navigation.csproj
+++ b/sources/engine/Stride.Navigation/Stride.Navigation.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--serialization</StrideAssemblyProcessorOptions>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>

--- a/sources/engine/Stride.Particles.Tests/Stride.Particles.Tests.csproj
+++ b/sources/engine/Stride.Particles.Tests/Stride.Particles.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Particles.Tests</AssemblyName>
     <RootNamespace>Stride.Particles.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/sources/engine/Stride.Particles/Stride.Particles.csproj
+++ b/sources/engine/Stride.Particles/Stride.Particles.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--parameter-key --auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StridePackAssets>true</StridePackAssets>

--- a/sources/engine/Stride.Physics.Tests/Stride.Physics.Tests.csproj
+++ b/sources/engine/Stride.Physics.Tests/Stride.Physics.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Physics.Tests</AssemblyName>
     <RootNamespace>Stride.Physics.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/sources/engine/Stride.Physics/Stride.Physics.csproj
+++ b/sources/engine/Stride.Physics/Stride.Physics.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--serialization --parameter-key</StrideAssemblyProcessorOptions>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>

--- a/sources/engine/Stride.Rendering/Stride.Rendering.csproj
+++ b/sources/engine/Stride.Rendering/Stride.Rendering.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePackAssets>true</StridePackAssets>
     <StrideAssetAssembly>true</StrideAssetAssembly>

--- a/sources/engine/Stride.SpriteStudio.Runtime/Stride.SpriteStudio.Runtime.csproj
+++ b/sources/engine/Stride.SpriteStudio.Runtime/Stride.SpriteStudio.Runtime.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--serialization --parameter-key</StrideAssemblyProcessorOptions>
   </PropertyGroup>

--- a/sources/engine/Stride.UI.Tests/Stride.UI.Tests.csproj
+++ b/sources/engine/Stride.UI.Tests/Stride.UI.Tests.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.UI.Tests</AssemblyName>
     <RootNamespace>Stride.UI.Tests</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/sources/engine/Stride.UI/Stride.UI.csproj
+++ b/sources/engine/Stride.UI/Stride.UI.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
   </PropertyGroup>
   <ItemGroup>

--- a/sources/engine/Stride.Video/Stride.Video.csproj
+++ b/sources/engine/Stride.Video/Stride.Video.csproj
@@ -2,10 +2,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
-    <!-- Opt into a net10.0-macos build so AVFoundation / CoreVideo / Metal bindings are available
-         for AVFoundationVideoBackend on macOS desktop. iOS already has net10.0-ios via StrideRuntime. -->
-    <StrideExplicitMacOSRuntime>true</StrideExplicitMacOSRuntime>
+    <!-- Includes net10.0-macos so AVFoundation / CoreVideo / Metal bindings are available
+         for AVFoundationVideoBackend on macOS desktop. iOS already comes via the mobile set. -->
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworksMacOS)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>

--- a/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
+++ b/sources/engine/Stride.VirtualReality/Stride.VirtualReality.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
     <StrideNativeOutputName>libstridevr</StrideNativeOutputName>
     <StrideNativeWindowsArm64Enabled>false</StrideNativeWindowsArm64Enabled>

--- a/sources/engine/Stride.Voxels/Stride.Voxels.csproj
+++ b/sources/engine/Stride.Voxels/Stride.Voxels.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StridePackAssets>true</StridePackAssets>
   </PropertyGroup>

--- a/sources/engine/Stride/Stride.csproj
+++ b/sources/engine/Stride/Stride.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>
     <StrideAssemblyProcessorOptions>--auto-module-initializer --serialization</StrideAssemblyProcessorOptions>
     <StrideCodeAnalysis>true</StrideCodeAnalysis>

--- a/sources/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props
+++ b/sources/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props
@@ -6,8 +6,8 @@
     Sets StrideMultiPlatformTest=true before delegating to the base Tests SDK so the
     consumer csproj doesn't need a pre-import PropertyGroup. The flag (read at props time
     in the base SDK) defaults StrideTestPlatforms from StridePlatforms (Stride.Local.props)
-    and suppresses the single-TFM fallback, letting the targets-time expansion produce
-    multi-TFM TargetFrameworks. Same shape as StrideRuntime in Stride.Frameworks.targets.
+    and suppresses the single-TFM fallback, so the base SDK's props-time StrideTestTargetFrameworks
+    sets drive the csproj's multi-TFM <TargetFrameworks>.
 
     Single-platform tests should keep importing Stride.Build.Sdk.Tests directly.
   -->

--- a/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props
+++ b/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props
@@ -48,11 +48,46 @@
   <!-- Multi-platform tests set <StrideMultiPlatformTest>true</StrideMultiPlatformTest> BEFORE
        this import to opt into multi-TFM. The flag (a) defaults StrideTestPlatforms from the
        build's StridePlatforms (Stride.Local.props), and (b) suppresses the single-TFM
-       fallback below so the targets-time StrideTestPlatforms expansion in Sdk.targets can
-       drive TargetFrameworks — mirroring the StrideRuntime mechanism in Stride.Frameworks.targets.
-       CLI -p:StrideTestPlatforms=… still overrides (global property). -->
+       fallback below so the StrideTestTargetFrameworks sets computed next drive the csproj's
+       <TargetFrameworks>. CLI -p:StrideTestPlatforms=… still overrides (global property). -->
   <PropertyGroup Condition="'$(StrideMultiPlatformTest)' == 'true' And '$(StrideTestPlatforms)' == ''">
     <StrideTestPlatforms>$(StridePlatforms)</StrideTestPlatforms>
+  </PropertyGroup>
+
+  <!-- Precomputed test framework sets a multi-platform test opts into directly in its csproj:
+       <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>. Computed here (props)
+       from StrideTestPlatforms so the value is known when the csproj body evaluates and the
+       literal <TargetFrameworks> element lives in the csproj (keeps SDK-style detection working).
+       Two variants: a test consuming Stride.Runtime libs bound to Microsoft.macOS APIs
+       (AVFoundation/Metal) picks ...MacOS to add net10.0-macos instead of collapsing to the base.
+       Order/conditions mirror the per-platform expansion (Game host-shadow, host-windows when a
+       mobile platform is present on a Windows host, then mobile). -->
+  <PropertyGroup Condition="'$(StrideTestPlatforms)' != ''">
+    <StrideAssetAssembly Condition="'$(StrideAssetAssembly)' == ''">true</StrideAssetAssembly>
+    <_StrideTestPlatforms>;$(StrideTestPlatforms);</_StrideTestPlatforms>
+    <!-- Game = host-loadable library TFM; auto-add for mobile-only lists (a desktop platform
+         fills that role when present). Opt out with StrideAssetAssembly=false. -->
+    <_StrideTestPlatforms Condition="'$(StrideAssetAssembly)' != 'false' And ($(_StrideTestPlatforms.Contains(';Android;')) Or $(_StrideTestPlatforms.Contains(';iOS;'))) And !$(_StrideTestPlatforms.Contains(';Game;')) And !$(_StrideTestPlatforms.Contains(';Linux;')) And !$(_StrideTestPlatforms.Contains(';macOS;')) And !$(_StrideTestPlatforms.Contains(';Windows;'))">;Game$(_StrideTestPlatforms)</_StrideTestPlatforms>
+
+    <!-- shared tail: host-windows (when a mobile platform is present on a Windows host) + mobile -->
+    <_StrideTestTargetFrameworksTail></_StrideTestTargetFrameworksTail>
+    <_StrideTestTargetFrameworksTail Condition="$(_StrideTestPlatforms.Contains(';Windows;')) And '$([MSBuild]::IsOSPlatform(Windows))' == 'true' And ($(_StrideTestPlatforms.Contains(';Android;')) Or $(_StrideTestPlatforms.Contains(';iOS;')))">$(_StrideTestTargetFrameworksTail)$(StrideFrameworkWindows);</_StrideTestTargetFrameworksTail>
+    <_StrideTestTargetFrameworksTail Condition="$(_StrideTestPlatforms.Contains(';Android;'))">$(_StrideTestTargetFrameworksTail)$(StrideFrameworkAndroid);</_StrideTestTargetFrameworksTail>
+    <_StrideTestTargetFrameworksTail Condition="$(_StrideTestPlatforms.Contains(';iOS;'))">$(_StrideTestTargetFrameworksTail)$(StrideFrameworkiOS);</_StrideTestTargetFrameworksTail>
+
+    <!-- desktop base ($(StrideFramework)), excluding macOS -->
+    <_StrideTestDesktop Condition="$(_StrideTestPlatforms.Contains(';Linux;')) Or ($(_StrideTestPlatforms.Contains(';Windows;')) And !($(_StrideTestPlatforms.Contains(';Android;')) Or $(_StrideTestPlatforms.Contains(';iOS;')))) Or $(_StrideTestPlatforms.Contains(';Game;'))">$(StrideFramework);</_StrideTestDesktop>
+
+    <!-- base set: macOS (when present) runs on the shared desktop TFM (folded in if no other desktop) -->
+    <_StrideTestTargetFrameworksBase>$(_StrideTestDesktop)</_StrideTestTargetFrameworksBase>
+    <_StrideTestTargetFrameworksBase Condition="'$(_StrideTestTargetFrameworksBase)' == '' And $(_StrideTestPlatforms.Contains(';macOS;'))">$(StrideFramework);</_StrideTestTargetFrameworksBase>
+    <_StrideTestTargetFrameworksBase>$(_StrideTestTargetFrameworksBase)$(_StrideTestTargetFrameworksTail)</_StrideTestTargetFrameworksBase>
+    <StrideTestTargetFrameworks>$([MSBuild]::Unescape($(_StrideTestTargetFrameworksBase.TrimEnd(';'))))</StrideTestTargetFrameworks>
+
+    <!-- macOS variant: tests consuming Stride.Runtime macOS-native libs add net10.0-macos (last) -->
+    <_StrideTestTargetFrameworksMac>$(_StrideTestDesktop)$(_StrideTestTargetFrameworksTail)</_StrideTestTargetFrameworksMac>
+    <_StrideTestTargetFrameworksMac Condition="$(_StrideTestPlatforms.Contains(';macOS;'))">$(_StrideTestTargetFrameworksMac)$(StrideFrameworkmacOS);</_StrideTestTargetFrameworksMac>
+    <StrideTestTargetFrameworksMacOS>$([MSBuild]::Unescape($(_StrideTestTargetFrameworksMac.TrimEnd(';'))))</StrideTestTargetFrameworksMacOS>
   </PropertyGroup>
 
   <!-- Single-TFM fallback for tests that set neither TargetFramework nor TargetFrameworks

--- a/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.targets
@@ -1,43 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- ================================================================ -->
-  <!-- TFM resolution from StrideTestPlatforms                          -->
-  <!-- ================================================================ -->
-  <!-- Mirrors StrideRuntime in Stride.Frameworks.targets — gated only on the opt-in property,
-       not on TargetFramework/TargetFrameworks being empty. MSBuild dispatches inner builds with
-       TargetFramework set as a global, so a TargetFramework='' gate would skip inner builds and
-       leave TargetFrameworks="" — which CPS reads as "single-TFM project with no TFM" and aborts
-       with InvalidProjectDataException ('TargetPath' is empty). Setting TargetFrameworks in both
-       outer and inner builds matches StrideRuntime's behavior and keeps CPS happy. The csproj
-       body sets <StrideTestPlatforms>$(StridePlatforms)</StrideTestPlatforms> (or
-       StrideMultiPlatformTest=true triggers the same default in Sdk.props before the body).
-       CLI -p:StrideTestPlatforms=… is a global property and still wins.
-       Windows / Linux / macOS all collapse to the cross-platform desktop $(StrideFramework). -->
-  <PropertyGroup Condition="'$(StrideTestPlatforms)' != ''">
-    <StrideAssetAssembly Condition="'$(StrideAssetAssembly)' == ''">true</StrideAssetAssembly>
-    <_StrideTestPlatforms>;$(StrideTestPlatforms);</_StrideTestPlatforms>
-    <!-- Game = host-loadable library TFM (test analog of MyGame.Game.dll); the asset compiler loads
-         the suite and its refs at the host TFM, so auto-add it for mobile-only platform lists (a desktop
-         platform fills that role when present). Opt out with StrideAssetAssembly=false. -->
-    <_StrideTestPlatforms Condition="'$(StrideAssetAssembly)' != 'false' And ($(_StrideTestPlatforms.Contains(';Android;')) Or $(_StrideTestPlatforms.Contains(';iOS;'))) And !$(_StrideTestPlatforms.Contains(';Game;')) And !$(_StrideTestPlatforms.Contains(';Linux;')) And !$(_StrideTestPlatforms.Contains(';macOS;')) And !$(_StrideTestPlatforms.Contains(';Windows;'))">;Game$(_StrideTestPlatforms)</_StrideTestPlatforms>
-    <_StrideTestTargetFrameworks></_StrideTestTargetFrameworks>
-    <!-- net10.0 desktop TFM: runnable on Linux/macOS, runnable on Windows without mobile,
-         or the Game library shadow (asset-compiler-only, no launcher). -->
-    <_StrideTestTargetFrameworks Condition="
-        $(_StrideTestPlatforms.Contains(';Linux;'))
-        Or ($(_StrideTestPlatforms.Contains(';macOS;')) And '$(StrideExplicitMacOSRuntime)' != 'true')
-        Or ($(_StrideTestPlatforms.Contains(';Windows;')) And !($(_StrideTestPlatforms.Contains(';Android;')) Or $(_StrideTestPlatforms.Contains(';iOS;'))))
-        Or $(_StrideTestPlatforms.Contains(';Game;'))
-    ">$(_StrideTestTargetFrameworks)$(StrideFramework);</_StrideTestTargetFrameworks>
-    <_StrideTestTargetFrameworks Condition="$(_StrideTestPlatforms.Contains(';Windows;')) And '$([MSBuild]::IsOSPlatform(Windows))' == 'true' And ($(_StrideTestPlatforms.Contains(';Android;')) Or $(_StrideTestPlatforms.Contains(';iOS;')))">$(_StrideTestTargetFrameworks)$(StrideFrameworkWindows);</_StrideTestTargetFrameworks>
-    <_StrideTestTargetFrameworks Condition="$(_StrideTestPlatforms.Contains(';Android;'))">$(_StrideTestTargetFrameworks)$(StrideFrameworkAndroid);</_StrideTestTargetFrameworks>
-    <_StrideTestTargetFrameworks Condition="$(_StrideTestPlatforms.Contains(';iOS;'))">$(_StrideTestTargetFrameworks)$(StrideFrameworkiOS);</_StrideTestTargetFrameworks>
-    <!-- macOS net10.0-macos when opted in (mirrors StrideExplicitMacOSRuntime in Stride.Frameworks.targets).
-         Needed for tests that consume Stride.Runtime libraries bound to Microsoft.macOS APIs
-         (AVFoundation, Metal, etc.) — without it the test only sees the shared $(StrideFramework). -->
-    <_StrideTestTargetFrameworks Condition="$(_StrideTestPlatforms.Contains(';macOS;')) And '$(StrideExplicitMacOSRuntime)' == 'true'">$(_StrideTestTargetFrameworks)$(StrideFrameworkmacOS);</_StrideTestTargetFrameworks>
-    <TargetFrameworks>$([MSBuild]::Unescape($(_StrideTestTargetFrameworks.TrimEnd(';'))))</TargetFrameworks>
-  </PropertyGroup>
+  <!-- TFM sets are computed in Sdk.props (StrideTestTargetFrameworks / ...MacOS) so a multi-platform
+       test declares <TargetFrameworks> in its csproj and Roslyn SDK-style detection works.
+       _StrideTestPlatforms (incl. the Game host-shadow) is derived there too and consumed below. -->
 
   <!-- Game TFM is asset-compiler-load-only: skip asset compile + APK packaging on it. -->
   <PropertyGroup Condition="'$(TargetFramework)' == '$(StrideFramework)' And $(_StrideTestPlatforms.Contains(';Game;'))">
@@ -75,8 +40,8 @@
   <!-- ================================================================ -->
   <!-- Stride.Frameworks.targets does this too, but it imports later (via base SDK), and the
        OutputPath below needs the correct $(StridePlatform) before that. Mirror the per-TFM
-       derivation here so non-StrideRuntime projects (which set TargetFramework in the csproj
-       body) get the right platform for output path / launcher gating. -->
+       derivation here so projects that set TargetFramework in the csproj body get the right
+       platform for output path / launcher gating. -->
   <PropertyGroup>
     <StrideTargetFramework>$(TargetFramework)</StrideTargetFramework>
     <StrideTargetFramework Condition="$(TargetFramework.StartsWith('$(StrideFrameworkWindows)'))">$(StrideFrameworkWindows)</StrideTargetFramework>

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
@@ -16,7 +16,6 @@
     What you should do here:
     - All conditional logic that depends on .csproj properties
     - Property computation based on user choices
-    - Target framework expansion (StrideRuntime → TargetFrameworks)
     - Build customization based on user configuration
 
     Rule: User properties from .csproj ARE visible here.

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Frameworks.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Frameworks.targets
@@ -1,9 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-    StrideRuntime is checked here in .targets (not .props) because
-    it's defined in the user's .csproj which loads AFTER Sdk.props
-    but BEFORE Sdk.targets.
+    Runs in .targets (not .props) because the re-derivations below depend on the inner-build
+    TargetFramework, which is only known after the base SDK targets resolve it.
   -->
 
   <!-- Re-evaluate StrideTargetFramework now that TargetFramework is known. The same logic
@@ -28,27 +27,6 @@
     <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkiOS)' ">iOS</StridePlatform>
     <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkmacOS)' ">macOS</StridePlatform>
     <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkUWP)' ">UWP</StridePlatform>
-  </PropertyGroup>
-
-  <!-- Define target frameworks for runtime -->
-  <PropertyGroup Condition=" '$(StrideRuntime)' == 'true' ">
-    <!-- Add default framework no matter what (needed for references) -->
-    <StrideRuntimeTargetFrameworks>$(StrideFramework)</StrideRuntimeTargetFrameworks>
-
-    <!-- Desktop platforms: Add net10.0-windows / net10.0-macos only if explicitly requested -->
-    <!-- Most projects only need net10.0; the OS-specific variants are for projects that bind
-         to native OS frameworks (Microsoft.Windows.* / Microsoft.macOS / AVFoundation / Metal). -->
-    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Windows;')) And '$(StrideExplicitWindowsRuntime)' == 'true'">$(StrideRuntimeTargetFrameworks);$(StrideFrameworkWindows)</StrideRuntimeTargetFrameworks>
-    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';macOS;')) And '$(StrideExplicitMacOSRuntime)' == 'true'">$(StrideRuntimeTargetFrameworks);$(StrideFrameworkmacOS)</StrideRuntimeTargetFrameworks>
-
-    <!-- Mobile/UWP platforms -->
-    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';Android;'))">$(StrideRuntimeTargetFrameworks);$(StrideFrameworkAndroid)</StrideRuntimeTargetFrameworks>
-    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';UWP;'))">$(StrideRuntimeTargetFrameworks);$(StrideFrameworkUWP)</StrideRuntimeTargetFrameworks>
-    <StrideRuntimeTargetFrameworks Condition="$(_StridePlatforms.Contains(';iOS;'))">$(StrideRuntimeTargetFrameworks);$(StrideFrameworkiOS)</StrideRuntimeTargetFrameworks>
-
-    <StrideRuntimeTargetFrameworks>$([MSBuild]::Unescape($(StrideRuntimeTargetFrameworks.Trim(';'))))</StrideRuntimeTargetFrameworks>
-
-    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Platform.props
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Platform.props
@@ -69,7 +69,7 @@
     <StrideCommonPreSettingsName Condition="'$(StrideCommonPreSettingsName)' == ''">Stride</StrideCommonPreSettingsName>
 
     <!-- Set default StridePlatforms based on OS (if not already set by user/build system) -->
-    <!-- Note: This MUST be set to enable multi-targeting with StrideRuntime=true -->
+    <!-- Note: drives the StrideRuntimeTargetFrameworks sets below (runtime multi-targeting) -->
     <StridePlatforms Condition="'$(StridePlatforms)' == '' And '$([MSBuild]::IsOSPlatform(Windows))'">Windows</StridePlatforms>
     <StridePlatforms Condition="'$(StridePlatforms)' == '' And '$([MSBuild]::IsOSPlatform(OSX))'">macOS</StridePlatforms>
     <StridePlatforms Condition="'$(StridePlatforms)' == '' And '$([MSBuild]::IsOSPlatform(Linux))'">Linux</StridePlatforms>
@@ -88,6 +88,32 @@
     <_StridePlatforms Condition="'$(StridePlatformAutoAddHost)' != 'false' And $([MSBuild]::IsOSPlatform(Windows)) And ($(_StridePlatforms.Contains(';Android;')) Or $(_StridePlatforms.Contains(';iOS;'))) And !$(_StridePlatforms.Contains(';Windows;'))">;Windows$(_StridePlatforms)</_StridePlatforms>
     <_StridePlatforms Condition="'$(StridePlatformAutoAddHost)' != 'false' And $([MSBuild]::IsOSPlatform(Linux)) And ($(_StridePlatforms.Contains(';Android;')) Or $(_StridePlatforms.Contains(';iOS;'))) And !$(_StridePlatforms.Contains(';Linux;'))">;Linux$(_StridePlatforms)</_StridePlatforms>
     <_StridePlatforms Condition="'$(StridePlatformAutoAddHost)' != 'false' And $([MSBuild]::IsOSPlatform(OSX)) And ($(_StridePlatforms.Contains(';Android;')) Or $(_StridePlatforms.Contains(';iOS;'))) And !$(_StridePlatforms.Contains(';macOS;'))">;macOS$(_StridePlatforms)</_StridePlatforms>
+  </PropertyGroup>
+
+  <!-- ================================================================ -->
+  <!-- Runtime Target-Framework Sets -->
+  <!-- ================================================================ -->
+  <!-- Precomputed framework lists a runtime assembly opts into directly in its csproj, e.g.
+       <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>. Computed here (props)
+       so the value is known when the csproj body evaluates and the literal <TargetFrameworks>
+       element lives in the csproj (keeps SDK-style project-system detection working).
+       Ordered base; desktop-native; mobile/UWP — gated on the active $(_StridePlatforms). -->
+  <PropertyGroup>
+    <!-- mobile/UWP tail shared by every variant -->
+    <_StrideRuntimeMobileFrameworks Condition="$(_StridePlatforms.Contains(';Android;'))">$(_StrideRuntimeMobileFrameworks);$(StrideFrameworkAndroid)</_StrideRuntimeMobileFrameworks>
+    <_StrideRuntimeMobileFrameworks Condition="$(_StridePlatforms.Contains(';UWP;'))">$(_StrideRuntimeMobileFrameworks);$(StrideFrameworkUWP)</_StrideRuntimeMobileFrameworks>
+    <_StrideRuntimeMobileFrameworks Condition="$(_StridePlatforms.Contains(';iOS;'))">$(_StrideRuntimeMobileFrameworks);$(StrideFrameworkiOS)</_StrideRuntimeMobileFrameworks>
+
+    <!-- desktop-native variants, included only when that platform is active -->
+    <_StrideRuntimeWindowsFramework Condition="$(_StridePlatforms.Contains(';Windows;'))">;$(StrideFrameworkWindows)</_StrideRuntimeWindowsFramework>
+    <_StrideRuntimeMacOSFramework Condition="$(_StridePlatforms.Contains(';macOS;'))">;$(StrideFrameworkmacOS)</_StrideRuntimeMacOSFramework>
+
+    <!-- base only: most runtime assemblies -->
+    <StrideRuntimeTargetFrameworks>$(StrideFramework)$(_StrideRuntimeMobileFrameworks)</StrideRuntimeTargetFrameworks>
+    <!-- + Windows desktop (e.g. raw input) -->
+    <StrideRuntimeTargetFrameworksWindows>$(StrideFramework)$(_StrideRuntimeWindowsFramework)$(_StrideRuntimeMobileFrameworks)</StrideRuntimeTargetFrameworksWindows>
+    <!-- + macOS desktop (e.g. AVFoundation / Metal) -->
+    <StrideRuntimeTargetFrameworksMacOS>$(StrideFramework)$(_StrideRuntimeMacOSFramework)$(_StrideRuntimeMobileFrameworks)</StrideRuntimeTargetFrameworksMacOS>
   </PropertyGroup>
 
   <!-- ================================================================ -->

--- a/sources/shaders/Stride.Shaders.Compilers/Stride.Shaders.Compilers.csproj
+++ b/sources/shaders/Stride.Shaders.Compilers/Stride.Shaders.Compilers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <StrideBuildTags>*</StrideBuildTags>

--- a/sources/shaders/Stride.Shaders.Effects/Stride.Shaders.Effects.csproj
+++ b/sources/shaders/Stride.Shaders.Effects/Stride.Shaders.Effects.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideBuildTags>*</StrideBuildTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>

--- a/sources/shaders/Stride.Shaders.Parsers/Stride.Shaders.Parsers.csproj
+++ b/sources/shaders/Stride.Shaders.Parsers/Stride.Shaders.Parsers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="gen_intrin_main.txt" />

--- a/sources/shaders/Stride.Shaders.Spirv/Stride.Shaders.Spirv.csproj
+++ b/sources/shaders/Stride.Shaders.Spirv/Stride.Shaders.Spirv.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/sources/shaders/Stride.Shaders/Stride.Shaders.csproj
+++ b/sources/shaders/Stride.Shaders/Stride.Shaders.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideBuildTags>*</StrideBuildTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrideAssemblyProcessor>true</StrideAssemblyProcessor>

--- a/sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj
+++ b/sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj
@@ -1,6 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
+    <TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyName>Stride.Tests.Combined</AssemblyName>
     <RootNamespace>Stride.Tests.Combined</RootNamespace>
     <!-- StrideTestPlatforms defaults from StridePlatforms via the MultiPlatform Tests SDK; pass

--- a/sources/tools/Stride.Graphics.RenderDocPlugin/Stride.Graphics.RenderDocPlugin.csproj
+++ b/sources/tools/Stride.Graphics.RenderDocPlugin/Stride.Graphics.RenderDocPlugin.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
   <PropertyGroup>
-    <StrideRuntime>true</StrideRuntime>
+    <TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>
     <StrideGraphicsApiDependent>true</StrideGraphicsApiDependent>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
# PR Details

**What:** Runtime and test projects now declare `<TargetFrameworks>`
directly from SDK-precomputed sets instead of the `StrideRuntime`/test-platform
flags expanded at targets-time:
- Runtime: `<StrideRuntime>true</StrideRuntime>` → `<TargetFrameworks>$(StrideRuntimeTargetFrameworks)</TargetFrameworks>`
- Tests: `<TargetFrameworks>$(StrideTestTargetFrameworks)</TargetFrameworks>` (or `$(StrideXplatEditorTargetFramework)` single-TFM)

The SDK computes these sets in props; the targets-time expansion blocks are removed.

**Why:** TFMs were only known after targets evaluation, so Roslyn's
`MSBuildWorkspace` misclassified the projects and failed to load `Stride.sln`.
Declaring `<TargetFrameworks>` at the csproj level makes them SDK-style, so
tooling (csharp-ls, any `MSBuildWorkspace` consumer) loads the solution with no
upstream patch.

**Behavior:** Zero build change — resolved `TargetFrameworks` are identical
across the full platform matrix (verified per-platform with
`dotnet msbuild -getProperty:TargetFrameworks`).