### PR TITLE
Asset URL namespace + assets constants

### DIFF
--- a/build/Stride.slnx
+++ b/build/Stride.slnx
@@ -70,10 +70,11 @@
     <Project Path="../sources/core/Stride.Core.CompilerServices.Tests/Stride.Core.CompilerServices.Tests.csproj" />
     <Project Path="../sources/core/Stride.Core.Mathematics.Tests/Stride.Core.Mathematics.Tests.csproj" />
     <Project Path="../sources/core/Stride.Core.Tests/Stride.Core.Tests.csproj">
-      <BuildType Solution="Release|Any CPU" Project="Debug" />
+      <BuildType Project="Debug" />
     </Project>
   </Folder>
   <Folder Name="/20-StrideRuntime/">
+    <Project Path="../sources/engine/Stride.Assets.Generators/Stride.Assets.Generators.csproj" />
     <Project Path="../sources/engine/Stride.Audio/Stride.Audio.csproj" />
     <Project Path="../sources/engine/Stride.Engine/Stride.Engine.csproj" />
     <Project Path="../sources/engine/Stride.Foundation/Stride.Foundation.csproj" />

--- a/sources/assets/Stride.AssetCompiler/BundlePacker.cs
+++ b/sources/assets/Stride.AssetCompiler/BundlePacker.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Stride.Core.Assets;
+using Stride.Core.Assets.Selectors;
 using Stride.Core.Diagnostics;
 using Stride.Core.IO;
 using Stride.Core.Serialization;
@@ -48,8 +49,27 @@ namespace Stride.AssetCompiler
                 // Prepare list of bundles gathered from all projects
                 var bundles = new List<Bundle>();
 
+                var assetNamespaces = new HashSet<string>(
+                    packageSession.Packages.Select(p => p.Container.AssetNamespace).Where(ns => ns != null),
+                    StringComparer.OrdinalIgnoreCase);
                 foreach (var project in packageSession.Packages)
                 {
+                    // Anchored selector patterns are authored package-relative; root them like the
+                    // package's URLs (unanchored gitignore patterns match at any segment already).
+                    // A pattern already qualified with a session namespace is left as-is: it anchors
+                    // at that package, and the transform stays idempotent.
+                    if (project.Container.AssetNamespace is { } assetNamespace)
+                    {
+                        foreach (var pathSelector in project.Bundles.SelectMany(b => b.Selectors).OfType<PathSelector>())
+                        {
+                            for (int i = 0; i < pathSelector.Paths.Count; i++)
+                            {
+                                var path = pathSelector.Paths[i];
+                                if (path.StartsWith('/') && !assetNamespaces.Contains(FirstSegment(path)))
+                                    pathSelector.Paths[i] = "/" + assetNamespace + path;
+                            }
+                        }
+                    }
                     bundles.AddRange(project.Bundles);
                 }
 
@@ -369,6 +389,12 @@ namespace Stride.AssetCompiler
             {
                 CollectBundle(databaseFileProvider, resolvedBundle, reference);
             }
+        }
+
+        private static string FirstSegment(string rootedPath)
+        {
+            var end = rootedPath.IndexOf('/', 1);
+            return end < 0 ? rootedPath.Substring(1) : rootedPath.Substring(1, end - 1);
         }
 
         /// <summary>

--- a/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
@@ -200,8 +200,8 @@ namespace Stride.AssetCompiler
         /// <summary>
         /// Writes the bare-to-canonical URL alias table (data/db/aliases) implementing using
         /// semantics: the root package's own namespace is implicitly in scope, other namespaces
-        /// enter via the projects' declared usings. The root package wins bare-name collisions;
-        /// colliding imports get no alias.
+        /// enter via the projects' declared usings or their own global-using declaration. The root
+        /// package wins bare-name collisions; colliding imports get no alias.
         /// </summary>
         private static void WriteContentAliases(ILogger logger, PackageSession projectSession, Package rootPackage, string outputDirectory)
         {
@@ -213,7 +213,7 @@ namespace Stride.AssetCompiler
                 if (scopedPackage.Container.AssetNamespace is not { } assetNamespace)
                     continue;
                 var isRoot = scopedPackage == rootPackage;
-                if (!isRoot && !projectSession.AssetNamespaceUsings.Contains(assetNamespace))
+                if (!isRoot && !projectSession.AssetNamespaceUsings.Contains(assetNamespace) && !scopedPackage.Container.AssetNamespaceGlobalUsing)
                     continue;
 
                 var namespaceRoot = "/" + assetNamespace;

--- a/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
@@ -199,21 +199,30 @@ namespace Stride.AssetCompiler
 
         /// <summary>
         /// Writes the bare-to-canonical URL alias table (data/db/aliases) implementing using
-        /// semantics: the root package's own namespace is implicitly in scope, other namespaces
-        /// enter via the projects' declared usings or their own global-using declaration. The root
-        /// package wins bare-name collisions; colliding imports get no alias.
+        /// semantics: the built game's own namespaces are implicitly in scope (the root package,
+        /// plus the chain package owning GameSettings when the root is a platform head), other
+        /// namespaces enter via the projects' declared usings or their own global-using
+        /// declaration. Self wins bare-name collisions; colliding imports get no alias.
         /// </summary>
         private static void WriteContentAliases(ILogger logger, PackageSession projectSession, Package rootPackage, string outputDirectory)
         {
+            var selfPackages = new HashSet<Package> { rootPackage };
+            foreach (var sessionPackage in projectSession.Packages)
+            {
+                if (sessionPackage.Container is not StandalonePackage { IsDependencyPackage: true }
+                    && sessionPackage.Assets.Any(a => a.Asset is GameSettingsAsset))
+                    selfPackages.Add(sessionPackage);
+            }
+
             var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
-            var rootAliases = new HashSet<string>(StringComparer.Ordinal);
+            var selfAliases = new HashSet<string>(StringComparer.Ordinal);
             var ambiguous = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var scopedPackage in projectSession.Packages.OrderBy(p => p == rootPackage ? 0 : 1))
+            foreach (var scopedPackage in projectSession.Packages.OrderBy(p => selfPackages.Contains(p) ? 0 : 1))
             {
                 if (scopedPackage.Container.AssetNamespace is not { } assetNamespace)
                     continue;
-                var isRoot = scopedPackage == rootPackage;
-                if (!isRoot && !projectSession.AssetNamespaceUsings.Contains(assetNamespace) && !scopedPackage.Container.AssetNamespaceGlobalUsing)
+                var isSelf = selfPackages.Contains(scopedPackage);
+                if (!isSelf && !projectSession.AssetNamespaceUsings.Contains(assetNamespace))
                     continue;
 
                 var namespaceRoot = "/" + assetNamespace;
@@ -229,9 +238,9 @@ namespace Stride.AssetCompiler
                     {
                         if (existing == canonical)
                             continue;
-                        if (rootAliases.Contains(bare))
+                        if (selfAliases.Contains(bare))
                         {
-                            logger.Warning($"Bare asset URL [{bare}] resolves to the root package's [{existing}]; qualify [{canonical}] explicitly to load it.");
+                            logger.Warning($"Bare asset URL [{bare}] resolves to the game's own [{existing}]; qualify [{canonical}] explicitly to load it.");
                         }
                         else
                         {
@@ -242,8 +251,8 @@ namespace Stride.AssetCompiler
                         continue;
                     }
                     aliases.Add(bare, canonical);
-                    if (isRoot)
-                        rootAliases.Add(bare);
+                    if (isSelf)
+                        selfAliases.Add(bare);
                 }
             }
 

--- a/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
@@ -175,6 +175,8 @@ namespace Stride.AssetCompiler
                 var bundleFiles = new List<string>();
                 bundlePacker.Build(builderOptions.Logger, projectSession, package, indexName, outputDirectory, builder.DisableCompressionIds, context.GetCompilationMode() != CompilationMode.AppStore, bundleFiles);
 
+                WriteContentAliases(builderOptions.Logger, projectSession, package, outputDirectory);
+
                 // Only write the up-to-date marker on success — otherwise MSBuild's Inputs/Outputs
                 // check on StrideCompileAsset would skip re-running CompilerApp next build, leaving
                 // the partial bundle in place and silently packing it into the APK.
@@ -192,6 +194,68 @@ namespace Stride.AssetCompiler
 
                 // Make sure that MSBuild doesn't hold anything else
                 VSProjectHelper.Reset();
+            }
+        }
+
+        /// <summary>
+        /// Writes the bare-to-canonical URL alias table (data/db/aliases) implementing using
+        /// semantics: the root package's own namespace is implicitly in scope, other namespaces
+        /// enter via the projects' declared usings. The root package wins bare-name collisions;
+        /// colliding imports get no alias.
+        /// </summary>
+        private static void WriteContentAliases(ILogger logger, PackageSession projectSession, Package rootPackage, string outputDirectory)
+        {
+            var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
+            var rootAliases = new HashSet<string>(StringComparer.Ordinal);
+            var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var scopedPackage in projectSession.Packages.OrderBy(p => p == rootPackage ? 0 : 1))
+            {
+                if (scopedPackage.Container.AssetNamespace is not { } assetNamespace)
+                    continue;
+                var isRoot = scopedPackage == rootPackage;
+                if (!isRoot && !projectSession.AssetNamespaceUsings.Contains(assetNamespace))
+                    continue;
+
+                var namespaceRoot = "/" + assetNamespace;
+                foreach (var assetItem in scopedPackage.Assets)
+                {
+                    if (!assetItem.Location.IsAbsolute)
+                        continue;
+                    var canonical = assetItem.Location.FullPath;
+                    var bare = assetItem.Location.MakeRelative(namespaceRoot).FullPath;
+                    if (ambiguous.Contains(bare))
+                        continue;
+                    if (aliases.TryGetValue(bare, out var existing))
+                    {
+                        if (existing == canonical)
+                            continue;
+                        if (rootAliases.Contains(bare))
+                        {
+                            logger.Warning($"Bare asset URL [{bare}] resolves to the root package's [{existing}]; qualify [{canonical}] explicitly to load it.");
+                        }
+                        else
+                        {
+                            aliases.Remove(bare);
+                            ambiguous.Add(bare);
+                            logger.Warning($"Bare asset URL [{bare}] is ambiguous between [{existing}] and [{canonical}]; qualify it explicitly.");
+                        }
+                        continue;
+                    }
+                    aliases.Add(bare, canonical);
+                    if (isRoot)
+                        rootAliases.Add(bare);
+                }
+            }
+
+            var aliasesFile = Path.Combine(outputDirectory, "db", "aliases");
+            if (aliases.Count > 0)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(aliasesFile));
+                File.WriteAllLines(aliasesFile, aliases.OrderBy(x => x.Key, StringComparer.Ordinal).Select(x => $"{x.Key}|{x.Value}"));
+            }
+            else if (File.Exists(aliasesFile))
+            {
+                File.Delete(aliasesFile);
             }
         }
 

--- a/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
@@ -113,6 +113,13 @@ namespace Stride.AssetCompiler
                 // Redirect ApplicationCache to the build directory so shader caches are per-project
                 ((FileSystemProvider)VirtualFileSystem.ApplicationCache).ChangeBasePath(Path.Combine(buildDirectory, "cache"));
 
+                // Swap replaced assets' content in the build session, so that id- and URL-based
+                // resolution (including compile-time content baking) use the replacement
+                var selfPackages = GetSelfPackages(projectSession, package);
+                if (!AssetReplacementAnalysis.TryCollect(package, selfPackages, builderOptions.Logger, out var assetReplacements))
+                    return BuildResultCode.BuildError;
+                AssetReplacementAnalysis.Substitute(assetReplacements);
+
                 // Process game settings asset
                 var gameSettingsAsset = package.GetGameSettingsAsset();
                 if (gameSettingsAsset == null)
@@ -175,13 +182,13 @@ namespace Stride.AssetCompiler
                 var bundleFiles = new List<string>();
                 bundlePacker.Build(builderOptions.Logger, projectSession, package, indexName, outputDirectory, builder.DisableCompressionIds, context.GetCompilationMode() != CompilationMode.AppStore, bundleFiles);
 
-                WriteContentAliases(builderOptions.Logger, projectSession, package, outputDirectory);
+                var aliasesFile = WriteContentAliases(builderOptions.Logger, projectSession, selfPackages, outputDirectory);
 
                 // Only write the up-to-date marker on success — otherwise MSBuild's Inputs/Outputs
                 // check on StrideCompileAsset would skip re-running CompilerApp next build, leaving
                 // the partial bundle in place and silently packing it into the APK.
                 if (result == BuildResultCode.Successful && builderOptions.MSBuildUpToDateCheckFileBase != null)
-                    SaveBuildUpToDateFile(builderOptions.MSBuildUpToDateCheckFileBase, builderOptions.PackageFile, package, bundleFiles);
+                    SaveBuildUpToDateFile(builderOptions.MSBuildUpToDateCheckFileBase, builderOptions.PackageFile, package, bundleFiles, aliasesFile);
 
                 return result;
             }
@@ -198,13 +205,10 @@ namespace Stride.AssetCompiler
         }
 
         /// <summary>
-        /// Writes the bare-to-canonical URL alias table (data/db/aliases) implementing using
-        /// semantics: the built game's own namespaces are implicitly in scope (the root package,
-        /// plus the chain package owning GameSettings when the root is a platform head), other
-        /// namespaces enter via the projects' declared usings or their own global-using
-        /// declaration. Self wins bare-name collisions; colliding imports get no alias.
+        /// The built game's own packages: the root package, plus non-dependency packages owning
+        /// GameSettings (the chain package when the root is a platform head).
         /// </summary>
-        private static void WriteContentAliases(ILogger logger, PackageSession projectSession, Package rootPackage, string outputDirectory)
+        private static HashSet<Package> GetSelfPackages(PackageSession projectSession, Package rootPackage)
         {
             var selfPackages = new HashSet<Package> { rootPackage };
             foreach (var sessionPackage in projectSession.Packages)
@@ -213,7 +217,17 @@ namespace Stride.AssetCompiler
                     && sessionPackage.Assets.Any(a => a.Asset is GameSettingsAsset))
                     selfPackages.Add(sessionPackage);
             }
+            return selfPackages;
+        }
 
+        /// <summary>
+        /// Writes the bare-to-canonical URL alias table (data/db/aliases) implementing using
+        /// semantics: self namespaces are implicitly in scope, others enter via declared usings or
+        /// their own global-using declaration. Self wins bare-name collisions; colliding imports
+        /// get no alias.
+        /// </summary>
+        private static string WriteContentAliases(ILogger logger, PackageSession projectSession, HashSet<Package> selfPackages, string outputDirectory)
+        {
             var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
             var selfAliases = new HashSet<string>(StringComparer.Ordinal);
             var ambiguous = new HashSet<string>(StringComparer.Ordinal);
@@ -256,22 +270,22 @@ namespace Stride.AssetCompiler
                 }
             }
 
+            // Always written (empty when no aliases) so it can be tracked as a build output
             var aliasesFile = Path.Combine(outputDirectory, "db", "aliases");
-            if (aliases.Count > 0)
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(aliasesFile));
-                File.WriteAllLines(aliasesFile, aliases.OrderBy(x => x.Key, StringComparer.Ordinal).Select(x => $"{x.Key}|{x.Value}"));
-            }
-            else if (File.Exists(aliasesFile))
-            {
-                File.Delete(aliasesFile);
-            }
+            Directory.CreateDirectory(Path.GetDirectoryName(aliasesFile));
+            File.WriteAllLines(aliasesFile, aliases.OrderBy(x => x.Key, StringComparer.Ordinal).Select(x => $"{x.Key}|{x.Value}"));
+            return aliasesFile;
         }
 
-        private void SaveBuildUpToDateFile(string msbuildUpToDateCheckFileBase, string packageFile, Package rootPackage, List<string> bundleFiles)
+        private void SaveBuildUpToDateFile(string msbuildUpToDateCheckFileBase, string packageFile, Package rootPackage, List<string> bundleFiles, string aliasesFile)
         {
             var inputs = new List<string>();
             var outputs = new List<string>();
+
+            // Namespace and usings declarations live only in the manifests (rewritten on change only,
+            // so timestamps are stable)
+            foreach (var manifest in rootPackage.Session.LoadedBuildManifests)
+                inputs.Add(new UFile(manifest).ToOSPath());
 
             // List asset folders from projects
             foreach (var package in rootPackage.Session.Packages)
@@ -324,6 +338,7 @@ namespace Stride.AssetCompiler
             {
                 outputs.Add(bundleFile);
             }
+            outputs.Add(aliasesFile);
 
             // Generate MSBuild up-to-date check property files
             File.WriteAllLines(msbuildUpToDateCheckFileBase + ".inputs", inputs, Encoding.UTF8);

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -116,6 +116,7 @@ namespace Stride.AssetCompiler
                 { "server=", "This Compiler is launched as a server", v => { } },
                 { "graphics-api=", "Graphics API to load (Direct3D11|Direct3D12|Vulkan). Applied at startup by GraphicsApiSelector.", v => { } },
                 { "pack-asset-assembly=", "Host-loadable asset assembly (package-relative path) to declare in the packed sdpkg; repeat for each", v => options.PackAssetAssemblies.Add(v) },
+                { "pack-asset-namespace=", "Asset URL namespace declaration to resolve into the packed sdpkg (true/false/name)", v => options.PackAssetNamespace = v },
                 { "t|threads=", "Number of threads to create. Default value is the number of hardware threads available.", v => options.ThreadCount = int.Parse(v) },
                 { "test=", "Run a test session.", v => options.TestName = v },
                 { "no-backup", "Upgrade verb only: skip backing up the files the upgrade overwrites (backup is on by default).", v => options.NoBackup = v != null },
@@ -393,7 +394,7 @@ namespace Stride.AssetCompiler
                     var intermediatePackagePath = options.BuildDirectory;
                     var generatedItems = new List<(string SourcePath, string PackagePath)>();
                     var logger = new LoggerResult();
-                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies))
+                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace))
                     {
                         foreach (var message in logger.Messages)
                         {

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -394,7 +394,7 @@ namespace Stride.AssetCompiler
                     var intermediatePackagePath = options.BuildDirectory;
                     var generatedItems = new List<(string SourcePath, string PackagePath)>();
                     var logger = new LoggerResult();
-                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace, defaultAssetNamespace: true))
+                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace, defaultAssetNamespace: true, options.PackAssetNamespaceGlobalUsing))
                     {
                         foreach (var message in logger.Messages)
                         {

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -394,7 +394,7 @@ namespace Stride.AssetCompiler
                     var intermediatePackagePath = options.BuildDirectory;
                     var generatedItems = new List<(string SourcePath, string PackagePath)>();
                     var logger = new LoggerResult();
-                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace, defaultAssetNamespace: true, options.PackAssetNamespaceGlobalUsing))
+                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace))
                     {
                         foreach (var message in logger.Messages)
                         {

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -394,7 +394,7 @@ namespace Stride.AssetCompiler
                     var intermediatePackagePath = options.BuildDirectory;
                     var generatedItems = new List<(string SourcePath, string PackagePath)>();
                     var logger = new LoggerResult();
-                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace))
+                    if (!PackAssetsHelper.Run(logger, csprojFile, intermediatePackagePath, generatedItems, options.PackAssetAssemblies, options.PackAssetNamespace, defaultAssetNamespace: true))
                     {
                         foreach (var message in logger.Messages)
                         {

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderOptions.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderOptions.cs
@@ -28,6 +28,7 @@ namespace Stride.AssetCompiler
         public string PackageFile { get; set; }
         public string PackageManifestFile { get; set; }
         public List<string> PackAssetAssemblies = new List<string>();
+        public string PackAssetNamespace { get; set; }
         public string MSBuildUpToDateCheckFileBase { get; set; }
         public List<string> MonitorPipeNames = new List<string>();
         public bool EnableFileLogging;

--- a/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
+++ b/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
@@ -17,7 +17,7 @@ namespace Stride.AssetCompiler.Tasks
 {
     public static class PackAssetsHelper
     {
-        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null)
+        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null, bool defaultAssetNamespace = false)
         {
             var package = Package.Load(logger, projectFile, new PackageLoadParameters()
             {
@@ -225,7 +225,22 @@ namespace Stride.AssetCompiler.Tasks
                 newPackage.RootAssets.Add(rootAsset);
 
             // Packed sdpkg stores the resolved namespace name, never the true/false sentinels.
-            newPackage.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace ?? package.AssetNamespace, package.Meta.Name);
+            // When the caller enables defaulting, an undeclared asset-carrying package defaults to
+            // namespaced (library default), except a game (has GameSettings) where the right choice
+            // isn't obvious: demand an explicit one.
+            var assetNamespaceDeclaration = !string.IsNullOrEmpty(assetNamespace) ? assetNamespace : package.AssetNamespace;
+            if (defaultAssetNamespace && assetNamespaceDeclaration is null && assets.Count > 0)
+            {
+                // Matches GameSettingsAsset.FileExtension (engine assembly, not referenced here)
+                if (assets.Any(a => string.Equals(a.FilePath.GetFileExtension(), ".sdgamesettings", StringComparison.OrdinalIgnoreCase)))
+                    logger.Error($"Package [{package.Meta.Name}] contains assets and a GameSettings asset but does not set StrideAssetNamespace; packing a game requires an explicit choice (true = asset URLs rooted /{package.Meta.Name}/, false = keep bare URLs).");
+                else
+                {
+                    assetNamespaceDeclaration = "true";
+                    logger.Info($"Package [{package.Meta.Name}] contains assets; defaulting StrideAssetNamespace to true (asset URLs rooted /{package.Meta.Name}/). Set it explicitly to silence this message.");
+                }
+            }
+            newPackage.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespaceDeclaration, package.Meta.Name);
 
             // Host-loadable asset assemblies, stored relative to the packed sdpkg (at stride/X.sdpkg).
             // Each path is lib/<tfm>/<name>.dll (built by the pack target); tag the entry with its TFM

--- a/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
+++ b/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
@@ -17,7 +17,7 @@ namespace Stride.AssetCompiler.Tasks
 {
     public static class PackAssetsHelper
     {
-        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null)
+        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null)
         {
             var package = Package.Load(logger, projectFile, new PackageLoadParameters()
             {
@@ -223,6 +223,9 @@ namespace Stride.AssetCompiler.Tasks
 
             foreach (var rootAsset in package.RootAssets)
                 newPackage.RootAssets.Add(rootAsset);
+
+            // Packed sdpkg stores the resolved namespace name, never the true/false sentinels.
+            newPackage.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace ?? package.AssetNamespace, package.Meta.Name);
 
             // Host-loadable asset assemblies, stored relative to the packed sdpkg (at stride/X.sdpkg).
             // Each path is lib/<tfm>/<name>.dll (built by the pack target); tag the entry with its TFM

--- a/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
+++ b/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
@@ -17,7 +17,7 @@ namespace Stride.AssetCompiler.Tasks
 {
     public static class PackAssetsHelper
     {
-        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null, bool defaultAssetNamespace = false, string assetNamespaceGlobalUsing = null)
+        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null)
         {
             var package = Package.Load(logger, projectFile, new PackageLoadParameters()
             {
@@ -224,30 +224,10 @@ namespace Stride.AssetCompiler.Tasks
             foreach (var rootAsset in package.RootAssets)
                 newPackage.RootAssets.Add(rootAsset);
 
-            // Packed sdpkg stores the resolved namespace name, never the true/false sentinels.
-            // When the caller enables defaulting, an undeclared asset-carrying package defaults to
-            // namespaced (library default), except a game (has GameSettings) where the right choice
-            // isn't obvious: demand an explicit one.
-            // Matches GameSettingsAsset.FileExtension (engine assembly, not referenced here)
-            var hasGameSettings = assets.Any(a => string.Equals(a.FilePath.GetFileExtension(), ".sdgamesettings", StringComparison.OrdinalIgnoreCase));
+            // Packed sdpkg stores the resolved namespace name (default = the authored package name),
+            // never sentinels: the packed name is authoritative for consumers.
             var assetNamespaceDeclaration = !string.IsNullOrEmpty(assetNamespace) ? assetNamespace : package.AssetNamespace;
-            if (defaultAssetNamespace && assetNamespaceDeclaration is null && assets.Count > 0)
-            {
-                if (hasGameSettings)
-                    logger.Error($"Package [{package.Meta.Name}] contains assets and a GameSettings asset but does not set StrideAssetNamespace; packing a game requires an explicit choice (true = asset URLs rooted /{package.Meta.Name}/, false = keep bare URLs).");
-                else
-                {
-                    assetNamespaceDeclaration = "true";
-                    logger.Info($"Package [{package.Meta.Name}] contains assets; defaulting StrideAssetNamespace to true (asset URLs rooted /{package.Meta.Name}/). Set it explicitly to silence this message.");
-                }
-            }
             newPackage.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespaceDeclaration, package.Meta.Name);
-
-            // Converted games default to global-using: their compiled code may hold bare URL strings.
-            var globalUsingDeclaration = !string.IsNullOrEmpty(assetNamespaceGlobalUsing) ? assetNamespaceGlobalUsing
-                : package.AssetNamespaceGlobalUsing ? "true" : null;
-            newPackage.AssetNamespaceGlobalUsing = newPackage.AssetNamespace is not null
-                && (globalUsingDeclaration is null ? hasGameSettings : string.Equals(globalUsingDeclaration, "true", StringComparison.OrdinalIgnoreCase));
 
             // Host-loadable asset assemblies, stored relative to the packed sdpkg (at stride/X.sdpkg).
             // Each path is lib/<tfm>/<name>.dll (built by the pack target); tag the entry with its TFM

--- a/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
+++ b/sources/assets/Stride.AssetCompiler/Tasks/PackAssets.cs
@@ -17,7 +17,7 @@ namespace Stride.AssetCompiler.Tasks
 {
     public static class PackAssetsHelper
     {
-        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null, bool defaultAssetNamespace = false)
+        public static bool Run(Core.Diagnostics.Logger logger, string projectFile, string intermediatePackagePath, List<(string SourcePath, string PackagePath)> generatedItems, IReadOnlyList<string> assetAssemblies = null, string assetNamespace = null, bool defaultAssetNamespace = false, string assetNamespaceGlobalUsing = null)
         {
             var package = Package.Load(logger, projectFile, new PackageLoadParameters()
             {
@@ -228,11 +228,12 @@ namespace Stride.AssetCompiler.Tasks
             // When the caller enables defaulting, an undeclared asset-carrying package defaults to
             // namespaced (library default), except a game (has GameSettings) where the right choice
             // isn't obvious: demand an explicit one.
+            // Matches GameSettingsAsset.FileExtension (engine assembly, not referenced here)
+            var hasGameSettings = assets.Any(a => string.Equals(a.FilePath.GetFileExtension(), ".sdgamesettings", StringComparison.OrdinalIgnoreCase));
             var assetNamespaceDeclaration = !string.IsNullOrEmpty(assetNamespace) ? assetNamespace : package.AssetNamespace;
             if (defaultAssetNamespace && assetNamespaceDeclaration is null && assets.Count > 0)
             {
-                // Matches GameSettingsAsset.FileExtension (engine assembly, not referenced here)
-                if (assets.Any(a => string.Equals(a.FilePath.GetFileExtension(), ".sdgamesettings", StringComparison.OrdinalIgnoreCase)))
+                if (hasGameSettings)
                     logger.Error($"Package [{package.Meta.Name}] contains assets and a GameSettings asset but does not set StrideAssetNamespace; packing a game requires an explicit choice (true = asset URLs rooted /{package.Meta.Name}/, false = keep bare URLs).");
                 else
                 {
@@ -241,6 +242,12 @@ namespace Stride.AssetCompiler.Tasks
                 }
             }
             newPackage.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespaceDeclaration, package.Meta.Name);
+
+            // Converted games default to global-using: their compiled code may hold bare URL strings.
+            var globalUsingDeclaration = !string.IsNullOrEmpty(assetNamespaceGlobalUsing) ? assetNamespaceGlobalUsing
+                : package.AssetNamespaceGlobalUsing ? "true" : null;
+            newPackage.AssetNamespaceGlobalUsing = newPackage.AssetNamespace is not null
+                && (globalUsingDeclaration is null ? hasGameSettings : string.Equals(globalUsingDeclaration, "true", StringComparison.OrdinalIgnoreCase));
 
             // Host-loadable asset assemblies, stored relative to the packed sdpkg (at stride/X.sdpkg).
             // Each path is lib/<tfm>/<name>.dll (built by the pack target); tag the entry with its TFM

--- a/sources/assets/Stride.AssetCompiler/build/Stride.AssetCompiler.targets
+++ b/sources/assets/Stride.AssetCompiler/build/Stride.AssetCompiler.targets
@@ -332,9 +332,12 @@
     <PropertyGroup Condition="'$(StrideContainsAssetTypes)' == 'true'">
       <_StridePackAssetAssembliesArg>@(_StrideHostAssetAssembly->' --pack-asset-assembly=&quot;%(Identity)&quot;', '')</_StridePackAssetAssembliesArg>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(StrideAssetNamespace)' != ''">
+      <_StridePackAssetNamespaceArg> --pack-asset-namespace=&quot;$(StrideAssetNamespace)&quot;</_StridePackAssetNamespaceArg>
+    </PropertyGroup>
     <Error Condition="'$(StrideContainsAssetTypes)' == 'true' And '@(_StrideHostAssetAssembly)' == ''"
            Text="StrideContainsAssetTypes=true but none of the target framework(s) '$(TargetFrameworks)$(TargetFramework)' is host-compatible: the asset compiler needs a base netX.0 or net*-windows* build to load. A mobile-only asset package can't ship a host-loadable assembly." />
-    <Exec Command="dotnet &quot;$(StrideCompileAssetCommand)&quot; pack &quot;$(MSBuildProjectFullPath)&quot; --build-path=&quot;$(ProjectDir)$(BaseIntermediateOutputPath)stride\pack&quot;$(_StridePackAssetAssembliesArg)" ConsoleToMsBuild="true">
+    <Exec Command="dotnet &quot;$(StrideCompileAssetCommand)&quot; pack &quot;$(MSBuildProjectFullPath)&quot; --build-path=&quot;$(ProjectDir)$(BaseIntermediateOutputPath)stride\pack&quot;$(_StridePackAssetAssembliesArg)$(_StridePackAssetNamespaceArg)" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" ItemName="PackAssetsLine" />
     </Exec>
     <ItemGroup>

--- a/sources/assets/Stride.Core.Assets.Quantum.Tests/Helpers/Types.cs
+++ b/sources/assets/Stride.Core.Assets.Quantum.Tests/Helpers/Types.cs
@@ -129,7 +129,7 @@ public static class Types
 
         public List<MyReferenceable> References { get; set; } = [];
 
-        public static int MemberCount => 4 + 3; // 4 (number of members in Asset) + 3 (number of members in Types.MyAssetWithRef2)
+        public static int MemberCount => 5 + 3; // 5 (number of members in Asset) + 3 (number of members in Types.MyAssetWithRef2)
     }
 
     [DataContract]

--- a/sources/assets/Stride.Core.Assets.Tests/TestAssetReplacement.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestAssetReplacement.cs
@@ -1,0 +1,198 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Stride.Core;
+using Stride.Core.Assets.Analysis;
+using Stride.Core.Diagnostics;
+using Stride.Core.IO;
+
+namespace Stride.Core.Assets.Tests
+{
+    public class TestAssetReplacement
+    {
+        private static (PackageSession Session, Package Game, Package Plugin) CreateSessionWithPlugin()
+        {
+            var session = new PackageSession();
+
+            var pluginPackage = new Package();
+            pluginPackage.Meta.Name = "Plugin";
+            session.Projects.Add(new StandalonePackage(pluginPackage) { IsDependencyPackage = true });
+
+            var gamePackage = new Package();
+            var game = new SolutionProject(gamePackage, Guid.NewGuid(), "MyGame.csproj") { AssetNamespace = "MyGame" };
+            session.Projects.Add(game);
+            game.FlattenedDependencies.Add(new Dependency(pluginPackage));
+
+            return (session, gamePackage, pluginPackage);
+        }
+
+        private static Package AddPlugin(Package gamePackage, string name)
+        {
+            var pluginPackage = new Package();
+            pluginPackage.Meta.Name = name;
+            gamePackage.Session.Projects.Add(new StandalonePackage(pluginPackage) { IsDependencyPackage = true });
+            gamePackage.Container.FlattenedDependencies.Add(new Dependency(pluginPackage));
+            return pluginPackage;
+        }
+
+        [Fact]
+        public void TestReplacementCollectedAndSubstituted()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var target = new AssetItem("Logo", new AssetObjectTest { Name = "Original" });
+            plugin.Assets.Add(target);
+            var targetId = target.Id;
+            var replacement = new AssetItem("Overrides/Logo", new AssetObjectTest { Name = "Replacement", Replaces = new UFile("/Plugin/Logo") });
+            game.Assets.Add(replacement);
+
+            var logger = new LoggerResult();
+            Assert.True(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out var replacements));
+            Assert.False(logger.HasErrors);
+            var entry = Assert.Single(replacements);
+            Assert.Equal(targetId, entry.Target.Id);
+            Assert.Equal(replacement.Id, entry.Replacement.Id);
+
+            AssetReplacementAnalysis.Substitute(replacements);
+
+            // The replaced asset keeps its identity (id and location) but carries the replacement's content
+            var substituted = game.FindAsset(new UFile("/Plugin/Logo"));
+            Assert.NotNull(substituted);
+            Assert.Equal(targetId, substituted.Id);
+            Assert.Equal(targetId, substituted.Asset.Id);
+            Assert.Equal("Replacement", ((AssetObjectTest)substituted.Asset).Name);
+            Assert.NotSame(replacement.Asset, substituted.Asset);
+            // The clone must not carry the declaration (it would point at its own location)
+            Assert.Null(substituted.Asset.Replaces);
+            // The replacement asset itself is untouched at its own URL
+            var replacementItem = game.FindAsset(new UFile("/MyGame/Overrides/Logo"));
+            Assert.NotNull(replacementItem);
+            Assert.Equal(replacement.Id, replacementItem.Id);
+        }
+
+        [Fact]
+        public void TestReplacementMissingTargetFails()
+        {
+            var (_, game, _) = CreateSessionWithPlugin();
+            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/DoesNotExist") }));
+
+            var logger = new LoggerResult();
+            Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
+            Assert.True(logger.HasErrors);
+        }
+
+        [Fact]
+        public void TestReplacementTypeMismatchFails()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
+            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTestSub { Replaces = new UFile("/Plugin/Logo") }));
+
+            var logger = new LoggerResult();
+            Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
+            Assert.True(logger.HasErrors);
+        }
+
+        [Fact]
+        public void TestReplacementOfSelfFails()
+        {
+            var (_, game, _) = CreateSessionWithPlugin();
+            game.Assets.Add(new AssetItem("Logo", new AssetObjectTest { Replaces = new UFile("/MyGame/Logo") }));
+
+            var logger = new LoggerResult();
+            Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
+            Assert.True(logger.HasErrors);
+        }
+
+        [Fact]
+        public void TestReplacementOfSourceCodeAssetFails()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            plugin.Assets.Add(new AssetItem("Effect", new SourceCodeAssetTest()));
+            game.Assets.Add(new AssetItem("Overrides/Effect", new SourceCodeAssetTest { Replaces = new UFile("/Plugin/Effect") }));
+
+            var logger = new LoggerResult();
+            Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
+            Assert.True(logger.HasErrors);
+        }
+
+        [Fact]
+        public void TestDerivedReplacementDoesNotSelfReference()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var target = new AssetItem("Logo", new AssetObjectTest { Name = "Original" });
+            plugin.Assets.Add(target);
+
+            // The editor's "Create replacing asset" derives from the target (archetype -> target)
+            var derived = target.CreateDerivedAsset();
+            derived.Replaces = new UFile("/Plugin/Logo");
+            var replacement = new AssetItem("Overrides/Logo", derived);
+            game.Assets.Add(replacement);
+
+            var logger = new LoggerResult();
+            Assert.True(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out var replacements));
+            AssetReplacementAnalysis.Substitute(replacements);
+
+            // The substituted clone carries the target's id: keeping the archetype would make it
+            // reference itself
+            var substituted = game.FindAsset(new UFile("/Plugin/Logo"));
+            Assert.NotNull(substituted);
+            Assert.Equal(target.Id, substituted.Id);
+            Assert.Null(substituted.Asset.Archetype);
+            // The authored replacer keeps its archetype (editor inheritance is untouched)
+            Assert.NotNull(game.FindAsset(new UFile("/MyGame/Overrides/Logo")).Asset.Archetype);
+        }
+
+        [Fact]
+        public void TestChainedReplacementFails()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var plugin2 = AddPlugin(game, "Plugin2");
+            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
+            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
+            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin2/Fixups/Logo") }));
+
+            var logger = new LoggerResult();
+            Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
+            Assert.True(logger.HasErrors);
+        }
+
+        [Fact]
+        public void TestRootPackageReplacementWinsOverDependency()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var plugin2 = AddPlugin(game, "Plugin2");
+            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
+            var gameReplacement = new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") });
+            game.Assets.Add(gameReplacement);
+            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
+
+            var logger = new LoggerResult();
+            Assert.True(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out var replacements));
+            Assert.False(logger.HasErrors);
+            Assert.Equal(gameReplacement.Id, Assert.Single(replacements).Replacement.Id);
+        }
+
+        [Fact]
+        public void TestDuplicateReplacementSameScopeFails()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var plugin2 = AddPlugin(game, "Plugin2");
+            var plugin3 = AddPlugin(game, "Plugin3");
+            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
+            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
+            plugin3.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
+
+            var logger = new LoggerResult();
+            Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
+            Assert.True(logger.HasErrors);
+        }
+    }
+
+    [DataContract("!SourceCodeAssetTest")]
+    [AssetDescription(".sdsrctest")]
+    public class SourceCodeAssetTest : SourceCodeAsset
+    {
+    }
+}

