### PR TITLE
fix: CharacterComponent account for collider mass

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CharacterComponentAbstract.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CharacterComponentAbstract.cs
@@ -18,7 +18,7 @@ public abstract class CharacterComponentAbstract : BodyComponent, ISimulationUpd
     /// <inheritdoc/>
     protected override void AttachInner(NRigidPose pose, BodyInertia shapeInertia, TypedIndex shapeIndex)
     {
-        base.AttachInner(pose, new BodyInertia { InverseMass = 1f }, shapeIndex);
+        base.AttachInner(pose, new BodyInertia { InverseMass = shapeInertia.InverseMass }, shapeIndex);
 
         Debug.Assert(BodyReference.HasValue);
         Debug.Assert(Simulation is not null);


### PR DESCRIPTION
# PR Details
With the new CharacterComponent implementation, we can now pass the mass from the colliders to the body appropriately, improving behavior when pushing objects or when under constraints. Tensor is purposefully ignored as this would prevent the character from staying upright.

## Related Issue
None reported

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**