### PR TITLE
Added .slnx parsing for visix extension

### DIFF
--- a/sources/core/Stride.Core.Design/Solutions/Solution.cs
+++ b/sources/core/Stride.Core.Design/Solutions/Solution.cs
@@ -11,10 +11,10 @@
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions
 // of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
 // TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
@@ -46,9 +46,14 @@ public class Solution
     }
 
     private Solution(Solution original)
-        : this(original.FullPath, original.Headers, original.Projects, original.GlobalSections, original.Properties)
-    {
-    }
+        : this(
+            original.FullPath,
+            original.Headers,
+            original.Projects,
+            original.GlobalSections,
+            original.Properties
+        )
+    { }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Solution" /> class.
@@ -58,7 +63,13 @@ public class Solution
     /// <param name="projects">The projects.</param>
     /// <param name="globalSections">The global sections.</param>
     /// <param name="properties">The properties.</param>
-    public Solution(string fullpath, IEnumerable<string> headers, IEnumerable<Project> projects, IEnumerable<Section> globalSections, IEnumerable<PropertyItem> properties)
+    public Solution(
+        string fullpath,
+        IEnumerable<string> headers,
+        IEnumerable<Project> projects,
+        IEnumerable<Section> globalSections,
+        IEnumerable<PropertyItem> properties
+    )
     {
         FullPath = fullpath;
         this.Headers = new List<string>(headers);
@@ -79,10 +90,7 @@ public class Solution
     /// <value>The children.</value>
     public IEnumerable<Project> Children
     {
-        get
-        {
-            return Projects.Where(project => project.GetParentProject(this) == null);
-        }
+        get { return Projects.Where(project => project.GetParentProject(this) == null); }
     }
 
     /// <summary>
@@ -132,6 +140,16 @@ public class Solution
     /// <param name="solutionPath">The solution path.</param>
     public void SaveAs(string solutionPath)
     {
+        // TODO:
+        // Writing only supports the legacy text based .sln format. Routing a .slnx through the text
+        // writer would corrupt the file, so fail explicitly instead.
+        if (solutionPath.IsSolutionX())
+        {
+            throw new NotSupportedException(
+                $"Saving the XML based '.slnx' solution format is not supported. Path: '{solutionPath}'."
+            );
+        }
+
         // If the solution file already exists, we want to write it only if it has actually changed, to prevent Visual Studio to reload the solution
         if (File.Exists(solutionPath))
         {
@@ -176,6 +194,12 @@ public class Solution
     /// <returns>Solution.</returns>
     public static Solution FromFile(string solutionFullPath)
     {
+        if (solutionFullPath.IsSolutionX())
+        {
+            using var stream = new FileStream(solutionFullPath, FileMode.Open, FileAccess.Read);
+            return SolutionXReader.ReadSolutionFile(solutionFullPath, stream);
+        }
+
         using var reader = new SolutionReader(solutionFullPath);
         var solution = reader.ReadSolutionFile();
         solution.FullPath = solutionFullPath;
@@ -190,6 +214,11 @@ public class Solution
     /// <returns>Solution.</returns>
     public static Solution FromStream(string solutionFullPath, Stream stream)
     {
+        if (solutionFullPath.IsSolutionX())
+        {
+            return SolutionXReader.ReadSolutionFile(solutionFullPath, stream);
+        }
+
         using var reader = new SolutionReader(solutionFullPath, stream);
         var solution = reader.ReadSolutionFile();
         solution.FullPath = solutionFullPath;

--- a/sources/core/Stride.Core.Design/Solutions/Solution.cs
+++ b/sources/core/Stride.Core.Design/Solutions/Solution.cs
@@ -11,10 +11,10 @@
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-//
+// 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions
 // of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
 // TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
@@ -46,14 +46,9 @@ public class Solution
     }
 
     private Solution(Solution original)
-        : this(
-            original.FullPath,
-            original.Headers,
-            original.Projects,
-            original.GlobalSections,
-            original.Properties
-        )
-    { }
+        : this(original.FullPath, original.Headers, original.Projects, original.GlobalSections, original.Properties)
+    {
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Solution" /> class.
@@ -63,13 +58,7 @@ public class Solution
     /// <param name="projects">The projects.</param>
     /// <param name="globalSections">The global sections.</param>
     /// <param name="properties">The properties.</param>
-    public Solution(
-        string fullpath,
-        IEnumerable<string> headers,
-        IEnumerable<Project> projects,
-        IEnumerable<Section> globalSections,
-        IEnumerable<PropertyItem> properties
-    )
+    public Solution(string fullpath, IEnumerable<string> headers, IEnumerable<Project> projects, IEnumerable<Section> globalSections, IEnumerable<PropertyItem> properties)
     {
         FullPath = fullpath;
         this.Headers = new List<string>(headers);
@@ -90,7 +79,10 @@ public class Solution
     /// <value>The children.</value>
     public IEnumerable<Project> Children
     {
-        get { return Projects.Where(project => project.GetParentProject(this) == null); }
+        get
+        {
+            return Projects.Where(project => project.GetParentProject(this) == null);
+        }
     }
 
     /// <summary>

--- a/sources/core/Stride.Core.Design/Solutions/SolutionXExtensions.cs
+++ b/sources/core/Stride.Core.Design/Solutions/SolutionXExtensions.cs
@@ -1,0 +1,20 @@
+namespace Stride.Core.Solutions
+{
+    /// <summary>
+    /// Helper class to encapsulate logic helpers from `.Slnx` support.
+    /// </summary>
+    internal static class SolutionXExtensions
+    {
+        /// <summary>
+        /// Determines whether the specified file path is a Visual Studio XML based solution file (<c>.slnx</c>).
+        /// </summary>
+        public static bool IsSolutionX(this string filePath)
+        {
+            return string.Equals(
+                Path.GetExtension(filePath),
+                ".slnx",
+                StringComparison.OrdinalIgnoreCase
+            );
+        }
+    }
+}

--- a/sources/core/Stride.Core.Design/Solutions/SolutionXReader.cs
+++ b/sources/core/Stride.Core.Design/Solutions/SolutionXReader.cs
@@ -1,0 +1,168 @@
+using System.Xml.Linq;
+
+namespace Stride.Core.Solutions
+{
+    /// <summary>
+    /// Reads a Visual Studio XML based solution file (<c>.slnx</c>) into a <see cref="Solution"/> model.
+    /// </summary>
+    /// <remarks>
+    /// <see href="https://github.com/microsoft/vs-solutionpersistence/blob/main/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/Slnx.xsd">schema</see> for the <c>.slnx</c> file format.
+    /// </remarks>
+    internal class SolutionXReader
+    {
+        /// <summary>
+        /// Reads a <c>.slnx</c> solution from the specified stream.
+        /// </summary>
+        /// <param name="solutionFullPath">The full path of the solution, used to resolve relative project paths.</param>
+        /// <param name="stream">The stream containing the XML solution.</param>
+        /// <returns>The parsed <see cref="Solution"/>.</returns>
+        /// <exception cref="SolutionFileException">The file is not a valid <c>.slnx</c> document.</exception>
+        public static Solution ReadSolutionFile(string solutionFullPath, Stream stream)
+        {
+            var solution = new Solution { FullPath = solutionFullPath };
+
+            XDocument document;
+            try
+            {
+                document = XDocument.Load(stream);
+            }
+            catch (System.Xml.XmlException ex)
+            {
+                throw new SolutionFileException(
+                    $"Invalid .slnx file '{solutionFullPath}': the file is not a well-formed XML document.",
+                    ex
+                );
+            }
+
+            var root =
+                document.Root
+                ?? throw new SolutionFileException(
+                    $"Invalid .slnx file '{solutionFullPath}': the document is empty."
+                );
+
+            if (!string.Equals(root.Name.LocalName, "Solution", StringComparison.Ordinal))
+            {
+                throw new SolutionFileException(
+                    $"Invalid .slnx file '{solutionFullPath}': expected root element 'Solution' but found '{root.Name.LocalName}'."
+                );
+            }
+
+            var solutionDirectory = Path.GetDirectoryName(solutionFullPath) ?? string.Empty;
+
+            ReadContainer(root, Guid.Empty, solution, solutionDirectory);
+
+            return solution;
+        }
+
+        private static void ReadContainer(
+            XElement container,
+            Guid parentGuid,
+            Solution solution,
+            string solutionDirectory
+        )
+        {
+            foreach (var element in container.Elements())
+            {
+                switch (element.Name.LocalName)
+                {
+                    case "Project":
+                        solution.Projects.Add(ReadProject(element, parentGuid, solutionDirectory));
+                        break;
+
+                    case "Folder":
+                        var folder = ReadFolder(element, parentGuid);
+                        solution.Projects.Add(folder);
+                        // Projects and nested folders declared inside a folder are parented to it.
+                        ReadContainer(element, folder.Guid, solution, solutionDirectory);
+                        break;
+                }
+            }
+        }
+
+        private static Project ReadProject(
+            XElement element,
+            Guid parentGuid,
+            string solutionDirectory
+        )
+        {
+            var path =
+                (string?)element.Attribute("Path")
+                ?? throw new SolutionFileException(
+                    "Invalid .slnx file: a 'Project' element is missing the required 'Path' attribute."
+                );
+
+            var relativePath = NormalizePath(path);
+            var fullPath = Path.GetFullPath(Path.Combine(solutionDirectory, relativePath));
+
+            var displayName = (string?)element.Attribute("DisplayName");
+            var name = !string.IsNullOrEmpty(displayName)
+                ? displayName!
+                : Path.GetFileNameWithoutExtension(relativePath);
+
+            var typeGuid = ResolveProjectTypeGuid((string?)element.Attribute("Type"), relativePath);
+
+            return new Project(
+                Guid.NewGuid(),
+                typeGuid,
+                name,
+                fullPath,
+                parentGuid,
+                [],
+                null,
+                null
+            );
+        }
+
+        private static Project ReadFolder(XElement element, Guid parentGuid)
+        {
+            var folderPath =
+                (string?)element.Attribute("Name")
+                ?? throw new SolutionFileException(
+                    "Invalid .slnx file: a 'Folder' element is missing the required 'Name' attribute."
+                );
+
+            // Folder names are expressed as a path (e.g. "/Group/SubGroup/"); the display name is the last segment.
+            var name = folderPath.Trim('/', '\\');
+            var lastSeparator = name.LastIndexOfAny(['/', '\\']);
+            if (lastSeparator >= 0)
+            {
+                name = name[(lastSeparator + 1)..];
+            }
+
+            return new Project(
+                Guid.NewGuid(),
+                KnownProjectTypeGuid.SolutionFolder,
+                name,
+                folderPath,
+                parentGuid,
+                [],
+                null,
+                null
+            );
+        }
+
+        private static Guid ResolveProjectTypeGuid(string? type, string relativePath)
+        {
+            // The 'Type' attribute is optional and, when present, may contain an explicit project type GUID.
+            if (!string.IsNullOrWhiteSpace(type) && Guid.TryParse(type, out var explicitGuid))
+            {
+                return explicitGuid;
+            }
+
+            // Otherwise the type is inferred from the project file extension, as Visual Studio does.
+            return Path.GetExtension(relativePath).ToLowerInvariant() switch
+            {
+                ".csproj" => KnownProjectTypeGuid.CSharpNewSystem,
+                ".vbproj" => KnownProjectTypeGuid.VisualBasic,
+                ".fsproj" => KnownProjectTypeGuid.FSharp,
+                ".vcxproj" => KnownProjectTypeGuid.VisualC,
+                _ => Guid.Empty,
+            };
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar);
+        }
+    }
+}

--- a/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
+++ b/sources/tools/Stride.VisualStudio.Package/Stride.VisualStudio.Package.csproj
@@ -65,6 +65,8 @@
     <Compile Include="..\..\core\Stride.Core.Design\Solutions\SolutionFileException.cs" Link="Core\Solutions\SolutionFileException.cs" />
     <Compile Include="..\..\core\Stride.Core.Design\Solutions\SolutionReader.cs" Link="Core\Solutions\SolutionReader.cs" />
     <Compile Include="..\..\core\Stride.Core.Design\Solutions\SolutionWriter.cs" Link="Core\Solutions\SolutionWriter.cs" />
+    <Compile Include="..\..\core\Stride.Core.Design\Solutions\SolutionXReader.cs" Link="Core\Solutions\SolutionXReader.cs" />
+    <Compile Include="..\..\core\Stride.Core.Design\Solutions\SolutionXExtensions.cs" Link="Core\Solutions\SolutionXExtensions.cs" />
     <Compile Include="..\..\core\Stride.Core\ScalarStyle.cs" Link="Yaml\ScalarStyle.cs" />
     <Compile Include="..\..\core\Stride.Core\DataStyle.cs" Link="Yaml\DataStyle.cs" />
     <Compile Include="..\..\core\Stride.Core.Yaml\*.cs" Link="Yaml\%(Filename)%(Extension).cs" />


### PR DESCRIPTION
# PR Details

I had to compile stride shaders as separate package rescently and noticed that visix extensions does not work. Upon digging on source of evil I found that it only supports `.sln` solutions.

Key edits:
* Adds SolutionXReader based on https://github.com/microsoft/vs-solutionpersistence/blob/main/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/Slnx.xsd
* Adds check if we are trying to write `.slnx` will throw. (adds todo the way that slnx's are written needs to be somehow considered)
* Checks if we are reading `.slnx` parsing it to solution correctly

## Related Issue

https://github.com/stride3d/stride/issues/3238

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

I'm not sure how to run test's here, tested that compiled extension works on test `slnx` and `sln` project:

<img width="1405" height="514" alt="image" src="https://github.com/user-attachments/assets/0e81b044-e0b8-4f7a-b841-c8e1f96668df" />