--- a/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
@@ -116,6 +116,45 @@ namespace Stride.Core.Assets.Tests
         }
 
         [Fact]
+        public void TestNamespacedSaveRelativizesSamePrefixReferences()
+        {
+            var dirPath = Path.Combine(DirectoryTestBase, "TestNamespacedSaveRelativizesSamePrefixReferences");
+            if (Directory.Exists(dirPath))
+                Directory.Delete(dirPath, true);
+            Directory.CreateDirectory(dirPath);
+
+            var package = new Package { FullPath = Path.Combine(dirPath, "MyGame.sdpkg") };
+            package.AssetFolders.Add(new AssetFolder("Assets"));
+            var project = new SolutionProject(package, Guid.NewGuid(), Path.Combine(dirPath, "MyGame.csproj")) { AssetNamespace = "MyGame" };
+            var session = new PackageSession();
+            session.Projects.Add(project);
+
+            var target = new AssetItem("Target", new AssetObjectTest());
+            package.Assets.Add(target);
+            // Same-prefix references save bare; foreign prefixes stay rooted
+            var source = new AssetObjectTest();
+            var sourceItem = new AssetItem("Source", source);
+            package.Assets.Add(sourceItem);
+            source.Reference = new AssetReference(target.Id, target.Location);
+            sourceItem.IsDirty = true;
+            var other = new AssetObjectTest { Reference = new AssetReference(AssetId.New(), "/OtherPkg/Thing") };
+            var otherItem = new AssetItem("Other", other);
+            package.Assets.Add(otherItem);
+            otherItem.IsDirty = true;
+
+            var result = new LoggerResult();
+            session.Save(result);
+            Assert.False(result.HasErrors, string.Join("\n", result.Messages));
+
+            var sourceYaml = File.ReadAllText(Path.Combine(dirPath, "Assets", "Source.sdtest"));
+            Assert.Contains($"{target.Id}:Target", sourceYaml);
+            Assert.DoesNotContain("/MyGame/", sourceYaml);
+            Assert.Contains(":/OtherPkg/Thing", File.ReadAllText(Path.Combine(dirPath, "Assets", "Other.sdtest")));
+            // The in-memory reference stays canonical (the transform is write-only)
+            Assert.Equal("/MyGame/Target", source.Reference.Location);
+        }
+
+        [Fact]
         public void TestSaveKeepsAuthoredPackageName()
         {
             var dirPath = Path.Combine(DirectoryTestBase, "TestSaveKeepsAuthoredPackageName");

--- a/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
@@ -77,6 +77,45 @@ namespace Stride.Core.Assets.Tests
         }
 
         [Fact]
+        public void TestNamespacedAssetMoveDeletesOldFileOnSave()
+        {
+            var dirPath = Path.Combine(DirectoryTestBase, "TestNamespacedAssetMoveDeletesOldFileOnSave");
+            if (Directory.Exists(dirPath))
+                Directory.Delete(dirPath, true);
+            Directory.CreateDirectory(dirPath);
+
+            // A SolutionProject container (standalone packages are read-only, never saved) with a
+            // resolved namespace, like the editor loader produces.
+            var package = new Package { FullPath = Path.Combine(dirPath, "MyGame.sdpkg") };
+            package.AssetFolders.Add(new AssetFolder("Assets"));
+            var project = new SolutionProject(package, Guid.NewGuid(), Path.Combine(dirPath, "MyGame.csproj")) { AssetNamespace = "MyGame" };
+            var session = new PackageSession();
+            session.Projects.Add(project);
+            var assetItem = new AssetItem("Ground", new AssetObjectTest());
+            package.Assets.Add(assetItem);
+            assetItem.IsDirty = true;
+            Assert.Equal("/MyGame/Ground", assetItem.Location.FullPath);
+
+            var result = new LoggerResult();
+            session.Save(result);
+            Assert.False(result.HasErrors);
+            var oldFile = Path.Combine(dirPath, "Assets", "Ground.sdtest");
+            Assert.True(File.Exists(oldFile));
+
+            // Rename + move into a subfolder: the next save must delete the previous file at its
+            // bare disk path (the previous-state snapshot is a detached clone with rooted locations).
+            package.Assets.Remove(assetItem);
+            var movedItem = assetItem.Clone(newLocation: new UFile("Sub/Ground2"));
+            package.Assets.Add(movedItem);
+            movedItem.IsDirty = true;
+            result = new LoggerResult();
+            session.Save(result);
+            Assert.False(result.HasErrors, string.Join("\n", result.Messages));
+            Assert.False(File.Exists(oldFile));
+            Assert.True(File.Exists(Path.Combine(dirPath, "Assets", "Sub", "Ground2.sdtest")));
+        }
+
+        [Fact]
         public void TestSaveKeepsAuthoredPackageName()
         {
             var dirPath = Path.Combine(DirectoryTestBase, "TestSaveKeepsAuthoredPackageName");

--- a/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Diagnostics;
@@ -74,6 +74,30 @@ namespace Stride.Core.Assets.Tests
             Assert.True(project2.AssetFolders.Count > 0);
             var sourceFolder = project.AssetFolders.First().Path;
             Assert.Equal(sourceFolder, project2.AssetFolders.First().Path);
+        }
+
+        [Fact]
+        public void TestSaveKeepsAuthoredPackageName()
+        {
+            var dirPath = Path.Combine(DirectoryTestBase, "TestSaveKeepsAuthoredPackageName");
+            if (Directory.Exists(dirPath))
+                Directory.Delete(dirPath, true);
+            Directory.CreateDirectory(dirPath);
+
+            // The session renames Meta.Name to the csproj-derived identity; the authored name must
+            // survive a save (it is the package's namespace identity).
+            var package = new Package { FullPath = Path.Combine(dirPath, "MyGame.Game.sdpkg"), AuthoredName = "MyGame" };
+            package.Meta.Name = "MyGame.Game";
+            var project = new SolutionProject(package, Guid.NewGuid(), Path.Combine(dirPath, "MyGame.Game.csproj"));
+            var session = new PackageSession();
+            session.Projects.Add(project);
+            package.IsDirty = true;
+
+            var result = new LoggerResult();
+            session.Save(result);
+            Assert.False(result.HasErrors);
+            Assert.Matches(@"(?m)^\s*Name: MyGame\s*$", File.ReadAllText(package.FullPath));
+            Assert.Equal("MyGame.Game", package.Meta.Name);
         }
 
         [Fact]

--- a/sources/assets/Stride.Core.Assets/Analysis/AssetReplacementAnalysis.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/AssetReplacementAnalysis.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Diagnostics;
+
+namespace Stride.Core.Assets.Analysis;
+
+/// <summary>A validated <see cref="Asset.Replaces"/> declaration.</summary>
+public readonly record struct AssetReplacement(AssetItem Target, AssetItem Replacement);
+
+/// <summary>
+/// Build-time support for <see cref="Asset.Replaces"/>: validates the declarations visible from the
+/// root package, then substitutes each replaced asset's content in the build session so both
+/// compile-time baking and the compiled content index resolve to the replacement.
+/// </summary>
+public static class AssetReplacementAnalysis
+{
+    /// <summary>
+    /// Collects and validates the replacement declarations of <paramref name="rootPackage"/> and its
+    /// dependencies. When two packages replace the same URL, a declaration from
+    /// <paramref name="selfPackages"/> (the built game's own packages) wins over a dependency's;
+    /// other conflicts, missing targets and incompatible asset types are errors.
+    /// </summary>
+    /// <returns>false when any declaration is invalid (errors are logged).</returns>
+    public static bool TryCollect(Package rootPackage, IReadOnlySet<Package> selfPackages, ILogger logger, out List<AssetReplacement> replacements)
+    {
+        var replacementsByUrl = new Dictionary<string, AssetReplacement>(StringComparer.OrdinalIgnoreCase);
+        var success = true;
+
+        foreach (var package in rootPackage.GetPackagesWithDependencies())
+        {
+            foreach (var assetItem in package.Assets)
+            {
+                if (assetItem.Asset.Replaces is not { } target)
+                    continue;
+
+                var targetItem = rootPackage.FindAsset(target);
+                if (ValidateDeclaration(assetItem, targetItem) is { } error)
+                {
+                    logger.Error(error);
+                    success = false;
+                    continue;
+                }
+
+                var targetUrl = targetItem!.Location.FullPath;
+                if (replacementsByUrl.TryGetValue(targetUrl, out var entry))
+                {
+                    var existing = entry.Replacement;
+                    if (existing.Id == assetItem.Id)
+                        continue;
+                    var existingIsSelf = existing.Package is not null && selfPackages.Contains(existing.Package);
+                    var newIsSelf = assetItem.Package is not null && selfPackages.Contains(assetItem.Package);
+                    if (existingIsSelf == newIsSelf)
+                    {
+                        logger.Error($"Assets [{existing.Location}] and [{assetItem.Location}] both replace [{targetUrl}]; only one replacement per URL is allowed.");
+                        success = false;
+                    }
+                    else if (newIsSelf)
+                    {
+                        logger.Info($"Asset [{assetItem.Location}] takes precedence over [{existing.Location}] for replacing [{targetUrl}].");
+                        replacementsByUrl[targetUrl] = entry with { Replacement = assetItem };
+                    }
+                    else
+                    {
+                        logger.Info($"Asset [{existing.Location}] takes precedence over [{assetItem.Location}] for replacing [{targetUrl}].");
+                    }
+                    continue;
+                }
+                replacementsByUrl.Add(targetUrl, new AssetReplacement(targetItem, assetItem));
+            }
+        }
+
+        replacements = [.. replacementsByUrl.Values];
+        return success;
+    }
+
+    /// <summary>
+    /// Validates a single replacement declaration against its resolved target.
+    /// </summary>
+    /// <returns>An error message, or null when the declaration is valid.</returns>
+    public static string? ValidateDeclaration(AssetItem replacer, AssetItem? target)
+    {
+        if (target is null)
+            return $"Asset [{replacer.Location}] replaces [{replacer.Asset.Replaces}], which does not exist in the package or its dependencies.";
+        if (target.Id == replacer.Id)
+            return $"Asset [{replacer.Location}] cannot replace itself.";
+        if (target.Asset.Replaces is not null)
+            return $"Asset [{replacer.Location}] cannot replace [{target.Location}], which itself replaces [{target.Asset.Replaces}]; chained replacements are not supported.";
+        if (!target.Asset.GetType().IsAssignableFrom(replacer.Asset.GetType()))
+            return $"Asset [{replacer.Location}] of type [{replacer.Asset.GetType().Name}] cannot replace [{target.Location}] of type [{target.Asset.GetType().Name}].";
+        if (target.Asset is SourceCodeAsset)
+        {
+            // Source code assets compile from their file on disk, not from the in-memory asset
+            return $"Asset [{replacer.Location}] cannot replace [{target.Location}]: replacing source code assets is not supported.";
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Collects the session's replacement declarations without validation, keyed by replaced URL
+    /// (first declaration wins). For editor use, where problems surface as diagnostics instead of errors.
+    /// </summary>
+    public static Dictionary<string, AssetItem>? CollectSessionReplacements(PackageSession? session)
+    {
+        if (session is null)
+            return null;
+
+        Dictionary<string, AssetItem>? replacements = null;
+        foreach (var package in session.Packages)
+        {
+            foreach (var item in package.Assets)
+            {
+                if (item.Asset.Replaces is { } target)
+                {
+                    replacements ??= new Dictionary<string, AssetItem>(StringComparer.OrdinalIgnoreCase);
+                    replacements.TryAdd(target.FullPath, item);
+                }
+            }
+        }
+        return replacements;
+    }
+
+    /// <summary>
+    /// Swaps each replaced asset's content for a clone of its replacement, keeping the replaced
+    /// asset's identity (id and location) so id- and URL-based resolution — including compile-time
+    /// content baking — use the replacement. For build sessions only (the swap is never saved).
+    /// </summary>
+    public static void Substitute(IEnumerable<AssetReplacement> replacements)
+    {
+        foreach (var (target, replacement) in replacements)
+        {
+            var clone = AssetCloner.Clone(replacement.Asset)!;
+            clone.Id = target.Id;
+            // Substitution changes content, not build membership: the swapped asset must not carry
+            // the declaration (it would point at its own location)
+            clone.Replaces = null;
+            // Derived content is stored flattened, so the archetype adds nothing here — and after
+            // the id stamp it would reference the clone itself
+            clone.Archetype = null;
+            var package = target.Package!;
+            package.Assets.Remove(target);
+            package.Assets.Add(new AssetItem(target.Location, clone) { SourceFolder = target.SourceFolder });
+        }
+    }
+}

--- a/sources/assets/Stride.Core.Assets/Asset.cs
+++ b/sources/assets/Stride.Core.Assets/Asset.cs
@@ -89,6 +89,17 @@ public abstract class Asset
     [MemberCollection(NotNullItems = true)]
     public TagCollection Tags { get; private set; }
 
+    /// <summary>
+    /// Gets or sets the URL of an asset this asset replaces: at build time, the replaced asset's
+    /// content is substituted with this asset's, so everything resolving the replaced asset
+    /// (including references inside dependency packages) gets this asset instead.
+    /// </summary>
+    [DataMember(-600)]
+    [Display(Browsable = false)]
+    [NonOverridable]
+    [DefaultValue(null)]
+    public UFile? Replaces { get; set; }
+
     [DataMember(-500)]
     [Display(Browsable = false)]
     [NonOverridable]
@@ -137,6 +148,9 @@ public abstract class Asset
         
         // Write the new id into the new asset.
         newAsset.Id = newId;
+
+        // A derived asset does not inherit the replacement declaration
+        newAsset.Replaces = null;
 
         // Create the base of this asset
         newAsset.Archetype = new AssetReference(Id, baseLocation);

--- a/sources/assets/Stride.Core.Assets/AssetBuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/AssetBuildManifest.cs
@@ -46,6 +46,11 @@ public sealed class AssetBuildManifest
     public string? RootNamespace { get; set; }
 
     /// <summary>
+    /// Asset URL namespace declaration: "true" = the package name, any other value = that name. Absent = bare URLs.
+    /// </summary>
+    public string? AssetNamespace { get; set; }
+
+    /// <summary>
     /// Host-loadable assemblies whose types appear in assets; the asset compiler loads exactly these.
     /// </summary>
     public List<UFile> AssetAssemblies { get; } = [];

--- a/sources/assets/Stride.Core.Assets/AssetBuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/AssetBuildManifest.cs
@@ -51,6 +51,11 @@ public sealed class AssetBuildManifest
     public string? AssetNamespace { get; set; }
 
     /// <summary>
+    /// Namespaces this project brings into scope: their assets resolve by bare URL (using semantics).
+    /// </summary>
+    public List<string> AssetNamespaceUsings { get; } = [];
+
+    /// <summary>
     /// Host-loadable assemblies whose types appear in assets; the asset compiler loads exactly these.
     /// </summary>
     public List<UFile> AssetAssemblies { get; } = [];

--- a/sources/assets/Stride.Core.Assets/AssetFileSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/AssetFileSerializer.cs
@@ -112,7 +112,7 @@ public static class AssetFileSerializer
     /// <param name="yamlMetadata"></param>
     /// <param name="log">The logger.</param>
     /// <exception cref="System.ArgumentNullException">filePath</exception>
-    public static void Save(string filePath, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null)
+    public static void Save(string filePath, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null, string? assetNamespace = null)
     {
         ArgumentNullException.ThrowIfNull(filePath);
 
@@ -125,7 +125,7 @@ public static class AssetFileSerializer
         }
 
         using var stream = new MemoryStream();
-        Save(stream, asset, yamlMetadata, log);
+        Save(stream, asset, yamlMetadata, log, assetNamespace);
         File.WriteAllBytes(filePath, stream.ToArray());
     }
 
@@ -141,7 +141,7 @@ public static class AssetFileSerializer
     /// or
     /// assetFileExtension
     /// </exception>
-    public static void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null)
+    public static void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null, string? assetNamespace = null)
     {
         ArgumentNullException.ThrowIfNull(stream);
         if (asset == null) return;
@@ -150,6 +150,6 @@ public static class AssetFileSerializer
             ?? throw new ArgumentException("Unable to find a serializer for the specified asset. No asset file extension registered to AssetRegistry");
         var serializer = FindSerializer(assetFileExtension)
             ?? throw new InvalidOperationException($"Unable to find a serializer for [{assetFileExtension}]");
-        serializer.Save(stream, asset, yamlMetadata, log);
+        serializer.Save(stream, asset, yamlMetadata, log, assetNamespace);
     }
 }

--- a/sources/assets/Stride.Core.Assets/AssetItem.cs
+++ b/sources/assets/Stride.Core.Assets/AssetItem.cs
@@ -167,7 +167,11 @@ public sealed class AssetItem : IFileSynchronizable
 
             rootDirectory = rootDirectory is not null ? UPath.Combine(rootDirectory, localSourceFolder) : localSourceFolder;
 
-            var locationAndExtension = AlternativePath ?? new UFile(Location + AssetRegistry.GetDefaultExtension(Asset.GetType()));
+            // Namespaced packages root their locations /Namespace/...; on disk the file lives at the bare path
+            var location = Location;
+            if (location.IsAbsolute && Package?.Container?.AssetNamespace is { } assetNamespace)
+                location = location.MakeRelative("/" + assetNamespace);
+            var locationAndExtension = AlternativePath ?? new UFile(location + AssetRegistry.GetDefaultExtension(Asset.GetType()));
             return rootDirectory is not null ? UPath.Combine(rootDirectory, locationAndExtension) : locationAndExtension;
         }
     }

--- a/sources/assets/Stride.Core.Assets/AssetItem.cs
+++ b/sources/assets/Stride.Core.Assets/AssetItem.cs
@@ -167,9 +167,10 @@ public sealed class AssetItem : IFileSynchronizable
 
             rootDirectory = rootDirectory is not null ? UPath.Combine(rootDirectory, localSourceFolder) : localSourceFolder;
 
-            // Namespaced packages root their locations /Namespace/...; on disk the file lives at the bare path
+            // Namespaced packages root their locations /Namespace/...; on disk the file lives at the
+            // bare path. Detached packages (clones) carry the resolved namespace on the package itself.
             var location = Location;
-            if (location.IsAbsolute && Package?.Container?.AssetNamespace is { } assetNamespace)
+            if (location.IsAbsolute && (Package?.Container?.AssetNamespace ?? Package?.AssetNamespace) is { } assetNamespace)
                 location = location.MakeRelative("/" + assetNamespace);
             var locationAndExtension = AlternativePath ?? new UFile(location + AssetRegistry.GetDefaultExtension(Asset.GetType()));
             return rootDirectory is not null ? UPath.Combine(rootDirectory, locationAndExtension) : locationAndExtension;

--- a/sources/assets/Stride.Core.Assets/AssetItem.cs
+++ b/sources/assets/Stride.Core.Assets/AssetItem.cs
@@ -51,11 +51,17 @@ public sealed class AssetItem : IFileSynchronizable
     }
 
     /// <summary>
-    /// Gets the location of this asset.
+    /// Gets the qualified URL of this asset (rooted under its package's namespace, e.g. /MyGame/Ground).
     /// </summary>
     /// <value>The location.</value>
     [DataMember]
     public UFile Location { get => location; internal set => location = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>
+    /// The asset's unqualified URL: its <see cref="Location"/> without the package namespace root
+    /// (equal to <see cref="Location"/> for a bare package).
+    /// </summary>
+    public UFile UnqualifiedUrl => new(AssetNamespaceHelper.Unqualify(Location.FullPath, Package?.Container?.AssetNamespace ?? Package?.AssetNamespace));
 
     /// <summary>
     /// Gets or sets the real location of this asset if it is overriden (similar to `Link` in C# project files).
@@ -167,11 +173,8 @@ public sealed class AssetItem : IFileSynchronizable
 
             rootDirectory = rootDirectory is not null ? UPath.Combine(rootDirectory, localSourceFolder) : localSourceFolder;
 
-            // Namespaced packages root their locations /Namespace/...; on disk the file lives at the
-            // bare path. Detached packages (clones) carry the resolved namespace on the package itself.
-            var location = Location;
-            if (location.IsAbsolute && (Package?.Container?.AssetNamespace ?? Package?.AssetNamespace) is { } assetNamespace)
-                location = location.MakeRelative("/" + assetNamespace);
+            // Namespaced packages root their locations /Namespace/...; on disk the file lives at the bare path.
+            var location = UnqualifiedUrl;
             var locationAndExtension = AlternativePath ?? new UFile(location + AssetRegistry.GetDefaultExtension(Asset.GetType()));
             return rootDirectory is not null ? UPath.Combine(rootDirectory, locationAndExtension) : locationAndExtension;
         }

--- a/sources/assets/Stride.Core.Assets/AssetNamespaceHelper.cs
+++ b/sources/assets/Stride.Core.Assets/AssetNamespaceHelper.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+namespace Stride.Core.Assets;
+
+/// <summary>
+/// The prefix arithmetic behind asset namespaces: a qualified URL is /Namespace/Path, its
+/// unqualified form drops the /Namespace root. Shared by the container/asset accessors and the
+/// reference serializers so the math lives in one place.
+/// </summary>
+internal static class AssetNamespaceHelper
+{
+    /// <summary>Prepends /assetNamespace to an unqualified URL. No-op when the namespace is empty or the URL is already qualified (rooted).</summary>
+    public static string Qualify(string url, string? assetNamespace)
+    {
+        if (string.IsNullOrEmpty(assetNamespace) || url.StartsWith('/'))
+            return url;
+        return "/" + assetNamespace + "/" + url;
+    }
+
+    /// <summary>Drops the /assetNamespace root from a qualified URL. No-op when the namespace is empty or the URL is not under it.</summary>
+    public static string Unqualify(string url, string? assetNamespace)
+    {
+        if (string.IsNullOrEmpty(assetNamespace))
+            return url;
+        var root = "/" + assetNamespace + "/";
+        return url.StartsWith(root, StringComparison.OrdinalIgnoreCase) ? url.Substring(root.Length) : url;
+    }
+}

--- a/sources/assets/Stride.Core.Assets/Compiler/RootPackageAssetEnumerator.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/RootPackageAssetEnumerator.cs
@@ -78,10 +78,11 @@ public class RootPackageAssetEnumerator : IPackageCompilerSource
             CollectReferences(dependency, assetsReferenced, packagesProcessed);
         }
 
-        // 3. Some types are marked with AlwaysMarkAsRoot
+        // 3. Some types are marked with AlwaysMarkAsRoot; assets replacing another asset are
+        //    typically referenced by nothing, so they must be roots to get compiled
         foreach (var assetItem in package.Assets)
         {
-            if (AssetRegistry.IsAssetTypeAlwaysMarkAsRoot(assetItem.Asset.GetType()))
+            if (AssetRegistry.IsAssetTypeAlwaysMarkAsRoot(assetItem.Asset.GetType()) || assetItem.Asset.Replaces is not null)
             {
                 assetsReferenced.Add(assetItem);
             }

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -410,6 +410,9 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
         // Clone this asset
         var package = AssetCloner.Clone(this);
         package.FullPath = FullPath;
+        // The clone is detached (no container): carry the resolved namespace so rooted
+        // locations still resolve to bare disk paths (AssetItem.FullPath).
+        package.AssetNamespace = Container?.AssetNamespace ?? AssetNamespace;
         foreach (var asset in Assets)
         {
             var newAsset = asset.Asset;

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -118,6 +118,13 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
     public PackageMeta Meta { get; set; } = new PackageMeta();
 
     /// <summary>
+    /// The authored name from the package file, when the session renamed <see cref="Meta"/>.Name to the
+    /// csproj-derived identity; saving writes this name back so the file keeps its authored identity.
+    /// </summary>
+    [DataMemberIgnore]
+    public string? AuthoredName { get; set; }
+
+    /// <summary>
     /// Gets the asset directories to lookup.
     /// </summary>
     /// <value>The asset directories.</value>

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -178,7 +178,8 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
     public List<AssetAssembly> AssetAssemblies { get; } = [];
 
     /// <summary>
-    /// Asset URL namespace declaration: null/"false" = bare URLs, "true" = the package name, any other value = that name.
+    /// Asset URL namespace: unset = the package name (the default), any other value = that custom
+    /// prefix. Packed sdpkgs store the resolved name.
     /// </summary>
     [DataMember(106)]
     [DefaultValue(null)]

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -170,6 +170,13 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
     [DataMember(105)]
     public List<AssetAssembly> AssetAssemblies { get; } = [];
 
+    /// <summary>
+    /// Asset URL namespace declaration: null/"false" = bare URLs, "true" = the package name, any other value = that name.
+    /// </summary>
+    [DataMember(106)]
+    [DefaultValue(null)]
+    public string? AssetNamespace { get; set; }
+
     // Keep saved .sdpkg files minimal: skip empty collections (ShouldSerialize* is discovered by ObjectDescriptor).
     private bool ShouldSerializeAssetFolders() => AssetFolders.Count > 0;
     private bool ShouldSerializeResourceFolders() => ResourceFolders.Count > 0;
@@ -179,6 +186,7 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
     private bool ShouldSerializeTemplateFolders() => TemplateFolders.Count > 0;
     private bool ShouldSerializeRootAssets() => RootAssets.Count > 0;
     private bool ShouldSerializeAssetAssemblies() => AssetAssemblies.Count > 0;
+    private bool ShouldSerializeAssetNamespace() => AssetNamespace is not null;
 
     /// <summary>
     /// Gets the loaded templates from the <see cref="TemplateFolders"/>
@@ -928,6 +936,8 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
 
             // Try to load only if asset is not already in the package or assetRef.Asset is null
             var assetPath = assetFile.AssetLocation;
+            if (Container?.AssetNamespace is { } assetNamespace)
+                assetPath = UPath.Combine(new UDirectory("/" + assetNamespace), assetPath);
 
             var assetFullPath = fileUPath.ToOSPath();
             var assetContent = assetFile.AssetContent;

--- a/sources/assets/Stride.Core.Assets/Package.cs
+++ b/sources/assets/Stride.Core.Assets/Package.cs
@@ -497,7 +497,8 @@ public sealed partial class Package : IFileSynchronizable, IAssetFinder
             }
 
             // Inject a copy of the base into the current asset when saving
-            AssetFileSerializer.Save((string)assetPath, (object)asset.Asset, (AttachedYamlAssetMetadata)asset.YamlMetadata, log);
+            AssetFileSerializer.Save((string)assetPath, (object)asset.Asset, (AttachedYamlAssetMetadata)asset.YamlMetadata, log,
+                asset.Package?.Container?.AssetNamespace);
 
             // Save generated asset (if necessary)
             if (asset.Asset is IProjectFileGeneratorAsset codeGeneratorAsset)

--- a/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
+++ b/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
@@ -344,9 +344,14 @@ public sealed class PackageAssetCollection : ICollection<AssetItem>, IReadOnlyCo
             throw new ArgumentException("Asset location [{0}] cannot contain drive information".ToFormat(location), nameof(item));
         }
 
