### PR TITLE
Backup modified files before upgrade

### DIFF
--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -354,8 +354,15 @@ namespace Stride.AssetCompiler
 
                     var sessionResult = PackageSession.Load(upgradeTarget, loadParameters);
                     sessionResult.CopyTo(options.Logger);
-                    if (sessionResult.HasErrors || sessionResult.Session == null)
+                    if (sessionResult.Session == null)
                         return (int)BuildResultCode.BuildError;
+
+                    // Be lenient like Game Studio: load errors (e.g. a project that won't build against the new
+                    // version, so its script-referencing assets load as IUnloadable) don't abort the upgrade.
+                    // Reconcile and save whatever loaded — IUnloadable round-trips its original YAML, so nothing
+                    // is lost — and let the exit code below still report the errors.
+                    if (sessionResult.HasErrors)
+                        options.Logger.Warning("The session loaded with errors; upgrading and saving the assets that loaded. Fix the errors and re-run for a complete upgrade.");
 
                     ReconcileBases(sessionResult.Session, options.Logger);
 

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -117,6 +117,7 @@ namespace Stride.AssetCompiler
                 { "pack-asset-assembly=", "Host-loadable asset assembly (package-relative path) to declare in the packed sdpkg; repeat for each", v => options.PackAssetAssemblies.Add(v) },
                 { "t|threads=", "Number of threads to create. Default value is the number of hardware threads available.", v => options.ThreadCount = int.Parse(v) },
                 { "test=", "Run a test session.", v => options.TestName = v },
+                { "no-backup", "Upgrade verb only: skip backing up the files the upgrade overwrites (backup is on by default).", v => options.NoBackup = v != null },
                 { "property:", "Properties. Format is name1=value1;name2=value2", v =>
                 {
                     if (!string.IsNullOrEmpty(v))
@@ -347,6 +348,8 @@ namespace Stride.AssetCompiler
                         PackageUpgradeRequested = (pkg, upgrades) => PackageUpgradeRequestedAnswer.UpgradeAll,
                         // Whole-solution upgrade may start mixed (e.g. a shared pack already bumped); tolerate the transient NU1605.
                         AllowUpgradeDowngradeRestore = true,
+                        // Snapshot every file the upgrade overwrites into a timestamped backup folder unless opted out.
+                        BackupBeforeUpgrade = !options.NoBackup,
                     };
 
                     var sessionResult = PackageSession.Load(upgradeTarget, loadParameters);

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderOptions.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderOptions.cs
@@ -15,6 +15,8 @@ namespace Stride.AssetCompiler
 
         public bool Verbose = false;
         public bool Debug = false;
+        // Upgrade verb only: skip the copy-on-write backup of files the in-place upgrade overwrites (on by default).
+        public bool NoBackup { get; set; }
         // This should not be a list
         public bool DisableAutoCompileProjects { get; set; }
         public string ProjectConfiguration { get; set; }

--- a/sources/assets/Stride.Core.Assets/CodeUpgrade/CodeUpgradeRunner.cs
+++ b/sources/assets/Stride.Core.Assets/CodeUpgrade/CodeUpgradeRunner.cs
@@ -26,8 +26,9 @@ public interface ICodeUpgradeRunner
 {
     /// <param name="solutionPath">The solution to open (already restored at the old versions), or <c>null</c> for a standalone project.</param>
     /// <param name="pending">The projects pending source migration, with the upgrader that declared rules and the version each is upgraded from.</param>
+    /// <param name="backup">The copy-on-write backup to snapshot each source file into before overwriting it, or <c>null</c> when no backup is requested.</param>
     /// <param name="log">The logger.</param>
-    void Run(UFile? solutionPath, IReadOnlyList<PendingCodeUpgrade> pending, ILogger log);
+    void Run(UFile? solutionPath, IReadOnlyList<PendingCodeUpgrade> pending, UpgradeBackup? backup, ILogger log);
 }
 
 /// <summary>

--- a/sources/assets/Stride.Core.Assets/PackageLoadParameters.cs
+++ b/sources/assets/Stride.Core.Assets/PackageLoadParameters.cs
@@ -136,6 +136,13 @@ public sealed class PackageLoadParameters
     public bool AllowUpgradeDowngradeRestore { get; set; }
 
     /// <summary>
+    /// When set, an in-place upgrade snapshots each original file into a timestamped backup folder right before
+    /// it overwrites it (copy-on-write — only modified files are copied), so the upgrade stays recoverable.
+    /// Front-ends opt in (the asset compiler and GameStudio default it on); off for normal loads.
+    /// </summary>
+    public bool BackupBeforeUpgrade { get; set; }
+
+    /// <summary>
     /// Occurs when an asset is about to be loaded, if false is returned the asset will be ignored and not loaded.
     /// </summary>
     public Func<PackageLoadingAssetFile, bool> TemporaryAssetFilter;

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -495,6 +495,13 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
     public AssemblyContainer AssemblyContainer { get; }
 
     /// <summary>
+    /// The copy-on-write backup armed for an in-place upgrade (see <see cref="PackageLoadParameters.BackupBeforeUpgrade"/>),
+    /// or <c>null</c> when no backup is requested. The upgrade write points call <see cref="UpgradeBackup.Snapshot"/>
+    /// on it before overwriting a file.
+    /// </summary>
+    public UpgradeBackup? UpgradeBackup { get; private set; }
+
+    /// <summary>
     /// The targeted visual studio version (if specified by the loaded package)
     /// </summary>
     public Version? VisualStudioVersion { get; set; }
@@ -903,6 +910,26 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
         LoadMissingAssets(log, [.. Packages], loadParameters);
     }
 
