### PR TITLE
fix: GameProfilingSystem crashes on Vulkan (FastTextRenderer null command buffer)

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -346,50 +346,51 @@ namespace Stride.Profiling
                 renderTargetSize = new Size2(renderTarget.Width, renderTarget.Height);
             }
 
-            var renderContext = RenderContext.GetShared(Services);
-            var renderDrawContext = renderContext.GetThreadContext();
-
             if (fastTextRenderer == null)
             {
-                fastTextRenderer = new FastTextRenderer(renderDrawContext.GraphicsContext)
+                fastTextRenderer = new FastTextRenderer(Game.GraphicsContext)
                 {
                     DebugSpriteFont = Content.Load<Texture>("StrideDebugSpriteFont"),
                     TextColor = TextColor,
                 };
             }
 
-            using (renderDrawContext.PushRenderTargetsAndRestore())
+            // Render through the game's main GraphicsContext (as DebugTextSystem does). The per-thread
+            // RenderContext command list used previously is Close()d after the compositor renders and is never
+            // re-begun, so on Vulkan its native command buffer is null and FastTextRenderer.End() crashes when
+            // recording draw commands into it (0xC0000005 — issue #1020). The main command list is reset and
+            // begun every frame in GameBase.BeginDraw, so it is always valid here. On Direct3D11 this is
+            // equivalent (the thread context already shared the main command list).
+            var graphicsContext = Game.GraphicsContext;
+            graphicsContext.CommandList.SetRenderTargetAndViewport(null, renderTarget);
+            viewportHeight = graphicsContext.CommandList.Viewport.Height;
+            fastTextRenderer.Begin(graphicsContext);
+            lock (stringLock)
             {
-                renderDrawContext.CommandList.SetRenderTargetAndViewport(null, renderTarget);
-                viewportHeight = renderDrawContext.CommandList.Viewport.Height;
-                fastTextRenderer.Begin(renderDrawContext.GraphicsContext);
-                lock (stringLock)
+                var currentHeight = textDrawStartOffset.Y;
+                fastTextRenderer.DrawString(graphicsContext, fpsStatString, textDrawStartOffset.X, currentHeight);
+                currentHeight += TopRowHeight;
+
+                if (FilteringMode == GameProfilingResults.CpuEvents)
                 {
-                    var currentHeight = textDrawStartOffset.Y;
-                    fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, fpsStatString, textDrawStartOffset.X, currentHeight);
+                    fastTextRenderer.DrawString(graphicsContext, gcMemoryString, textDrawStartOffset.X, currentHeight);
                     currentHeight += TopRowHeight;
-
-                    if (FilteringMode == GameProfilingResults.CpuEvents)
-                    {
-                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gcMemoryString, textDrawStartOffset.X, currentHeight);
-                        currentHeight += TopRowHeight;
-                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gcCollectionsString, textDrawStartOffset.X, currentHeight);
-                        currentHeight += TopRowHeight;
-                    }
-                    else if (FilteringMode == GameProfilingResults.GpuEvents)
-                    {
-                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gpuGeneralInfoString, textDrawStartOffset.X, currentHeight);
-                        currentHeight += TopRowHeight;
-                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, gpuInfoString, textDrawStartOffset.X, currentHeight);
-                        currentHeight += TopRowHeight;
-                    }
-
-                    if (FilteringMode != GameProfilingResults.Fps)
-                        fastTextRenderer.DrawString(renderDrawContext.GraphicsContext, profilersString, textDrawStartOffset.X, currentHeight);
+                    fastTextRenderer.DrawString(graphicsContext, gcCollectionsString, textDrawStartOffset.X, currentHeight);
+                    currentHeight += TopRowHeight;
+                }
+                else if (FilteringMode == GameProfilingResults.GpuEvents)
+                {
+                    fastTextRenderer.DrawString(graphicsContext, gpuGeneralInfoString, textDrawStartOffset.X, currentHeight);
+                    currentHeight += TopRowHeight;
+                    fastTextRenderer.DrawString(graphicsContext, gpuInfoString, textDrawStartOffset.X, currentHeight);
+                    currentHeight += TopRowHeight;
                 }
 
-                fastTextRenderer.End(renderDrawContext.GraphicsContext);
+                if (FilteringMode != GameProfilingResults.Fps)
+                    fastTextRenderer.DrawString(graphicsContext, profilersString, textDrawStartOffset.X, currentHeight);
             }
+
+            fastTextRenderer.End(graphicsContext);
         }
 
         /// <summary>

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -355,12 +355,6 @@ namespace Stride.Profiling
                 };
             }
 