-        if (location.IsAbsolute)
+        // Namespaced packages root their locations /Namespace/...; everything else stays relative
+        // (that reservation is what makes rooted URLs collision-free).
+        var namespaced = Package.Container?.AssetNamespace is not null;
+        if (location.IsAbsolute != namespaced)
         {
-            throw new ArgumentException("Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), nameof(item));
+            throw new ArgumentException(namespaced
+                ? "Asset location [{0}] of a namespaced package must be rooted (start with '/')".ToFormat(location)
+                : "Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), nameof(item));
         }
 
         if (location.GetDirectory()?.StartsWith("..", StringComparison.Ordinal) == true)

--- a/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
+++ b/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Reflection;
 using Stride.Core.Diagnostics;
+using Stride.Core.IO;
 
 namespace Stride.Core.Assets;
 
@@ -328,7 +329,20 @@ public sealed class PackageAssetCollection : ICollection<AssetItem>, IReadOnlyCo
         // Note: we ignore name collisions if asset is not referenceable
         var referenceable = item.Asset.GetType().GetCustomAttribute<AssetDescriptionAttribute>()?.Referenceable ?? true;
 
+        // Namespaced packages root their locations /Namespace/...; creation paths author
+        // package-relative locations, rooted here like the loaders do. Plain packages stay
+        // relative-only (that reservation is what makes rooted URLs collision-free).
         var location = item.Location;
+        if (Package.Container?.AssetNamespace is { } assetNamespace)
+        {
+            if (!location.IsAbsolute)
+                item.Location = location = UPath.Combine(new UDirectory("/" + assetNamespace), location);
+        }
+        else if (location.IsAbsolute)
+        {
+            throw new ArgumentException("Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), nameof(item));
+        }
+
         if (referenceable && mapPathToId.ContainsKey(location))
         {
             throw new ArgumentException("An asset [{0}] with the same location [{1}] is already registered ".ToFormat(mapPathToId[location], location.GetDirectoryAndFileName()), nameof(item));
@@ -342,16 +356,6 @@ public sealed class PackageAssetCollection : ICollection<AssetItem>, IReadOnlyCo
         if (location.HasDrive)
         {
             throw new ArgumentException("Asset location [{0}] cannot contain drive information".ToFormat(location), nameof(item));
-        }
-
-        // Namespaced packages root their locations /Namespace/...; everything else stays relative
-        // (that reservation is what makes rooted URLs collision-free).
-        var namespaced = Package.Container?.AssetNamespace is not null;
-        if (location.IsAbsolute != namespaced)
-        {
-            throw new ArgumentException(namespaced
-                ? "Asset location [{0}] of a namespaced package must be rooted (start with '/')".ToFormat(location)
-                : "Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), nameof(item));
         }
 
         if (location.GetDirectory()?.StartsWith("..", StringComparison.Ordinal) == true)

--- a/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
+++ b/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
@@ -330,16 +330,15 @@ public sealed class PackageAssetCollection : ICollection<AssetItem>, IReadOnlyCo
         var referenceable = item.Asset.GetType().GetCustomAttribute<AssetDescriptionAttribute>()?.Referenceable ?? true;
 
         // Namespaced packages root their locations /Namespace/...; creation paths author
-        // package-relative locations, rooted here like the loaders do. Plain packages stay
+        // unqualified locations, qualified here like the loaders do. Plain packages stay
         // relative-only (that reservation is what makes rooted URLs collision-free).
         // Detached packages (clones, pack-time copies) have no container: locations pass through.
         var location = item.Location;
         if (Package.Container is { } container)
         {
-            if (container.AssetNamespace is { } assetNamespace)
+            if (container.AssetNamespace is not null)
             {
-                if (!location.IsAbsolute)
-                    item.Location = location = UPath.Combine(new UDirectory("/" + assetNamespace), location);
+                item.Location = location = container.Qualify(location);
             }
             else if (location.IsAbsolute)
             {

--- a/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
+++ b/sources/assets/Stride.Core.Assets/PackageAssetCollection.cs
@@ -332,15 +332,19 @@ public sealed class PackageAssetCollection : ICollection<AssetItem>, IReadOnlyCo
         // Namespaced packages root their locations /Namespace/...; creation paths author
         // package-relative locations, rooted here like the loaders do. Plain packages stay
         // relative-only (that reservation is what makes rooted URLs collision-free).
+        // Detached packages (clones, pack-time copies) have no container: locations pass through.
         var location = item.Location;
-        if (Package.Container?.AssetNamespace is { } assetNamespace)
+        if (Package.Container is { } container)
         {
-            if (!location.IsAbsolute)
-                item.Location = location = UPath.Combine(new UDirectory("/" + assetNamespace), location);
-        }
-        else if (location.IsAbsolute)
-        {
-            throw new ArgumentException("Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), nameof(item));
+            if (container.AssetNamespace is { } assetNamespace)
+            {
+                if (!location.IsAbsolute)
+                    item.Location = location = UPath.Combine(new UDirectory("/" + assetNamespace), location);
+            }
+            else if (location.IsAbsolute)
+            {
+                throw new ArgumentException("Asset location [{0}] must be relative and not absolute (not start with '/')".ToFormat(location), nameof(item));
+            }
         }
 
         if (referenceable && mapPathToId.ContainsKey(location))
@@ -372,7 +376,7 @@ public sealed class PackageAssetCollection : ICollection<AssetItem>, IReadOnlyCo
                 {
                     if (otherPackage.Assets.ContainsById(item.Id))
                     {
-                        throw new ArgumentException("Cannot add the asset [{0}] that is already in different package [{1}] in the current session".ToFormat(item.Id, otherPackage.Meta.Name));
+                        throw new ArgumentException("Cannot add the asset [{0}] [{1}] to package [{2}] [{3}]: it is already in package [{4}] [{5}] in the current session".ToFormat(item.Id, item.Location, Package.Meta.Name, Package.FullPath, otherPackage.Meta.Name, otherPackage.FullPath));
                     }
                 }
             }

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -181,6 +181,8 @@ partial class PackageSession
             container.Package.Meta.Name = manifest.PackageName;
         if (container.Package.Meta.Version is null)
             container.Package.Meta.Version = !string.IsNullOrEmpty(manifest.PackageVersion) ? new PackageVersion(manifest.PackageVersion) : new PackageVersion("1.0.0");
+        if (!string.IsNullOrEmpty(manifest.AssetNamespace) && (isOwner || container.AssetNamespace is null))
+            container.AssetNamespace = PackageContainer.ResolveAssetNamespace(manifest.AssetNamespace, container.Package.Meta.Name);
 
         foreach (var assembly in manifest.AssetAssemblies)
             container.Assemblies.Add(Resolve(assembly));

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -57,6 +57,7 @@ partial class PackageSession
                 }
                 var manifest = YamlSerializer.Load<AssetBuildManifest>(file);
                 manifests.Add(file, manifest);
+                session.AssetNamespaceUsings.UnionWith(manifest.AssetNamespaceUsings);
                 var directory = Path.GetDirectoryName(file)!;
                 foreach (var reference in manifest.ReferencedManifests)
                     queue.Enqueue(Path.GetFullPath(Path.Combine(directory, reference)));

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -206,13 +206,16 @@ partial class PackageSession
         var isOwner = projectDirectory is not null && string.Equals(projectDirectory.ToOSPath().TrimEnd(Path.DirectorySeparatorChar), Path.GetDirectoryName(packagePath), StringComparison.OrdinalIgnoreCase);
         if (isOwner || container.Package.RootNamespace is null)
             container.Package.RootNamespace = manifest.RootNamespace;
-        // An authored sdpkg keeps its authored identity; implicit packages take the csproj-derived name
-        if (!string.IsNullOrEmpty(manifest.PackageName) && (container.Package.Meta.Name is null || (isOwner && !File.Exists(packagePath))))
+        // The session package name stays csproj-derived (it keys dependency matching); the authored
+        // sdpkg name only serves as the namespace identity below.
+        var authoredName = File.Exists(packagePath) ? container.Package.Meta.Name : null;
+        container.Package.AuthoredName ??= authoredName;
+        if ((isOwner || container.Package.Meta.Name is null) && !string.IsNullOrEmpty(manifest.PackageName))
             container.Package.Meta.Name = manifest.PackageName;
         if (container.Package.Meta.Version is null)
             container.Package.Meta.Version = !string.IsNullOrEmpty(manifest.PackageVersion) ? new PackageVersion(manifest.PackageVersion) : new PackageVersion("1.0.0");
         if (!string.IsNullOrEmpty(manifest.AssetNamespace) && (isOwner || container.AssetNamespace is null))
-            container.AssetNamespace = PackageContainer.ResolveAssetNamespace(manifest.AssetNamespace, container.Package.Meta.Name);
+            container.AssetNamespace = PackageContainer.ResolveAssetNamespace(manifest.AssetNamespace, container.Package.AuthoredName ?? container.Package.Meta.Name);
 
         foreach (var assembly in manifest.AssetAssemblies)
             container.Assemblies.Add(Resolve(assembly));

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
@@ -206,7 +206,8 @@ partial class PackageSession
         var isOwner = projectDirectory is not null && string.Equals(projectDirectory.ToOSPath().TrimEnd(Path.DirectorySeparatorChar), Path.GetDirectoryName(packagePath), StringComparison.OrdinalIgnoreCase);
         if (isOwner || container.Package.RootNamespace is null)
             container.Package.RootNamespace = manifest.RootNamespace;
-        if ((isOwner || container.Package.Meta.Name is null) && !string.IsNullOrEmpty(manifest.PackageName))
+        // An authored sdpkg keeps its authored identity; implicit packages take the csproj-derived name
+        if (!string.IsNullOrEmpty(manifest.PackageName) && (container.Package.Meta.Name is null || (isOwner && !File.Exists(packagePath))))
             container.Package.Meta.Name = manifest.PackageName;
         if (container.Package.Meta.Version is null)
             container.Package.Meta.Version = !string.IsNullOrEmpty(manifest.PackageVersion) ? new PackageVersion(manifest.PackageVersion) : new PackageVersion("1.0.0");
@@ -295,7 +296,7 @@ partial class PackageSession
             var package = Package.LoadRaw(log, sdpkgPath);
             package.Meta.Name = library.Name;
             package.Meta.Version = library.Version.ToPackageVersion();
-            var container = new StandalonePackage(package);
+            var container = new StandalonePackage(package) { IsDependencyPackage = true };
             // The packed sdpkg's declarations (host-loadable, narrowed to asset types) are the
             // complete list; a package declaring none gets no assembly loaded.
             var sdpkgDirectory = Path.GetDirectoryName(sdpkgPath)!;

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -244,14 +244,11 @@ partial class PackageSession
                 continue;
 
             // Make every dependency assembly known to the container for later lazy resolution
-            var assemblies = new List<string>();
             foreach (var runtimeAssembly in targetLibrary.RuntimeAssemblies.Concat(targetLibrary.RuntimeTargets))
             {
                 if (runtimeAssembly.Path.EndsWith("_._", StringComparison.Ordinal) || runtimeAssembly.Path.Contains("/native/"))
                     continue;
-                var assemblyFile = Path.Combine(libraryPath, runtimeAssembly.Path.Replace('/', Path.DirectorySeparatorChar));
-                assemblies.Add(assemblyFile);
-                AssemblyContainer.RegisterDependency(assemblyFile);
+                AssemblyContainer.RegisterDependency(Path.Combine(libraryPath, runtimeAssembly.Path.Replace('/', Path.DirectorySeparatorChar)));
             }
 
             // Only packages shipping a stride/<Id>.sdpkg participate in asset compilation
@@ -270,14 +267,11 @@ partial class PackageSession
             package.Meta.Name = library.Name;
             package.Meta.Version = library.Version.ToPackageVersion();
             var container = new StandalonePackage(package);
-            // Prefer the assemblies the packed sdpkg declares (host-loadable, narrowed to asset
-            // types); fall back to the lock file's runtime assemblies when it declares none.
+            // The packed sdpkg's declarations (host-loadable, narrowed to asset types) are the
+            // complete list; a package declaring none gets no assembly loaded.
             var sdpkgDirectory = Path.GetDirectoryName(sdpkgPath)!;
             var hostAssetAssemblies = SelectHostAssetAssemblies(package.AssetAssemblies);
-            if (hostAssetAssemblies.Count > 0)
-                container.Assemblies.AddRange(hostAssetAssemblies.Select(a => Path.GetFullPath(Path.Combine(sdpkgDirectory, a.Path!.ToOSPath()))));
-            else
-                container.Assemblies.AddRange(assemblies);
+            container.Assemblies.AddRange(hostAssetAssemblies.Select(a => Path.GetFullPath(Path.Combine(sdpkgDirectory, a.Path!.ToOSPath()))));
             Projects.Add(container);
             package.State = PackageState.DependenciesReady;
             sdpkgPackagesByName.Add(library.Name, container);

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -214,7 +214,7 @@ partial class PackageSession
             container.Package.Meta.Name = manifest.PackageName;
         if (container.Package.Meta.Version is null)
             container.Package.Meta.Version = !string.IsNullOrEmpty(manifest.PackageVersion) ? new PackageVersion(manifest.PackageVersion) : new PackageVersion("1.0.0");
-        if (!string.IsNullOrEmpty(manifest.AssetNamespace) && (isOwner || container.AssetNamespace is null))
+        if (isOwner || container.AssetNamespace is null)
             container.AssetNamespace = PackageContainer.ResolveAssetNamespace(manifest.AssetNamespace, container.Package.AuthoredName ?? container.Package.Meta.Name);
 
         foreach (var assembly in manifest.AssetAssemblies)

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -62,6 +62,7 @@ partial class PackageSession
                 foreach (var reference in manifest.ReferencedManifests)
                     queue.Enqueue(Path.GetFullPath(Path.Combine(directory, reference)));
             }
+            session.LoadedBuildManifests = [.. manifests.Keys];
 
             // Multiple manifests can share one authored sdpkg (e.g. a platform-head exe and its
             // game library both point at the game's sdpkg via StrideCurrentPackagePath). Dedup by
@@ -120,9 +121,38 @@ partial class PackageSession
                     container.FlattenedDependencies.Add(new Dependency(dependency.Package));
             }
 
+            // Nupkg packages need a closure too (e.g. a plugin's UI page references the engine's
+            // default font by id): the packages of the lock files they came from
+            var sdpkgClosures = new Dictionary<StandalonePackage, HashSet<StandalonePackage>>();
+            foreach (var packages in packagesByLockFile.Values)
+            {
+                foreach (var package in packages)
+                {
+                    if (!sdpkgClosures.TryGetValue(package, out var closure))
+                        sdpkgClosures[package] = closure = [];
+                    closure.UnionWith(packages);
+                }
+            }
+            foreach (var (package, closure) in sdpkgClosures)
+            {
+                closure.Remove(package);
+                foreach (var dependency in closure)
+                    package.FlattenedDependencies.Add(new Dependency(dependency.Package));
+            }
+
             // Load + register exactly the declared assemblies, then load assets (folder scan +
             // precomputed project assets); no dependency resolution, no MSBuild
             session.LoadMissingAssets(sessionResult, [.. session.Packages], loadParameters);
+
+            // Read-only (nupkg) packages need the bare-to-canonical reference restamp too (their
+            // authored yaml stores same-prefix references bare); the session analysis below only
+            // covers local packages
+            var dependencyAnalysisParameters = new AssetAnalysisParameters { IsProcessingAssetReferences = true, IsLoggingAssetNotFoundAsError = false };
+            foreach (var package in session.Packages)
+            {
+                if (package.IsReadOnly)
+                    AssetAnalysis.Run(package.Assets, sessionResult, dependencyAnalysisParameters);
+            }
 
             CheckAssetNamespaceDisjointness(session, sessionResult);
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.BuildManifest.cs
@@ -124,6 +124,8 @@ partial class PackageSession
             // precomputed project assets); no dependency resolution, no MSBuild
             session.LoadMissingAssets(sessionResult, [.. session.Packages], loadParameters);
 
+            CheckAssetNamespaceDisjointness(session, sessionResult);
+
             // Fix relative references
             var analysis = new PackageSessionAnalysis(session, GetPackageAnalysisParametersForLoad());
             analysis.Run().CopyTo(sessionResult);
@@ -140,6 +142,32 @@ partial class PackageSession
         finally
         {
             AssetReferenceAnalysis.EnableCaching = false;
+        }
+    }
+
+    /// <summary>
+    /// Packages sharing an asset namespace present one URL surface, so their rooted URLs must be
+    /// disjoint — checked across ALL namespaced packages, independent of dependency visibility.
+    /// </summary>
+    internal static void CheckAssetNamespaceDisjointness(PackageSession session, ILogger log)
+    {
+        var packagesByLocation = new Dictionary<UFile, Package>();
+        foreach (var package in session.Packages)
+        {
+            if (package.Container.AssetNamespace is null)
+                continue;
+            foreach (var asset in package.Assets)
+            {
+                if (packagesByLocation.TryGetValue(asset.Location, out var other))
+                {
+                    if (other != package)
+                        log.Error($"Asset URL [{asset.Location}] exists in both [{other.Meta.Name}] and [{package.Meta.Name}], which share the same asset namespace; rename one of the assets.");
+                }
+                else
+                {
+                    packagesByLocation.Add(asset.Location, package);
+                }
+            }
         }
     }
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -186,6 +186,14 @@ partial class PackageSession
                 if (containsAssetTypesProperty is { IsImported: false } && bool.TryParse(containsAssetTypesProperty.EvaluatedValue, out var containsAssetTypes))
                     project.ContainsAssetTypes = containsAssetTypes;
 
+                // Asset URL namespace + using declarations (no SDK default exists, so imported values
+                // are deliberate authoring, e.g. Directory.Build.props)
+                var assetNamespace = msProject.GetPropertyValue(SolutionProject.AssetNamespaceProperty);
+                if (!string.IsNullOrEmpty(assetNamespace))
+                    project.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace, package.Meta.Name);
+                foreach (var usingName in msProject.GetPropertyValue(SolutionProject.AssetNamespaceUsingsProperty).Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    AssetNamespaceUsings.Add(usingName);
+
                 // Note: Platform might be incorrect if Stride is not restored yet (it won't include Stride targets)
                 // Also, if already set, don't try to query it again
                 if (project.Type == ProjectType.Executable && project.Platform == PlatformType.Shared)

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using NuGet.Commands;
@@ -175,7 +175,9 @@ partial class PackageSession
                 project.AssemblyProcessorSerializationHashFile = msProject.GetProperty("StrideAssemblyProcessorSerializationHashFile")?.EvaluatedValue;
                 if (project.AssemblyProcessorSerializationHashFile != null)
                     project.AssemblyProcessorSerializationHashFile = Path.Combine(Path.GetDirectoryName(projectPath), project.AssemblyProcessorSerializationHashFile);
-                package.Meta.Name = (msProject.GetProperty("PackageId") ?? msProject.GetProperty("AssemblyName"))?.EvaluatedValue ?? package.Meta.Name;
+                // An authored sdpkg keeps its authored identity; implicit packages take the csproj-derived name
+                if (package.Meta.Name is null || package.FullPath is null || !File.Exists(package.FullPath))
+                    package.Meta.Name = (msProject.GetProperty("PackageId") ?? msProject.GetProperty("AssemblyName"))?.EvaluatedValue ?? package.Meta.Name;
 
                 project.Type = VSProjectHelper.GetProjectTypeFromProject(msProject);
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -43,7 +43,8 @@ partial class PackageSession
     /// Populates <see cref="Package.PrecomputedProjectAssets"/> from a build manifest so the dev-redirect
     /// package's project assets (shaders) load from source with no MSBuild evaluation.
     /// </summary>
-    private static void LoadProjectAssetsFromManifest(Package package, string projectFile, string manifestFile)
+    /// <returns>The manifest, or null when it could not be parsed.</returns>
+    private static AssetBuildManifest? LoadProjectAssetsFromManifest(Package package, string projectFile, string manifestFile)
     {
         package.PrecomputedProjectAssets = [];
 
@@ -54,7 +55,7 @@ partial class PackageSession
         }
         catch
         {
-            return;
+            return null;
         }
 
         var manifestDirectory = Path.GetDirectoryName(manifestFile)!;
@@ -72,6 +73,7 @@ partial class PackageSession
             var link = item.Link is not null ? UPath.Combine(projectDirectory, item.Link) : null;
             package.PrecomputedProjectAssets.Add(new PackageLoadingAssetFile(filePath, projectDirectory) { Link = link });
         }
+        return manifest;
     }
 
     /// <summary>
@@ -392,11 +394,16 @@ partial class PackageSession
                         if (manifestFile != null)
                         {
                             var devPackage = Package.LoadRaw(log, file);
+                            devPackage.AuthoredName ??= devPackage.Meta.Name;
                             devPackage.Meta.Name = projectDependency.Name;
                             devPackage.Meta.Version = projectDependency.Version;
-                            LoadProjectAssetsFromManifest(devPackage, devRedirectProject!, manifestFile);
+                            var devManifest = LoadProjectAssetsFromManifest(devPackage, devRedirectProject!, manifestFile);
 
                             var devContainer = new StandalonePackage(devPackage);
+                            // Same namespace surface as a real nupkg (whose packed sdpkg stores the
+                            // resolved name): the csproj-driven declarations come from the manifest,
+                            // the identity from the authored sdpkg
+                            devContainer.AssetNamespace = PackageContainer.ResolveAssetNamespace(devManifest?.AssetNamespace, devPackage.AuthoredName ?? devPackage.Meta.Name);
                             devContainer.Assemblies.AddRange(projectDependency.Assemblies);
                             // The consumer's flattened graph already covers this package's dependencies; mark it
                             // ready so we don't recurse the whole engine project tree into the session.

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -175,9 +175,11 @@ partial class PackageSession
                 project.AssemblyProcessorSerializationHashFile = msProject.GetProperty("StrideAssemblyProcessorSerializationHashFile")?.EvaluatedValue;
                 if (project.AssemblyProcessorSerializationHashFile != null)
                     project.AssemblyProcessorSerializationHashFile = Path.Combine(Path.GetDirectoryName(projectPath), project.AssemblyProcessorSerializationHashFile);
-                // An authored sdpkg keeps its authored identity; implicit packages take the csproj-derived name
-                if (package.Meta.Name is null || package.FullPath is null || !File.Exists(package.FullPath))
-                    package.Meta.Name = (msProject.GetProperty("PackageId") ?? msProject.GetProperty("AssemblyName"))?.EvaluatedValue ?? package.Meta.Name;
+                // The session package name stays csproj-derived (it keys dependency matching); the authored
+                // sdpkg name only serves as the namespace identity below.
+                var authoredName = package.FullPath is not null && File.Exists(package.FullPath) ? package.Meta.Name : null;
+                package.AuthoredName ??= authoredName;
+                package.Meta.Name = (msProject.GetProperty("PackageId") ?? msProject.GetProperty("AssemblyName"))?.EvaluatedValue ?? package.Meta.Name;
 
                 project.Type = VSProjectHelper.GetProjectTypeFromProject(msProject);
 
@@ -192,7 +194,7 @@ partial class PackageSession
                 // are deliberate authoring, e.g. Directory.Build.props)
                 var assetNamespace = msProject.GetPropertyValue(SolutionProject.AssetNamespaceProperty);
                 if (!string.IsNullOrEmpty(assetNamespace))
-                    project.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace, package.Meta.Name);
+                    project.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace, authoredName ?? package.Meta.Name);
                 foreach (var usingName in msProject.GetPropertyValue(SolutionProject.AssetNamespaceUsingsProperty).Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                     AssetNamespaceUsings.Add(usingName);
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.Dependencies.cs
@@ -193,10 +193,9 @@ partial class PackageSession
                 // Asset URL namespace + using declarations (no SDK default exists, so imported values
                 // are deliberate authoring, e.g. Directory.Build.props)
                 var assetNamespace = msProject.GetPropertyValue(SolutionProject.AssetNamespaceProperty);
-                if (!string.IsNullOrEmpty(assetNamespace))
-                    project.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace, authoredName ?? package.Meta.Name);
-                foreach (var usingName in msProject.GetPropertyValue(SolutionProject.AssetNamespaceUsingsProperty).Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                    AssetNamespaceUsings.Add(usingName);
+                project.AssetNamespace = PackageContainer.ResolveAssetNamespace(assetNamespace, authoredName ?? package.Meta.Name);
+                foreach (var usingItem in msProject.GetItems(SolutionProject.AssetNamespaceUsingItem))
+                    AssetNamespaceUsings.Add(usingItem.EvaluatedInclude);
 
                 // Note: Platform might be incorrect if Stride is not restored yet (it won't include Stride targets)
                 // Also, if already set, don't try to query it again

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -29,6 +29,7 @@ public abstract class PackageContainer
     {
         Package = package;
         Package.Container = this;
+        AssetNamespace = ResolveAssetNamespace(package.AssetNamespace, package.Meta.Name);
     }
 
     /// <summary>
@@ -37,6 +38,22 @@ public abstract class PackageContainer
     public PackageSession? Session { get; private set; }
 
     public Package Package { get; }
+
+    /// <summary>
+    /// Resolved asset URL namespace: this package's asset locations are rooted under /Namespace/; null = bare URLs.
+    /// </summary>
+    public string? AssetNamespace { get; set; }
+
+    /// <summary>
+    /// Resolves an asset namespace declaration: null/"false" = none, "true" = the package name, any other value = that name.
+    /// </summary>
+    public static string? ResolveAssetNamespace(string? declaration, string packageName) => declaration switch
+    {
+        null or "" => null,
+        _ when string.Equals(declaration, "false", StringComparison.OrdinalIgnoreCase) => null,
+        _ when string.Equals(declaration, "true", StringComparison.OrdinalIgnoreCase) => packageName,
+        _ => declaration,
+    };
 
     public ObservableCollection<DependencyRange> DirectDependencies { get; } = [];
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -533,6 +533,11 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
     public HashSet<string> AssetNamespaceUsings { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// The build manifest files this session was loaded from, empty for other load paths.
+    /// </summary>
+    public IReadOnlyCollection<string> LoadedBuildManifests { get; internal set; } = [];
+
+    /// <summary>
     /// Gets the user packages (excluding system packages).
     /// </summary>
     /// <value>The user packages.</value>

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -499,6 +499,11 @@ public sealed partial class PackageSession : IDisposable, IAssetFinder
     public ProjectCollection Projects { get; }
 
     /// <summary>
+    /// Namespaces the loaded projects bring into scope (using semantics): their assets also resolve by bare URL.
+    /// </summary>
+    public HashSet<string> AssetNamespaceUsings { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets the user packages (excluding system packages).
     /// </summary>
     /// <value>The user packages.</value>

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -332,6 +332,10 @@ public class SolutionProject : PackageContainer
     // The msbuild property behind ContainsAssetTypes.
     public const string ContainsAssetTypesProperty = "StrideContainsAssetTypes";
 
+    // The msbuild properties behind PackageContainer.AssetNamespace and the using declarations.
+    public const string AssetNamespaceProperty = "StrideAssetNamespace";
+    public const string AssetNamespaceUsingsProperty = "StrideAssetNamespaceUsings";
+
     // Editor/asset-compiler loadability, from the msbuild StrideContainsAssetTypes property (null = use default below).
     public bool? ContainsAssetTypes { get; set; }
 

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -45,15 +45,18 @@ public abstract class PackageContainer
     public string? AssetNamespace { get; set; }
 
     /// <summary>
-    /// Resolves an asset namespace declaration: null/"false" = none, "true" = the package name, any other value = that name.
+    /// Resolves an asset namespace declaration: unset = the package name (namespacing is always on
+    /// for named packages; nameless packages stay bare), any other value = that custom prefix.
+    /// Legacy true/false sentinels resolve like unset.
     /// </summary>
-    public static string? ResolveAssetNamespace(string? declaration, string packageName) => declaration switch
+    public static string? ResolveAssetNamespace(string? declaration, string? packageName)
     {
-        null or "" => null,
-        _ when string.Equals(declaration, "false", StringComparison.OrdinalIgnoreCase) => null,
-        _ when string.Equals(declaration, "true", StringComparison.OrdinalIgnoreCase) => packageName,
-        _ => declaration,
-    };
+        if (string.IsNullOrEmpty(declaration)
+            || string.Equals(declaration, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(declaration, "false", StringComparison.OrdinalIgnoreCase))
+            return string.IsNullOrEmpty(packageName) ? null : packageName;
+        return declaration;
+    }
 
     public ObservableCollection<DependencyRange> DirectDependencies { get; } = [];
 
@@ -348,9 +351,9 @@ public class SolutionProject : PackageContainer
     // The msbuild property behind ContainsAssetTypes.
     public const string ContainsAssetTypesProperty = "StrideContainsAssetTypes";
 
-    // The msbuild properties behind PackageContainer.AssetNamespace and the using declarations.
+    // The msbuild properties/items behind PackageContainer.AssetNamespace and the using declarations.
     public const string AssetNamespaceProperty = "StrideAssetNamespace";
-    public const string AssetNamespaceUsingsProperty = "StrideAssetNamespaceUsings";
+    public const string AssetNamespaceUsingItem = "StrideAssetNamespaceUsing";
 
     // Editor/asset-compiler loadability, from the msbuild StrideContainsAssetTypes property (null = use default below).
     public bool? ContainsAssetTypes { get; set; }

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -44,6 +44,12 @@ public abstract class PackageContainer
     /// </summary>
     public string? AssetNamespace { get; set; }
 
+    /// <summary>Qualifies an unqualified asset URL under this package's namespace (no-op when bare).</summary>
+    public UFile Qualify(UFile url) => new(AssetNamespaceHelper.Qualify(url.FullPath, AssetNamespace));
+
+    /// <summary>Unqualifies an asset URL under this package's namespace (no-op when bare or not under it).</summary>
+    public UFile Unqualify(UFile url) => new(AssetNamespaceHelper.Unqualify(url.FullPath, AssetNamespace));
+
     /// <summary>
     /// Resolves an asset namespace declaration: unset = the package name (namespacing is always on
     /// for named packages; nameless packages stay bare), any other value = that custom prefix.

--- a/sources/assets/Stride.Core.Assets/PackageSession.cs
+++ b/sources/assets/Stride.Core.Assets/PackageSession.cs
@@ -219,7 +219,18 @@ public abstract class PackageContainer
 
     protected virtual void SavePackage()
     {
-        AssetFileSerializer.Save(Package.FullPath, Package, null);
+        // The session renames Meta.Name to the csproj-derived identity; the file keeps its authored name
+        var sessionName = Package.Meta.Name;
+        if (Package.AuthoredName is not null)
+            Package.Meta.Name = Package.AuthoredName;
+        try
+        {
+            AssetFileSerializer.Save(Package.FullPath, Package, null);
+        }
+        finally
+        {
+            Package.Meta.Name = sessionName;
+        }
     }
 
     internal void SetSessionInternal(PackageSession? session)
@@ -239,6 +250,11 @@ public class StandalonePackage : PackageContainer
     /// Optional list of assemblies to load, typically filled using NuGet.
     /// </summary>
     public List<string> Assemblies { get; } = [];
+
+    /// <summary>
+    /// True for packages pulled in as NuGet dependencies, false for the built project chain.
+    /// </summary>
+    public bool IsDependencyPackage { get; set; }
 
     public override string ToString() => $"Package: {Package.Meta.Name}";
 }

--- a/sources/assets/Stride.Core.Assets/Serializers/AssetReferenceSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/AssetReferenceSerializer.cs
@@ -29,6 +29,7 @@ internal class AssetReferenceSerializer : AssetScalarSerializerBase
 
     public override string ConvertTo(ref ObjectContext objectContext)
     {
-        return objectContext.Instance.ToString()!;
+        var assetReference = (AssetReference)objectContext.Instance;
+        return ReferenceSerializationHelper.FormatReference(ref objectContext, assetReference.Id, assetReference.Location);
     }
 }

--- a/sources/assets/Stride.Core.Assets/Serializers/ContentReferenceSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/ContentReferenceSerializer.cs
@@ -33,6 +33,6 @@ public class ContentReferenceSerializer : AssetScalarSerializerBase
     {
         var attachedReference = AttachedReferenceManager.GetAttachedReference(objectContext.Instance)
             ?? throw new YamlException($"Unable to extract asset reference from object [{objectContext.Instance}]");
-        return $"{attachedReference.Id}:{attachedReference.Url}";
+        return ReferenceSerializationHelper.FormatReference(ref objectContext, attachedReference.Id, attachedReference.Url);
     }
 }

