### PR TITLE
Share the asset-build cache per game, and garbage-collect it

### DIFF
--- a/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
@@ -168,6 +168,7 @@ namespace Stride.AssetCompiler
                 // Run builder
                 var result = builder.Run(Builder.Mode.Build);
                 builder.WriteIndexFile(false);
+                builder.WriteClosureFile();
 
                 // Fill list of bundles
                 var bundlePacker = new BundlePacker();

--- a/sources/assets/Stride.AssetCompiler/build/Stride.AssetCompiler.targets
+++ b/sources/assets/Stride.AssetCompiler/build/Stride.AssetCompiler.targets
@@ -56,7 +56,15 @@
     <StrideIsExecutable Condition=" '$(OutputType)' == 'AppContainerExe'">true</StrideIsExecutable>
     <StrideIsExecutable Condition=" '$(AndroidApplication)' == 'true'">true</StrideIsExecutable>
 
-    <!--asset BuildPath for all platforms (same as package)-->
+    <!-- Redirected = this project (a platform head) borrows the game library's DB it points at via
+         StrideCurrentPackagePath, so editor + all heads share one DB per game (the index is already
+         per-platform, so heads don't collide). Only when that game library is a *different* project:
+         a single project that is its own game (points at itself) stays an owner, resolving to its own
+         obj below so its Clean clears the cache. -->
+    <_StrideCurrentPackageDir Condition="'$(StrideCurrentPackagePath)' != ''">$([MSBuild]::NormalizeDirectory($([System.IO.Path]::GetDirectoryName('$(StrideCurrentPackagePath)'))))</_StrideCurrentPackageDir>
+    <_StrideProjectDir Condition="'$(ProjectDir)' != ''">$([MSBuild]::NormalizeDirectory('$(ProjectDir)'))</_StrideProjectDir>
+    <StrideCompileAssetBuildRedirected Condition="'$(StrideCompileAssetBuildPath)' == '' And '$(_StrideCurrentPackageDir)' != '' And '$(_StrideCurrentPackageDir)' != '$(_StrideProjectDir)'">true</StrideCompileAssetBuildRedirected>
+    <StrideCompileAssetBuildPath Condition="'$(StrideCompileAssetBuildRedirected)' == 'true'">$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine($([System.IO.Path]::GetDirectoryName('$(StrideCurrentPackagePath)')), 'obj/stride/assetbuild/data'))))</StrideCompileAssetBuildPath>
     <StrideCompileAssetBuildPath Condition="'$(StrideCompileAssetBuildPath)' == ''">$(ProjectDir)$(BaseIntermediateOutputPath)stride\assetbuild\data</StrideCompileAssetBuildPath>
 
     <!-- Compiled-asset output path, unified across platforms. -->
@@ -202,13 +210,15 @@
   </Target>
 
   <!-- Clean assets -->
+  <!-- A head borrows the game library's shared DB, so its Clean must not wipe it; cleaning the game
+       library (the owner) still clears the shared cache for all platforms + the editor. -->
   <Target Name="StrideCleanAssetsOnClean" AfterTargets="Clean" Condition="'$(StrideSkipAssetsClean)' != 'true'">
-    <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
+    <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)') And '$(StrideCompileAssetBuildRedirected)' != 'true'" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
     <RemoveDir Condition="Exists('$(StrideCompileAssetOutputPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetOutputPath)"/>
   </Target>
 
   <Target Name="StrideCleanAsset" Condition="'$(StrideIsExecutable)' == 'true' And '$(StrideCompilerSkipBuild)' != 'true'">
-    <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
+    <RemoveDir Condition="Exists('$(StrideCompileAssetBuildPath)') And '$(StrideCompileAssetBuildRedirected)' != 'true'" ContinueOnError="true"  Directories="$(StrideCompileAssetBuildPath)"/>
     <RemoveDir Condition="Exists('$(StrideCompileAssetOutputPath)')" ContinueOnError="true"  Directories="$(StrideCompileAssetOutputPath)"/>
   </Target>
 

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
@@ -17,6 +17,9 @@ public class Builder : IDisposable
     public static readonly string DoNotCompressTag = "DoNotCompress";
     public static readonly string DoNotPackTag = "DoNotPack";
 