-            // Render through the game's main GraphicsContext (as DebugTextSystem does). The per-thread
-            // RenderContext command list used previously is Close()d after the compositor renders and is never
-            // re-begun, so on Vulkan its native command buffer is null and FastTextRenderer.End() crashes when
-            // recording draw commands into it (0xC0000005 — issue #1020). The main command list is reset and
-            // begun every frame in GameBase.BeginDraw, so it is always valid here. On Direct3D11 this is
-            // equivalent (the thread context already shared the main command list).
             var graphicsContext = Game.GraphicsContext;
             graphicsContext.CommandList.SetRenderTargetAndViewport(null, renderTarget);
             viewportHeight = graphicsContext.CommandList.Viewport.Height;

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -346,16 +346,14 @@ namespace Stride.Profiling
                 renderTargetSize = new Size2(renderTarget.Width, renderTarget.Height);
             }
 
-            if (fastTextRenderer == null)
-            {
-                fastTextRenderer = new FastTextRenderer(Game.GraphicsContext)
-                {
-                    DebugSpriteFont = Content.Load<Texture>("StrideDebugSpriteFont"),
-                    TextColor = TextColor,
-                };
-            }
-
             var graphicsContext = Game.GraphicsContext;
+
+            fastTextRenderer ??= new FastTextRenderer(graphicsContext)
+            {
+                DebugSpriteFont = Content.Load<Texture>("StrideDebugSpriteFont"),
+                TextColor = TextColor,
+            };
+
             graphicsContext.CommandList.SetRenderTargetAndViewport(null, renderTarget);
             viewportHeight = graphicsContext.CommandList.Viewport.Height;
             fastTextRenderer.Begin(graphicsContext);


### PR DESCRIPTION
# PR Details

Fixes a native crash (`0xC0000005`) on the **Vulkan** backend: enabling the on-screen game profiler (`GameProfilingSystem`, toggled with **F7**) crashes within a couple of frames inside `FastTextRenderer.End`.

```
Fatal error. 0xC0000005
   at Vortice.Vulkan.Vulkan.vkCmdBindVertexBuffers(...)   // on master; 4.3.x faults one call earlier at vkCmdBindPipeline
   at Stride.Graphics.CommandList.SetVertexBuffer(...)
   at Stride.Graphics.FastTextRenderer.End(...)
   at Stride.Profiling.GameProfilingSystem.Draw(...)
```

### Root cause

`GameProfilingSystem.Draw` rendered `FastTextRenderer` through `RenderContext.GetShared(Services).GetThreadContext()`. On Vulkan that returns a **thread-local pipeline-worker** command list, which is `Close()`d during the compositor's parallel scene rendering (`RenderSystem.Draw`) and **never re-begun** afterwards — so its native `VkCommandBuffer` is null, and recording draw commands into it in `FastTextRenderer.End` dereferences a null handle → access violation.

It only worked on Direct3D11 because D3D11 records serially (`IsDeferred == false`) and its thread contexts alias the single main command list via `GraphicsDevice.InternalMainCommandList` — which Vulkan intentionally does **not** set, because it does genuine parallel command-buffer recording. So the profiler was the one `GameSystem.Draw`-level caller reaching into a pipeline-internal context that isn't valid outside the render pipeline.

### Fix

Render through **`Game.GraphicsContext`** — the main, per-frame command list that `GameBase.BeginDraw` resets and begins every frame — exactly as **`DebugTextSystem`** (the other `FastTextRenderer` consumer) already does. Behaviour-preserving on Direct3D11 (that was already the main command list); fixes the crash on Vulkan. Single method changed; no `FastTextRenderer` change needed.

### Validation

Built the engine at a single consistent version and A/B-tested a minimal real game: **without** the change it crashes 3/3, **with** it runs cleanly and the profiler overlay renders. Minimal self-contained reproduction (clone + `dotnet run` on a Vulkan GPU): **https://github.com/sasvdw/stride-1020-vulkan-profiler-repro**

### Note / follow-up

This is the targeted caller fix. The deeper issue — `GetThreadContext()` silently handing a `GameSystem.Draw` an invalid (closed) command list on Vulkan, so *any* future out-of-pipeline drawing system is a latent crash — is a framework concern (`DebugTextSystem` even carries a `// TODO GRAPHICS REFACTOR where to get command list from?`). I've kept this PR minimal and low-risk and will raise that separately as a proposal.

## Related Issue

Closes #1020. Related: #630 (`[Vulkan] WriteDiscard support` — same `FastTextRenderer`-on-Vulkan area).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes. <!-- The xUnit graphics-regression harness isn't a real windowed Game and doesn't reproduce this (the crash needs a real swapchain + compositor); a standalone repro is linked above instead. -->
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.** <!-- Validated via the standalone Vulkan game repro above; this is a runtime-only change to the profiler system. -->