--- a/sources/assets/Stride.Core.Assets/Serializers/IAssetSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/IAssetSerializer.cs
@@ -16,5 +16,5 @@ public interface IAssetSerializer
 {
     object Load(Stream stream, UFile filePath, ILogger? log, bool clearBrokenObjectReferences, out bool aliasOccurred, out AttachedYamlAssetMetadata yamlMetadata);
 
-    void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null);
+    void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null, string? assetNamespace = null);
 }

--- a/sources/assets/Stride.Core.Assets/Serializers/ReferenceSerializationHelper.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/ReferenceSerializationHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Stride.Core.Yaml;
@@ -18,12 +18,9 @@ internal static class ReferenceSerializationHelper
         // A broken reference (empty id) could not restore the rooted form at load, so keep its spelling
         if (location is not null
             && id != AssetId.Empty
-            && objectContext.SerializerContext.Properties.TryGetValue(AssetObjectSerializerBackend.AssetNamespaceKey, out var assetNamespace)
-            && location.Length > assetNamespace.Length + 2
-            && location[0] == '/' && location[assetNamespace.Length + 1] == '/'
-            && string.Compare(location, 1, assetNamespace, 0, assetNamespace.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            && objectContext.SerializerContext.Properties.TryGetValue(AssetObjectSerializerBackend.AssetNamespaceKey, out var assetNamespace))
         {
-            location = location.Substring(assetNamespace.Length + 2);
+            location = AssetNamespaceHelper.Unqualify(location, assetNamespace);
         }
         return $"{id}:{location}";
     }

--- a/sources/assets/Stride.Core.Assets/Serializers/ReferenceSerializationHelper.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/ReferenceSerializationHelper.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Stride.Core.Yaml;
+using Stride.Core.Yaml.Serialization;
+
+namespace Stride.Core.Assets.Serializers;
+
+internal static class ReferenceSerializationHelper
+{
+    /// <summary>
+    /// Formats an "id:url" reference scalar. URLs under the saving package's own namespace
+    /// (<see cref="AssetObjectSerializerBackend.AssetNamespaceKey"/>) are written bare; the id
+    /// restores the canonical rooted form at load.
+    /// </summary>
+    public static string FormatReference(ref ObjectContext objectContext, AssetId id, string? location)
+    {
+        // A broken reference (empty id) could not restore the rooted form at load, so keep its spelling
+        if (location is not null
+            && id != AssetId.Empty
+            && objectContext.SerializerContext.Properties.TryGetValue(AssetObjectSerializerBackend.AssetNamespaceKey, out var assetNamespace)
+            && location.Length > assetNamespace.Length + 2
+            && location[0] == '/' && location[assetNamespace.Length + 1] == '/'
+            && string.Compare(location, 1, assetNamespace, 0, assetNamespace.Length, StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            location = location.Substring(assetNamespace.Length + 2);
+        }
+        return $"{id}:{location}";
+    }
+}

--- a/sources/assets/Stride.Core.Assets/Serializers/SourceCodeAssetSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/SourceCodeAssetSerializer.cs
@@ -40,7 +40,7 @@ internal class SourceCodeAssetSerializer : IAssetSerializer, IAssetSerializerFac
         return asset;
     }
 
-    public void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null)
+    public void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null, string? assetNamespace = null)
     {
         ((SourceCodeAsset)asset).Save(stream);
     }

--- a/sources/assets/Stride.Core.Assets/Serializers/UrlReferenceSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/UrlReferenceSerializer.cs
@@ -33,7 +33,7 @@ internal class UrlReferenceSerializer : AssetScalarSerializerBase
     {
         if (objectContext.Instance is UrlReferenceBase urlReference)
         {
-            return $"{urlReference.Id}:{urlReference.Url}";
+            return ReferenceSerializationHelper.FormatReference(ref objectContext, urlReference.Id, urlReference.Url);
         }
 
         throw new YamlException($"Unable to extract url reference from object [{objectContext.Instance}]");

--- a/sources/assets/Stride.Core.Assets/Serializers/YamlAssetSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/YamlAssetSerializer.cs
@@ -33,9 +33,13 @@ public class YamlAssetSerializer : IAssetSerializer, IAssetSerializerFactory
         return result;
     }
 
-    public void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null)
+    public void Save(Stream stream, object asset, AttachedYamlAssetMetadata? yamlMetadata, ILogger? log = null, string? assetNamespace = null)
     {
         var settings = new SerializerContextSettings(log);
+        if (assetNamespace is not null)
+        {
+            settings.Properties.Add(AssetObjectSerializerBackend.AssetNamespaceKey, assetNamespace);
+        }
         var overrides = yamlMetadata?.RetrieveMetadata(AssetObjectSerializerBackend.OverrideDictionaryKey);
         if (overrides != null)
         {

--- a/sources/assets/Stride.Core.Assets/Serializers/YamlAssetSerializer.cs
+++ b/sources/assets/Stride.Core.Assets/Serializers/YamlAssetSerializer.cs
@@ -40,17 +40,32 @@ public class YamlAssetSerializer : IAssetSerializer, IAssetSerializerFactory
         {
             settings.Properties.Add(AssetObjectSerializerBackend.AssetNamespaceKey, assetNamespace);
         }
-        var overrides = yamlMetadata?.RetrieveMetadata(AssetObjectSerializerBackend.OverrideDictionaryKey);
+        // Serialization mutates the metadata paths in place (AssetPartCollectionSerializer rewrites
+        // part collection indices between the guid keys and the serialized list indices). Work on a
+        // copy so the asset's attached metadata keeps its canonical (guid-keyed) form.
+        // A shallow copy is enough: FixupPaths builds fresh path objects rather than mutating the
+        // existing ones, so the original entries stay valid.
+        var overrides = Clone(yamlMetadata?.RetrieveMetadata(AssetObjectSerializerBackend.OverrideDictionaryKey));
         if (overrides != null)
         {
             settings.Properties.Add(AssetObjectSerializerBackend.OverrideDictionaryKey, overrides);
         }
-        var objectReferences = yamlMetadata?.RetrieveMetadata(AssetObjectSerializerBackend.ObjectReferencesKey);
+        var objectReferences = Clone(yamlMetadata?.RetrieveMetadata(AssetObjectSerializerBackend.ObjectReferencesKey));
         if (objectReferences != null)
         {
             settings.Properties.Add(AssetObjectSerializerBackend.ObjectReferencesKey, objectReferences);
         }
         AssetYamlSerializer.Default.Serialize(stream, asset, null, settings);
+    }
+
+    private static YamlAssetMetadata<T>? Clone<T>(YamlAssetMetadata<T>? source)
+    {
+        if (source == null)
+            return null;
+        var copy = new YamlAssetMetadata<T>();
+        foreach (var entry in source)
+            copy.Set(entry.Key, entry.Value);
+        return copy;
     }
 
     public IAssetSerializer TryCreate(string assetFileExtension)

--- a/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
@@ -19,6 +19,11 @@ public class AssetObjectSerializerBackend : DefaultObjectSerializerBackend
     private static readonly PropertyKey<YamlAssetPath> MemberPathKey = new("MemberPath", typeof(AssetObjectSerializerBackend));
     public static readonly PropertyKey<YamlAssetMetadata<OverrideType>> OverrideDictionaryKey = new("OverrideDictionary", typeof(AssetObjectSerializerBackend));
     public static readonly PropertyKey<YamlAssetMetadata<Guid>> ObjectReferencesKey = new("ObjectReferences", typeof(AssetObjectSerializerBackend));
+    /// <summary>
+    /// The saving package's asset namespace: reference URLs under it serialize bare (same-prefix
+    /// references stay stable in files; ids restore the canonical rooted form at load).
+    /// </summary>
+    public static readonly PropertyKey<string> AssetNamespaceKey = new("AssetNamespace", typeof(AssetObjectSerializerBackend));
 
     public AssetObjectSerializerBackend(ITypeDescriptorFactory typeDescriptorFactory)
     {

--- a/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
+++ b/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
@@ -28,6 +28,18 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
     /// </summary>
     public static readonly string ObjectIdUrl = "id://";
 
+    /// <summary>
+    /// Index lookup with bare-to-canonical alias fallback (using semantics for namespaced packages).
+    /// </summary>
+    private bool TryGetObjectId(string url, out ObjectId objectId)
+    {
+        if (ContentIndexMap.TryGetValue(url, out objectId))
+            return true;
+        return ObjectDatabase?.ContentAliases is { } aliases
+               && aliases.TryGetValue(url, out var canonical)
+               && ContentIndexMap.TryGetValue(canonical, out objectId);
+    }
+
     public IContentIndexMap ContentIndexMap { get; }
 
     public ObjectDatabase ObjectDatabase { get; }
@@ -44,7 +56,7 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
             {
                 _ = ObjectId.TryParse(url[ObjectIdUrl.Length..], out objectId);
             }
-            else if (!ContentIndexMap.TryGetValue(url, out objectId))
+            else if (!TryGetObjectId(url, out objectId))
             {
                 throw new FileNotFoundException($"Unable to find the file [{url}]");
             }
@@ -100,13 +112,13 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
 
     public override bool FileExists(string url)
     {
-        return ContentIndexMap.TryGetValue(url, out var objectId)
+        return TryGetObjectId(url, out var objectId)
                && ObjectDatabase.Exists(objectId);
     }
 
     public override long FileSize(string url)
     {
-        if (!ContentIndexMap.TryGetValue(url, out var objectId))
+        if (!TryGetObjectId(url, out var objectId))
             throw new FileNotFoundException();
 
         return ObjectDatabase.GetSize(objectId);
@@ -114,7 +126,7 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
 
     public override string GetAbsolutePath(string url)
     {
-        if (!ContentIndexMap.TryGetValue(url, out var objectId))
+        if (!TryGetObjectId(url, out var objectId))
             throw new FileNotFoundException();
 
         return ObjectDatabase.GetFilePath(objectId);
@@ -134,7 +146,7 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
             objectId = ObjectId.Empty;
             return null;
         }
-        return provider.ContentIndexMap.TryGetValue(resolveProviderResult.Path, out objectId) ? provider : null;
+        return provider.TryGetObjectId(resolveProviderResult.Path, out objectId) ? provider : null;
     }
 
     public static Regex CreateRegexForFileSearch(string url, string searchPattern, VirtualSearchOption searchOption)

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -83,12 +83,27 @@ public sealed partial class ContentManager : IContentManager
     /// </returns>
     public bool Exists(string url)
     {
-        return FileProvider.ContentIndexMap.TryGetValue(url, out _);
+        return FileProvider.ContentIndexMap.TryGetValue(ResolveUrl(url), out _);
     }
 
     public Stream OpenAsStream(string url, StreamFlags streamFlags = StreamFlags.None)
     {
-        return FileProvider.OpenStream(url, VirtualFileMode.Open, VirtualFileAccess.Read, streamFlags: streamFlags);
+        return FileProvider.OpenStream(ResolveUrl(url), VirtualFileMode.Open, VirtualFileAccess.Read, streamFlags: streamFlags);
+    }
+
+    /// <summary>
+    /// Resolves a bare URL through the shipped alias table (using semantics for namespaced packages);
+    /// exact index hits pass through untouched. Resolution happens before any caching so a canonical
+    /// URL and its bare alias share one loaded instance.
+    /// </summary>
+    private string ResolveUrl(string url)
+    {
+        // No provider (e.g. editor game thread resolves its database per-microthread) = no aliases
+        var fileProvider = databaseFileProviderService.FileProvider;
+        if (fileProvider is null || fileProvider.ContentIndexMap.TryGetValue(url, out _))
+            return url;
+        var aliases = fileProvider.ObjectDatabase?.ContentAliases;
+        return aliases is not null && aliases.TryGetValue(url, out var canonical) ? canonical : url;
     }
 
     /// <summary>
@@ -121,6 +136,7 @@ public sealed partial class ContentManager : IContentManager
 
         lock (LoadedAssetUrls)
         {
+            url = ResolveUrl(url);
             using var profile = Profiler.Begin(ContentProfilingKeys.ContentLoad, url);
             return DeserializeObject(url, url, type, null, settings);
         }
@@ -143,7 +159,7 @@ public sealed partial class ContentManager : IContentManager
             if (!LoadedAssetReferences.TryGetValue(obj, out var reference))
                 return false; // The object is not loaded
 
-            var url = newUrl ?? reference.Url;
+            var url = newUrl is not null ? ResolveUrl(newUrl) : reference.Url;
 
             using (var profile = Profiler.Begin(ContentProfilingKeys.ContentReload, url))
             {
@@ -179,7 +195,7 @@ public sealed partial class ContentManager : IContentManager
     /// <remarks>This function does not increase the reference count on the asset.</remarks>
     public object? Get(Type type, string url)
     {
-        return FindDeserializedObject(url, type)?.Object;
+        return FindDeserializedObject(ResolveUrl(url), type)?.Object;
     }
 
     /// <summary>
@@ -190,7 +206,7 @@ public sealed partial class ContentManager : IContentManager
     /// <returns><c>True</c> if an asset with the given URL is currently loaded, <c>false</c> otherwise.</returns>
     public bool IsLoaded(string url, bool loadedManuallyOnly = false)
     {
-        return LoadedAssetUrls.TryGetValue(url, out var reference) && (!loadedManuallyOnly || reference.PublicReferenceCount > 0);
+        return LoadedAssetUrls.TryGetValue(ResolveUrl(url), out var reference) && (!loadedManuallyOnly || reference.PublicReferenceCount > 0);
     }
 
     public bool TryGetAssetUrl(object obj, [NotNullWhen(true)] out string? url)
@@ -236,7 +252,7 @@ public sealed partial class ContentManager : IContentManager
         lock (LoadedAssetUrls)
         {
             // Try to find already loaded object
-            if (!LoadedAssetUrls.TryGetValue(url, out var reference))
+            if (!LoadedAssetUrls.TryGetValue(ResolveUrl(url), out var reference))
                 throw new InvalidOperationException("Content not loaded through this ContentManager.");
 
             // Release reference

--- a/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
@@ -65,6 +65,8 @@ public class ObjectDatabase : IDisposable
 
         BundleBackend = new BundleOdbBackend(vfsMainUrl);
 
+        ContentAliases = LoadContentAliases(vfsMainUrl, defaultBundleName);
+
         // Try to open the default pack file synchronously
         if (loadDefaultBundle)
         {
@@ -81,6 +83,37 @@ public class ObjectDatabase : IDisposable
     public ObjectDatabaseContentIndexMap ContentIndexMap { get; }
 
     public BundleOdbBackend BundleBackend { get; }
+
+    /// <summary>
+    /// Bare-to-canonical URL aliases (using semantics for namespaced packages); empty when none shipped.
+    /// One "bare|canonical" entry per line ('|' cannot appear in URLs).
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ContentAliases { get; }
+
+    // Bundle-specific aliases first (a combined host packages one "<bundle>.aliases" per suite so each
+    // suite's bare names stay in scope); fall back to the shared "aliases" (the standalone single-package case).
+    private static Dictionary<string, string> LoadContentAliases(string vfsMainUrl, string bundleName)
+    {
+        var bundleAliasesUrl = $"{vfsMainUrl}/{bundleName}.aliases";
+        return LoadContentAliases(VirtualFileSystem.FileExists(bundleAliasesUrl) ? bundleAliasesUrl : vfsMainUrl + "/aliases");
+    }
+
+    private static Dictionary<string, string> LoadContentAliases(string aliasesUrl)
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!VirtualFileSystem.FileExists(aliasesUrl))
+            return aliases;
+
+        using var stream = VirtualFileSystem.OpenStream(aliasesUrl, VirtualFileMode.Open, VirtualFileAccess.Read);
+        using var reader = new StreamReader(stream);
+        while (reader.ReadLine() is { } line)
+        {
+            var separator = line.IndexOf('|');
+            if (separator > 0)
+                aliases[line[..separator]] = line[(separator + 1)..];
+        }
+        return aliases;
+    }
 
     /// <summary>
     /// Creates a new instance of the <see cref="ObjectDatabase"/> class using default database path, index name, and local database path, and loading default bundle.

--- a/sources/core/Stride.Core.Tests/TestContentManager.cs
+++ b/sources/core/Stride.Core.Tests/TestContentManager.cs
@@ -252,6 +252,32 @@ public class TestContentManager
     }
 
     [Fact]
+    public void RootedUrl()
+    {
+        // Namespaced packages use rooted URLs (/Package/Path); they must round-trip as plain index keys.
+        var c1 = new C { I = 16, Child = new C { I = 32 } };
+        AttachedReferenceManager.SetUrl(c1.Child, "/MyGame/Sub/child");
+
+        var databaseProvider = CreateDatabaseProvider();
+        var assetManager1 = new ContentManager(databaseProvider);
+        var assetManager2 = new ContentManager(databaseProvider);
+
+        assetManager1.Save("/MyGame/Sub/c1", c1);
+
+        Assert.True(databaseProvider.FileProvider.FileExists("/MyGame/Sub/c1"));
+
+        var c1Copy = assetManager2.Load<C>("/MyGame/Sub/c1");
+        Assert.Equal(16, c1Copy.I);
+        Assert.Equal(32, c1Copy.Child.I);
+
+        Assert.True(assetManager2.TryGetAssetUrl(c1Copy, out var url));
+        Assert.Equal("/MyGame/Sub/c1", url);
+
+        var childCopy = assetManager2.Load<C>("/MyGame/Sub/child");
+        Assert.Equal(32, childCopy.I);
+    }
+
+    [Fact]
     public void LifetimeShared()
     {
         var c1 = new C { I = 16 };

--- a/sources/core/Stride.Core.Tests/TestContentManager.cs
+++ b/sources/core/Stride.Core.Tests/TestContentManager.cs
@@ -278,6 +278,43 @@ public class TestContentManager
     }
 
     [Fact]
+    public void UrlAlias()
+    {
+        // Bare URL resolves through the shipped alias table to the canonical rooted URL,
+        // canonicalized before caching so both spellings share one instance.
+        var a1 = new A { I = 18 };
+
+        VirtualFileSystem.CreateDirectory(VirtualFileSystem.ApplicationDatabasePath);
+        var aliasesUrl = VirtualFileSystem.ApplicationDatabasePath + "/aliases";
+        using (var stream = VirtualFileSystem.OpenStream(aliasesUrl, VirtualFileMode.Create, VirtualFileAccess.Write))
+        using (var writer = new StreamWriter(stream))
+            writer.Write("Sub/a|/MyGame/Sub/a\n");
+
+        try
+        {
+            var databaseProvider = CreateDatabaseProvider();
+            var assetManager = new ContentManager(databaseProvider);
+            assetManager.Save("/MyGame/Sub/a", a1);
+
+            Assert.True(assetManager.Exists("Sub/a"));
+
+            var viaAlias = assetManager.Load<A>("Sub/a");
+            var viaCanonical = assetManager.Load<A>("/MyGame/Sub/a");
+            Assert.Same(viaCanonical, viaAlias);
+            Assert.Equal(18, viaAlias.I);
+            Assert.True(assetManager.IsLoaded("Sub/a"));
+            Assert.True(assetManager.IsLoaded("/MyGame/Sub/a"));
+
+            assetManager.Unload("Sub/a");
+            assetManager.Unload(viaCanonical);
+        }
+        finally
+        {
+            VirtualFileSystem.FileDelete(aliasesUrl);
+        }
+    }
+
+    [Fact]
     public void LifetimeShared()
     {
         var c1 = new C { I = 16 };

--- a/sources/core/Stride.Core/build/Stride.AssetBuildManifest.targets
+++ b/sources/core/Stride.Core/build/Stride.AssetBuildManifest.targets
@@ -51,6 +51,7 @@
       <ProjectAssetsFile />
       <RootNamespace />
       <AssetNamespace />
+      <AssetNamespaceUsings />
       <ProjectDirectory Required="true" />
       <ExcludeDirectory />
       <Extensions />
@@ -95,6 +96,13 @@
             sb.AppendLine("RootNamespace: " + q(RootNamespace));
         if (!string.IsNullOrEmpty(AssetNamespace))
             sb.AppendLine("AssetNamespace: " + q(AssetNamespace));
+        var usings = new SortedSet<string>((AssetNamespaceUsings ?? "").Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(u => u.Trim()).Where(u => u.Length > 0), StringComparer.Ordinal);
+        if (usings.Count > 0)
+        {
+            sb.AppendLine("AssetNamespaceUsings:");
+            foreach (var entry in usings)
+                sb.AppendLine("    - " + q(entry));
+        }
 
         var assemblies = new SortedSet<string>(StringComparer.Ordinal);
         foreach (var item in AssetAssemblies ?? new Microsoft.Build.Framework.ITaskItem[0])
@@ -243,6 +251,7 @@
         ProjectAssetsFile="$(_StrideManifestProjectAssetsFile)"
         RootNamespace="$(RootNamespace)"
         AssetNamespace="$(StrideAssetNamespace)"
+        AssetNamespaceUsings="$(StrideAssetNamespaceUsings)"
         ProjectDirectory="$(MSBuildProjectDirectory)"
         ExcludeDirectory="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)'))"
         Extensions="$(_StrideManifestExtensions)"

--- a/sources/core/Stride.Core/build/Stride.AssetBuildManifest.targets
+++ b/sources/core/Stride.Core/build/Stride.AssetBuildManifest.targets
@@ -212,10 +212,13 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <!-- Conventional sdpkg next to the project (.csproj -> .sdpkg). A platform-head with no sdpkg
-           of its own becomes an implicit package named after the head (e.g. MyGame.Windows), with
-           assets flowing in from the referenced game library. -->
-      <_StrideAuthoredPackagePath>$(MSBuildProjectDirectory)\$(MSBuildProjectName).sdpkg</_StrideAuthoredPackagePath>
+      <!-- StrideCurrentPackagePath points a project at its sdpkg when the name doesn't follow the
+           convention; otherwise the conventional sdpkg next to the project (.csproj -> .sdpkg). Only
+           an existing file counts: a platform project (e.g. MyGame.Windows) may carry a dangling path
+           from an older layout, and must stay an implicit package named after itself (assets flow in
+           from the referenced game library) rather than resurrect a package at the missing path. -->
+      <_StrideAuthoredPackagePath Condition="'$(StrideCurrentPackagePath)' != '' And Exists('$(StrideCurrentPackagePath)')">$(StrideCurrentPackagePath)</_StrideAuthoredPackagePath>
+      <_StrideAuthoredPackagePath Condition="'$(_StrideAuthoredPackagePath)' == ''">$(MSBuildProjectDirectory)\$(MSBuildProjectName).sdpkg</_StrideAuthoredPackagePath>
       <_StrideManifestHostFramework>$(StrideFramework)</_StrideManifestHostFramework>
       <_StrideManifestHostFramework Condition="'$(_StrideManifestHostFramework)' == ''">$(TargetFramework)</_StrideManifestHostFramework>
       <_StrideManifestProjectAssetsFile Condition="Exists('$(ProjectAssetsFile)')">$(ProjectAssetsFile)</_StrideManifestProjectAssetsFile>
@@ -251,7 +254,7 @@
         ProjectAssetsFile="$(_StrideManifestProjectAssetsFile)"
         RootNamespace="$(RootNamespace)"
         AssetNamespace="$(StrideAssetNamespace)"
-        AssetNamespaceUsings="$(StrideAssetNamespaceUsings)"
+        AssetNamespaceUsings="@(StrideAssetNamespaceUsing)"
         ProjectDirectory="$(MSBuildProjectDirectory)"
         ExcludeDirectory="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)'))"
         Extensions="$(_StrideManifestExtensions)"

--- a/sources/core/Stride.Core/build/Stride.AssetBuildManifest.targets
+++ b/sources/core/Stride.Core/build/Stride.AssetBuildManifest.targets
@@ -50,6 +50,7 @@
       <TargetFramework />
       <ProjectAssetsFile />
       <RootNamespace />
+      <AssetNamespace />
       <ProjectDirectory Required="true" />
       <ExcludeDirectory />
       <Extensions />
@@ -92,6 +93,8 @@
             sb.AppendLine("NuGetLockFile: " + q(rel(ProjectAssetsFile)));
         if (!string.IsNullOrEmpty(RootNamespace))
             sb.AppendLine("RootNamespace: " + q(RootNamespace));
+        if (!string.IsNullOrEmpty(AssetNamespace))
+            sb.AppendLine("AssetNamespace: " + q(AssetNamespace));
 
         var assemblies = new SortedSet<string>(StringComparer.Ordinal);
         foreach (var item in AssetAssemblies ?? new Microsoft.Build.Framework.ITaskItem[0])
@@ -239,6 +242,7 @@
         TargetFramework="$(TargetFramework)"
         ProjectAssetsFile="$(_StrideManifestProjectAssetsFile)"
         RootNamespace="$(RootNamespace)"
+        AssetNamespace="$(StrideAssetNamespace)"
         ProjectDirectory="$(MSBuildProjectDirectory)"
         ExcludeDirectory="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)'))"
         Extensions="$(_StrideManifestExtensions)"

--- a/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GraphicsCompositorAssetNodeUpdater.cs
+++ b/sources/editor/Stride.Assets.Presentation/NodePresenters/Updaters/GraphicsCompositorAssetNodeUpdater.cs
@@ -75,7 +75,7 @@ namespace Stride.Assets.Presentation.NodePresenters.Updaters
         {
             if (root.PropertyProvider is GraphicsCompositorViewModel)
             {
-                root.Children.Where(x => x.Name != ArchetypeNodeUpdater.ArchetypeNodeName).ForEach(x => x.IsVisible = false);
+                root.Children.Where(x => x.Name != ArchetypeNodeUpdater.ArchetypeNodeName && x.Name != AssetReplacesNodeUpdater.ReplacesNodeName).ForEach(x => x.IsVisible = false);
             }
             base.FinalizeTree(root);
         }

--- a/sources/editor/Stride.Assets.Presentation/Preview/SoundPreview.cs
+++ b/sources/editor/Stride.Assets.Presentation/Preview/SoundPreview.cs
@@ -36,7 +36,7 @@ namespace Stride.Assets.Presentation.Preview
         protected bool VerifyAssetConsistency()
         {
             // Get absolute path of asset source on disk
-            var assetDirectory = (string)AssetItem.Location.GetParent();
+            var assetDirectory = AssetItem.FullPath.GetParent();
             var assetSource = UPath.Combine(assetDirectory, Asset.Source ?? "");
 
             // Check that the source file exist on the disk.

--- a/sources/editor/Stride.Assets.Presentation/Templates/GraphicsCompositorTemplateGenerator.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/GraphicsCompositorTemplateGenerator.cs
@@ -17,7 +17,7 @@ namespace Stride.Assets.Presentation.Templates
         {
             { new Guid("20947F4A-7B50-4716-AC85-D10EFF58CD33"), StridePackageUpgrader.DefaultGraphicsCompositorLevel9Url },
             { new Guid("D4EE3BD3-9B06-460E-9175-D6AFB2459463"), StridePackageUpgrader.DefaultGraphicsCompositorLevel10Url },
-            { new Guid("4BC182D7-69D5-4BE2-9AF3-1C82F67B629D"), "GraphicsCompositor/DefaultGraphicsCompositorVoxels" },
+            { new Guid("4BC182D7-69D5-4BE2-9AF3-1C82F67B629D"), "/Stride.Voxels/GraphicsCompositor/DefaultGraphicsCompositorVoxels" },
         };
 
         public override bool IsSupportingTemplate(TemplateDescription templateDescription)

--- a/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
+++ b/sources/editor/Stride.Assets.Presentation/View/EntityPropertyTemplates.xaml
@@ -194,12 +194,23 @@
           </i:Interaction.Behaviors>
         </Border>
         <DockPanel>
-          <sd:TextBox DockPanel.Dock="Top" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={sd:ContentReferenceToUrl}}"
-                        Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}">
-            <i:Interaction.Behaviors>
-              <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
-            </i:Interaction.Behaviors>
-          </sd:TextBox>
+          <Grid DockPanel.Dock="Top">
+            <sd:TextBox x:Name="UrlTextBox" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={sd:ContentReferenceToUrl}}"
+                          ToolTip="{Binding NodeValue, Converter={sd:ContentReferenceToUrl}}"
+                          Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}">
+              <i:Interaction.Behaviors>
+                <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
+              </i:Interaction.Behaviors>
+            </sd:TextBox>
+            <!-- Unfocused display: asset name never truncated, location dimmed with visible ellipsis -->
+            <DockPanel Margin="3,1,6,6" IsHitTestVisible="False" Background="{Binding Background, ElementName=UrlTextBox}"
+                       Visibility="{Binding IsKeyboardFocusWithin, ElementName=UrlTextBox, Converter={sd:VisibleOrCollapsed}, ConverterParameter={sd:False}, Mode=OneWay}">
+              <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center" Margin="3,0,0,0"
+                         Text="{Binding NodeValue, Converter={sd:ContentReferenceToDisplayName}}"/>
+              <TextBlock VerticalAlignment="Center" Margin="8,0,3,0" Opacity="0.6" TextTrimming="CharacterEllipsis"
+                         Text="{Binding NodeValue, Converter={sd:ContentReferenceToDisplayLocation}}"/>
+            </DockPanel>
+          </Grid>
           <UniformGrid Rows="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6,0">
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding HighlightMaterial}" CommandParameter="{Binding Editor}"
                     ToolTip="{sd:Localize Highlight this material in the scene editor, Context=ToolTip}" Visibility="{Binding HasCommand_HighlightMaterial, Converter={sd:VisibleOrCollapsed}}">

--- a/sources/editor/Stride.Core.Assets.Editor/Components/Properties/SessionObjectPropertiesViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Components/Properties/SessionObjectPropertiesViewModel.cs
@@ -51,6 +51,7 @@ namespace Stride.Core.Assets.Editor.Components.Properties
             RegisterNodePresenterCommand(new ResetOverrideCommand());
 
             RegisterNodePresenterUpdater(new ArchetypeNodeUpdater());