+    /// <summary>Suffix of the build-closure file written next to the index (see <see cref="WriteClosureFile"/>).</summary>
+    public const string ClosureFileExtension = ".closure";
+
     #region Public Members
 
     public const string MonitorPipeName = "Stride/BuildEngine/Monitor";
@@ -329,6 +332,42 @@ public class Builder : IDisposable
             if (outputObject.Tags.Contains(DoNotCompressTag))
                 DisableCompressionIds.Add(outputObject.ObjectId);
         }
+    }
+
+    /// <summary>
+    /// Writes the build closure next to the index file: the flat set of object ids this build references —
+    /// every command-cache entry plus every content output blob (direct and indirect). The editor's
+    /// startup GC reads it to keep a config's whole incremental cache alive, not just its final content,
+    /// so an idle config still gets a cache hit instead of a full recompute. Rewritten each build, so
+    /// superseded blobs drop out and become collectable.
+    /// </summary>
+    public void WriteClosureFile()
+    {
+        if (indexName == null)
+            return;
+
+        var closurePath = IndexFileFullPath + ClosureFileExtension;
+        VirtualFileSystem.FileDelete(closurePath);
+
+        var ids = new HashSet<ObjectId>();
+        foreach (var step in CollectCommandSteps(Root))
+        {
+            if (step.Result == null)
+                continue;
+
+            if (step.CommandHash != ObjectId.Empty)
+                ids.Add(step.CommandHash);
+            foreach (var output in step.Result.OutputObjects)
+            {
+                if (output.Key.Type == UrlType.Content)
+                    ids.Add(output.Value);
+            }
+        }
+
+        using var stream = VirtualFileSystem.OpenStream(closurePath, VirtualFileMode.Create, VirtualFileAccess.Write);
+        using var writer = new StreamWriter(stream);
+        foreach (var id in ids)
+            writer.WriteLine(id.ToString());
     }
 
     private static IEnumerable<CommandBuildStep> CollectCommandSteps(BuildStep step)

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
@@ -39,6 +39,12 @@ public class Builder : IDisposable
     public string BuilderName { get; set; }
 
     /// <summary>
+    /// Raised after each build step is processed (executed or skipped), with the step. Lets consumers observe
+    /// completed commands — e.g. the editor touches a reused command's blobs to keep its GC working set warm.
+    /// </summary>
+    public event Action<BuildStep> StepProcessed;
+
+    /// <summary>
     /// Indicate whether the build has been canceled
     /// </summary>
     public bool Cancelled { get; protected set; }
@@ -651,6 +657,7 @@ public class Builder : IDisposable
                     }
 
                     buildStep.RegisterResult(executeContext, status);
+                    StepProcessed?.Invoke(buildStep);
                     stepCounter.AddStepResult(status);
                 });
             }

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/CommandBuildStep.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/CommandBuildStep.cs
@@ -26,6 +26,13 @@ public class CommandBuildStep : BuildStep
     /// </summary>
     public CommandResultEntry Result { get; private set; }
 
+    /// <summary>
+    /// Hash of this command, computed during <see cref="Execute"/>. Identifies the command-cache entry
+    /// (<c>db/&lt;hash&gt;</c>) so it can be recorded in the build closure. <see cref="ObjectId.Empty"/>
+    /// if the step has not run or the hash could not be computed.
+    /// </summary>
+    public ObjectId CommandHash { get; private set; }
+
     /// <inheritdoc/>
     public override string OutputLocation => Command.OutputLocation;
 
@@ -94,10 +101,12 @@ public class CommandBuildStep : BuildStep
         var status = ResultStatus.NotProcessed;
         // if any external input has changed since the last execution (or if we don't have a successful execution in cache, trigger the command
         CommandResultEntry? matchingResult;
