### PR TITLE
Physics: skip inertia calculation for statics

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -253,6 +253,17 @@ public abstract class CollidableComponent : EntityComponent
 
     protected internal abstract CollidableReference? CollidableReference { get; }
 
+    /// <summary>
+    /// Whether this collidable needs its collider's inertia when attaching, see
+    /// <see cref="AttachInner"/>'s <c>shapeInertia</c> parameter.
+    /// </summary>
+    /// <remarks>
+    /// Inertia only affects bodies; statics discard it, and computing it is not free -
+    /// <see cref="Definitions.Colliders.MeshCollider"/>'s inertia iterates over every
+    /// triangle of the mesh. Colliders skip that work when this is false.
+    /// </remarks>
+    internal virtual bool ShouldCalculateInertia => true;
+
     public CollidableComponent()
     {
         _collider = new CompoundCollider();
@@ -277,7 +288,7 @@ public abstract class CollidableComponent : EntityComponent
 
         Debug.Assert(Processor is not null);
 
-        if (false == Collider.TryAttach(onSimulation.Simulation.Shapes, onSimulation.BufferPool, Processor.ShapeCache, out var index, out var centerOfMass, out var shapeInertia))
+        if (false == Collider.TryAttach(onSimulation.Simulation.Shapes, onSimulation.BufferPool, Processor.ShapeCache, ShouldCalculateInertia, out var index, out var centerOfMass, out var shapeInertia))
         {
             return;
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CompoundCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CompoundCollider.cs
@@ -65,7 +65,7 @@ public sealed class CompoundCollider : ICollider
         }
     }
 
-    bool ICollider.TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
+    bool ICollider.TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, bool shouldCalculateInertia, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
     {
         if (_colliders.Count == 0)
         {
@@ -89,7 +89,18 @@ public sealed class CompoundCollider : ICollider
 
             Buffer<CompoundChild> compoundChildren;
             System.Numerics.Vector3 shapeCenter;
-            compoundBuilder.BuildDynamicCompound(out compoundChildren, out inertia, out shapeCenter);
+
+            if (shouldCalculateInertia)
+            {
+                compoundBuilder.BuildDynamicCompound(out compoundChildren, out inertia, out shapeCenter);
+            }
+            else
+            {
+                // Same children and same weight-weighted center as BuildDynamicCompound, minus
+                // combining the children's inertia (it never reads their LocalInverseInertia)
+                compoundBuilder.BuildKinematicCompound(out compoundChildren, out shapeCenter);
+                inertia = default;
+            }
 
             index = IsBig ? shapes.Add(new BigCompound(compoundChildren, shapes, pool)) : shapes.Add(new Compound(compoundChildren));
             centerOfMass = shapeCenter.ToStride();

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/EmptyCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/EmptyCollider.cs
@@ -36,11 +36,11 @@ public sealed class EmptyCollider : ICollider
         transforms[0].Scale = new Vector3(0.1f);
     }
 
-    bool ICollider.TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
+    bool ICollider.TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, bool shouldCalculateInertia, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
     {
         index = new();
         centerOfMass = new();
-        inertia = new Sphere(1).ComputeInertia(1);
+        inertia = shouldCalculateInertia ? new Sphere(1).ComputeInertia(1) : default;
         return true;
     }
 

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/ICollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/ICollider.cs
@@ -23,7 +23,11 @@ public interface ICollider
     /// You must still transform this further into worldspace by using the world position and rotation the collidable's entity.
     /// </remarks>
     public void GetLocalTransforms(CollidableComponent collidable, Span<ShapeTransform> transforms);
-    internal bool TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia);
+    /// <remarks>
+    /// When <paramref name="shouldCalculateInertia"/> is false the caller does not read
+    /// <paramref name="inertia"/> - implementations skip computing it and may leave it default.
+    /// </remarks>
+    internal bool TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, bool shouldCalculateInertia, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia);
     internal void Detach(Shapes shapes, BufferPool pool, TypedIndex index);
     internal void AppendModel(List<BasicMeshBuffers> buffer, ShapeCacheSystem shapeCache, out object? cache);
 

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/MeshCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/MeshCollider.cs
@@ -82,7 +82,7 @@ public sealed class MeshCollider : ICollider
         return ShapeCacheSystem.GetClosestToDecomposableScale(collidable.Entity.Transform.WorldMatrix);
     }
 
-    bool ICollider.TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
+    bool ICollider.TryAttach(Shapes shapes, BufferPool pool, ShapeCacheSystem shapeCache, bool shouldCalculateInertia, out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
     {
         Debug.Assert(_component is not null);
 
@@ -90,7 +90,11 @@ public sealed class MeshCollider : ICollider
         var mesh = _cache.GetBepuMesh(ComputeMeshScale(_component));
 
         index = shapes.Add(mesh);
-        inertia = Closed ? mesh.ComputeClosedInertia(Mass) : mesh.ComputeOpenInertia(Mass);
+        // Computing a mesh's inertia iterates over every one of its triangles, avoid that
+        // whenever the collidable doesn't read the result (statics)
+        inertia = shouldCalculateInertia
+            ? Closed ? mesh.ComputeClosedInertia(Mass) : mesh.ComputeOpenInertia(Mass)
+            : default;
         centerOfMass = Vector3.Zero;
         //if (_containerComponent is BodyMeshContainerComponent _b)
         //{

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
@@ -68,6 +68,10 @@ public class StaticComponent : CollidableComponent
         }
     }
 
+    /// <inheritdoc/>
+    /// <remarks> Statics are not affected by forces, <see cref="AttachInner"/> discards the inertia </remarks>
+    internal override bool ShouldCalculateInertia => false;
+
     protected override void AttachInner(NRigidPose pose, BodyInertia shapeInertia, TypedIndex shapeIndex)
     {
         Debug.Assert(Processor is not null);


### PR DESCRIPTION
# PR Details

`ICollider.TryAttach` computes the shape's inertia unconditionally, but only bodies read it - `StaticComponent.AttachInner` discards the `shapeInertia` parameter unread. The waste is real for the non-trivial colliders: `MeshCollider`'s inertia iterates over every triangle of the mesh, and `CompoundCollider` additionally combines and inverts its children's inertia tensors in `BuildDynamicCompound`.

This PR adds a `ShouldCalculateInertia` flag through the attach path so statics skip that work

## Related Issue

/

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**