+            RegisterNodePresenterUpdater(new AssetReplacesNodeUpdater());
             RegisterNodePresenterUpdater(new DocumentationNodeUpdater(documentationService));
             RegisterNodePresenterUpdater(new OwnerAssetUpdater());
             RegisterNodePresenterUpdater(new PackageSettingsNodeUpdater());

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AssetInitialDirectoryProvider.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Commands/AssetInitialDirectoryProvider.cs
@@ -23,7 +23,7 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Commands
                 var projectPath = session.ActiveAssetView.SelectedAssetsPackage.PackagePath;
                 if (projectPath != null)
                 {
-                    var assetFullPath = UPath.Combine(projectPath.GetFullDirectory(), new UFile(asset.Url));
+                    var assetFullPath = asset.AssetItem.FullPath;
 
                     if (string.IsNullOrWhiteSpace(currentPath))
                     {

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AssetReplacesNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AssetReplacesNodeUpdater.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Stride.Core.Assets.Editor.Services;
+using Stride.Core.Assets.Editor.ViewModel;
+
+namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
+{
+    public sealed class AssetReplacesNodeUpdater : AssetNodePresenterUpdaterBase
+    {
+        public const string ReplacesNodeName = "ReplacesVirtual";
+
+        protected override void UpdateNode(IAssetNodePresenter node)
+        {
+            if (!(node.PropertyProvider is AssetViewModel) || node.Asset == null)
+                return;
+
+            // Add a link to the replaced asset in the root node, if this asset replaces one.
+            if (typeof(Asset).IsAssignableFrom(node.Type) && node.Asset.Asset.Replaces is { } replaces)
+            {
+                var session = node.Asset.Session;
+                var target = session.GetAssetByUrl(replaces.FullPath);
+                // An unresolved target renders as a broken reference, which is the diagnostic we want
+                var assetReference = target != null ? ContentReferenceHelper.CreateReference<AssetReference>(target) : new AssetReference(AssetId.Empty, replaces);
+                var replacesNode = node.Factory.CreateVirtualNodePresenter(node, ReplacesNodeName, typeof(AssetReference), int.MinValue + 1, () => assetReference);
+                replacesNode.DisplayName = nameof(Asset.Replaces);
+                replacesNode.IsReadOnly = true;
+            }
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
@@ -53,6 +53,10 @@
                         <Image Source="{StaticResource UpdateSelectedAssetsFromSource}" Width="12" Height="12" Margin="5"/>
                       </Button>
                     </Border>
+                    <Border BorderBrush="{StaticResource NormalBorderBrush}" BorderThickness="2" CornerRadius="3" Background="{StaticResource NormalBrush}"
+                          HorizontalAlignment="Right" VerticalAlignment="Bottom" Visibility="{Binding IsReplacing, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}">
+                      <Image Source="{StaticResource ImageAssetOverride}" Width="12" Height="12" Margin="5" ToolTip="{Binding ReplacesUrl, StringFormat={sd:Localize Replaces {0}}}"/>
+                    </Border>
                     <Button HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,3" Command="{Binding Dependencies.ToggleIsRootOnSelectedAssetCommand, FallbackValue={x:Null}}">
                       <Button.Style>
                         <Style TargetType="Button">
@@ -97,6 +101,10 @@
                           <TextBlock Text="{Binding Url, StringFormat={sd:Localize URL: {0}}}" FontWeight="Bold"/>
                           <TextBlock Text="{Binding TypeDisplayName, StringFormat={sd:Localize Type: {0}}}"/>
                           <TextBlock Text="{Binding Tags, Converter={sd:JoinStrings}, StringFormat={sd:Localize Tags: {0}}}"  Visibility="{Binding Tags, Converter={sd:Chained {sd:CountEnumerable}, {sd:NumericToBool}, {sd:VisibleOrCollapsed}}, FallbackValue={sd:Collapsed}}"/>
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding IsReplacing, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
+                            <Image Source="{StaticResource ImageAssetOverride}" Width="16" Height="16" Margin="0,2,0,0"/>
+                            <TextBlock Text="{Binding ReplacesUrl, StringFormat={sd:Localize Replaces {0}}}"/>
+                          </StackPanel>
                           <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsRoot, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Margin="0,2,0,0"/>
                             <TextBlock Text="{sd:Localize Included in build as root}"/>

--- a/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -1454,12 +1454,43 @@
           <Image Source="{StaticResource ImageFetchAsset}" Width="16" Height="16" Margin="-1"/>
         </Button>
       </UniformGrid>
-      <sd:TextBox SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}" Margin="5"
-                    ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
-        <i:Interaction.Behaviors>
-          <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
-        </i:Interaction.Behaviors>
-      </sd:TextBox>
+      <Grid>
+        <sd:TextBox x:Name="UrlTextBox" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}" Margin="5"
+                      ToolTip="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}"
+                      ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
+          <i:Interaction.Behaviors>
+            <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
+          </i:Interaction.Behaviors>
+        </sd:TextBox>
+        <!-- Unfocused display: left-aligned; name has priority (truncates last); the dimmed location prefix + slash
+             collapse together when space runs low, so no lone separator is left -->
+        <Grid x:Name="RefOverlay" Margin="6" IsHitTestVisible="False" Background="{Binding Background, ElementName=UrlTextBox}"
+              Visibility="{Binding IsKeyboardFocusWithin, ElementName=UrlTextBox, Converter={sd:VisibleOrCollapsed}, ConverterParameter={sd:False}, Mode=OneWay}">
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center">
+            <StackPanel Orientation="Horizontal">
+              <StackPanel.Visibility>
+                <MultiBinding Converter="{cvt:ReferenceLocationVisibility}" ConverterParameter="{sd:Double 24}">
+                  <Binding ElementName="RefOverlay" Path="ActualWidth"/>
+                  <Binding ElementName="RefName" Path="ActualWidth"/>
+                  <Binding Path="NodeValue" Converter="{cvt:ContentReferenceToDisplayLocation}"/>
+                </MultiBinding>
+              </StackPanel.Visibility>
+              <TextBlock Opacity="0.6" TextTrimming="CharacterEllipsis"
+                         Text="{Binding NodeValue, Converter={cvt:ContentReferenceToDisplayLocation}}">
+                <TextBlock.MaxWidth>
+                  <MultiBinding Converter="{sd:SubtractMultiConverter}" ConverterParameter="{sd:Double 6}">
+                    <Binding ElementName="RefOverlay" Path="ActualWidth"/>
+                    <Binding ElementName="RefName" Path="ActualWidth"/>
+                  </MultiBinding>
+                </TextBlock.MaxWidth>
+              </TextBlock>
+              <TextBlock Opacity="0.6" Text="/"/>
+            </StackPanel>
+            <TextBlock x:Name="RefName" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToDisplayName}}"
+                       TextTrimming="CharacterEllipsis" MaxWidth="{Binding ActualWidth, ElementName=RefOverlay}"/>
+          </StackPanel>
+        </Grid>
+      </Grid>
     </DockPanel>
   </DataTemplate>
 
@@ -1500,13 +1531,44 @@
           </i:Interaction.Behaviors>
         </Border>
         <DockPanel>
-          <sd:TextBox DockPanel.Dock="Top" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}"
-                                  Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
-            <i:Interaction.Behaviors>
-              <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
-              <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
-            </i:Interaction.Behaviors>
-          </sd:TextBox>
+          <Grid DockPanel.Dock="Top">
+            <sd:TextBox x:Name="UrlTextBox" SelectAllOnFocus="True" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}"
+                                    ToolTip="{Binding NodeValue, Converter={cvt:ContentReferenceToUrl}}"
+                                    Margin="2,0,5,5" ContextMenu="{StaticResource ReferenceContextMenu}" IsReadOnly="{Binding IsReadOnly}">
+              <i:Interaction.Behaviors>
+                <behaviors:ReferenceHostDragDropBehavior UsePreviewEvents="True" DisplayDropAdorner="InternalOnly"/>
+                <behaviors:TextBoxPropertyValueValidationBehavior AdornerStoryboard="{StaticResource HighlightBorderAdornerValidationErrorStoryboard}"/>
+              </i:Interaction.Behaviors>
+            </sd:TextBox>
+            <!-- Unfocused display: left-aligned; name has priority (truncates last); the dimmed location prefix + slash
+                 collapse together when space runs low, so no lone separator is left -->
+            <Grid x:Name="RefOverlayThumb" Margin="3,1,6,6" IsHitTestVisible="False" Background="{Binding Background, ElementName=UrlTextBox}"
+                  Visibility="{Binding IsKeyboardFocusWithin, ElementName=UrlTextBox, Converter={sd:VisibleOrCollapsed}, ConverterParameter={sd:False}, Mode=OneWay}">
+              <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center">
+                <StackPanel Orientation="Horizontal">
+                  <StackPanel.Visibility>
+                    <MultiBinding Converter="{cvt:ReferenceLocationVisibility}" ConverterParameter="{sd:Double 24}">
+                      <Binding ElementName="RefOverlayThumb" Path="ActualWidth"/>
+                      <Binding ElementName="RefNameThumb" Path="ActualWidth"/>
+                      <Binding Path="NodeValue" Converter="{cvt:ContentReferenceToDisplayLocation}"/>
+                    </MultiBinding>
+                  </StackPanel.Visibility>
+                  <TextBlock Opacity="0.6" TextTrimming="CharacterEllipsis"
+                             Text="{Binding NodeValue, Converter={cvt:ContentReferenceToDisplayLocation}}">
+                    <TextBlock.MaxWidth>
+                      <MultiBinding Converter="{sd:SubtractMultiConverter}" ConverterParameter="{sd:Double 6}">
+                        <Binding ElementName="RefOverlayThumb" Path="ActualWidth"/>
+                        <Binding ElementName="RefNameThumb" Path="ActualWidth"/>
+                      </MultiBinding>
+                    </TextBlock.MaxWidth>
+                  </TextBlock>
+                  <TextBlock Opacity="0.6" Text="/"/>
+                </StackPanel>
+                <TextBlock x:Name="RefNameThumb" Text="{Binding NodeValue, Converter={cvt:ContentReferenceToDisplayName}}"
+                           TextTrimming="CharacterEllipsis" MaxWidth="{Binding ActualWidth, ElementName=RefOverlayThumb}"/>
+              </StackPanel>
+            </Grid>
+          </Grid>
           <UniformGrid Rows="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6,0">
             <Button Style="{StaticResource ImageButtonStyle}" Command="{Binding PickupAsset}" CommandParameter="{Binding Type}"
                     ToolTip="{sd:Localize Select an asset, Context=ToolTip}" Visibility="{Binding HasCommand_PickupAsset, Converter={sd:VisibleOrCollapsed}}">