+    // Constructs the copy-on-write upgrade backup the first time an upgrade-enabled load runs, mirroring the
+    // solution directory (or, for a standalone project upgrade with no solution, the project's directory).
+    private void ArmUpgradeBackup(PackageLoadParameters loadParameters, ILogger log)
+    {
+        if (!loadParameters.BackupBeforeUpgrade || UpgradeBackup is not null)
+            return;
+
+        var root = SolutionPath is not null
+            ? Path.GetDirectoryName(SolutionPath.ToOSPath())
+            : Projects.OfType<SolutionProject>().Select(x => Path.GetDirectoryName(x.FullPath.ToOSPath())).FirstOrDefault();
+        if (!string.IsNullOrEmpty(root))
+            UpgradeBackup = new UpgradeBackup(root, DateTime.Now, log);
+    }
+
+    /// <summary>
+    /// Disarms the upgrade backup so subsequent saves no longer snapshot files. <see cref="Save"/> does this
+    /// automatically after persisting an upgrade; a front-end also calls it for a clean load where no save runs.
+    /// </summary>
+    public void DisarmUpgradeBackup() => UpgradeBackup = null;
+
     /// <summary>
     /// Make sure packages have their dependencies loaded.
     /// </summary>
@@ -913,6 +940,10 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
         var loadParameters = loadParametersArg ?? PackageLoadParameters.Default();
 
         var cancelToken = loadParameters.CancelToken;
+
+        // Arm the copy-on-write backup once, before any upgrade write point runs. Copy-on-write keeps this
+        // safe to arm eagerly: the backup folder is only created if an upgrade actually overwrites a file.
+        ArmUpgradeBackup(loadParameters, log);
 
         try
         {
@@ -944,7 +975,7 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
                 {
                     var pendingCodeUpgrades = DetectPendingCodeUpgrades(log, loadParameters);
                     if (pendingCodeUpgrades.Count > 0)
-                        codeUpgradeRunner.Run(SolutionPath, pendingCodeUpgrades, log);
+                        codeUpgradeRunner.Run(SolutionPath, pendingCodeUpgrades, UpgradeBackup, log);
                 }
                 catch (NotImplementedException)
                 {
@@ -1057,6 +1088,23 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
                 return;
             }
 
+            // Copy-on-write backup of the files this save is about to overwrite during an upgrade: the dirty
+            // packages and their dirty assets. No-op outside an upgrade (UpgradeBackup is null); copy-once.
+            if (UpgradeBackup is { } upgradeBackup)
+            {
+                foreach (var package in LocalPackages)
+                {
+                    if (package.IsDirty && package.FullPath is not null)
+                        upgradeBackup.Snapshot(package.FullPath.ToOSPath());
+
+                    foreach (var assetItem in package.Assets)
+                    {
+                        if (assetItem.IsDirty)
+                            upgradeBackup.Snapshot(assetItem.FullPath.ToOSPath());
+                    }
+                }
+            }
+
             // Suspend tracking when saving as we don't want to receive
             // all notification events
             dependencies?.BeginSavingSession();
@@ -1148,10 +1196,11 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
             dependencies?.EndSavingSession();
 
             // Once all packages and assets have been saved, we can save the solution (as we need to have fullpath to
-            // be setup for the packages). Skip when the session wasn't loaded from a .sln (empty FullPath).
+            // be setup for the packages). Skip when the session wasn't loaded from a .sln (empty FullPath). The
+            // callback snapshots the .sln only when Save actually rewrites it.
             if (packagesSaved && !string.IsNullOrEmpty(VSSolution.FullPath))
             {
-                VSSolution.Save();
+                VSSolution.Save(path => UpgradeBackup?.Snapshot(path));
             }
             saveCompletion?.SetResult(0);
             saveCompletion = null;
@@ -1159,6 +1208,10 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
 
         //System.Diagnostics.Trace.WriteLine("Elapsed saved: " + clock.ElapsedMilliseconds);
         IsDirty = packagesDirty;
+
+        // The backup (armed only during an upgrade) has done its job for this save; disarm so later saves of
+        // this session don't snapshot. Normal saves run with it already null, so this is a no-op.
+        DisarmUpgradeBackup();
     }
 
     private Dictionary<UFile, AssetItem> BuildAssetsOrPackagesToRemove()
@@ -1483,6 +1536,11 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
                         packageUpgradeAllowed = true;
                     if (upgradeAllowed == PackageUpgradeRequestedAnswer.DoNotUpgradeAny)
                         packageUpgradeAllowed = false;