+        var commandHash = ObjectId.Empty;
         try
         {
             // try to retrieve result from one of the object store
-            var commandHash = Command.ComputeCommandHash(executeContext);
+            commandHash = Command.ComputeCommandHash(executeContext);
+            CommandHash = commandHash;
             // Early exit if the hash of the command failed
             if (commandHash == ObjectId.Empty)
             {

--- a/sources/core/Stride.Core.Serialization/Storage/FileOdbBackend.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/FileOdbBackend.cs
@@ -221,6 +221,31 @@ public class FileOdbBackend : IOdbBackend
         return virtualFileProvider.GetAbsolutePath(BuildUrl(vfsRootUrl, objectId));
     }
 
+    /// <summary>
+    /// Touch throttle (X): a stored object's mtime is only refreshed by <see cref="Touch"/> if it is
+    /// already older than this, bounding write amplification. GC eviction age must stay above it.
+    /// </summary>
+    public static TimeSpan TouchThrottle { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Refreshes an object's last-write time so mtime-LRU GC treats it as recently used. Best-effort
+    /// and throttled by <see cref="TouchThrottle"/>; no-op on read-only backends.
+    /// </summary>
+    public void Touch(ObjectId objectId)
+    {
+        if (IsReadOnly)
+            return;
+
+        try
+        {
+            var info = new FileInfo(GetFilePath(objectId));
+            if (info.Exists && DateTime.UtcNow - info.LastWriteTimeUtc > TouchThrottle)
+                File.SetLastWriteTimeUtc(info.FullName, DateTime.UtcNow);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
     private static string ExtractPath(string url)
     {
         return url[..url.LastIndexOf('/')];

--- a/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
+++ b/sources/core/Stride.Core.Serialization/Storage/ObjectDatabase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Stride.Core.IO;
 
@@ -19,6 +20,12 @@ public class ObjectDatabase : IDisposable
     private readonly IOdbBackend backendRead1;
     private readonly IOdbBackend backendRead2;
     private readonly IOdbBackend backendWrite;
+
+    // Object ids touched (build-cache hits) this session. Re-touched periodically via
+    // RetouchWorkingSet so the open working set stays warm for mtime-LRU GC even during long idle
+    // stretches with no rebuilds. The editor never populates ContentIndexMap, so this is the only
+    // reliable live set. Session-scoped: reset when the database is recreated on the next open.
+    private readonly ConcurrentDictionary<ObjectId, byte> touchedObjectIds = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ObjectDatabase" /> class.
@@ -178,6 +185,30 @@ public class ObjectDatabase : IDisposable
             throw new InvalidOperationException("Read-only object database.");
 
         backendWrite.Delete(objectId);
+    }
+
+    /// <summary>
+    /// Refreshes an object's last-use time for mtime-LRU GC and records it in the session working set
+    /// (see <see cref="RetouchWorkingSet"/>). Best-effort and throttled; only the writable loose-file
+    /// store supports it (bundles/read-only backends are skipped).
+    /// </summary>
+    public void Touch(ObjectId objectId)
+    {
+        touchedObjectIds.TryAdd(objectId, 0);
+        (backendWrite as FileOdbBackend)?.Touch(objectId);
+    }
+
+    /// <summary>
+    /// Re-touches every object hit this session so the working set doesn't age out of the mtime-LRU
+    /// cache while the editor sits idle (no rebuilds to touch it on-hit). Throttled per file.
+    /// </summary>
+    public void RetouchWorkingSet()
+    {
+        if (backendWrite is not FileOdbBackend backend)
+            return;
+
+        foreach (var entry in touchedObjectIds)
+            backend.Touch(entry.Key);
     }
 
     public bool Exists(ObjectId objectId)

--- a/sources/editor/Stride.Core.Assets.Editor/Services/AssetBuilderService.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/AssetBuilderService.cs
@@ -1,12 +1,15 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Threading;
 using Stride.Core.Assets.Compiler;
 using Stride.Core.BuildEngine;
 using Stride.Core.Annotations;
 using Stride.Core.Collections;
 using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
+using Stride.Core.Serialization.Contents;
+using Stride.Core.Storage;
 
 namespace Stride.Core.Assets.Editor.Services
 {
@@ -18,6 +21,7 @@ namespace Stride.Core.Assets.Editor.Services
 
         private readonly DynamicBuilder builder;
         private readonly PriorityNodeQueue<AssetBuildUnit> queue = new PriorityNodeQueue<AssetBuildUnit>();
+        private readonly Timer retouchTimer;
 
         // TODO: this is temporary until we have thread local databases (and a better solution for databases used in standard tasks)
         public static readonly object OutOfMicrothreadDatabaseLock = new object();      
@@ -38,8 +42,13 @@ namespace Stride.Core.Assets.Editor.Services
                 BuilderName = "AssetBuilderService Builder",
                 ThreadCount = threadCount,
             };
+            builderInstance.StepProcessed += OnStepProcessed;
             builder = new DynamicBuilder(builderInstance, new AnonymousBuildStepProvider(GetNextBuildStep), "Asset Builder service thread.");
             builder.Start();
+
+            // Re-touch the session's live blobs periodically so a long-idle session (no rebuilds to
+            // touch them on-hit) doesn't let its working set age out and get swept by a later GC.
+            retouchTimer = new Timer(_ => RetouchLiveSet(), null, FileOdbBackend.TouchThrottle, FileOdbBackend.TouchThrottle);
         }
 
         public event EventHandler<AssetBuiltEventArgs> AssetBuilt;
@@ -55,7 +64,46 @@ namespace Stride.Core.Assets.Editor.Services
 
         public virtual void Dispose()
         {
+            retouchTimer.Dispose();
             builder.Dispose();
+        }
+
+        /// <summary>
+        /// On each processed command, touches its cache entry + output blobs so the editor's working set stays
+        /// warm for mtime-LRU GC and is recorded for periodic re-touch (see <see cref="ObjectDatabase.Touch"/>).
+        /// </summary>
+        private static void OnStepProcessed(BuildStep step)
+        {
+            if (step is not CommandBuildStep command || command.Result == null)
+                return;
+
+            var database = Builder.ObjectDatabase;
+            if (database == null)
+                return;
+
+            if (command.CommandHash != ObjectId.Empty)
+                database.Touch(command.CommandHash);
+            foreach (var output in command.Result.OutputObjects)
+            {
+                if (output.Key.Type == UrlType.Content)
+                    database.Touch(output.Value);
+            }
+        }
+
+        /// <summary>
+        /// Re-touches the objects hit this session (recorded by <see cref="OnStepProcessed"/>), keeping the
+        /// working set warm for mtime-LRU GC. Best-effort; throttled per file by <see cref="FileOdbBackend.TouchThrottle"/>.
+        /// </summary>
+        private void RetouchLiveSet()
+        {
+            try
+            {
+                Builder.ObjectDatabase?.RetouchWorkingSet();
+            }
+            catch (Exception)
+            {
+                // Best-effort maintenance; never surface on the timer thread.
+            }
         }
 
         private BuildStep GetNextBuildStep(int maxPriority)

--- a/sources/editor/Stride.GameStudio/Plugin/StrideEditorPlugin.cs
+++ b/sources/editor/Stride.GameStudio/Plugin/StrideEditorPlugin.cs
@@ -35,11 +35,15 @@ namespace Stride.GameStudio.Plugin
             var buildDirectory = fallbackDirectory;
             try
             {
-                var package = session.CurrentProject ?? session.LocalPackages.First();
-                if (package != null)
+                var currentPackage = (session.CurrentProject ?? session.LocalPackages.FirstOrDefault())?.Package;
+                if (currentPackage != null)
                 {
-                    // In package, we override editor build directory to be per-project and be shared with game build directory
-                    buildDirectory = new UFile($"{package.PackagePath.GetFullDirectory()}\\obj\\stride\\assetbuild\\data").ToOSPath();
+                    // Editor build DB lives under the shared game library (the package that owns
+                    // GameSettings), not the startup platform head — so adding/removing/regenerating a
+                    // head can't relocate or corrupt it. FindAsset resolves through dependencies, so
+                    // from a head this lands on its game library; falls back to the current package.
+                    var buildPackage = currentPackage.FindAsset(Stride.Assets.GameSettingsAsset.GameSettingsLocation)?.Package ?? currentPackage;
+                    buildDirectory = new UFile($"{buildPackage.FullPath.GetFullDirectory()}\\obj\\stride\\assetbuild\\data").ToOSPath();
                 }
 
                 // Attempt to create the directory to ensure it is valid.

--- a/sources/editor/Stride.GameStudio/Plugin/StrideEditorPlugin.cs
+++ b/sources/editor/Stride.GameStudio/Plugin/StrideEditorPlugin.cs
@@ -10,6 +10,7 @@ using Stride.Core.Assets.Editor.Settings;
 using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Diagnostics;
 using Stride.Core.IO;
+using Stride.Core.Storage;
 using Stride.Editor;
 using Stride.Editor.Annotations;
 using Stride.Editor.Build;
@@ -55,6 +56,9 @@ namespace Stride.GameStudio.Plugin
                 buildDirectory = fallbackDirectory;
             }
 
+            // Reclaim stale cache entries before the builder opens the DB (nothing holds it yet, so no coordination needed).
+            CollectBuildCache(buildDirectory);
+
             var pluginService = session.ServiceProvider.Get<IAssetsPluginService>();
             var previewFactories = new Dictionary<Type, AssetPreviewFactory>();
             foreach (var stridePlugin in pluginService.Plugins.OfType<StrideAssetsPlugin>())
@@ -96,6 +100,115 @@ namespace Stride.GameStudio.Plugin
 
             GameStudioViewModel.GameStudio.Preview = new PreviewViewModel(session);
             GameStudioViewModel.GameStudio.Debugging = new DebuggingViewModel(GameStudioViewModel.GameStudio, strideDebugService);
+        }
+
+        /// <summary>Delete cache blobs unused longer than this (Y). Must stay above <see cref="FileOdbBackend.TouchThrottle"/> (X).</summary>
+        private static readonly TimeSpan EvictionAge = TimeSpan.FromDays(14);
+
+        /// <summary>Run the sweep at most this often across launches, tracked via the marker file's mtime.</summary>
+        private static readonly TimeSpan GcInterval = TimeSpan.FromHours(24);
+
+        /// <summary>
+        /// Startup GC for the shared asset-build cache. A blob survives if either source keeps it live:
+        /// <list type="bullet">
+        /// <item>fresh mtime — the editor touches its working set on hit and re-touches it (<see cref="ObjectDatabase.Touch"/>);</item>
+        /// <item>listed in a current config's <c>index.&lt;config&gt;.closure</c> — each CLI/head build writes its full
+        /// reachable set (command entries + output blobs), dated by the file's mtime.</item>
+        /// </list>
+        /// Everything else is deleted: content past <see cref="EvictionAge"/> unreferenced by a fresh index/closure,
+        /// and stale configs' index/closure files. Marker-gated to once per <see cref="GcInterval"/>, age-only, best-effort.
+        /// </summary>
+        private static void CollectBuildCache(string buildDirectory)
+        {
+            try
+            {
+                if (!Directory.Exists(buildDirectory))
+                    return;
+
+                var marker = Path.Combine(buildDirectory, "gc.stamp");
+                if (File.Exists(marker) && DateTime.UtcNow - File.GetLastWriteTimeUtc(marker) < GcInterval)
+                    return;
+
+                // The content store lives under db/; blobs + command entries are in its 2-hex-char subdirs.
+                // bundles/, tmp/ and the index files (all also under db/) fall outside those, so they're skipped.
+                var contentRoot = Path.Combine(buildDirectory, "db");
+                if (!Directory.Exists(contentRoot))
+                    return;
+
+                // Y >= X floor: a live file's mtime is at most X stale (touch throttle), so never evict within X.
+                var age = EvictionAge > FileOdbBackend.TouchThrottle ? EvictionAge : FileOdbBackend.TouchThrottle;
+                var cutoff = DateTime.UtcNow - age;
+
+                // Keep blobs referenced by a still-current index/closure; superseded/orphaned blobs (in
+                // none) are left to age out below.
+                var referenced = CollectReferencedBlobs(contentRoot, cutoff);
+
+                foreach (var dir in Directory.EnumerateDirectories(contentRoot))
+                {
+                    if (Path.GetFileName(dir).Length != 2)
+                        continue;
+
+                    foreach (var file in Directory.EnumerateFiles(dir))
+                    {
+                        if (referenced.Contains(file))
+                            continue;
+
+                        try
+                        {
+                            if (File.GetLastWriteTimeUtc(file) < cutoff)
+                                File.Delete(file);
+                        }
+                        catch (IOException) { }               // in use / racing another process — skip
+                        catch (UnauthorizedAccessException) { }
+                    }
+                }
+
+                File.WriteAllText(marker, string.Empty);
+            }
+            catch (Exception)
+            {
+                // Best-effort reclaim; a failure here must not stop the session from opening.
+            }
+        }
+
+        /// <summary>
+        /// Reads the index/closure files at the content-store root and returns the absolute blob paths they
+        /// reference (reconstructed via the db/&lt;id[0..1]&gt;/&lt;id[2..]&gt; layout). A per-config
+        /// <c>index.*</c> carries its build time in its mtime: once older than <paramref name="cutoff"/> the
+        /// config is stale, so its index/closure files are deleted and their blobs left to age out below.
+        /// </summary>
+        private static HashSet<string> CollectReferencedBlobs(string contentRoot, DateTime cutoff)
+        {
+            var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var indexFile in Directory.EnumerateFiles(contentRoot))
+            {
+                try
+                {
+                    if (Path.GetFileName(indexFile).StartsWith("index.", StringComparison.OrdinalIgnoreCase)
+                        && File.GetLastWriteTimeUtc(indexFile) < cutoff)
+                    {
+                        File.Delete(indexFile);
+                        continue;
+                    }
+
+                    foreach (var raw in File.ReadLines(indexFile))
+                    {
+                        var line = raw.Trim();
+                        if (line.Length == 0 || line[0] == '#')
+                            continue;
+
+                        // Each line ends with the object id (a plain closure line is just the id; an index
+                        // line is "<url> <id>"), so the trailing whitespace-delimited token is the id.
+                        var parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                        var id = parts[^1];
+                        if (id.Length == 32)
+                            referenced.Add(Path.Combine(contentRoot, id[..2], id[2..]));
+                    }
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+            return referenced;
         }
 
         public override void RegisterAssetPreviewViewTypes(IDictionary<Type, Type> assetPreviewViewTypes)


### PR DESCRIPTION
# PR Details

GameStudio kept its compiled-asset cache under the startup platform project `obj`, which *Update Platforms* deletes/regenerates, so changing a platform could wipe the live cache and crash. It also wasn't shared with CLI/VS builds, and grew forever.

**Changes:**
- **Cache under the game library, shared by all.** Editor + every platform reuse one cache per game (faster, crash-proof).
- **Startup GC (mtime-LRU).** Once/day, sweeps content unused beyond a retention window. No size cap.
- **Per-config build closure.** Each CLI/head build records its full reachable set so GC knows what's current, and can reclaim it (index + blobs) once stale.

Cleaning the game library clears the shared cache; cleaning a head leaves it intact.