--- a/sources/editor/Stride.Core.Assets.Editor/View/ValueConverters/ContentReferenceToDisplayUrl.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/ValueConverters/ContentReferenceToDisplayUrl.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using System.Reflection;
+
+using Stride.Core.Assets.Editor.Services;
+using Stride.Core.Assets.Editor.ViewModel;
+using Stride.Core.Serialization;
+using Stride.Core.Serialization.Contents;
+using Stride.Core.Presentation.Quantum.ViewModels;
+using Stride.Core.Translation;
+using Stride.Core.Translation.Presentation.ValueConverters;
+
+namespace Stride.Core.Assets.Editor.View.ValueConverters
+{
+    /// <summary>
+    /// The asset name part of a reference URL, for the unfocused display overlay (never truncated).
+    /// </summary>
+    public class ContentReferenceToDisplayName : LocalizableConverter<ContentReferenceToDisplayName>
+    {
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ContentReferenceDisplayUrl.Split(value, Assembly).Name;
+        }
+    }
+
+    /// <summary>
+    /// The location part of a reference URL without the trailing slash (directories, and the /Package/
+    /// root when the target's namespace is not in scope for the session), for the unfocused display
+    /// overlay. The separating slash is rendered separately so it survives ellipsis trimming.
+    /// </summary>
+    public class ContentReferenceToDisplayLocation : LocalizableConverter<ContentReferenceToDisplayLocation>
+    {
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ContentReferenceDisplayUrl.Split(value, Assembly).Location;
+        }
+    }
+
+    internal static class ContentReferenceDisplayUrl
+    {
+        public static (string Location, string Name) Split(object value, Assembly assembly)
+        {
+            if (value == null)
+                return (string.Empty, ContentReferenceHelper.EmptyReference);
+
+            if (value == NodeViewModel.DifferentValues)
+                return (string.Empty, TranslationManager.Instance.GetString("(Different values)", assembly));
+
+            var contentReference = value as IReference ?? AttachedReferenceManager.GetOrCreateAttachedReference(value);
+            var asset = contentReference != null && contentReference.Id != AssetId.Empty ? SessionViewModel.Instance.GetAssetById(contentReference.Id) : null;
+            if (asset == null)
+                return (string.Empty, ContentReferenceHelper.BrokenReference);
+
+            // In-scope namespaces resolve by bare URL for the open game; display them bare too
+            var url = asset.Url;
+            if (url.StartsWith('/') && asset.AssetItem.Package?.Container?.AssetNamespace is { } assetNamespace
+                && url.Length > assetNamespace.Length + 2 && url[assetNamespace.Length + 1] == '/'
+                && string.Compare(url, 1, assetNamespace, 0, assetNamespace.Length, StringComparison.OrdinalIgnoreCase) == 0
+                && SessionViewModel.Instance.IsAssetNamespaceInScope(assetNamespace))
+            {
+                url = url.Substring(assetNamespace.Length + 2);
+            }
+
+            var slash = url.LastIndexOf('/');
+            return slash < 0 ? (string.Empty, url) : (url.Substring(0, slash), url.Substring(slash + 1));
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/View/ValueConverters/ContentReferenceToDisplayUrl.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/ValueConverters/ContentReferenceToDisplayUrl.cs
@@ -53,14 +53,12 @@ namespace Stride.Core.Assets.Editor.View.ValueConverters
             if (asset == null)
                 return (string.Empty, ContentReferenceHelper.BrokenReference);
 
-            // In-scope namespaces resolve by bare URL for the open game; display them bare too
+            // In-scope namespaces resolve by unqualified URL for the open game; display them unqualified too
             var url = asset.Url;
-            if (url.StartsWith('/') && asset.AssetItem.Package?.Container?.AssetNamespace is { } assetNamespace
-                && url.Length > assetNamespace.Length + 2 && url[assetNamespace.Length + 1] == '/'
-                && string.Compare(url, 1, assetNamespace, 0, assetNamespace.Length, StringComparison.OrdinalIgnoreCase) == 0
+            if (asset.AssetItem.Package?.Container is { AssetNamespace: { } assetNamespace } container
                 && SessionViewModel.Instance.IsAssetNamespaceInScope(assetNamespace))
             {
-                url = url.Substring(assetNamespace.Length + 2);
+                url = container.Unqualify(url).FullPath;
             }
 
             var slash = url.LastIndexOf('/');

--- a/sources/editor/Stride.Core.Assets.Editor/View/ValueConverters/ReferenceLocationVisibility.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/ValueConverters/ReferenceLocationVisibility.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using System.Windows;
+
+using Stride.Core.Presentation.ValueConverters;
+
+namespace Stride.Core.Assets.Editor.View.ValueConverters
+{
+    /// <summary>
+    /// Visibility of the dimmed location prefix (and its slash) in a reference field. Visible only when the
+    /// location is non-empty AND enough width remains after the asset name — so the name keeps priority and
+    /// the prefix is dropped whole rather than leaving a lone separator when space runs out.
+    /// Values: [0] container width, [1] name width, [2] location string. Parameter: minimum remaining width.
+    /// </summary>
+    public class ReferenceLocationVisibility : OneWayMultiValueConverter<ReferenceLocationVisibility>
+    {
+        public override object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length < 3 || values[2] is not string location || string.IsNullOrEmpty(location))
+                return Visibility.Collapsed;
+
+            var containerWidth = System.Convert.ToDouble(values[0], culture);
+            var nameWidth = System.Convert.ToDouble(values[1], culture);
+            var threshold = parameter != null ? System.Convert.ToDouble(parameter, culture) : 0.0;
+            return containerWidth - nameWidth >= threshold ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -1062,7 +1062,11 @@ namespace Stride.Core.Assets.Editor.ViewModel
         {
             foreach (var asset in assets)
             {
-                if (asset.AssetItem.Location.HasDirectory && (directory.Parent == null || !asset.Url.StartsWith(directory.Parent.Path, StringComparison.Ordinal)))
+                // Locations in namespaced packages are rooted /Namespace/...; the directory tree is bare
+                var location = asset.AssetItem.Location;
+                if (location.IsAbsolute && asset.AssetItem.Package?.Container?.AssetNamespace is { } assetNamespace)
+                    location = location.MakeRelative("/" + assetNamespace);
+                if (location.HasDirectory && (directory.Parent == null || !location.FullPath.StartsWith(directory.Parent.Path, StringComparison.Ordinal)))
                 {
                     throw new InvalidOperationException("One of the asset does not match the directory hierarchy.");
                 }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetCollectionViewModel.cs
@@ -1063,9 +1063,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             foreach (var asset in assets)
             {
                 // Locations in namespaced packages are rooted /Namespace/...; the directory tree is bare
-                var location = asset.AssetItem.Location;
-                if (location.IsAbsolute && asset.AssetItem.Package?.Container?.AssetNamespace is { } assetNamespace)
-                    location = location.MakeRelative("/" + assetNamespace);
+                var location = asset.AssetItem.UnqualifiedUrl;
                 if (location.HasDirectory && (directory.Parent == null || !location.FullPath.StartsWith(directory.Parent.Path, StringComparison.Ordinal)))
                 {
                     throw new InvalidOperationException("One of the asset does not match the directory hierarchy.");

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
@@ -73,7 +73,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
         protected readonly SessionNodeContainer NodeContainer;
         protected readonly bool Initializing;
         private readonly AnonymousCommand clearArchetypeCommand;
+        private readonly AnonymousCommand clearReplacesCommand;
         private readonly AnonymousCommand createDerivedAssetCommand;
+        private readonly AnonymousCommand createReplacingAssetCommand;
         private Package package;
         private string name;
         private DirectoryBaseViewModel directory;
@@ -107,7 +109,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
             assetCommands = new ObservableList<MenuCommandInfo>();
             createDerivedAssetCommand = new AnonymousCommand(ServiceProvider, CreateDerivedAsset) { IsEnabled = CanDerive };
+            createReplacingAssetCommand = new AnonymousCommand(ServiceProvider, CreateReplacingAsset) { IsEnabled = CanReplace };
             clearArchetypeCommand = new AnonymousCommand(ServiceProvider, ClearArchetype) { IsEnabled = Asset.Archetype != null };
+            clearReplacesCommand = new AnonymousCommand(ServiceProvider, ClearReplaces) { IsEnabled = IsReplacing };
             // TODO: make the view model independent of the view (ie. MenuCommandInfo.Icon and remove this dispatcher call.
             Dispatcher.InvokeAsync(() =>
             {
@@ -116,9 +120,19 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     DisplayName = "Create derived asset",
                     Icon = new Image { Source = new BitmapImage(new Uri("/Stride.Core.Assets.Editor;component/Resources/Icons/copy_link-32.png", UriKind.RelativeOrAbsolute)) },
                 });
+                assetCommands.Add(new MenuCommandInfo(ServiceProvider, createReplacingAssetCommand)
+                {
+                    DisplayName = "Create replacing asset",
+                    Icon = new Image { Source = new BitmapImage(new Uri("/Stride.Core.Assets.Editor;component/Resources/Icons/copy_link-32.png", UriKind.RelativeOrAbsolute)) },
+                });
                 assetCommands.Add(new MenuCommandInfo(ServiceProvider, clearArchetypeCommand)
                 {
                     DisplayName = "Clear archetype",
+                    Icon = new Image { Source = new BitmapImage(new Uri("/Stride.Core.Assets.Editor;component/Resources/Icons/delete_link-32.png", UriKind.RelativeOrAbsolute)) },
+                });
+                assetCommands.Add(new MenuCommandInfo(ServiceProvider, clearReplacesCommand)
+                {
+                    DisplayName = "Clear replaces",
                     Icon = new Image { Source = new BitmapImage(new Uri("/Stride.Core.Assets.Editor;component/Resources/Icons/delete_link-32.png", UriKind.RelativeOrAbsolute)) },
                 });
             }).Forget();
@@ -220,6 +234,21 @@ namespace Stride.Core.Assets.Editor.ViewModel
         public bool HasBeenUpgraded { get; }
 
         public bool CanDerive => AssetType.GetCustomAttribute<AssetDescriptionAttribute>()?.AllowArchetype ?? false;
+
+        /// <summary>
+        /// Gets whether a replacing asset (an asset with <see cref="Core.Assets.Asset.Replaces"/> targeting this one) can be created from this asset.
+        /// </summary>
+        public bool CanReplace => CanDerive && Asset is not SourceCodeAsset;
+
+        /// <summary>
+        /// Gets whether this asset replaces another asset in the built game.
+        /// </summary>
+        public bool IsReplacing => Asset.Replaces is not null;
+
+        /// <summary>
+        /// The URL this asset replaces, or <c>null</c>.
+        /// </summary>
+        public string ReplacesUrl => Asset.Replaces?.FullPath;
 
         public IReadOnlyObservableCollection<MenuCommandInfo> AssetCommands => assetCommands;
 
@@ -353,6 +382,12 @@ namespace Stride.Core.Assets.Editor.ViewModel
         protected virtual void OnAssetPropertyChanged(string propertyName, IGraphNode node, NodeIndex index, object oldValue, object newValue)
         {
             clearArchetypeCommand.IsEnabled = Asset.Archetype != null;
+            if (propertyName == nameof(Core.Assets.Asset.Replaces))
+            {
+                clearReplacesCommand.IsEnabled = IsReplacing;
+                OnPropertyChanged(nameof(IsReplacing), nameof(ReplacesUrl));
+                Session.CheckAssetReplacements(this);
+            }
         }
 
         protected virtual IObjectNode GetPropertiesRootNode()
@@ -584,6 +619,11 @@ namespace Stride.Core.Assets.Editor.ViewModel
             }
             AssetItem.IsDeleted = IsDeleted;
             Session.SourceTracker?.UpdateAssetStatus(this);
+
+            // Replacement diagnostics cross-reference assets (duplicates, targets), so deleting or
+            // restoring one can affect others' validity
+            if (!Initializing && (Asset.Replaces != null || Session.HasAssetReplacements))
+                Session.CheckAssetReplacements(this);
         }
 
         private bool IsNewNameValid(string newName, out string error)
@@ -627,18 +667,43 @@ namespace Stride.Core.Assets.Editor.ViewModel
         private void CreateDerivedAsset()
         {
             if (CanDerive)
+                CreateChildAsset(Name + "-Derived", replaces: false);
+        }
+
+        private void CreateReplacingAsset()
+        {
+            if (CanReplace)
+                CreateChildAsset(Name, replaces: true);
+        }
+
+        private void CreateChildAsset(string baseName, bool replaces)
+        {
+            var targetDirectory = FindValidCreationLocation(assetItem.Asset.GetType(), directory, Session.CurrentProject);
+
+            if (targetDirectory == null)
+                return;
+
+            var childName = NamingHelper.ComputeNewName(baseName, targetDirectory.Assets, x => x.Name);
+            var childUrl = UFile.Combine(targetDirectory.Path, childName);
+            var childAsset = assetItem.CreateDerivedAsset();
+            if (replaces)
+                childAsset.Replaces = assetItem.Location;
+            var childAssetItem = new AssetItem(childUrl, childAsset);
+            targetDirectory.Package.CreateAsset(targetDirectory, childAssetItem, true, null);
+            if (replaces)
+                Session.CheckAssetReplacements();
+        }
+
+        private void ClearReplaces()
+        {
+            using (var transaction = UndoRedoService.CreateTransaction())
             {
-                var targetDirectory = FindValidCreationLocation(assetItem.Asset.GetType(), directory, Session.CurrentProject);
-
-                if (targetDirectory == null)
-                    return;
-
-                var childName = NamingHelper.ComputeNewName(Name + "-Derived", targetDirectory.Assets, x => x.Name);
-                var childUrl = UFile.Combine(targetDirectory.Path, childName);
-                var childAsset = assetItem.CreateDerivedAsset();
-                var childAssetItem = new AssetItem(childUrl, childAsset);
-                targetDirectory.Package.CreateAsset(targetDirectory, childAssetItem, true, null);
+                PropertyGraph.RootNode[nameof(Core.Assets.Asset.Replaces)].Update(null);
+                UndoRedoService.SetName(transaction, "Clear replaces");
             }
+
+            // Force refreshing the property grid
+            Session.AssetViewProperties.RefreshSelectedPropertiesAsync().Forget();
         }
 
         private void ClearArchetype()

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/PackageViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/PackageViewModel.cs
@@ -715,8 +715,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// </summary>
         private string GetDisplayDirectory(UFile location)
         {
-            if (Package.Container?.AssetNamespace is { } assetNamespace)
-                location = location.MakeRelative("/" + assetNamespace);
+            if (Package.Container is { } container)
+                location = container.Unqualify(location);
             return location.GetFullDirectory() ?? "";
         }
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/PackageViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/PackageViewModel.cs
@@ -217,17 +217,17 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 var message = $"Processing asset {progress + 1}/{workProgress.Maximum}...";
                 workProgress.UpdateProgressAsync(message, progress);
 
-                var url = asset.Location;
+                var url = GetDisplayDirectory(asset.Location);
                 DirectoryBaseViewModel directory;
                 var projectSourceCodeAsset = asset.Asset as IProjectAsset;
                 // TODO CSPROJ=XKPKG override rather than cast to subclass
                 if (projectSourceCodeAsset != null && this is ProjectViewModel project)
                 {
-                    directory = project.GetOrCreateProjectDirectory(url.GetFullDirectory() ?? "", false);
+                    directory = project.GetOrCreateProjectDirectory(url, false);
                 }
                 else
                 {
-                    directory = GetOrCreateAssetDirectory(url.GetFullDirectory() ?? "", false);
+                    directory = GetOrCreateAssetDirectory(url, false);
                 }
                 CreateAsset(directory, asset, false, loggerResult, true);
                 ++progress;
@@ -562,7 +562,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 // Create directories and view models, actually add assets to package.
                 foreach (var asset in fixedAssets)
                 {
-                    var location = asset.Location.GetFullDirectory() ?? "";
+                    var location = GetDisplayDirectory(asset.Location);
                     var assetDirectory = project == null ?
                         GetOrCreateAssetDirectory(location, true) :
                         project.GetOrCreateProjectDirectory(location, true);
@@ -707,6 +707,17 @@ namespace Stride.Core.Assets.Editor.ViewModel
         public DirectoryBaseViewModel GetOrCreateAssetDirectory(string assetDirectory, bool canUndoRedoCreation)
         {
             return AssetMountPoint.GetOrCreateDirectory(assetDirectory, canUndoRedoCreation);
+        }
+
+        /// <summary>
+        /// The directory a location shows under in the tree: the package node is the namespace root,
+        /// so a namespaced package's own locations display bare.
+        /// </summary>
+        private string GetDisplayDirectory(UFile location)
+        {
+            if (Package.Container?.AssetNamespace is { } assetNamespace)
+                location = location.MakeRelative("/" + assetNamespace);
+            return location.GetFullDirectory() ?? "";
         }
 
         /// <inheritdoc/>

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -1048,6 +1048,24 @@ namespace Stride.Core.Assets.Editor.ViewModel
         }
 
         /// <summary>
+        /// True when assets under this namespace resolve by bare URL for the open game: its own
+        /// packages, explicit usings and global-using dependencies.
+        /// </summary>
+        public bool IsAssetNamespaceInScope(string assetNamespace)
+        {
+            if (session.AssetNamespaceUsings.Contains(assetNamespace))
+                return true;
+            foreach (var package in AllPackages)
+            {
+                if (package.Package.Container?.AssetNamespace is { } candidate
+                    && string.Equals(candidate, assetNamespace, StringComparison.OrdinalIgnoreCase)
+                    && !package.Package.IsReadOnly)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Creates a <see cref="IDisposable"/> object that represents a context where most of the standard mechanisms relying on property changes are disabled, such as
         /// property changes notifications, creation of <see cref="ActionItem"/>, andpropagation of properties between a base and a derived asset.
         /// </summary>

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Stride.Core.Assets.Analysis;
+using Stride.Core.Assets.Diagnostics;
 using Stride.Core.Assets.Editor.Components.Properties;
 using Stride.Core.Assets.Editor.Components.Transactions;
 using Stride.Core.Assets.Editor.Components.TemplateDescriptions;
@@ -431,6 +432,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 sessionViewModel.AssetLog.AddLogger(LogKey.Get("Session"), sessionResult);
 
                 sessionViewModel.CheckConsistency();
+                sessionViewModel.CheckAssetReplacements();
 
                 sessionResult.OperationCancelled = cancellationSource.IsCancellationRequested;
             }
@@ -1009,6 +1011,57 @@ namespace Stride.Core.Assets.Editor.ViewModel
         }
 
         /// <summary>
+        /// Gets whether any asset of the session declares <see cref="Asset.Replaces"/>.
+        /// </summary>
+        public bool HasAssetReplacements => AllAssets.Any(x => x.Asset.Replaces != null);
+
+        /// <summary>
+        /// Raised whenever <see cref="CheckAssetReplacements"/> runs, i.e. the session's replacement
+        /// declarations may have changed.
+        /// </summary>
+        public event EventHandler AssetReplacementsChanged;
+
+        /// <summary>
+        /// Validates every <see cref="Asset.Replaces"/> declaration of the session, reporting problems
+        /// in the asset log. Declarations cross-reference each other (duplicates, targets), so any
+        /// change re-validates them all; <paramref name="changedAsset"/> additionally gets its
+        /// messages cleared when it no longer declares anything (cleared or deleted).
+        /// </summary>
+        public void CheckAssetReplacements(AssetViewModel changedAsset = null)
+        {
+            foreach (var asset in AllAssets)
+            {
+                if (asset.Asset.Replaces != null)
+                    CheckAssetReplacement(asset);
+            }
+            if (changedAsset != null && (changedAsset.IsDeleted || changedAsset.Asset.Replaces == null))
+                AssetLog.ClearMessages(LogKey.Get(changedAsset.Id, AssetReplacementLogName));
+            AssetReplacementsChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private const string AssetReplacementLogName = "AssetReplacement";
+
+        private void CheckAssetReplacement([NotNull] AssetViewModel asset)
+        {
+            var logKey = LogKey.Get(asset.Id, AssetReplacementLogName);
+            AssetLog.ClearMessages(logKey);
+            if (asset.Asset.Replaces is not { } target)
+                return;
+
+            var targetItem = asset.AssetItem.Package?.FindAsset(target);
+            var error = AssetReplacementAnalysis.ValidateDeclaration(asset.AssetItem, targetItem);
+            if (error == null)
+            {
+                var duplicate = AllAssets.FirstOrDefault(x => x != asset && x.Asset.Replaces is { } other && string.Equals(other.FullPath, target.FullPath, StringComparison.OrdinalIgnoreCase));
+                if (duplicate != null)
+                    error = $"[{duplicate.Url}] also replaces [{target}]; only one replacement per URL is allowed.";
+            }
+
+            if (error != null)
+                AssetLog.GetLogger(logKey).Log(new AssetSerializableLogMessage(asset.Id, asset.Url, LogMessageType.Warning, error));
+        }
+
+        /// <summary>
         /// Notifies the session that a property of some assets has been changed.
         /// </summary>
         /// <remarks>
@@ -1039,6 +1092,18 @@ namespace Stride.Core.Assets.Editor.ViewModel
             AssetViewModel result;
             assetIdMap.TryGetValue(id, out result);
             return result;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="AssetViewModel"/> instance of the asset which has the given URL, if available.
+        /// </summary>
+        /// <param name="url">The URL of the asset to look for.</param>
+        /// <returns>An <see cref="AssetViewModel"/> that matches the given URL if available. Otherwise, <c>null</c>.</returns>
+        [CanBeNull]
+        public AssetViewModel GetAssetByUrl([NotNull] string url)
+        {
+            var assetItem = session.FindAsset(new UFile(url));
+            return assetItem != null ? GetAssetById(assetItem.Id) : null;
         }
 
         public Type GetAssetViewModelType(AssetItem assetItem)

--- a/sources/editor/Stride.Editor/Build/GameStudioDatabase.cs
+++ b/sources/editor/Stride.Editor/Build/GameStudioDatabase.cs
@@ -21,6 +21,10 @@ namespace Stride.Editor.Build
     public class GameStudioDatabase : IDisposable
     {
         private readonly Dictionary<ObjectUrl, OutputObject> database = new Dictionary<ObjectUrl, OutputObject>();
+        private readonly HashSet<string> pendingReplacementTargets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly object assetReplacementsLock = new object();
+        private Dictionary<string, AssetItem> cachedAssetReplacements;
+        private bool assetReplacementsValid;
         private readonly GameStudioBuilderService assetBuilderService;
         private readonly GameSettingsProviderService settingsProvider;
         internal readonly AssetCompilerContext CompilerContext = new AssetCompilerContext { CompilationContext = typeof(AssetCompilationContext) };
@@ -45,7 +49,8 @@ namespace Stride.Editor.Build
             UpdateGameSettings(settingsProvider.CurrentGameSettings);
             settingsProvider.GameSettingsChanged += OnGameSettingsChanged;
 
-            ((AssetDependencyManager)assetBuilderService.SessionViewModel.DependencyManager).AssetChanged += OnAssetChanged;          
+            ((AssetDependencyManager)assetBuilderService.SessionViewModel.DependencyManager).AssetChanged += OnAssetChanged;
+            assetBuilderService.SessionViewModel.AssetReplacementsChanged += OnAssetReplacementsChanged;
         }
 
         private void OnAssetChanged(AssetItem sender, bool oldValue, bool newValue)
@@ -56,11 +61,18 @@ namespace Stride.Editor.Build
             //}
         }
 
+        private void OnAssetReplacementsChanged(object sender, EventArgs e)
+        {
+            lock (assetReplacementsLock)
+                assetReplacementsValid = false;
+        }
+
         public void Dispose()
         {
             isDisposed = true;
             databaseLock.Dispose();
             settingsProvider.GameSettingsChanged -= OnGameSettingsChanged;
+            assetBuilderService.SessionViewModel.AssetReplacementsChanged -= OnAssetReplacementsChanged;
             ((AssetDependencyManager)assetBuilderService.SessionViewModel.DependencyManager).AssetChanged -= OnAssetChanged;
             CompilerContext.Dispose();
             database.Clear();
@@ -86,7 +98,25 @@ namespace Stride.Editor.Build
             return lockObject;
         }
 
-        public async Task Build(AssetItem asset, BuildDependencyType dependencyType = BuildDependencyType.Runtime)
+        public Task Build(AssetItem asset, BuildDependencyType dependencyType = BuildDependencyType.Runtime)
+        {
+            return Build(asset, GetAssetReplacements(asset.Package?.Session));
+        }
+
+        private Dictionary<string, AssetItem> GetAssetReplacements(PackageSession session)
+        {
+            lock (assetReplacementsLock)
+            {
+                if (!assetReplacementsValid)
+                {
+                    cachedAssetReplacements = AssetReplacementAnalysis.CollectSessionReplacements(session);
+                    assetReplacementsValid = true;
+                }
+                return cachedAssetReplacements;
+            }
+        }
+
+        private async Task Build(AssetItem asset, Dictionary<string, AssetItem> assetReplacements)
         {
             if (isDisposed)
                 throw new ObjectDisposedException(nameof(GameStudioDatabase));
@@ -123,6 +153,63 @@ namespace Stride.Editor.Build
                 foreach (var outputObject in buildUnit.OutputObjects)
                 {
                     database[outputObject.Key] = outputObject.Value;
+                }
+            }
+
+            await ApplyAssetReplacements(buildUnit, assetReplacements);
+        }
+
+        /// <summary>
+        /// Redirects the database entries of replaced URLs found among the build outputs to their
+        /// replacement's compiled content, so the editor game resolves them like the built game does.
+        /// </summary>
+        private async Task ApplyAssetReplacements(EditorGameBuildUnit buildUnit, Dictionary<string, AssetItem> assetReplacements)
+        {
+            if (assetReplacements == null || buildUnit.Failed)
+                return;
+
+            List<(ObjectUrl Target, AssetItem Replacement)> toApply = null;
+            foreach (var output in buildUnit.OutputObjects)
+            {
+                if (output.Key.Type == UrlType.Content
+                    && assetReplacements.TryGetValue(output.Key.Path, out var replacement)
+                    && !string.Equals(replacement.Location.FullPath, output.Key.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    (toApply ??= new List<(ObjectUrl, AssetItem)>()).Add((output.Key, replacement));
+                }
+            }
+            if (toApply == null)
+                return;
+
+            foreach (var (target, replacement) in toApply)
+            {
+                // Reentrancy guard on the build only: the replacement's own dependency graph can
+                // include the replaced URL. The redirect is always (re)applied, so a concurrent
+                // build merging the original content back cannot leave the target un-redirected.
+                bool buildReplacement;
+                lock (pendingReplacementTargets)
+                    buildReplacement = pendingReplacementTargets.Add(target.Path);
+                try
+                {
+                    if (buildReplacement)
+                        await Build(replacement, assetReplacements);
+
+                    using ((await databaseLock.ReserveSyncLock()).Lock())
+                    {
+                        if (isDisposed)
+                            return;
+
+                        if (database.TryGetValue(new ObjectUrl(UrlType.Content, replacement.Location), out var replacementOutput))
+                            database[target] = replacementOutput;
+                    }
+                }
+                finally
+                {
+                    if (buildReplacement)
+                    {
+                        lock (pendingReplacementTargets)
+                            pendingReplacementTargets.Remove(target.Path);
+                    }
                 }
             }
         }

--- a/sources/editor/Stride.Editor/Build/StrideShaderImporter.cs
+++ b/sources/editor/Stride.Editor/Build/StrideShaderImporter.cs
@@ -75,7 +75,8 @@ namespace Stride.Editor.Build
 
             foreach (var package in systemPackages)
             {
-                var mapPackage = new Package { FullPath = package.PackagePath };
+                // Carry the resolved namespace so the wrapped StandalonePackage resolves rooted shader locations
+                var mapPackage = new Package { FullPath = package.PackagePath, AssetNamespace = package.Package.Container?.AssetNamespace };
                 foreach (var asset in package.Assets)
                 {
                     if (typeof(EffectShaderAsset).IsAssignableFrom(asset.AssetType))
@@ -110,7 +111,8 @@ namespace Stride.Editor.Build
 
             foreach (var package in packages)
             {
-                var mapPackage = new Package { FullPath = package.PackagePath };
+                // Carry the resolved namespace so the wrapped StandalonePackage resolves rooted shader locations
+                var mapPackage = new Package { FullPath = package.PackagePath, AssetNamespace = package.Package.Container?.AssetNamespace };
                 foreach (var asset in package.Assets)
                 {
                     if (typeof(EffectShaderAsset).IsAssignableFrom(asset.AssetType))

--- a/sources/editor/Stride.Editor/EditorGame/ContentLoader/EditorContentLoader.cs
+++ b/sources/editor/Stride.Editor/EditorGame/ContentLoader/EditorContentLoader.cs
@@ -15,6 +15,7 @@ using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core;
 using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
+using Stride.Core.IO;
 using Stride.Core.MicroThreading;
 using Stride.Core.Serialization.Contents;
 using Stride.Core.Storage;
@@ -63,6 +64,12 @@ namespace Stride.Editor.EditorGame.ContentLoader
         /// </summary>
         private readonly Dictionary<AssetItem, ReloadingAsset> assetsToReloadMapping = new Dictionary<AssetItem, ReloadingAsset>();
 
+        /// <summary>
+        /// Last known replace target per replacing asset, so clearing or retargeting a declaration
+        /// also refreshes the previously replaced URL.
+        /// </summary>
+        private readonly Dictionary<AssetId, UFile> lastKnownReplaces = new Dictionary<AssetId, UFile>();
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EditorContentLoader"/> class
@@ -78,6 +85,11 @@ namespace Stride.Editor.EditorGame.ContentLoader
             Editor = editor ?? throw new ArgumentNullException(nameof(editor));
             GameDispatcher = gameDispatcher ?? throw new ArgumentNullException(nameof(gameDispatcher));
             Session = asset.Session;
+            foreach (var sessionAsset in Session.AllAssets)
+            {
+                if (sessionAsset.Asset.Replaces is { } replacedUrl)
+                    lastKnownReplaces[sessionAsset.Id] = replacedUrl;
+            }
             Session.AssetPropertiesChanged += AssetPropertiesChanged;
             Game = game ?? throw new ArgumentNullException(nameof(game));
             Manager = new LoaderReferenceManager(GameDispatcher, this);
@@ -486,6 +498,36 @@ namespace Stride.Editor.EditorGame.ContentLoader
 
             // If GameSettingsAssets.ColorSpace was changed, rebuild the whole scene
             var assets = e.Assets.ToList();
+
+            // A change to a replacing asset must refresh the content loaded under the replaced URL;
+            // clearing or retargeting the declaration must also refresh the previous one.
+            // Lock: the session raises this event from the thread pool, so invocations can overlap.
+            foreach (var replacer in e.Assets)
+            {
+                UFile previousUrl;
+                var replacedUrl = replacer.Asset.Replaces;
+                lock (lastKnownReplaces)
+                {
+                    lastKnownReplaces.TryGetValue(replacer.Id, out previousUrl);
+                    if (replacedUrl is not null)
+                        lastKnownReplaces[replacer.Id] = replacedUrl;
+                    else
+                        lastKnownReplaces.Remove(replacer.Id);
+                }
+
+                AddReplaceTarget(replacedUrl);
+                if (previousUrl is not null && previousUrl != replacedUrl)
+                    AddReplaceTarget(previousUrl);
+            }
+
+            void AddReplaceTarget(UFile replacedUrl)
+            {
+                if (replacedUrl is null)
+                    return;
+                var target = Session.GetAssetByUrl(replacedUrl.FullPath);
+                if (target != null && !assets.Contains(target))
+                    assets.Add(target);
+            }
 
             var references = await ComputeReferences();
             var assetsToProcess = new Queue<AssetViewModel>(assets);

--- a/sources/editor/Stride.GameStudio.AutoTesting/UITestHost.cs
+++ b/sources/editor/Stride.GameStudio.AutoTesting/UITestHost.cs
@@ -624,11 +624,15 @@ internal sealed class UITestHost
         private static object? SearchTree(DependencyObject node, string idOrTitle, bool returnElement)
         {
             // Anchorables (panels) match by ContentId; documents (asset editors) typically have
-            // an empty ContentId and identify via Title (the asset URL).
+            // an empty ContentId and identify via Title (the asset URL). Asset URLs may carry a
+            // /Namespace/ prefix, so a bare name also matches its last path segment.
             if (node is FrameworkElement fe && fe.DataContext is LayoutContent lc
-                && (string.Equals(lc.ContentId, idOrTitle, StringComparison.Ordinal)
-                    || string.Equals(lc.Title, idOrTitle, StringComparison.Ordinal)))
+                && (Matches(lc.ContentId) || Matches(lc.Title)))
                 return returnElement ? fe : lc;
+
+            bool Matches(string? candidate)
+                => string.Equals(candidate, idOrTitle, StringComparison.Ordinal)
+                   || (candidate is not null && candidate.EndsWith("/" + idOrTitle, StringComparison.Ordinal));
             var count = VisualTreeHelper.GetChildrenCount(node);
             for (var i = 0; i < count; i++)
             {

--- a/sources/editor/Stride.GameStudio/View/GameStudioWindow.xaml.cs
+++ b/sources/editor/Stride.GameStudio/View/GameStudioWindow.xaml.cs
@@ -363,7 +363,7 @@ namespace Stride.GameStudio.View
             if (startupPackage == null)
                 return;
 
-            var gameSettingsAsset = startupPackage.Assets.FirstOrDefault(x => x.Url == Assets.GameSettingsAsset.GameSettingsLocation);
+            var gameSettingsAsset = startupPackage.Assets.FirstOrDefault(x => x.AssetItem.UnqualifiedUrl == Assets.GameSettingsAsset.GameSettingsLocation);
             if (gameSettingsAsset == null)
             {
                 // Scan dependencies for game settings
@@ -378,7 +378,7 @@ namespace Stride.GameStudio.View
                     if (dependencyPackageViewModel == null)
                         continue;
 
-                    gameSettingsAsset = dependencyPackageViewModel.Assets.FirstOrDefault(x => x.Url == Assets.GameSettingsAsset.GameSettingsLocation);
+                    gameSettingsAsset = dependencyPackageViewModel.Assets.FirstOrDefault(x => x.AssetItem.UnqualifiedUrl == Assets.GameSettingsAsset.GameSettingsLocation);
                     if (gameSettingsAsset != null)
                         break;
                 }

--- a/sources/engine/Stride.Assets.Generators/AssetUrlConstantsGenerator.cs
+++ b/sources/engine/Stride.Assets.Generators/AssetUrlConstantsGenerator.cs
@@ -1,0 +1,411 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Stride.Assets.Generators;
+
+/// <summary>
+/// Generates typed <c>UrlReference</c> constants for the project's authored assets, exposed as
+/// AdditionalFiles by Stride.AssetConstants.targets, so game code can write
+/// <c>Assets.Materials.Ground</c> instead of a URL string.
+/// </summary>
+[Generator]
+public class AssetUrlConstantsGenerator : IIncrementalGenerator
+{
+    private const string DefaultClassName = "Assets";
+    private const string GeneratedFileName = "StrideAssetConstants.g.cs";
+
+    private const string AssetFolderMetadataKey = "build_metadata.AdditionalFiles.StrideAssetFolder";
+    private const string AssetContentTypeMapMetadataKey = "build_metadata.AdditionalFiles.StrideAssetContentTypeMap";
+    private const string UrlReferenceTypeName = "global::Stride.Core.Serialization.UrlReference";
+    private const string AssetContentTypeAttributeFullName = "Stride.Core.Assets.AssetContentTypeAttribute";
+    private const string DataContractAttributeFullName = "Stride.Core.DataContractAttribute";
+    private const string StrideCoreAssetsAssemblyName = "Stride.Core.Assets";
+
+    private static readonly DiagnosticDescriptor IdentifierCollision = new(
+        "STRDIAG012",
+        "Asset constant identifier collision",
+        "The asset '{0}' maps to identifier '{1}' which is already taken; it was emitted as '{2}'",
+        "Stride",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor ClassNameConflict = new(
+        "STRDIAG013",
+        "Asset constants class name conflicts with a namespace",
+        "The asset constants class '{0}.{1}' conflicts with an existing namespace; set <StrideAssetConstantsClassName> (e.g. '{2}') to generate under a different name",
+        "Stride",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal sealed record AssetEntry(string RelativePath, string Tag);
+
+    internal sealed record MapEntry(string Tag, string TypeName);
+
+    internal sealed record Config(string UrlNamespace, string ClassName, string Namespace);
+
+    internal sealed record TagType(string Tag, string TypeName);
+
+    internal sealed record ConflictInfo(bool HasConflict, string Namespace, string ClassName, string Suggestion)
+    {
+        public static readonly ConflictInfo None = new(false, "", "", "");
+    }
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var filesWithOptions = context.AdditionalTextsProvider.Combine(context.AnalyzerConfigOptionsProvider);
+
+        var assets = filesWithOptions
+            .Select(static (pair, cancellationToken) => ReadAssetEntry(pair.Left, pair.Right.GetOptions(pair.Left), cancellationToken))
+            .Where(static entry => entry is not null)
+            .Select(static (entry, _) => entry!)
+            .Collect();
+
+        var mapEntries = filesWithOptions
+            .SelectMany(static (pair, cancellationToken) => ReadMapEntries(pair.Left, pair.Right.GetOptions(pair.Left), cancellationToken))
+            .Collect();
+
+        var config = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => ReadConfig(provider));
+
+        // Keep the compilation out of the source-output stage: it changes every keystroke. The
+        // symbol-dependent parts (type table, name conflict) run in their own stages returning
+        // value-equatable results, so the emit stays cached when assets and config are unchanged.
+        // hasAssets keeps the symbol work off projects that only reference Stride.Engine.
+        var hasAssets = assets.Select(static (entries, _) => !entries.IsEmpty);
+
+        var typeTable = context.CompilationProvider.Combine(mapEntries).Combine(hasAssets)
+            .Select(static (data, cancellationToken) => data.Right
+                ? ResolveTagTypes(data.Left.Left, data.Left.Right, cancellationToken)
+                : ImmutableArray<TagType>.Empty)
+            .WithComparer(TagTableComparer.Instance);
+
+        var conflict = context.CompilationProvider.Combine(config).Combine(hasAssets)
+            .Select(static (data, _) => data.Right
+                ? ResolveConflict(data.Left.Left, data.Left.Right)
+                : ConflictInfo.None);
+
+        var input = assets.Combine(typeTable).Combine(config).Combine(conflict);
+        context.RegisterSourceOutput(input, static (productionContext, data) =>
+            Emit(productionContext, data.Left.Left.Left, data.Left.Left.Right, data.Left.Right, data.Right));
+    }
+
+    private static Config ReadConfig(AnalyzerConfigOptionsProvider provider)
+    {
+        provider.GlobalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespace);
+        provider.GlobalOptions.TryGetValue("build_property.StrideAssetUrlNamespace", out var urlNamespace);
+        provider.GlobalOptions.TryGetValue("build_property.StrideAssetConstantsClassName", out var className);
+        provider.GlobalOptions.TryGetValue("build_property.StrideAssetConstantsNamespace", out var constantsNamespace);
+        return new Config(
+            urlNamespace ?? "",
+            string.IsNullOrEmpty(className) ? DefaultClassName : SanitizeIdentifier(className!),
+            (string.IsNullOrEmpty(constantsNamespace) ? rootNamespace : constantsNamespace) ?? "");
+    }
+
+    // Resolves each asset tag to its runtime type (map files first, compilation symbols override),
+    // sorted so equal resolutions produce an equal array.
+    private static ImmutableArray<TagType> ResolveTagTypes(Compilation compilation, ImmutableArray<MapEntry> mapEntries, CancellationToken cancellationToken)
+    {
+        var tagTypes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var mapEntry in mapEntries.OrderBy(entry => entry.Tag, StringComparer.Ordinal).ThenBy(entry => entry.TypeName, StringComparer.Ordinal))
+        {
+            if (tagTypes.ContainsKey(mapEntry.Tag))
+                continue;
+            if (compilation.GetTypeByMetadataName(mapEntry.TypeName) is { TypeKind: TypeKind.Class, DeclaredAccessibility: Accessibility.Public } type)
+                tagTypes[mapEntry.Tag] = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        }
+        foreach (var pair in ScanCompilationForAssetTypes(compilation, cancellationToken))
+            tagTypes[pair.Key] = pair.Value;
+        return tagTypes
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => new TagType(pair.Key, pair.Value))
+            .ToImmutableArray();
+    }
+
+    private static ConflictInfo ResolveConflict(Compilation compilation, Config config)
+        => HasClassNameConflict(compilation, config, out var suggestion)
+            ? new ConflictInfo(true, config.Namespace, config.ClassName, suggestion)
+            : ConflictInfo.None;
+
+    // ImmutableArray equality is by-reference, so compare element-wise to let equal tables cache.
+    private sealed class TagTableComparer : IEqualityComparer<ImmutableArray<TagType>>
+    {
+        public static readonly TagTableComparer Instance = new();
+
+        public bool Equals(ImmutableArray<TagType> x, ImmutableArray<TagType> y)
+        {
+            if (x.Length != y.Length)
+                return false;
+            for (var i = 0; i < x.Length; i++)
+            {
+                if (!x[i].Equals(y[i]))
+                    return false;
+            }
+            return true;
+        }
+
+        public int GetHashCode(ImmutableArray<TagType> obj)
+        {
+            var hash = 17;
+            foreach (var entry in obj)
+                hash = unchecked(hash * 31 + entry.GetHashCode());
+            return hash;
+        }
+    }
+
+    private static AssetEntry? ReadAssetEntry(AdditionalText file, AnalyzerConfigOptions options, CancellationToken cancellationToken)
+    {
+        if (!options.TryGetValue(AssetFolderMetadataKey, out var folder) || string.IsNullOrEmpty(folder))
+            return null;
+
+        // Asset-ness is decided by content, not extension: authored assets start with a YAML tag line
+        var text = file.GetText(cancellationToken);
+        if (text is null || text.Lines.Count == 0)
+            return null;
+        var firstLine = text.Lines[0].ToString().Trim();
+        if (firstLine.Length < 2 || firstLine[0] != '!')
+            return null;
+        var tag = firstLine.Substring(1).Trim();
+        // Package files are not loadable content (an asset folder can contain the sdpkg itself)
+        if (tag.Length == 0 || tag == "Package")
+            return null;
+
+        var relativePath = GetRelativeAssetPath(folder!, file.Path);
+        return relativePath is null ? null : new AssetEntry(relativePath, tag);
+    }
+
+    private static IEnumerable<MapEntry> ReadMapEntries(AdditionalText file, AnalyzerConfigOptions options, CancellationToken cancellationToken)
+    {
+        if (!options.TryGetValue(AssetContentTypeMapMetadataKey, out var isMap) || !string.Equals(isMap, "true", StringComparison.OrdinalIgnoreCase))
+            yield break;
+        var text = file.GetText(cancellationToken);
+        if (text is null)
+            yield break;
+        foreach (var textLine in text.Lines)
+        {
+            var line = textLine.ToString().Trim();
+            if (line.Length == 0 || line[0] == '#')
+                continue;
+            var separator = line.IndexOf('|');
+            if (separator <= 0 || separator == line.Length - 1)
+                continue;
+            yield return new MapEntry(line.Substring(0, separator).Trim(), line.Substring(separator + 1).Trim());
+        }
+    }
+
+    /// <summary>
+    /// Asset URL path relative to its asset folder: forward slashes, no extension.
+    /// </summary>
+    private static string? GetRelativeAssetPath(string folder, string filePath)
+    {
+        folder = folder.Replace('/', '\\').TrimEnd('\\');
+        var file = filePath.Replace('/', '\\');
+        if (!file.StartsWith(folder + "\\", StringComparison.OrdinalIgnoreCase))
+            return null;
+        var relative = file.Substring(folder.Length + 1).Replace('\\', '/');
+        var lastSlash = relative.LastIndexOf('/');
+        var lastDot = relative.LastIndexOf('.');
+        if (lastDot > lastSlash)
+            relative = relative.Substring(0, lastDot);
+        return relative.Length == 0 ? null : relative;
+    }
+
+    private static void Emit(SourceProductionContext context, ImmutableArray<AssetEntry> assets, ImmutableArray<TagType> typeTable, Config config, ConflictInfo conflict)
+    {
+        var entries = assets
+            .OrderBy(entry => entry.RelativePath, StringComparer.Ordinal)
+            .ToList();
+        if (entries.Count == 0)
+            return;
+
+        if (conflict.HasConflict)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(ClassNameConflict, Location.None, conflict.Namespace, conflict.ClassName, conflict.Suggestion));
+            return;
+        }
+
+        // Tag -> emitted runtime type text (resolved from compilation symbols and map files); else untyped
+        var tagTypes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in typeTable)
+            tagTypes[entry.Tag] = entry.TypeName;
+
+        var root = new Node();
+        foreach (var entry in entries)
+        {
+            var segments = entry.RelativePath.Split('/');
+            var node = root;
+            for (int i = 0; i < segments.Length - 1; i++)
+                node = node.GetOrAddChild(segments[i]);
+            node.Leaves.Add((segments[segments.Length - 1], entry));
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("// <auto-generated/>");
+        var indent = 0;
+        if (config.Namespace.Length > 0)
+        {
+            builder.Append("namespace ").AppendLine(SanitizeNamespace(config.Namespace));
+            builder.AppendLine("{");
+            indent++;
+        }
+        EmitClass(context, builder, root, config.ClassName, config, tagTypes, indent);
+        if (config.Namespace.Length > 0)
+            builder.AppendLine("}");
+
+        context.AddSource(GeneratedFileName, builder.ToString());
+    }
+
+    private static bool HasClassNameConflict(Compilation compilation, Config config, out string suggestion)
+    {
+        suggestion = "";
+        // Only source-declared namespaces conflict outright (CS0434); referenced-assembly
+        // namespaces of the same name are legal until a use site is ambiguous.
+        var ns = compilation.Assembly.GlobalNamespace;
+        if (config.Namespace.Length > 0)
+        {
+            foreach (var part in config.Namespace.Split('.'))
+            {
+                ns = ns.GetNamespaceMembers().FirstOrDefault(member => member.Name == part);
+                if (ns is null)
+                    return false;
+            }
+        }
+        if (!ns.GetNamespaceMembers().Any(member => member.Name == config.ClassName))
+            return false;
+        suggestion = SanitizeIdentifier(compilation.AssemblyName?.Replace(".", "") + config.ClassName);
+        return true;
+    }
+
+    /// <summary>
+    /// Compilation-visible asset types (e.g. a ProjectReference'd plugin): [AssetContentType]
+    /// gives the runtime type, the [DataContract] alias is the YAML tag. Only assemblies that
+    /// reference Stride.Core.Assets can declare asset types, so anything else is skipped whole.
+    /// </summary>
+    private static Dictionary<string, string> ScanCompilationForAssetTypes(Compilation compilation, CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var assembly in EnumerateAssetTypeAssemblies(compilation))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CollectAssetTypes(assembly.GlobalNamespace, result);
+        }
+        return result;
+    }
+
+    private static IEnumerable<IAssemblySymbol> EnumerateAssetTypeAssemblies(Compilation compilation)
+    {
+        if (compilation.SourceModule.ReferencedAssemblies.Any(identity => identity.Name == StrideCoreAssetsAssemblyName))
+            yield return compilation.Assembly;
+        foreach (var reference in compilation.SourceModule.ReferencedAssemblySymbols)
+        {
+            if (reference.Modules.Any(module => module.ReferencedAssemblies.Any(identity => identity.Name == StrideCoreAssetsAssemblyName)))
+                yield return reference;
+        }
+    }
+
+    private static void CollectAssetTypes(INamespaceSymbol ns, Dictionary<string, string> result)
+    {
+        foreach (var member in ns.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol nested:
+                    CollectAssetTypes(nested, result);
+                    break;
+                case INamedTypeSymbol { TypeKind: TypeKind.Class } type:
+                    string? tag = null;
+                    INamedTypeSymbol? contentType = null;
+                    foreach (var attribute in type.GetAttributes())
+                    {
+                        var attributeName = attribute.AttributeClass?.ToDisplayString();
+                        if (attributeName == AssetContentTypeAttributeFullName)
+                            contentType = attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0].Value as INamedTypeSymbol : null;
+                        else if (attributeName == DataContractAttributeFullName && attribute.ConstructorArguments.Length > 0 && attribute.ConstructorArguments[0].Value is string alias)
+                            tag = alias;
+                    }
+                    if (contentType is { TypeKind: TypeKind.Class, DeclaredAccessibility: Accessibility.Public })
+                        result[tag ?? type.Name] = contentType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    break;
+            }
+        }
+    }
+
+    private sealed class Node
+    {
+        public SortedDictionary<string, Node> Children { get; } = new(StringComparer.Ordinal);
+        public List<(string Name, AssetEntry Entry)> Leaves { get; } = [];
+
+        public Node GetOrAddChild(string name)
+        {
+            if (!Children.TryGetValue(name, out var child))
+                Children.Add(name, child = new Node());
+            return child;
+        }
+    }
+
+    private static void EmitClass(SourceProductionContext context, StringBuilder builder, Node node, string className, Config config, Dictionary<string, string> tagTypes, int indent)
+    {
+        var pad = new string(' ', indent * 4);
+        builder.Append(pad).Append("internal static partial class ").AppendLine(className);
+        builder.Append(pad).AppendLine("{");
+
+        // Members and nested classes share one declaration space, and none may shadow the container
+        var usedNames = new HashSet<string>(StringComparer.Ordinal) { className };
+
+        var children = new List<(string Identifier, Node Child)>();
+        foreach (var pair in node.Children)
+            children.Add((TakeIdentifier(context, usedNames, pair.Key, pair.Key), pair.Value));
+        foreach (var (name, entry) in node.Leaves)
+        {
+            var identifier = TakeIdentifier(context, usedNames, name, entry.RelativePath);
+            var url = config.UrlNamespace.Length > 0 ? $"/{config.UrlNamespace}/{entry.RelativePath}" : entry.RelativePath;
+            var type = tagTypes.TryGetValue(entry.Tag, out var contentType) ? $"{UrlReferenceTypeName}<{contentType}>" : UrlReferenceTypeName;
+            builder.Append(pad).Append("    public static readonly ").Append(type).Append(' ').Append(identifier)
+                .Append(" = new ").Append(type).Append("(\"").Append(url.Replace("\\", "\\\\").Replace("\"", "\\\"")).AppendLine("\");");
+        }
+        foreach (var (identifier, child) in children)
+            EmitClass(context, builder, child, identifier, config, tagTypes, indent + 1);
+
+        builder.Append(pad).AppendLine("}");
+    }
+
+    private static string TakeIdentifier(SourceProductionContext context, HashSet<string> usedNames, string name, string sourcePath)
+    {
+        var identifier = SanitizeIdentifier(name);
+        if (!usedNames.Add(identifier))
+        {
+            var index = 1;
+            string candidate;
+            do
+            {
+                candidate = $"{identifier}_{index++}";
+            }
+            while (!usedNames.Add(candidate));
+            context.ReportDiagnostic(Diagnostic.Create(IdentifierCollision, Location.None, sourcePath, identifier, candidate));
+            identifier = candidate;
+        }
+        return identifier;
+    }
+
+    private static string SanitizeIdentifier(string name)
+    {
+        if (name.Length == 0)
+            return "_";
+        var builder = new StringBuilder(name.Length + 1);
+        if (SyntaxFacts.IsIdentifierStartCharacter(name[0]))
+            builder.Append(name[0]);
+        else if (SyntaxFacts.IsIdentifierPartCharacter(name[0]))
+            builder.Append('_').Append(name[0]);
+        else
+            builder.Append('_');
+        for (int i = 1; i < name.Length; i++)
+            builder.Append(SyntaxFacts.IsIdentifierPartCharacter(name[i]) ? name[i] : '_');
+        var identifier = builder.ToString();
+        return SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None ? "@" + identifier : identifier;
+    }
+
+    private static string SanitizeNamespace(string ns)
+        => string.Join(".", ns.Split('.').Select(SanitizeIdentifier));
+}

--- a/sources/engine/Stride.Assets.Generators/Stride.Assets.Generators.csproj
+++ b/sources/engine/Stride.Assets.Generators/Stride.Assets.Generators.csproj
@@ -1,0 +1,34 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk/Sdk/Sdk.props" />
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Roslyn generators turning a project's Stride assets into typed C# constants</Description>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.CodeAnalysis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets" />
+</Project>

--- a/sources/engine/Stride.Assets.Tests/Stride.Assets.Tests.csproj
+++ b/sources/engine/Stride.Assets.Tests/Stride.Assets.Tests.csproj
@@ -10,11 +10,16 @@
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />
     <ProjectReference Include="..\Stride.Assets\Stride.Assets.csproj" />
     <ProjectReference Include="..\Stride.Assets.Models\Stride.Assets.Models.csproj" />
+    <ProjectReference Include="..\Stride.Assets.Generators\Stride.Assets.Generators.csproj" />
+    <ProjectReference Include="..\Stride.SpriteStudio.Offline\Stride.SpriteStudio.Offline.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\assets\Stride.Core.Assets.Tests\Helpers\GuidGenerator.cs">
       <Link>GuidGenerator.cs</Link>
     </Compile>
+    <Compile Include="TestAssetContentTypeMap.cs" />
+    <Compile Include="TestAssetUrlConstantsGenerator.cs" />
     <Compile Include="TestCodeUpgrade.cs" />
     <Compile Include="TestMemberRequiredComponentChecks.cs" />
     <Compile Include="XunitAttributes.cs" />
@@ -50,6 +55,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="materials\testTextureGeneric.sdmat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Stride.Engine\buildTransitive\Stride.AssetContentTypeMap.txt">
+      <Link>Stride.AssetContentTypeMap.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="readme.md" />