+
+                    // The confirmation callback may have opted out of the backup (e.g. the GameStudio dialog's
+                    // checkbox); disarm so the upgrade writes that follow this point don't snapshot.
+                    if (!loadParameters.BackupBeforeUpgrade)
+                        DisarmUpgradeBackup();
                 }
 
                 if (!PackageLoadParameters.ShouldUpgrade(upgradeAllowed))

--- a/sources/assets/Stride.Core.Assets/UpgradeBackup.cs
+++ b/sources/assets/Stride.Core.Assets/UpgradeBackup.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Stride.Core.Diagnostics;
+
+namespace Stride.Core.Assets;
+
+/// <summary>
+/// Copy-on-write snapshot of the files an in-place upgrade is about to overwrite. Armed by
+/// <see cref="PackageLoadParameters.BackupBeforeUpgrade"/> and called from each upgrade write point right
+/// before it overwrites a file. The timestamped backup folder is created lazily on the first real snapshot
+/// (so nothing is written when an upgrade modifies no files), and each original is copied at most once
+/// (a file may be touched by several upgraders).
+/// </summary>
+public sealed class UpgradeBackup
+{
+    private readonly string rootDirectory;
+    private readonly string backupFolderName;
+    private readonly ILogger? log;
+    private readonly object lockObject = new();
+    private readonly HashSet<string> snapshotted = new(StringComparer.OrdinalIgnoreCase);
+    private string? backupDirectory;
+
+    /// <param name="rootDirectory">
+    /// The folder the backup mirrors — each file is stored under it preserving its path relative to this
+    /// root. Usually the solution directory (the project directory for a standalone upgrade).
+    /// </param>
+    /// <param name="timestamp">The upgrade start time, used to name the backup folder.</param>
+    /// <param name="log">Logger that receives a single notice when the backup folder is first created.</param>
+    public UpgradeBackup(string rootDirectory, DateTime timestamp, ILogger? log = null)
+    {
+        this.rootDirectory = Path.GetFullPath(rootDirectory);
+        backupFolderName = $".stride-backup-{timestamp:yyyyMMdd-HHmmss}";
+        this.log = log;
+    }
+
+    /// <summary>
+    /// Copies <paramref name="originalFullPath"/> into the backup folder (preserving its path relative to the
+    /// backup root) the first time it is seen. No-op if the file doesn't exist, lies outside the root, or sits
+    /// under <c>bin/</c>, <c>obj/</c>, or the backup folder. Safe to call repeatedly for the same file.
+    /// </summary>
+    public void Snapshot(string originalFullPath)
+    {
+        if (string.IsNullOrEmpty(originalFullPath))
+            return;
+
+        var fullPath = Path.GetFullPath(originalFullPath);
+
+        var relative = Path.GetRelativePath(rootDirectory, fullPath);
+        // Outside the root (relative escapes with "..") or excluded build/backup output: skip.
+        if (relative.StartsWith("..", StringComparison.Ordinal) || Path.IsPathRooted(relative))
+            return;
+        if (relative.StartsWith(".stride-backup", StringComparison.Ordinal)
+            || ContainsSegment(relative, "bin")
+            || ContainsSegment(relative, "obj"))
+            return;
+
+        lock (lockObject)
+        {
+            if (!snapshotted.Add(fullPath))
+                return;
+
+            if (!File.Exists(fullPath))
+                return;
+
+            if (backupDirectory is null)
+            {
+                // First file actually backed up: announce the folder once. Covers every upgrade write point
+                // (source, project, assets) and entry point (compiler, Game Studio) since all funnel here.
+                backupDirectory = Path.Combine(rootDirectory, backupFolderName);
+                if (log is not null)
+                    log.Info($"Upgrade: backing up the originals of modified files to [{backupDirectory}]. Review the changes before building.");
+            }
+            var target = Path.Combine(backupDirectory, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(fullPath, target, overwrite: true);
+        }
+    }
+
+    private static bool ContainsSegment(string relativePath, string segment)
+    {
+        foreach (var part in relativePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        {
+            if (string.Equals(part, segment, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/sources/core/Stride.Core.Design/Solutions/Solution.cs
+++ b/sources/core/Stride.Core.Design/Solutions/Solution.cs
@@ -140,18 +140,20 @@ public class Solution
     /// <summary>
     /// Saves this instance to the <see cref="FullPath"/> path.
     /// </summary>
-    public void Save()
+    /// <param name="onBeforeOverwrite">Invoked with the path just before an existing file is overwritten (only when its content changed).</param>
+    public void Save(Action<string>? onBeforeOverwrite = null)
     {
-        SaveAs(FullPath);
+        SaveAs(FullPath, onBeforeOverwrite);
     }
 
     /// <summary>
     /// Saves this instance to the specified path.
     /// </summary>
     /// <param name="solutionPath">The solution path.</param>
-    public void SaveAs(string solutionPath)
+    /// <param name="onBeforeOverwrite">Invoked with the path just before an existing file is overwritten (only when its content changed).</param>
+    public void SaveAs(string solutionPath, Action<string>? onBeforeOverwrite = null)
     {
-        SolutionSerialization.Write(this, solutionPath);
+        SolutionSerialization.Write(this, solutionPath, onBeforeOverwrite);
     }
 
     /// <summary>

--- a/sources/core/Stride.Core.Design/Solutions/SolutionSerialization.cs
+++ b/sources/core/Stride.Core.Design/Solutions/SolutionSerialization.cs
@@ -52,7 +52,7 @@ internal static class SolutionSerialization
         return ToSolution(model, solutionFullPath);
     }
 
-    public static void Write(Solution solution, string outputPath)
+    public static void Write(Solution solution, string outputPath, Action<string>? onBeforeOverwrite = null)
     {
         // Behave like Visual Studio: a solution loaded from disk keeps everything it had (platforms, build
         // configurations, solution folders, projects Stride doesn't manage) and only its project list is
@@ -76,7 +76,10 @@ internal static class SolutionSerialization
         {
             serializer.SaveAsync(tempPath, model, CancellationToken.None).GetAwaiter().GetResult();
             if (!File.ReadAllBytes(outputPath).AsSpan().SequenceEqual(File.ReadAllBytes(tempPath)))
+            {
+                onBeforeOverwrite?.Invoke(outputPath);
                 File.Copy(tempPath, outputPath, overwrite: true);
+            }
         }
         finally
         {

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -442,45 +442,61 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 await workProgress.NotifyWorkFinished(cancellationSource.IsCancellationRequested, sessionResult.HasErrors);
             }
 
+            // An upgrade (package or pure asset-format) dirties the freshly-loaded session.
+            // Persist it now so the upgrade and its backup complete now instead of manual save later.
+            var loadedSession = sessionResult.Session;
+            if (loadedSession.LocalPackages.Any(package => package.IsDirty || package.Assets.IsDirty))
+                await sessionViewModel.SaveSession();    // save persists the upgrade and disarms the backup
+            else
+                loadedSession.DisarmUpgradeBackup();     // clean load: no save runs, so disarm here
+
             return sessionViewModel;
         }
 
         private static PackageLoadParameters CreatePackageLoadParameters(WorkProgressViewModel workProgress, CancellationTokenSource cancellationSource)
         {
-            return new PackageLoadParameters
+            // Snapshot every file the upgrade overwrites into a timestamped backup folder under the solution.
+            // Copy-on-write, so it costs nothing unless an upgrade actually runs and modifies files. The dialog
+            // checkbox below can opt out; the callback updates this flag, which the session honors.
+            var loadParameters = new PackageLoadParameters
             {
                 CancelToken = cancellationSource.Token,
-                PackageUpgradeRequested = (package, pendingUpgrades) =>
-                {
-                    // Generate message (in markdown, so we need to double line feeds)
-                    // Note: ** is markdown
-                    var message = new StringBuilder();
-                    message.AppendLine(string.Format(Tr._p("Message", "The following dependencies in the **{0}** package need to be upgraded:"), package.Meta.Name));
-                    message.AppendLine();
-
-                    foreach (var pendingUpgrade in pendingUpgrades)
-                    {
-                        message.AppendLine(string.Format(Tr._p("Message", "- Dependency to **{0}** must be upgraded from version **{1}** to **{2}**"), pendingUpgrade.Dependency.Name, pendingUpgrade.Dependency.Version, pendingUpgrade.PackageUpgrader.Attribute.UpdatedVersionRange.MinVersion));
-                    }
-
-                    message.AppendLine();
-                    message.AppendLine(string.Format(Tr._p("Message", "Upgrading assets might break them. We recommend you make a manual backup of your project before you upgrade."), package.Meta.Name));
-
-                    var buttons = new[]
-                    {
-                        new DialogButtonInfo { Content = Tr._p("Button", "Upgrade"), Result = (int)PackageUpgradeRequestedAnswer.Upgrade },
-                        new DialogButtonInfo { Content = Tr._p("Button", "Skip"), Result = (int)PackageUpgradeRequestedAnswer.DoNotUpgrade },
-                    };
-                    var checkBoxMessage = Tr._p("Message", "Do this for every package in the solution");
-                    var messageBoxResult = workProgress.ServiceProvider.Get<IDialogService>().CheckedMessageBoxAsync(message.ToString(), false, checkBoxMessage, buttons).Result;
-                    var result = (PackageUpgradeRequestedAnswer)messageBoxResult.Result;
-                    if (messageBoxResult.IsChecked == true)
-                    {
-                        result = result == PackageUpgradeRequestedAnswer.Upgrade ? PackageUpgradeRequestedAnswer.UpgradeAll : PackageUpgradeRequestedAnswer.DoNotUpgradeAny;
-                    }
-                    return result;
-                }
+                BackupBeforeUpgrade = true,
             };
+            loadParameters.PackageUpgradeRequested = (package, pendingUpgrades) =>
+            {
+                // Generate message (in markdown, so we need to double line feeds)
+                // Note: ** is markdown
+                var message = new StringBuilder();
+                message.AppendLine(string.Format(Tr._p("Message", "The following dependencies in the **{0}** package need to be upgraded:"), package.Meta.Name));
+                message.AppendLine();
+
+                foreach (var pendingUpgrade in pendingUpgrades)
+                {
+                    message.AppendLine(string.Format(Tr._p("Message", "- Dependency to **{0}** must be upgraded from version **{1}** to **{2}**"), pendingUpgrade.Dependency.Name, pendingUpgrade.Dependency.Version, pendingUpgrade.PackageUpgrader.Attribute.UpdatedVersionRange.MinVersion));
+                }
+
+                message.AppendLine();
+                message.AppendLine(Tr._p("Message", "Upgrading assets might break them. We also recommend committing or backing up your project first."));
+
+                var buttons = new[]
+                {
+                    new DialogButtonInfo { Content = Tr._p("Button", "Upgrade"), Result = (int)PackageUpgradeRequestedAnswer.Upgrade },
+                    new DialogButtonInfo { Content = Tr._p("Button", "Skip"), Result = (int)PackageUpgradeRequestedAnswer.DoNotUpgrade },
+                };
+                var applyToAll = new DialogCheckBoxInfo { Content = Tr._p("Message", "Do this for every package in the solution"), IsChecked = false };
+                var backup = new DialogCheckBoxInfo { Content = Tr._p("Message", "Back up each modified file to a timestamped folder under the solution"), IsChecked = true };
+                var buttonResult = workProgress.ServiceProvider.Get<IDialogService>().CheckedMessageBoxAsync(message.ToString(), [applyToAll, backup], buttons).Result;
+
+                loadParameters.BackupBeforeUpgrade = backup.IsChecked == true;
+                var result = (PackageUpgradeRequestedAnswer)buttonResult;
+                if (applyToAll.IsChecked == true)
+                {
+                    result = result == PackageUpgradeRequestedAnswer.Upgrade ? PackageUpgradeRequestedAnswer.UpgradeAll : PackageUpgradeRequestedAnswer.DoNotUpgradeAny;
+                }
+                return result;
+            };
+            return loadParameters;
         }
 
         public override void Destroy()

--- a/sources/engine/Stride.Assets/CodeUpgrade/CodePackageUpgrader.cs
+++ b/sources/engine/Stride.Assets/CodeUpgrade/CodePackageUpgrader.cs
@@ -54,6 +54,9 @@ public abstract class CodePackageUpgrader : PackageUpgrader, ICodeUpgradeProvide
         if (projectFullPath == null)
             return true;
 
+        // Snapshot the original csproj before the passes below rewrite it.
+        session.UpgradeBackup?.Snapshot(projectFullPath.ToOSPath());
+
         // Bump the upgrader's own package family to the current version (subclass hook).
         UpgradeProjectReferences(projectFullPath, log);
 

--- a/sources/engine/Stride.Assets/CodeUpgrade/RoslynCodeUpgradeRunner.cs
+++ b/sources/engine/Stride.Assets/CodeUpgrade/RoslynCodeUpgradeRunner.cs
@@ -23,7 +23,7 @@ namespace Stride.Assets;
 /// </summary>
 internal sealed class RoslynCodeUpgradeRunner : ICodeUpgradeRunner
 {
-    public void Run(UFile? solutionPath, IReadOnlyList<PendingCodeUpgrade> pending, ILogger log)
+    public void Run(UFile? solutionPath, IReadOnlyList<PendingCodeUpgrade> pending, UpgradeBackup? backup, ILogger log)
     {
         // Resolve each pending upgrader's applicable code rules up front. If nothing applies, never open
         // the (expensive) workspace — this keeps project-only upgrades at exactly today's cost.
@@ -71,7 +71,13 @@ internal sealed class RoslynCodeUpgradeRunner : ICodeUpgradeRunner
         try
         {
             // Escape any ambient synchronization context; MSBuildWorkspace is async-heavy.
-            Task.Run(() => RunAsync(solutionPath, plans, log)).GetAwaiter().GetResult();
+            Task.Run(() => RunAsync(solutionPath, plans, backup, log)).GetAwaiter().GetResult();
+        }
+        catch (NotImplementedException)
+        {
+            // Unsupported upgrade output (e.g. project-level changes) is an upgrader-authoring error —
+            // surface it loudly instead of degrading to a warning.
+            throw;
         }
         catch (Exception ex)
         {
@@ -79,7 +85,7 @@ internal sealed class RoslynCodeUpgradeRunner : ICodeUpgradeRunner
         }
     }
 
-    private static async Task RunAsync(UFile? solutionPath, List<(PendingCodeUpgrade Pending, List<CodeUpgrade> Upgrades)> plans, ILogger log)
+    private static async Task RunAsync(UFile? solutionPath, List<(PendingCodeUpgrade Pending, List<CodeUpgrade> Upgrades)> plans, UpgradeBackup? backup, ILogger log)
     {
         var cancellationToken = CancellationToken.None;
 
@@ -128,6 +134,9 @@ internal sealed class RoslynCodeUpgradeRunner : ICodeUpgradeRunner
         var changedCount = 0;
         foreach (var projectChanges in solution.GetChanges(originalSolution).GetProjectChanges())
         {
+            // We persist changed .cs text only; reject any other project change rather than drop it silently.
+            EnsureNoUnsupportedChanges(projectChanges);
+
             foreach (var documentId in projectChanges.GetChangedDocuments())
             {
                 var newDocument = solution.GetDocument(documentId);
@@ -141,6 +150,9 @@ internal sealed class RoslynCodeUpgradeRunner : ICodeUpgradeRunner
 
                 try
                 {
+                    // Snapshot the original before overwriting it (copy-on-write; no-op when no backup is armed).
+                    backup?.Snapshot(newDocument.FilePath);
+
                     using var writer = new StreamWriter(newDocument.FilePath, append: false, encoding);
                     newText.Write(writer, cancellationToken);
                 }
@@ -156,7 +168,32 @@ internal sealed class RoslynCodeUpgradeRunner : ICodeUpgradeRunner
         }
 
         if (changedCount > 0)
-            log.Info($"Code upgrade: migrated {changedCount} source file(s). Review the changes before building (back up / commit first if you haven't).");
+            log.Info($"Code upgrade: migrated {changedCount} source file(s).");
+    }
+
+    // Enumerates the full ProjectChanges surface except GetChangedDocuments (the only delta the runner persists);
+    // anything else would need workspace.TryApplyChanges() to reach the .csproj, so fail loud instead of dropping it.
+    private static void EnsureNoUnsupportedChanges(ProjectChanges projectChanges)
+    {
+        if (projectChanges.GetAddedDocuments().Any()
+            || projectChanges.GetRemovedDocuments().Any()
+            || projectChanges.GetChangedAdditionalDocuments().Any()
+            || projectChanges.GetAddedAdditionalDocuments().Any()
+            || projectChanges.GetRemovedAdditionalDocuments().Any()
+            || projectChanges.GetChangedAnalyzerConfigDocuments().Any()
+            || projectChanges.GetAddedAnalyzerConfigDocuments().Any()
+            || projectChanges.GetRemovedAnalyzerConfigDocuments().Any()
+            || projectChanges.GetAddedMetadataReferences().Any()
+            || projectChanges.GetRemovedMetadataReferences().Any()
+            || projectChanges.GetAddedProjectReferences().Any()
+            || projectChanges.GetRemovedProjectReferences().Any()
+            || projectChanges.GetAddedAnalyzerReferences().Any()
+            || projectChanges.GetRemovedAnalyzerReferences().Any())
+        {
+            throw new NotImplementedException(
+                $"Code upgrade for [{projectChanges.NewProject.Name}] produced changes other than regular document " +
+                "text (added/removed docs, references, etc.); the runner persists changed .cs text only.");
+        }
     }
 
     private static bool PathsEqual(string? a, string? b)

--- a/sources/presentation/Stride.Core.Presentation.Dialogs/DialogService.cs
+++ b/sources/presentation/Stride.Core.Presentation.Dialogs/DialogService.cs
@@ -69,6 +69,11 @@ namespace Stride.Core.Presentation.Dialogs
             return DialogHelper.CheckedMessageBox(Dispatcher, message, ApplicationName, isChecked, checkboxMessage, buttons, image);
         }
 
+        public Task<int> CheckedMessageBoxAsync(string message, IReadOnlyCollection<DialogCheckBoxInfo> checkBoxes, IReadOnlyCollection<DialogButtonInfo> buttons, MessageBoxImage image = MessageBoxImage.None)
+        {
+            return DialogHelper.MultiCheckedMessageBox(Dispatcher, message, ApplicationName, checkBoxes, buttons, image);
+        }
+
         public MessageBoxResult BlockingMessageBox(string message, MessageBoxButton buttons = MessageBoxButton.OK, MessageBoxImage image = MessageBoxImage.None)
         {
             return (MessageBoxResult)DialogHelper.BlockingMessageBox(Dispatcher, message, ApplicationName, IDialogService.GetButtons(buttons), image);

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Themes/ThemeSelector.xaml
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Themes/ThemeSelector.xaml
@@ -337,6 +337,38 @@
     </Setter>
   </Style>
 
+  <Style TargetType="{x:Type wnd:MultiCheckedMessageBox}" BasedOn="{StaticResource {x:Type wnd:MessageBox}}">
+    <Setter Property="MessageTemplate">
+      <Setter.Value>
+        <DataTemplate>
+          <DockPanel LastChildFill="True"
+                     MinWidth="{Binding MinWidth, RelativeSource={RelativeSource AncestorType=ContentPresenter}, FallbackValue=320}"
+                     MaxHeight="{Binding MaxHeight, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Converter={cvt:SumNum}, ConverterParameter={me:Double -20}, FallbackValue=748}" >
+            <i:Interaction.Behaviors>
+              <behaviors:ResizeBehavior SizeRatio="5,3"/>
+            </i:Interaction.Behaviors>
+            <ItemsControl DockPanel.Dock="Bottom" Margin="0,15,0,5" VerticalAlignment="Bottom"
+                          HorizontalContentAlignment="Stretch"
+                          ItemsSource="{Binding CheckBoxes, RelativeSource={RelativeSource AncestorType=wnd:MultiCheckedMessageBox}}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <CheckBox Margin="0,3,0,0" HorizontalContentAlignment="Stretch" IsChecked="{Binding IsChecked, Mode=TwoWay}">
+                    <TextBlock Text="{Binding Content}" TextWrapping="Wrap"/>
+                  </CheckBox>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Image DockPanel.Dock="Left" Source="{Binding Image, RelativeSource={RelativeSource AncestorType=wnd:MultiCheckedMessageBox}}"
+                   HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,5" RenderOptions.BitmapScalingMode="HighQuality"
+                   Height="{Binding RelativeSource={RelativeSource Self}, Path=Source.PixelHeight}" Width="{Binding RelativeSource={RelativeSource Self}, Path=Source.PixelWidth}"
+                   Visibility="{Binding Image, RelativeSource={RelativeSource AncestorType=wnd:MultiCheckedMessageBox}, Converter={cvt:Chained {cvt:ObjectToBool}, {cvt:VisibleOrCollapsed}}}" />
+            <ctrl:MarkdownTextBlock Text="{Binding}" VerticalAlignment="Center"/>
+          </DockPanel>
+        </DataTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
   <Style TargetType="{x:Type ctrl:MarkdownTextBlock}">
     <Setter Property="HyperlinkCommand" Value="{x:Static cmd:UtilityCommands.OpenHyperlinkCommand}" />
     <Setter Property="Template">

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Windows/DialogHelper.cs
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Windows/DialogHelper.cs
@@ -32,6 +32,12 @@ namespace Stride.Core.Presentation.Windows
             return dispatcher.InvokeTask(() => Windows.CheckedMessageBox.Show(message, caption, buttons, image, checkboxMessage, isChecked));
         }
 
+        [NotNull]
+        public static Task<int> MultiCheckedMessageBox([NotNull] IDispatcherService dispatcher, string message, string caption, IEnumerable<DialogCheckBoxInfo> checkBoxes, IEnumerable<DialogButtonInfo> buttons, MessageBoxImage image = MessageBoxImage.None)
+        {
+            return dispatcher.InvokeTask(() => Windows.MultiCheckedMessageBox.Show(message, caption, buttons, image, checkBoxes));
+        }
+
         public static int BlockingMessageBox([NotNull] IDispatcherService dispatcher, string message, string caption, IEnumerable<DialogButtonInfo> buttons, MessageBoxImage image = MessageBoxImage.None)
         {
             return PushFrame(dispatcher, () => MessageBox(dispatcher, message, caption, buttons, image));

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Windows/MultiCheckedMessageBox.cs
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Windows/MultiCheckedMessageBox.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using Stride.Core.Annotations;
+
+namespace Stride.Core.Presentation.Windows
+{
+    using MessageBoxImage = Services.MessageBoxImage;
+
+    /// <summary>
+    /// A message box that shows any number of independent check boxes below the message. Each
+    /// <see cref="DialogCheckBoxInfo"/> carries its own label and check state; the same instances are read
+    /// back after the dialog closes to get the user's choices.
+    /// </summary>
+    public class MultiCheckedMessageBox : MessageBox
+    {
+        /// <summary>
+        /// Identifies the <see cref="CheckBoxes"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CheckBoxesProperty =
+            DependencyProperty.Register(nameof(CheckBoxes), typeof(IEnumerable<DialogCheckBoxInfo>), typeof(MultiCheckedMessageBox));
+
+        public IEnumerable<DialogCheckBoxInfo> CheckBoxes
+        {
+            get { return (IEnumerable<DialogCheckBoxInfo>)GetValue(CheckBoxesProperty); }
+            set { SetValue(CheckBoxesProperty, value); }
+        }
+
+        /// <summary>
+        /// Shows the dialog. The <paramref name="checkBoxes"/> instances are updated in place with the user's
+        /// choices; the return value is the result of the button used to close it.
+        /// </summary>
+        [NotNull]
+        public static async Task<int> Show(string message, string caption, [NotNull] IEnumerable<DialogButtonInfo> buttons, MessageBoxImage image, [NotNull] IEnumerable<DialogCheckBoxInfo> checkBoxes)
+        {
+            var buttonList = buttons.ToList();
+            var messageBox = new MultiCheckedMessageBox
+            {
+                Title = caption,
+                Content = message,
+                ButtonsSource = buttonList,
+                CheckBoxes = checkBoxes.ToList(),
+            };
+            SetImage(messageBox, image);
+            SetKeyBindings(messageBox, buttonList);
+
+            await messageBox.ShowModal();
+            return messageBox.ButtonResult;
+        }
+    }
+}

--- a/sources/presentation/Stride.Core.Presentation/Services/IDialogService.cs
+++ b/sources/presentation/Stride.Core.Presentation/Services/IDialogService.cs
@@ -136,6 +136,18 @@ public interface IDialogService
     Task<CheckedMessageBoxResult> CheckedMessageBoxAsync(string message, bool? isChecked, string checkboxMessage, IReadOnlyCollection<DialogButtonInfo> buttons, MessageBoxImage image = MessageBoxImage.None);
 
     /// <summary>
+    /// Displays a modal message box with one or more independent check boxes between the message and the buttons.
+    /// Each <paramref name="checkBoxes"/> instance is updated in place with the user's choice; the returned value
+    /// is the result of the button used to close the window.
+    /// </summary>
+    /// <param name="message">The text to display as message in the message box.</param>
+    /// <param name="checkBoxes">The check boxes to display; their <see cref="DialogCheckBoxInfo.IsChecked"/> reflects the user's choice on return.</param>
+    /// <param name="buttons">The buttons to display in the message box.</param>
+    /// <param name="image">The image to display in the message box.</param>
+    /// <returns>An <see cref="int"/> value indicating which button the user pressed to close the window.</returns>
+    Task<int> CheckedMessageBoxAsync(string message, IReadOnlyCollection<DialogCheckBoxInfo> checkBoxes, IReadOnlyCollection<DialogButtonInfo> buttons, MessageBoxImage image = MessageBoxImage.None);
+
+    /// <summary>
     /// Displays a modal message box and returns a task that completes when the message box is closed.
     /// </summary>
     /// <param name="message">The text to display as message in the message box.</param>

--- a/sources/presentation/Stride.Core.Presentation/Windows/DialogCheckBoxInfo.cs
+++ b/sources/presentation/Stride.Core.Presentation/Windows/DialogCheckBoxInfo.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Presentation.ViewModels;
+
+namespace Stride.Core.Presentation.Windows;
+
+/// <summary>
+/// Represents a check box in a checkable message box. The same instance carries the initial state in and
+/// the user's choice out: <see cref="IsChecked"/> reflects the user's selection once the dialog closes.
+/// </summary>
+public sealed class DialogCheckBoxInfo : ViewModelBase
+{
+    private object? content;
+    private bool? isChecked;
+
+    /// <summary>
+    /// The label shown next to the check box.
+    /// </summary>
+    public object? Content
+    {
+        get => content;
+        set => SetValue(ref content, value);
+    }
+
+    /// <summary>
+    /// The check state: the initial value going in, the user's choice coming out.
+    /// </summary>
+    public bool? IsChecked
+    {
+        get => isChecked;
+        set => SetValue(ref isChecked, value);
+    }
+}


### PR DESCRIPTION
# PR Details

Before an in-place project **upgrade** overwrites files, snapshot each original so the upgrade stays recoverable.
**Copy-on-write** — a file is copied into a timestamped `.stride-backup-<yyyyMMdd-HHmmss>/` folder (under the solution root) *only* the moment something is about to overwrite it, so only files that actually change are backed up.
No-op upgrades create no folder.

Tested on a 4.1 project (with all types of changes: sln, csproj, cs, assets and sdpkg changes):

<img width="556" height="447" alt="image" src="https://github.com/user-attachments/assets/a9a41ddc-4ed8-4728-8463-e5d1799c6f15" />  
<br/>
<img width="194" height="464" alt="image" src="https://github.com/user-attachments/assets/accfa4ac-8402-45bd-823c-70482413ae16" />

Red: backup
Blue: actual change on HDD

## Details

Every write point and entry point goes through one shared `UpgradeBackup.Snapshot`:

| File | Snapshotted when |
|------|------------------|
| `.cs` | a Roslyn migration rewrites a changed document |
| `.csproj` | before the version-bump / structural passes rewrite it |
| assets / `.sdpkg` | dirty items, before `PackageSession.Save` writes them |
| `.sln` | only when the solution serializer actually changes it |

Works for both the **asset compiler** (`stride upgrade` / `StrideUpgradeAssets`) and **Game Studio** (in-process via `PackageSession`).

### Default on, opt-out

- Compiler: `--no-backup` (off by default → backup on).
- Game Studio: a "Back up each modified file…" checkbox in the upgrade dialog (checked by default).

The folder is announced once when first created, covering all file types:
> `Upgrade: backing up the originals of modified files to [<folder>]. Review the changes before building.`

### Notable changes
- Game Studio now do an eager asset/sdpkg save (before it was eager-saving sln/csproj only, but not assets). It was anyway necessary otherwise it wouldn't work well to properly disarm the backup.
- Adds a reusable **multi-checkbox message box** (`MultiCheckedMessageBox` + `DialogCheckBoxInfo`, `ItemsControl`-based, wrapping labels) so the Game Studio dialog can show both "apply to all" and the backup opt-out. Split into its own commit.
- The Roslyn runner now **fails loud** (`NotImplementedException`) if an upgrade produces anything beyond changed `.cs` text (added/removed docs, references) — those would need `workspace.TryApplyChanges()` and aren't persisted today, so they're rejected rather than dropped silently.