--- a/sources/engine/Stride.Assets.Tests/TestAssetContentTypeMap.cs
+++ b/sources/engine/Stride.Assets.Tests/TestAssetContentTypeMap.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Stride.Core;
+using Stride.Core.Assets;
+using Xunit;
+
+namespace Stride.Assets.Tests
+{
+    /// <summary>
+    /// Keeps the checked-in asset tag -> content type map (consumed by the asset URL constants
+    /// generator) in sync with the engine's [AssetContentType] declarations.
+    /// </summary>
+    public class TestAssetContentTypeMap
+    {
+        [Fact]
+        public void EngineMapMatchesAssetContentTypeDeclarations()
+        {
+            var assetAssemblies = new[]
+            {
+                typeof(Textures.TextureAsset).Assembly,
+                typeof(Models.ModelAsset).Assembly,
+                typeof(SpriteStudio.Offline.SpriteStudioModelAsset).Assembly,
+            };
+
+            var expected = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var assembly in assetAssemblies)
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    var contentType = type.GetCustomAttribute<AssetContentTypeAttribute>();
+                    if (contentType == null)
+                        continue;
+                    var tag = type.GetCustomAttribute<DataContractAttribute>()?.Alias ?? type.Name;
+                    expected.Add($"{tag}|{contentType.ContentType.FullName}");
+                }
+            }
+
+            var mapPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Stride.AssetContentTypeMap.txt");
+            var actual = new SortedSet<string>(
+                File.ReadAllLines(mapPath).Select(line => line.Trim()).Where(line => line.Length > 0 && line[0] != '#'),
+                StringComparer.Ordinal);
+
+            if (!expected.SetEquals(actual))
+            {
+                var message = new StringBuilder();
+                message.AppendLine("Stride.AssetContentTypeMap.txt is out of sync with [AssetContentType] declarations.");
+                foreach (var line in expected.Except(actual))
+                    message.AppendLine($"  missing: {line}");
+                foreach (var line in actual.Except(expected))
+                    message.AppendLine($"  stale:   {line}");
+                Assert.Fail(message.ToString());
+            }
+        }
+    }
+}

--- a/sources/engine/Stride.Assets.Tests/TestAssetUrlConstantsGenerator.cs
+++ b/sources/engine/Stride.Assets.Tests/TestAssetUrlConstantsGenerator.cs
@@ -1,0 +1,284 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Stride.Assets.Generators;
+using Xunit;
+
+namespace Stride.Assets.Tests
+{
+    public class TestAssetUrlConstantsGenerator
+    {
+        private const string AssetFolder = @"C:\proj\Assets";
+
+        [Fact]
+        public void TypedViaMapWithNestedFolders()
+        {
+            var result = Run(
+            [
+                Asset(@"Ground Textures\Skybox texture.sdtex", "!Texture"),
+                Map("Texture|Stride.Graphics.Texture"),
+            ]);
+
+            Assert.Contains("internal static partial class Assets", result.Source);
+            Assert.Contains("internal static partial class Ground_Textures", result.Source);
+            Assert.Contains("global::Stride.Core.Serialization.UrlReference<global::Stride.Graphics.Texture> Skybox_texture", result.Source);
+            Assert.Contains("\"/MyGame/Ground Textures/Skybox texture\"", result.Source);
+            AssertCompiles(result);
+        }
+
+        [Fact]
+        public void UntypedFallbackForUnknownTag()
+        {
+            var result = Run([Asset("Thing.sdcustom", "!SomeUnknownCustomTag")]);
+
+            Assert.Contains("global::Stride.Core.Serialization.UrlReference Thing", result.Source);
+            Assert.DoesNotContain("UrlReference<", result.Source);
+            AssertCompiles(result);
+        }
+
+        [Fact]
+        public void UnqualifiedUrlWhenNoNamespace()
+        {
+            var result = Run([Asset("Ground.sdtex", "!Texture")], urlNamespace: "");
+
+            Assert.Contains("\"Ground\"", result.Source);
+            Assert.DoesNotContain("\"/", result.Source);
+        }
+
+        [Fact]
+        public void SanitizationAndCollisionSuffix()
+        {
+            var result = Run(
+            [
+                Asset("A b.sdtex", "!UnknownTagKeepsThemUntyped"),
+                Asset("A_b.sdtex", "!UnknownTagKeepsThemUntyped"),
+                Asset("2 Cool.sdtex", "!UnknownTagKeepsThemUntyped"),
+            ]);
+
+            Assert.Contains("UrlReference A_b ", result.Source);
+            Assert.Contains("UrlReference A_b_1 ", result.Source);
+            Assert.Contains("UrlReference _2_Cool ", result.Source);
+            Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "STRDIAG012");
+            AssertCompiles(result);
+        }
+
+        [Fact]
+        public void KeywordFolderIsEscaped()
+        {
+            var result = Run([Asset(@"new\Ground.sdtex", "!Texture")]);
+
+            Assert.Contains("internal static partial class @new", result.Source);
+            Assert.Contains("\"/MyGame/new/Ground\"", result.Source);
+            AssertCompiles(result);
+        }
+
+        [Fact]
+        public void NamespaceConflictSkipsGeneration()
+        {
+            var result = Run(
+                [Asset("Ground.sdtex", "!Texture")],
+                source: "namespace MyGame.Assets { public class Foo { } }");
+
+            Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "STRDIAG013");
+            Assert.Null(result.Source);
+        }
+
+        [Fact]
+        public void CompilationSymbolsWinOverMap()
+        {
+            var result = Run(
+            [
+                Asset("Thing.sdcustom", "!CustomThing"),
+                Map("CustomThing|Stride.Graphics.Texture"),
+            ],
+                source: """
+                    using Stride.Core;
+                    using Stride.Core.Assets;
+                    namespace MyPlugin
+                    {
+                        public class CustomContent { }
+
+                        [DataContract("CustomThing")]
+                        [AssetContentType(typeof(CustomContent))]
+                        public class CustomThingAsset { }
+                    }
+                    """);
+
+            Assert.Contains("UrlReference<global::MyPlugin.CustomContent> Thing", result.Source);
+            AssertCompiles(result);
+        }
+
+        [Fact]
+        public void NonAssetFilesAreSkipped()
+        {
+            var result = Run(
+            [
+                (Path.Combine(AssetFolder, "shader.sdsl"), "shader Foo {}", AssetFolder, false),
+                (Path.Combine(AssetFolder, "note.txt"), "hello", AssetFolder, false),
+                (Path.Combine(AssetFolder, "MyGame.Game.sdpkg"), "!Package\nId: 00000000-0000-0000-0000-000000000002\n", AssetFolder, false),
+            ]);
+
+            Assert.Null(result.Source);
+        }
+
+        [Fact]
+        public void EmitIsCachedWhenOnlyUnrelatedSourceChanges()
+        {
+            var (driver, _) = TrackingDriver([Asset("Ground.sdtex", "!Texture"), Map("Texture|Stride.Graphics.Texture")]);
+
+            var result = driver.RunGenerators(CreateCompilation("public class TestDummy { }"));
+            // An unrelated source edit produces a new compilation but the same assets, resolved
+            // types and config, so the source emit must stay cached instead of regenerating.
+            result = result.RunGenerators(CreateCompilation("public class TestDummy { public void Extra() { } }"));
+
+            Assert.All(OutputReasons(result), reason => Assert.Equal(IncrementalStepRunReason.Cached, reason));
+        }
+
+        [Fact]
+        public void EmitRefiresWhenAssetsChange()
+        {
+            var (driver, texts) = TrackingDriver([Asset("Ground.sdtex", "!Texture")]);
+            var result = driver.RunGenerators(CreateCompilation("public class TestDummy { }"));
+
+            // Retag the asset: its entry changes, so the emit must re-run (guards against the
+            // custom array comparer over-caching) and reflect the new (untyped) constant.
+            var retagged = new TestAdditionalText(texts[0].Path, "!Sound\nId: 00000000-0000-0000-0000-000000000001\n");
+            result = result.ReplaceAdditionalText(texts[0], retagged)
+                .RunGenerators(CreateCompilation("public class TestDummy { }"));
+
+            Assert.Contains(OutputReasons(result), reason => reason != IncrementalStepRunReason.Cached);
+        }
+
+        private static IEnumerable<IncrementalStepRunReason> OutputReasons(GeneratorDriver driver)
+            => driver.GetRunResult().Results.Single().TrackedOutputSteps
+                .SelectMany(pair => pair.Value)
+                .SelectMany(step => step.Outputs)
+                .Select(output => output.Reason);
+
+        private static (GeneratorDriver Driver, AdditionalText[] Texts) TrackingDriver((string Path, string Content, string? Folder, bool IsMap)[] files)
+        {
+            var texts = files.Select(file => (AdditionalText)new TestAdditionalText(file.Path, file.Content)).ToArray();
+            var perFileOptions = files.ToDictionary(
+                file => file.Path,
+                file =>
+                {
+                    var options = new Dictionary<string, string>();
+                    if (file.Folder != null)
+                        options["build_metadata.AdditionalFiles.StrideAssetFolder"] = file.Folder;
+                    if (file.IsMap)
+                        options["build_metadata.AdditionalFiles.StrideAssetContentTypeMap"] = "true";
+                    return options;
+                });
+            var globalOptions = new Dictionary<string, string>
+            {
+                ["build_property.RootNamespace"] = "MyGame",
+                ["build_property.StrideAssetUrlNamespace"] = "MyGame",
+            };
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [new AssetUrlConstantsGenerator().AsSourceGenerator()],
+                additionalTexts: texts,
+                parseOptions: null,
+                optionsProvider: new TestOptionsProvider(globalOptions, perFileOptions),
+                driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+            return (driver, texts);
+        }
+
+        private static Compilation CreateCompilation(string source)
+            => CSharpCompilation.Create("MyGame.Game",
+                [CSharpSyntaxTree.ParseText(source)],
+                References.Value,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        private static (string Path, string Content, string? Folder, bool IsMap) Asset(string relativePath, string tag)
+            => (Path.Combine(AssetFolder, relativePath), $"{tag}\nId: 00000000-0000-0000-0000-000000000001\n", AssetFolder, false);
+
+        private static (string Path, string Content, string? Folder, bool IsMap) Map(string content)
+            => (@"C:\maps\Test.AssetContentTypeMap.txt", content, null, true);
+
+        private sealed record RunResult(string? Source, ImmutableArray<Diagnostic> Diagnostics, Compilation Output);
+
+        private static RunResult Run(
+            (string Path, string Content, string? Folder, bool IsMap)[] files,
+            string urlNamespace = "MyGame",
+            string source = "public class TestDummy { }")
+        {
+            var compilation = CSharpCompilation.Create("MyGame.Game",
+                [CSharpSyntaxTree.ParseText(source)],
+                References.Value,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var texts = files.Select(file => (AdditionalText)new TestAdditionalText(file.Path, file.Content)).ToArray();
+            var perFileOptions = files.ToDictionary(
+                file => file.Path,
+                file =>
+                {
+                    var options = new Dictionary<string, string>();
+                    if (file.Folder != null)
+                        options["build_metadata.AdditionalFiles.StrideAssetFolder"] = file.Folder;
+                    if (file.IsMap)
+                        options["build_metadata.AdditionalFiles.StrideAssetContentTypeMap"] = "true";
+                    return options;
+                });
+            var globalOptions = new Dictionary<string, string>
+            {
+                ["build_property.RootNamespace"] = "MyGame",
+                ["build_property.StrideAssetUrlNamespace"] = urlNamespace,
+            };
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [new AssetUrlConstantsGenerator().AsSourceGenerator()],
+                additionalTexts: texts,
+                optionsProvider: new TestOptionsProvider(globalOptions, perFileOptions));
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var output, out var diagnostics);
+
+            var generated = driver.GetRunResult().Results.Single().GeneratedSources;
+            return new RunResult(generated.Length > 0 ? generated[0].SourceText.ToString() : null, diagnostics, output);
+        }
+
+        private static void AssertCompiles(RunResult result)
+        {
+            var errors = result.Output.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToList();
+            Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors));
+        }
+
+        private static readonly Lazy<PortableExecutableReference[]> References = new(() =>
+            ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+                .Split(Path.PathSeparator)
+                .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                .Select(path => MetadataReference.CreateFromFile(path))
+                .ToArray());
+
+        private sealed class TestAdditionalText(string path, string content) : AdditionalText
+        {
+            public override string Path => path;
+            public override SourceText GetText(CancellationToken cancellationToken = default) => SourceText.From(content);
+        }
+
+        private sealed class TestOptions(Dictionary<string, string>? values) : AnalyzerConfigOptions
+        {
+            public override bool TryGetValue(string key, out string value)
+            {
+                value = null!;
+                return values?.TryGetValue(key, out value!) == true;
+            }
+        }
+
+        private sealed class TestOptionsProvider(Dictionary<string, string> globalOptions, Dictionary<string, Dictionary<string, string>> perFileOptions)
+            : AnalyzerConfigOptionsProvider
+        {
+            public override AnalyzerConfigOptions GlobalOptions { get; } = new TestOptions(globalOptions);
+            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => new TestOptions(null);
+            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => new TestOptions(perFileOptions.TryGetValue(textFile.Path, out var options) ? options : null);
+        }
+    }
+}

--- a/sources/engine/Stride.Assets/GameSettingsAssetExtensions.cs
+++ b/sources/engine/Stride.Assets/GameSettingsAssetExtensions.cs
@@ -16,10 +16,14 @@ namespace Stride.Assets
         /// <returns>The <see cref="GameSettingsAsset"/> from the given <see cref="Package"/> if available. Null otherwise.</returns>
         public static GameSettingsAsset GetGameSettingsAsset(this Package package)
         {
-            var gameSettingsAsset = package.FindAsset(GameSettingsAsset.GameSettingsLocation);
+            // Namespaced packages root their asset locations /Namespace/...
+            var location = package.Container?.AssetNamespace is { } assetNamespace
+                ? $"/{assetNamespace}/{GameSettingsAsset.GameSettingsLocation}"
+                : GameSettingsAsset.GameSettingsLocation;
+            var gameSettingsAsset = package.FindAsset(location);
             if (gameSettingsAsset == null && package.TemporaryAssets.Count > 0)
             {
-                gameSettingsAsset = package.TemporaryAssets.Find(x => x.Location == GameSettingsAsset.GameSettingsLocation);
+                gameSettingsAsset = package.TemporaryAssets.Find(x => x.Location == location);
             }
             return gameSettingsAsset?.Asset as GameSettingsAsset;
         }

--- a/sources/engine/Stride.Assets/GameSettingsAssetExtensions.cs
+++ b/sources/engine/Stride.Assets/GameSettingsAssetExtensions.cs
@@ -3,6 +3,7 @@
 
 using Stride.Core.Assets;
 using Stride.Core;
+using Stride.Core.IO;
 using Stride.Graphics;
 
 namespace Stride.Assets
@@ -16,14 +17,23 @@ namespace Stride.Assets
         /// <returns>The <see cref="GameSettingsAsset"/> from the given <see cref="Package"/> if available. Null otherwise.</returns>
         public static GameSettingsAsset GetGameSettingsAsset(this Package package)
         {
-            // Namespaced packages root their asset locations /Namespace/...
-            var location = package.Container?.AssetNamespace is { } assetNamespace
-                ? $"/{assetNamespace}/{GameSettingsAsset.GameSettingsLocation}"
-                : GameSettingsAsset.GameSettingsLocation;
-            var gameSettingsAsset = package.FindAsset(location);
-            if (gameSettingsAsset == null && package.TemporaryAssets.Count > 0)
+            // Searched per package: namespaced packages root their asset locations /Namespace/...
+            static AssetItem FindInPackage(Package candidate)
             {
-                gameSettingsAsset = package.TemporaryAssets.Find(x => x.Location == location);
+                var location = new UFile(candidate.Container?.AssetNamespace is { } assetNamespace
+                    ? $"/{assetNamespace}/{GameSettingsAsset.GameSettingsLocation}"
+                    : GameSettingsAsset.GameSettingsLocation);
+                return candidate.Assets.Find(location) ?? candidate.TemporaryAssets.Find(x => x.Location == location);
+            }
+
+            var gameSettingsAsset = FindInPackage(package);
+            if (gameSettingsAsset == null && package.Container != null)
+            {
+                foreach (var dependency in package.Container.FlattenedDependencies)
+                {
+                    if (dependency.Package != null && (gameSettingsAsset = FindInPackage(dependency.Package)) != null)
+                        break;
+                }
             }
             return gameSettingsAsset?.Asset as GameSettingsAsset;
         }

--- a/sources/engine/Stride.Assets/GameSettingsFactory.cs
+++ b/sources/engine/Stride.Assets/GameSettingsFactory.cs
@@ -20,7 +20,7 @@ namespace Stride.Assets
         {
             var asset = new GameSettingsAsset();
 
-            asset.SplashScreenTexture = AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("d26edb11-10bd-403c-b3c2-9c7fcccf25e5"), "StrideDefaultSplashScreen");
+            asset.SplashScreenTexture = AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("d26edb11-10bd-403c-b3c2-9c7fcccf25e5"), "/Stride.Engine/StrideDefaultSplashScreen");
             asset.SplashScreenColor = Color.Black;
 
             //add default filters, todo maybe a config file somewhere is better

--- a/sources/engine/Stride.Assets/Materials/MaterialAssetCompiler.cs
+++ b/sources/engine/Stride.Assets/Materials/MaterialAssetCompiler.cs
@@ -30,8 +30,8 @@ namespace Stride.Assets.Materials
         public override IEnumerable<ObjectUrl> GetInputFiles(AssetItem assetItem)
         {
             // Note: might not be needed in all cases, but let's not bother for now (they are only 9kb)
-            yield return new ObjectUrl(UrlType.Content, "StrideEnvironmentLightingDFGLUT16");
-            yield return new ObjectUrl(UrlType.Content, "StrideEnvironmentLightingDFGLUT8");
+            yield return new ObjectUrl(UrlType.Content, "/Stride.Engine/StrideEnvironmentLightingDFGLUT16");
+            yield return new ObjectUrl(UrlType.Content, "/Stride.Engine/StrideEnvironmentLightingDFGLUT8");
         }
 
         protected override void Prepare(AssetCompilerContext context, AssetItem assetItem, string targetUrlInStorage, AssetCompilerResult result)

--- a/sources/engine/Stride.Assets/StridePackageUpgrader.cs
+++ b/sources/engine/Stride.Assets/StridePackageUpgrader.cs
@@ -31,8 +31,8 @@ namespace Stride.Assets
         // Should match Stride.nupkg
         public const string CurrentVersion = StrideVersion.NuGetVersion;
 
-        public static readonly string DefaultGraphicsCompositorLevel9Url = "DefaultGraphicsCompositorLevel9";
-        public static readonly string DefaultGraphicsCompositorLevel10Url = "DefaultGraphicsCompositorLevel10";
+        public static readonly string DefaultGraphicsCompositorLevel9Url = "/Stride.Engine/DefaultGraphicsCompositorLevel9";
+        public static readonly string DefaultGraphicsCompositorLevel10Url = "/Stride.Engine/DefaultGraphicsCompositorLevel10";
 
         public static readonly Guid DefaultGraphicsCompositorLevel9CameraSlot = new Guid("bbfef2cb-8c63-4cab-9caf-6ae48f44a8ba");
         public static readonly Guid DefaultGraphicsCompositorLevel10CameraSlot = new Guid("d0a6bf72-b3cd-4bd4-94ca-69952999d537");

--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -88,7 +88,7 @@ namespace Stride.Profiling
             {
                 fastTextRenderer = new FastTextRenderer(Game.GraphicsContext)
                 {
-                    DebugSpriteFont = Content.Load<Texture>("StrideDebugSpriteFont"),
+                    DebugSpriteFont = Content.Load<Texture>("/Stride.Engine/StrideDebugSpriteFont"),
                     TextColor = TextColor,
                 };
             }

--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
@@ -350,7 +350,7 @@ namespace Stride.Profiling
 
             fastTextRenderer ??= new FastTextRenderer(graphicsContext)
             {
-                DebugSpriteFont = Content.Load<Texture>("StrideDebugSpriteFont"),
+                DebugSpriteFont = Content.Load<Texture>("/Stride.Engine/StrideDebugSpriteFont"),
                 TextColor = TextColor,
             };
 

--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -9,6 +9,9 @@
     <StrideCodeAnalysis>true</StrideCodeAnalysis>
     <StridePackAssets>true</StridePackAssets>
     <StrideContainsAssetTypes>true</StrideContainsAssetTypes>
+    <!-- RootNamespace is Stride, so the default constants class would be the type Stride.Assets,
+         colliding with the Stride.Assets namespace in assemblies that see engine internals -->
+    <StrideAssetConstantsNamespace>Stride.Engine</StrideAssetConstantsNamespace>
     <!-- force generate Resource.designer.cs to namespace Stride.Engine to fix issue #553 -->
     <AndroidResgenNamespace>Stride.Engine</AndroidResgenNamespace>
   </PropertyGroup>
@@ -20,6 +23,10 @@
   <ItemGroup>
     <None Include="buildTransitive\**\*.targets" PackagePath="buildTransitive\" Pack="true" />
     <None Include="buildTransitive\**\*.props" PackagePath="buildTransitive\" Pack="true" />
+    <None Include="buildTransitive\Stride.AssetContentTypeMap.txt" PackagePath="buildTransitive\" Pack="true" />
+    <!-- Asset URL constants generator, packaged here so it reaches every asset-bearing consumer;
+         the ProjectReference only orders the build. -->
+    <None Include="..\Stride.Assets.Generators\bin\$(Configuration)\netstandard2.0\Stride.Assets.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" />

--- a/sources/engine/Stride.Engine/Stride.Engine.sdpkg
+++ b/sources/engine/Stride.Engine/Stride.Engine.sdpkg
@@ -6,6 +6,6 @@ AssetFolders:
 ResourceFolders:
     - !dir AssetPackage/Resources
 RootAssets:
-    - c90f3988-0544-4cbe-993f-13af7d9c23c6:StrideDefaultFont
-    - d26edb11-10bd-403c-b3c2-9c7fcccf25e5:StrideDefaultSplashScreen
-    - FF02239B-3697-4EBB-9F37-FE880659E64B:StrideDebugSpriteFont
+    - c90f3988-0544-4cbe-993f-13af7d9c23c6:/Stride.Engine/StrideDefaultFont
+    - d26edb11-10bd-403c-b3c2-9c7fcccf25e5:/Stride.Engine/StrideDefaultSplashScreen
+    - FF02239B-3697-4EBB-9F37-FE880659E64B:/Stride.Engine/StrideDebugSpriteFont

--- a/sources/engine/Stride.Engine/buildTransitive/Stride.AssetConstants.targets
+++ b/sources/engine/Stride.Engine/buildTransitive/Stride.AssetConstants.targets
@@ -1,0 +1,141 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Exposes the project's authored assets to Roslyn components as AdditionalFiles
+       (with their asset-folder root and the resolved asset URL namespace), feeding the
+       asset URL constants generator in Stride.Assets.Generators. -->
+
+  <PropertyGroup>
+    <StrideAssetConstantsImported>true</StrideAssetConstantsImported>
+    <StrideGenerateAssetConstants Condition="'$(StrideGenerateAssetConstants)' == ''">true</StrideGenerateAssetConstants>
+    <!-- Only an existing StrideCurrentPackagePath counts; a dangling path (e.g. a platform project
+         carrying one from an older layout) falls back to the conventional sdpkg next to the project. -->
+    <_StrideAssetConstantsPackagePath Condition="'$(StrideCurrentPackagePath)' != '' And Exists('$(StrideCurrentPackagePath)')">$(StrideCurrentPackagePath)</_StrideAssetConstantsPackagePath>
+    <_StrideAssetConstantsPackagePath Condition="'$(_StrideAssetConstantsPackagePath)' == ''">$(MSBuildProjectDirectory)\$(MSBuildProjectName).sdpkg</_StrideAssetConstantsPackagePath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(StrideGenerateAssetConstants)' == 'true'">
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="StrideAssetFolder" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="StrideAssetContentTypeMap" />
+    <CompilerVisibleProperty Include="StrideAssetUrlNamespace" />
+    <CompilerVisibleProperty Include="StrideAssetConstantsClassName" />
+    <CompilerVisibleProperty Include="StrideAssetConstantsNamespace" />
+    <!-- Engine asset tag -> content type map, shipped next to this file; plugins register
+         their own the same way from their buildTransitive targets. -->
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)Stride.AssetContentTypeMap.txt"
+                     Condition="Exists('$(_StrideAssetConstantsPackagePath)') And Exists('$(MSBuildThisFileDirectory)Stride.AssetContentTypeMap.txt')"
+                     StrideAssetContentTypeMap="true" />
+  </ItemGroup>
+
+  <UsingTask TaskName="StrideCollectAssetConstantsInputs"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <PackagePath Required="true" />
+      <AssetNamespace />
+      <PackageName />
+      <AssetFiles ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+      <ResolvedNamespace ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        Func<string, string> unquote = s =>
+        {
+            s = s.Trim();
+            if (s.Length >= 2 && s[0] == '"' && s[s.Length - 1] == '"')
+                s = s.Substring(1, s.Length - 2).Replace("\\\\", "\\").Replace("\\\"", "\"");
+            return s;
+        };
+
+        // Line-based scan of the authored sdpkg: Meta.Name + AssetFolders paths.
+        var authoredName = (string)null;
+        var folderPaths = new List<string>();
+        string topLevelKey = null;
+        foreach (var rawLine in File.ReadAllLines(PackagePath))
+        {
+            if (rawLine.Length == 0)
+                continue;
+            if (!char.IsWhiteSpace(rawLine[0]) && rawLine[0] != '-')
+            {
+                var colon = rawLine.IndexOf(':');
+                topLevelKey = colon > 0 ? rawLine.Substring(0, colon).Trim() : null;
+                continue;
+            }
+            var line = rawLine.TrimStart(' ', '-');
+            if (topLevelKey == "Meta" && authoredName == null && line.StartsWith("Name:", StringComparison.Ordinal))
+                authoredName = unquote(line.Substring("Name:".Length));
+            else if (topLevelKey == "AssetFolders" && line.StartsWith("Path:", StringComparison.Ordinal))
+            {
+                var value = line.Substring("Path:".Length).Trim();
+                if (value.StartsWith("!dir", StringComparison.Ordinal))
+                    value = value.Substring("!dir".Length);
+                value = unquote(value);
+                if (value.Length > 0)
+                    folderPaths.Add(value);
+            }
+        }
+
+        // URL namespace, mirroring the session loader: explicit custom value wins;
+        // true/false/unset resolve to the authored package name, then the project's.
+        var ns = (AssetNamespace ?? "").Trim();
+        if (ns.Length == 0 || string.Equals(ns, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(ns, "false", StringComparison.OrdinalIgnoreCase))
+            ns = !string.IsNullOrEmpty(authoredName) ? authoredName : (PackageName ?? "");
+        ResolvedNamespace = ns;
+
+        var baseDir = Path.GetDirectoryName(Path.GetFullPath(PackagePath));
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var items = new List<Microsoft.Build.Framework.ITaskItem>();
+        var excludedDirectories = new HashSet<string>(new[] { "bin", "obj", ".git", ".vs" }, StringComparer.OrdinalIgnoreCase);
+        foreach (var folderPath in folderPaths)
+        {
+            var folder = Path.GetFullPath(Path.Combine(baseDir, folderPath));
+            if (!Directory.Exists(folder))
+                continue;
+            foreach (var file in Directory.EnumerateFiles(folder, "*", SearchOption.AllDirectories))
+            {
+                if (!seen.Add(file))
+                    continue;
+                // Skip package files and build/VCS directories (an asset folder can be '.')
+                if (string.Equals(Path.GetExtension(file), ".sdpkg", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var relativeDir = Path.GetDirectoryName(file.Substring(folder.Length + 1)) ?? "";
+                if (relativeDir.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).Any(segment => excludedDirectories.Contains(segment)))
+                    continue;
+                var item = new Microsoft.Build.Utilities.TaskItem(file);
+                item.SetMetadata("StrideAssetFolder", folder);
+                items.Add(item);
+            }
+        }
+        AssetFiles = items.ToArray();
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Before GenerateMSBuildEditorConfigFileCore so both the items' metadata and the
+       resolved namespace property land in the analyzer config; runs in design-time
+       builds too, keeping IDE IntelliSense in sync with on-disk assets. -->
+  <Target Name="StrideCollectAssetConstants"
+          BeforeTargets="GenerateMSBuildEditorConfigFileCore;CoreCompile"
+          Condition="'$(StrideGenerateAssetConstants)' == 'true' And Exists('$(_StrideAssetConstantsPackagePath)')">
+    <PropertyGroup>
+      <!-- Package identity fallback chain, same as the asset build manifest -->
+      <_StrideAssetConstantsPackageName>$(PackageId)</_StrideAssetConstantsPackageName>
+      <_StrideAssetConstantsPackageName Condition="'$(_StrideAssetConstantsPackageName)' == ''">$(AssemblyName)</_StrideAssetConstantsPackageName>
+      <_StrideAssetConstantsPackageName Condition="'$(_StrideAssetConstantsPackageName)' == ''">$(MSBuildProjectName)</_StrideAssetConstantsPackageName>
+    </PropertyGroup>
+    <StrideCollectAssetConstantsInputs
+        PackagePath="$(_StrideAssetConstantsPackagePath)"
+        AssetNamespace="$(StrideAssetNamespace)"
+        PackageName="$(_StrideAssetConstantsPackageName)">
+      <Output TaskParameter="AssetFiles" ItemName="_StrideAssetConstantsFile" />
+      <Output TaskParameter="ResolvedNamespace" PropertyName="StrideAssetUrlNamespace" />
+    </StrideCollectAssetConstantsInputs>
+    <ItemGroup>
+      <AdditionalFiles Include="@(_StrideAssetConstantsFile)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/sources/engine/Stride.Engine/buildTransitive/Stride.AssetContentTypeMap.txt
+++ b/sources/engine/Stride.Engine/buildTransitive/Stride.AssetContentTypeMap.txt
@@ -1,0 +1,30 @@
+# Maps asset YAML tags (DataContract alias of the asset type) to the content type
+# loadable through the ContentManager ([AssetContentType] of the asset type), for the
+# asset URL constants generator. Kept in sync with the engine's [AssetContentType]
+# declarations by Stride.Assets.Tests.TestAssetContentTypeMap. Lines: <tag>|<content type>
+Animation|Stride.Animations.AnimationClip
+ColliderShapeAsset|Stride.Physics.PhysicsColliderShape
+GameSettingsAsset|Stride.Engine.Design.GameSettings
+GraphicsCompositorAsset|Stride.Rendering.Compositing.GraphicsCompositor
+HeightmapAsset|Stride.Physics.Heightmap
+HullAsset|Stride.BepuPhysics.Definitions.DecomposedHulls
+MaterialAsset|Stride.Rendering.Material
+Model|Stride.Rendering.Model
+NavigationMeshAsset|Stride.Navigation.NavigationMesh
+PrefabAsset|Stride.Engine.Prefab
+PrefabModelAsset|Stride.Rendering.Model
+PregeneratedSpriteFont|Stride.Graphics.SpriteFont
+ProceduralModelAsset|Stride.Rendering.Model
+RenderTexture|Stride.Graphics.Texture
+SceneAsset|Stride.Engine.Scene
+Skeleton|Stride.Rendering.Skeleton
+SkyboxAsset|Stride.Rendering.Skyboxes.Skybox
+Sound|Stride.Audio.Sound
+SpriteFont|Stride.Graphics.SpriteFont
+SpriteSheet|Stride.Graphics.SpriteSheet
+SpriteStudioAnimationAsset|Stride.Animations.AnimationClip
+SpriteStudioSheetAsset|Stride.SpriteStudio.Runtime.SpriteStudioSheet
+Texture|Stride.Graphics.Texture
+UILibraryAsset|Stride.Engine.UILibrary
+UIPageAsset|Stride.Engine.UIPage
+Video|Stride.Video.Video

--- a/sources/engine/Stride.Engine/buildTransitive/Stride.Engine.targets
+++ b/sources/engine/Stride.Engine/buildTransitive/Stride.Engine.targets
@@ -18,4 +18,7 @@
   <ItemGroup Condition="'$(StrideRemoteEffectCompilerEnabled)' != ''">
     <RuntimeHostConfigurationOption Include="Stride.Engine.RemoteEffectCompilerEnabled" Value="$(StrideRemoteEffectCompilerEnabled)" Trim="true" />
   </ItemGroup>
+
+  <!-- Asset URL constants generator inputs (in-repo projects import this from Sdk.targets instead) -->
+  <Import Project="$(MSBuildThisFileDirectory)Stride.AssetConstants.targets" Condition="'$(StrideAssetConstantsImported)' == ''" />
 </Project>

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialSpecularMicrofacetEnvironmentGGXLUT.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialSpecularMicrofacetEnvironmentGGXLUT.cs
@@ -24,8 +24,8 @@ namespace Stride.Rendering.Materials
         public ShaderSource Generate(MaterialGeneratorContext context)
         {
             var texture = context.GraphicsProfile >= GraphicsProfile.Level_10_0
-                ? AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("a49995f8-2380-4baa-a03e-f8d1da35b79a"), "StrideEnvironmentLightingDFGLUT16")
-                : AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("87540190-ab97-4b4e-b3c2-d57d2fbb1ff3"), "StrideEnvironmentLightingDFGLUT8");
+                ? AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("a49995f8-2380-4baa-a03e-f8d1da35b79a"), "/Stride.Engine/StrideEnvironmentLightingDFGLUT16")
+                : AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("87540190-ab97-4b4e-b3c2-d57d2fbb1ff3"), "/Stride.Engine/StrideEnvironmentLightingDFGLUT8");
             context.Parameters.Set(MaterialSpecularMicrofacetEnvironmentGGXLUTKeys.EnvironmentLightingDFG_LUT, texture);
 
             return new ShaderClassSource("MaterialSpecularMicrofacetEnvironmentGGXLUT");

--- a/sources/presentation/Stride.Core.Presentation.Wpf/ValueConverters/SubtractMultiConverter.cs
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/ValueConverters/SubtractMultiConverter.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Globalization;
+using Stride.Core.Annotations;
+
+namespace Stride.Core.Presentation.ValueConverters
+{
+    /// <summary>
+    /// Subtracts every value after the first (and the numeric parameter, if any) from the first value.
+    /// The result is clamped to be non-negative. Useful to compute a remaining layout width.
+    /// </summary>
+    public class SubtractMultiConverter : OneWayMultiValueConverter<SubtractMultiConverter>
+    {
+        [NotNull]
+        public override object Convert([NotNull] object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length < 2)
+                throw new InvalidOperationException("This multi converter must be invoked with at least two elements");
+
+            double result;
+            try
+            {
+                result = ConverterHelper.ConvertToDouble(values[0], culture);
+                for (var i = 1; i < values.Length; i++)
+                    result -= ConverterHelper.ConvertToDouble(values[i], culture);
+                if (parameter != null)
+                    result -= ConverterHelper.ConvertToDouble(parameter, culture);
+            }
+            catch (Exception exception)
+            {
+                throw new ArgumentException("The values of this converter must be convertible to a double.", exception);
+            }
+
+            return Math.Max(0.0, result);
+        }
+    }
+}

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets
@@ -119,6 +119,7 @@
 
   <!-- Asset build manifest (engine self-build path; NuGet consumers get it via Stride.Core buildTransitive) -->
   <Import Project="$(StrideRoot)sources\core\Stride.Core\build\Stride.AssetBuildManifest.targets" Condition="'$(StrideAssetBuildManifestImported)' == '' And Exists('$(StrideRoot)sources\core\Stride.Core\build\Stride.AssetBuildManifest.targets')" />
+  <Import Project="$(StrideRoot)sources\engine\Stride.Engine\buildTransitive\Stride.AssetConstants.targets" Condition="'$(StrideAssetConstantsImported)' == '' And Exists('$(StrideRoot)sources\engine\Stride.Engine\buildTransitive\Stride.AssetConstants.targets')" />
   <PropertyGroup>
     <StrideAssetBuildManifestImported>true</StrideAssetBuildManifestImported>
   </PropertyGroup>
@@ -170,6 +171,14 @@
        outer dispatch (which has no TF global). Both then race on obj/. -->
   <ItemGroup Condition="!$(MSBuildProjectName.StartsWith('Stride.Core.CompilerServices'))">
     <ProjectReference Include="$(StrideRoot)sources\core\Stride.Core.CompilerServices\Stride.Core.CompilerServices.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- Asset URL constants generator, only where its inputs exist (an authored sdpkg next to the
+       project); consumers get it from the Stride.Engine package instead. -->
+  <ItemGroup Condition="'$(StrideGenerateAssetConstants)' != 'false' And Exists('$(MSBuildProjectDirectory)\$(MSBuildProjectName).sdpkg')">
+    <ProjectReference Include="$(StrideRoot)sources\engine\Stride.Assets.Generators\Stride.Assets.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj
+++ b/sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj
@@ -81,6 +81,12 @@
       </_StrideSuiteDepBundle>
       <_StrideSuiteIndex Include="$(StrideRoot)bin\Tests\%(ProjectReference.Filename)\$(StridePlatform)-$(StrideGraphicsApi)\$(Configuration)\data\db\index"
                          Condition="$([System.String]::Copy('%(ProjectReference.Filename)').Contains('.Tests'))" />
+      <!-- Each suite's bare->canonical alias table, renamed to <SuiteName>.aliases (ObjectDatabase loads
+           it by bundle name) so every suite's bare URLs resolve in the merged host, which ships none of its own. -->
+      <_StrideSuiteAliases Include="$(StrideRoot)bin\Tests\%(ProjectReference.Filename)\$(StridePlatform)-$(StrideGraphicsApi)\$(Configuration)\data\db\aliases"
+                           Condition="$([System.String]::Copy('%(ProjectReference.Filename)').Contains('.Tests'))">
+        <SuiteName>%(ProjectReference.Filename)</SuiteName>
+      </_StrideSuiteAliases>
     </ItemGroup>
     <Copy SourceFiles="@(_StrideSuiteBundle)"
           DestinationFiles="@(_StrideSuiteBundle->'$(OutputPath)data\db\bundles\%(SuiteName).bundle')"
@@ -95,6 +101,10 @@
           DestinationFiles="$(OutputPath)data\db\index"
           SkipUnchangedFiles="true"
           Condition="Exists('%(_StrideSuiteIndex.Identity)')" />
+    <Copy SourceFiles="@(_StrideSuiteAliases)"
+          DestinationFiles="@(_StrideSuiteAliases->'$(OutputPath)data\db\%(SuiteName).aliases')"
+          SkipUnchangedFiles="true"
+          Condition="Exists('%(_StrideSuiteAliases.Identity)')" />
   </Target>
 
   <!-- iOS/Android: package the collected data/db tree into the .app/APK. CompilerApp.targets'

--- a/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
+++ b/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
@@ -45,6 +45,11 @@ public class AssetPluginPackagingTests
         var index = File.ReadAllText(Directory.GetFiles(dbDir, "index.Consumer.*")[0]);
         Assert.Matches(@"(?m)^/StrideAssetPlugin/PluginPage ", index);
         Assert.Matches(@"(?m)^Page ", index);
+
+        // The consumer's StrideAssetNamespaceUsings brings the plugin namespace into scope: the
+        // deployed alias table maps its bare URL to the canonical one.
+        var aliases = File.ReadAllText(Path.Combine(consumerDir, "bin", "Debug", "net10.0", "data", "db", "aliases"));
+        Assert.Contains("PluginPage|/StrideAssetPlugin/PluginPage", aliases);
     }
 
     [Fact]

--- a/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
+++ b/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
@@ -50,6 +50,22 @@ public class AssetPluginPackagingTests
         // deployed alias table maps its bare URL to the canonical one.
         var aliases = File.ReadAllText(Path.Combine(consumerDir, "bin", "Debug", "net10.0", "data", "db", "aliases"));
         Assert.Contains("PluginPage|/StrideAssetPlugin/PluginPage", aliases);
+
+        AssertRuntimeContentResolves(consumerDir);
+    }
+
+    /// <summary>Run the built consumer: it loads content by canonical and bare (aliased) URLs.</summary>
+    private void AssertRuntimeContentResolves(string consumerDir)
+    {
+        // On Linux the consumer's engine module initializer fails to resolve Vortice.Vulkan
+        // (consumer-packaging gap, tracked separately), so the runtime check is Windows-only.
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var binDir = Path.Combine(consumerDir, "bin", "Debug", "net10.0");
+        var run = Dotnet.Exec(["exec", Path.Combine(binDir, "Consumer.dll")], binDir, output, timeoutMin: 2);
+        Assert.True(run.ExitCode == 0, $"Consumer runtime content check failed (exit {run.ExitCode}).");
+        Assert.Contains("CONTENT OK PluginPage", run.Output);
     }
 
     [Fact]
@@ -76,6 +92,8 @@ public class AssetPluginPackagingTests
 
         var aliases = File.ReadAllText(Path.Combine(consumerDir, "bin", "Debug", "net10.0", "data", "db", "aliases"));
         Assert.Contains("PluginPage|/StrideAssetPlugin/PluginPage", aliases);
+
+        AssertRuntimeContentResolves(consumerDir);
     }
 
     /// <summary>

--- a/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
+++ b/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
@@ -86,14 +86,7 @@ public class AssetPluginPackagingTests
             "-o", feedDir,
         };
         if (!declareAssetAssembly)
-        {
-            // Assembly-only shape: when assets are present the sdpkg packs regardless, and the
-            // loader's legacy fallback (lock-file runtime assemblies) loads the dll even without
-            // a declaration — which would hide the mechanism this case tests.
-            Directory.Delete(Path.Combine(pluginDir, "Assets"), recursive: true);
-            File.Delete(Path.Combine(pluginDir, "StrideAssetPlugin.sdpkg"));
             packArgs.Add("-p:StrideContainsAssetTypes=false");
-        }
         var pack = Dotnet.Exec(packArgs, pluginDir, output, timeoutMin: 10);
         Assert.True(pack.ExitCode == 0, $"Plugin pack failed with exit {pack.ExitCode}");
 

--- a/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
+++ b/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
@@ -18,6 +18,10 @@ namespace Stride.Packaging.Tests;
 /// The consumer's root assets include a UI page whose default button references engine assets —
 /// regression guard for #3258 (bundle packing must resolve assets of a referenced project's package
 /// from lock-file-loaded dependencies; a single-project consumer does not reproduce it).
+///
+/// The plugin is namespaced (StrideAssetNamespace=true) and ships a root asset of its own, so the
+/// consumer build must compile it under its rooted /StrideAssetPlugin/ URL and resolve its
+/// engine-asset references through the plugin package's own dependency closure.
 /// </summary>
 [Collection("Packaging")]
 public class AssetPluginPackagingTests
@@ -31,15 +35,22 @@ public class AssetPluginPackagingTests
     [Fact]
     public void ConsumerResolvesPluginTypeWhenAssetAssemblyDeclared()
     {
-        var result = RunCase(declareAssetAssembly: true);
+        var (result, consumerDir) = RunCase(declareAssetAssembly: true);
         Assert.True(result.ExitCode == 0, $"Consumer build should succeed (exit {result.ExitCode}).");
         Assert.DoesNotContain(UnresolvedSpinScript, result.Output);
+
+        // The namespaced plugin's root asset compiles under its rooted URL; the consumer's own
+        // package is not namespaced, so its assets stay bare.
+        var dbDir = Path.Combine(consumerDir, "obj", "stride", "assetbuild", "data", "db");
+        var index = File.ReadAllText(Directory.GetFiles(dbDir, "index.Consumer.*")[0]);
+        Assert.Matches(@"(?m)^/StrideAssetPlugin/PluginPage ", index);
+        Assert.Matches(@"(?m)^Page ", index);
     }
 
     [Fact]
     public void ConsumerFailsWhenAssetAssemblyNotDeclared()
     {
-        var result = RunCase(declareAssetAssembly: false);
+        var (result, _) = RunCase(declareAssetAssembly: false);
         // Unresolved type is only a warning (IUnloadable substituted), so assert on the diagnostic
         // rather than the exit code.
         Assert.Contains(UnresolvedSpinScript, result.Output);
@@ -49,7 +60,7 @@ public class AssetPluginPackagingTests
     /// Pack the plugin into an isolated feed, then build the consumer against it. Each case runs in
     /// its own temp tree with its own NuGet cache so the fixed 1.0.0 plugin package never collides.
     /// </summary>
-    private ExecResult RunCase(bool declareAssetAssembly)
+    private (ExecResult Result, string ConsumerDir) RunCase(bool declareAssetAssembly)
     {
         var version = TestEnvironment.ResolveStrideVersion();
         var fixtures = TestEnvironment.FixturesDir();
@@ -75,14 +86,21 @@ public class AssetPluginPackagingTests
             "-o", feedDir,
         };
         if (!declareAssetAssembly)
+        {
+            // Assembly-only shape: when assets are present the sdpkg packs regardless, and the
+            // loader's legacy fallback (lock-file runtime assemblies) loads the dll even without
+            // a declaration — which would hide the mechanism this case tests.
+            Directory.Delete(Path.Combine(pluginDir, "Assets"), recursive: true);
+            File.Delete(Path.Combine(pluginDir, "StrideAssetPlugin.sdpkg"));
             packArgs.Add("-p:StrideContainsAssetTypes=false");
+        }
         var pack = Dotnet.Exec(packArgs, pluginDir, output, timeoutMin: 10);
         Assert.True(pack.ExitCode == 0, $"Plugin pack failed with exit {pack.ExitCode}");
 
         // Consumer restores Stride.* from bin/packages and StrideAssetPlugin from the fresh feed.
         NuGetConsumerFeed.WriteStrictNuGetConfig(consumerDir,
             [new ExtraFeed("plugin-feed", feedDir, "StrideAssetPlugin")]);
-        return ConsumerBuild.Run(Path.Combine(consumerDir, "Consumer.csproj"), consumerDir, output, timeoutMin: 10,
-            $"-p:StrideEngineVersion={version}", $"-p:RestorePackagesPath={nugetCache}");
+        return (ConsumerBuild.Run(Path.Combine(consumerDir, "Consumer.csproj"), consumerDir, output, timeoutMin: 10,
+            $"-p:StrideEngineVersion={version}", $"-p:RestorePackagesPath={nugetCache}"), consumerDir);
     }
 }

--- a/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
+++ b/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
@@ -61,17 +61,34 @@ public class AssetPluginPackagingTests
         Assert.Contains(UnresolvedSpinScript, result.Output);
     }
 
+    [Fact]
+    public void PluginUrlsIdenticalViaProjectReference()
+    {
+        // PackageReference and ProjectReference are interchangeable: consuming the plugin as a
+        // project must produce the same canonical URL and alias entry as consuming its nupkg.
+        var (result, consumerDir) = RunCase(declareAssetAssembly: true, viaProjectReference: true);
+        Assert.True(result.ExitCode == 0, $"Consumer build should succeed (exit {result.ExitCode}).");
+        Assert.DoesNotContain(UnresolvedSpinScript, result.Output);
+
+        var dbDir = Path.Combine(consumerDir, "obj", "stride", "assetbuild", "data", "db");
+        var index = File.ReadAllText(Directory.GetFiles(dbDir, "index.Consumer.*")[0]);
+        Assert.Matches(@"(?m)^/StrideAssetPlugin/PluginPage ", index);
+
+        var aliases = File.ReadAllText(Path.Combine(consumerDir, "bin", "Debug", "net10.0", "data", "db", "aliases"));
+        Assert.Contains("PluginPage|/StrideAssetPlugin/PluginPage", aliases);
+    }
+
     /// <summary>
     /// Pack the plugin into an isolated feed, then build the consumer against it. Each case runs in
     /// its own temp tree with its own NuGet cache so the fixed 1.0.0 plugin package never collides.
     /// </summary>
-    private (ExecResult Result, string ConsumerDir) RunCase(bool declareAssetAssembly)
+    private (ExecResult Result, string ConsumerDir) RunCase(bool declareAssetAssembly, bool viaProjectReference = false)
     {
         var version = TestEnvironment.ResolveStrideVersion();
         var fixtures = TestEnvironment.FixturesDir();
 
         var caseDir = Path.Combine(Path.GetTempPath(), "stride-packaging-tests",
-            $"plugin-{(declareAssetAssembly ? "pos" : "neg")}-{Guid.NewGuid():N}");
+            $"plugin-{(viaProjectReference ? "proj" : declareAssetAssembly ? "pos" : "neg")}-{Guid.NewGuid():N}");
         var pluginDir = Path.Combine(caseDir, "plugin");
         var consumerDir = Path.Combine(caseDir, "consumer");
         var feedDir = Path.Combine(caseDir, "feed");
@@ -82,18 +99,29 @@ public class AssetPluginPackagingTests
 
         // Plugin restores Stride.* from bin/packages.
         NuGetConsumerFeed.WriteStrictNuGetConfig(pluginDir);
-        var packArgs = new List<string>
+        if (viaProjectReference)
         {
-            "pack", Path.Combine(pluginDir, "StrideAssetPlugin.csproj"),
-            "-c", "Debug", "-v:m",
-            $"-p:StrideEngineVersion={version}",
-            $"-p:RestorePackagesPath={nugetCache}",
-            "-o", feedDir,
-        };
-        if (!declareAssetAssembly)
-            packArgs.Add("-p:StrideContainsAssetTypes=false");
-        var pack = Dotnet.Exec(packArgs, pluginDir, output, timeoutMin: 10);
-        Assert.True(pack.ExitCode == 0, $"Plugin pack failed with exit {pack.ExitCode}");
+            // Same fixture consumed as a project instead of its nupkg.
+            var gameProject = Path.Combine(consumerDir, "Consumer.Game", "Consumer.Game.csproj");
+            File.WriteAllText(gameProject, File.ReadAllText(gameProject).Replace(
+                """<PackageReference Include="StrideAssetPlugin" Version="1.0.0" />""",
+                """<ProjectReference Include="..\..\plugin\StrideAssetPlugin.csproj" />"""));
+        }
+        else
+        {
+            var packArgs = new List<string>
+            {
+                "pack", Path.Combine(pluginDir, "StrideAssetPlugin.csproj"),
+                "-c", "Debug", "-v:m",
+                $"-p:StrideEngineVersion={version}",
+                $"-p:RestorePackagesPath={nugetCache}",
+                "-o", feedDir,
+            };
+            if (!declareAssetAssembly)
+                packArgs.Add("-p:StrideContainsAssetTypes=false");
+            var pack = Dotnet.Exec(packArgs, pluginDir, output, timeoutMin: 10);
+            Assert.True(pack.ExitCode == 0, $"Plugin pack failed with exit {pack.ExitCode}");
+        }
 
         // Consumer restores Stride.* from bin/packages and StrideAssetPlugin from the fresh feed.
         NuGetConsumerFeed.WriteStrictNuGetConfig(consumerDir,

--- a/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
+++ b/tests/enduser/Stride.Packaging.Tests/AssetPluginPackagingTests.cs
@@ -19,9 +19,9 @@ namespace Stride.Packaging.Tests;
 /// regression guard for #3258 (bundle packing must resolve assets of a referenced project's package
 /// from lock-file-loaded dependencies; a single-project consumer does not reproduce it).
 ///
-/// The plugin is namespaced (StrideAssetNamespace=true) and ships a root asset of its own, so the
-/// consumer build must compile it under its rooted /StrideAssetPlugin/ URL and resolve its
-/// engine-asset references through the plugin package's own dependency closure.
+/// Namespacing is on by default: the plugin ships a root asset of its own, so the consumer build
+/// must compile it under its rooted /StrideAssetPlugin/ URL and resolve its engine-asset
+/// references through the plugin package's own dependency closure.
 /// </summary>
 [Collection("Packaging")]
 public class AssetPluginPackagingTests
@@ -39,17 +39,18 @@ public class AssetPluginPackagingTests
         Assert.True(result.ExitCode == 0, $"Consumer build should succeed (exit {result.ExitCode}).");
         Assert.DoesNotContain(UnresolvedSpinScript, result.Output);
 
-        // The namespaced plugin's root asset compiles under its rooted URL; the consumer's own
-        // package is not namespaced, so its assets stay bare.
+        // Namespacing is on by default: both the plugin's and the consumer's own assets compile
+        // under their rooted URLs.
         var dbDir = Path.Combine(consumerDir, "obj", "stride", "assetbuild", "data", "db");
         var index = File.ReadAllText(Directory.GetFiles(dbDir, "index.Consumer.*")[0]);
         Assert.Matches(@"(?m)^/StrideAssetPlugin/PluginPage ", index);
-        Assert.Matches(@"(?m)^Page ", index);
+        Assert.Matches(@"(?m)^/Consumer/Page ", index);
 
-        // The consumer's StrideAssetNamespaceUsings brings the plugin namespace into scope: the
-        // deployed alias table maps its bare URL to the canonical one.
+        // The consumer's StrideAssetNamespaceUsing items bring both namespaces into scope: the
+        // deployed alias table maps bare URLs to the canonical ones.
         var aliases = File.ReadAllText(Path.Combine(consumerDir, "bin", "Debug", "net10.0", "data", "db", "aliases"));
         Assert.Contains("PluginPage|/StrideAssetPlugin/PluginPage", aliases);
+        Assert.Contains("Page|/Consumer/Page", aliases);
 
         AssertRuntimeContentResolves(consumerDir);
     }
@@ -89,6 +90,7 @@ public class AssetPluginPackagingTests
         var dbDir = Path.Combine(consumerDir, "obj", "stride", "assetbuild", "data", "db");
         var index = File.ReadAllText(Directory.GetFiles(dbDir, "index.Consumer.*")[0]);
         Assert.Matches(@"(?m)^/StrideAssetPlugin/PluginPage ", index);
+        Assert.Matches(@"(?m)^/Consumer/Page ", index);
 
         var aliases = File.ReadAllText(Path.Combine(consumerDir, "bin", "Debug", "net10.0", "data", "db", "aliases"));
         Assert.Contains("PluginPage|/StrideAssetPlugin/PluginPage", aliases);

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Consumer.Game/Consumer.Game.csproj
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Consumer.Game/Consumer.Game.csproj
@@ -6,6 +6,8 @@
     <!-- No asset types of its own; also keeps the plugin's packed sdpkg declaration the only
          path that can load the plugin assembly, which is what the tests probe. -->
     <StrideContainsAssetTypes>false</StrideContainsAssetTypes>
+    <!-- Bring the plugin's namespace into scope: its assets also resolve by bare URL. -->
+    <StrideAssetNamespaceUsings>StrideAssetPlugin</StrideAssetNamespaceUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Stride.Engine" Version="$(StrideEngineVersion)" />

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Consumer.Game/Consumer.Game.csproj
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Consumer.Game/Consumer.Game.csproj
@@ -6,9 +6,13 @@
     <!-- No asset types of its own; also keeps the plugin's packed sdpkg declaration the only
          path that can load the plugin assembly, which is what the tests probe. -->
     <StrideContainsAssetTypes>false</StrideContainsAssetTypes>
-    <!-- Bring the plugin's namespace into scope: its assets also resolve by bare URL. -->
-    <StrideAssetNamespaceUsings>StrideAssetPlugin</StrideAssetNamespaceUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- Bring the plugin's namespace into scope, plus our own: this package owns no GameSettings,
+         so it is not implicit self scope and needs a using for bare URL access. -->
+    <StrideAssetNamespaceUsing Include="StrideAssetPlugin" />
+    <StrideAssetNamespaceUsing Include="Consumer" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Stride.Engine" Version="$(StrideEngineVersion)" />
     <PackageReference Include="Stride.UI" Version="$(StrideEngineVersion)" />

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Program.cs
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Program.cs
@@ -9,7 +9,7 @@ using Stride.Core.Storage;
 
 var content = new ContentManager(new DatabaseFileProviderService(new DatabaseFileProvider(ObjectDatabase.CreateDefaultDatabase())));
 
-foreach (var url in new[] { "/StrideAssetPlugin/PluginPage", "PluginPage", "Page" })
+foreach (var url in new[] { "/StrideAssetPlugin/PluginPage", "PluginPage", "/Consumer/Page", "Page" })
 {
     if (!content.Exists(url))
     {

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Program.cs
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Consumer/Program.cs
@@ -1,5 +1,22 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-// The test only builds this project (asset compilation runs at build time); it is never run.
-System.Console.WriteLine("Consumer build placeholder.");
+// Headless runtime check, run by the packaging tests after building: the compiled content must
+// resolve from the deployed database by canonical rooted URL and by bare URL through the alias table.
+using Stride.Core.IO;
+using Stride.Core.Serialization.Contents;
+using Stride.Core.Storage;
+
+var content = new ContentManager(new DatabaseFileProviderService(new DatabaseFileProvider(ObjectDatabase.CreateDefaultDatabase())));
+
+foreach (var url in new[] { "/StrideAssetPlugin/PluginPage", "PluginPage", "Page" })
+{
+    if (!content.Exists(url))
+    {
+        System.Console.WriteLine($"CONTENT MISSING {url}");
+        return 1;
+    }
+    using var stream = content.OpenAsStream(url);
+    System.Console.WriteLine($"CONTENT OK {url} {stream.Length}");
+}
+return 0;

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/Assets/PluginPage.sduipage
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/Assets/PluginPage.sduipage
@@ -1,0 +1,49 @@
+!UIPageAsset
+Id: b7a54c3e-2f18-4d06-9a41-8c5e6d2b7f30
+SerializedVersion: {Stride: 2.1.0.1}
+Tags: []
+Design:
+    Resolution: {X: 1280.0, Y: 720.0, Z: 1000.0}
+Hierarchy:
+    RootParts:
+        - !Grid ref!! 7f21c4b8-3a5d-4e92-b6c7-0d8f1a2e3c45
+    Parts:
+        -   UIElement: !TextBlock
+                Id: 9c3e5a71-6b2f-4d08-8e94-1f0a2b3c4d56
+                DependencyProperties: {}
+                BackgroundColor: {R: 0, G: 0, B: 0, A: 0}
+                HorizontalAlignment: Center
+                VerticalAlignment: Center
+                Margin: {}
+                Text: Plugin button
+                Font: c90f3988-0544-4cbe-993f-13af7d9c23c6:StrideDefaultFont
+                TextSize: 20.0
+                TextColor: {R: 240, G: 240, B: 240, A: 255}
+                OutlineColor: {R: 0, G: 0, B: 0, A: 255}
+                OutlineThickness: 0.0
+        -   UIElement: !Grid
+                Id: 7f21c4b8-3a5d-4e92-b6c7-0d8f1a2e3c45
+                DependencyProperties: {}
+                BackgroundColor: {R: 0, G: 0, B: 0, A: 0}
+                Margin: {}
+                Children:
+                    9612d462b5c5f0adf93cac55fe1c06b6: !Button ref!! 5e8b2d4f-7c16-4a30-9f58-3b6c7d8e9a01
+                RowDefinitions: {}
+                ColumnDefinitions: {}
+                LayerDefinitions: {}
+        -   UIElement: !Button
+                Id: 5e8b2d4f-7c16-4a30-9f58-3b6c7d8e9a01
+                DependencyProperties: {}
+                DrawLayerNumber: 2
+                BackgroundColor: {R: 0, G: 0, B: 0, A: 0}
+                Margin: {}
+                Content: !TextBlock ref!! 9c3e5a71-6b2f-4d08-8e94-1f0a2b3c4d56
+                PressedImage: !SpriteFromSheet
+                    Sheet: 1be3340c-b797-4557-bff7-d9be92dfdb42:StrideUIDesigns
+                    CurrentFrame: 2
+                NotPressedImage: !SpriteFromSheet
+                    Sheet: 1be3340c-b797-4557-bff7-d9be92dfdb42:StrideUIDesigns
+                    CurrentFrame: 1
+                MouseOverImage: !SpriteFromSheet
+                    Sheet: 1be3340c-b797-4557-bff7-d9be92dfdb42:StrideUIDesigns
+                Color: {R: 255, G: 255, B: 255, A: 255}

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.csproj
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.csproj
@@ -8,6 +8,8 @@
          automatically (out-of-tree default), so consumers load it for asset compilation.
          Override StrideContainsAssetTypes=false to exercise the negative case. -->
     <StridePackAssets>true</StridePackAssets>
+    <!-- Namespaced plugin: its asset URLs are rooted /StrideAssetPlugin/... in consumers. -->
+    <StrideAssetNamespace>true</StrideAssetNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Stride.Engine" Version="$(StrideEngineVersion)" />

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.csproj
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.csproj
@@ -4,10 +4,8 @@
     <RootNamespace>StrideAssetPlugin</RootNamespace>
     <PackageId>StrideAssetPlugin</PackageId>
     <Version>1.0.0</Version>
-    <!-- Pack the project as a Stride asset package: the dll is declared as an asset assembly
-         automatically (out-of-tree default), so consumers load it for asset compilation.
-         Override StrideContainsAssetTypes=false to exercise the negative case. -->
-    <StridePackAssets>true</StridePackAssets>
+    <!-- The dll is declared as an asset assembly automatically (out-of-tree default), so consumers
+         load it for asset compilation. Override StrideContainsAssetTypes=false for the negative case. -->
     <!-- Namespaced plugin: its asset URLs are rooted /StrideAssetPlugin/... in consumers. -->
     <StrideAssetNamespace>true</StrideAssetNamespace>
   </PropertyGroup>

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.csproj
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.csproj
@@ -6,8 +6,7 @@
     <Version>1.0.0</Version>
     <!-- The dll is declared as an asset assembly automatically (out-of-tree default), so consumers
          load it for asset compilation. Override StrideContainsAssetTypes=false for the negative case. -->
-    <!-- Namespaced plugin: its asset URLs are rooted /StrideAssetPlugin/... in consumers. -->
-    <StrideAssetNamespace>true</StrideAssetNamespace>
+    <!-- Namespacing is on by default: asset URLs are rooted /StrideAssetPlugin/... in consumers. -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Stride.Engine" Version="$(StrideEngineVersion)" />

--- a/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.sdpkg
+++ b/tests/enduser/Stride.Packaging.Tests/Fixtures/Plugin/StrideAssetPlugin.sdpkg
@@ -1,0 +1,12 @@
+!Package
+SerializedVersion: {Assets: 3.1.0.0}
+Meta:
+    Name: StrideAssetPlugin
+    Version: 1.0.0
+    Authors: []
+    Owners: []
+    Dependencies: null
+AssetFolders:
+    -   Path: !dir Assets
+RootAssets:
+    - b7a54c3e-2f18-4d06-9a41-8c5e6d2b7f30:PluginPage


### PR DESCRIPTION
# PR Details

Makes asset URLs package-aware so assets from different packages no longer collide — while existing games keep working unchanged. On by default (engine included); no migration, old bare games stay valid forever.

Also lands two related features: **typed asset constants** (an `Assets` class generated for compile-time asset URLs) and **asset `Replaces`** (an asset can override another asset's content in the build).

## Highlights

**Per-package namespacing**
- Assets are addressable as `/PackageName/Path` (the prefix is the package name).
- Every package has a namespace; the **game's is the default in-scope one** (user-configurable), so the game's own assets stay simple `Content.Load("Models/BoxF")` while packages ones are qualified `Content.Load("/Package/Models/BoxF")`.
- Cross-package references can stay bare via first-class **`using`-style declarations**; a check keeps them unambiguous.
- A `ProjectReference` resolves identically to the equivalent `PackageReference`.

**Typed asset constants**
- A source generator emits an `Assets` class (mirroring the folder tree) from a project's assets, so URLs can be referenced from code with compile-time checking:
  ```csharp
  // was: Content.Load<Material>("Materials/Ground")
  var material = Content.Load(Assets.Materials.Ground);
  ```

**Asset `Replaces`**
- An asset can declare it **replaces** another asset's content in the build session, with editor UX (link row, tile badge, clear command, diagnostics):
  ```yaml
  Replaces: Materials/Ground   # this asset's content is built in place of Materials/Ground
  ```

**Editor polish**
- Reference fields show the asset name with a dimmed, scope-aware location prefix + full-URL tooltip, and refresh live when a referenced asset is renamed or moved.

## Future

A Roslyn analyzer could validate asset URLs written as raw strings in code — e.g. flag `Content.Load<Material>("Materials/Ground")` when that path doesn't exist and offer a fix to `Assets.Materials.Ground`.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#3258 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->