### PR TITLE
fix: Game settings config overrides not working properly

### DIFF
--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -263,7 +263,7 @@ namespace Stride.Engine
             {
                 PlatformConfigurations.RendererName = GraphicsAdapterFactory.DefaultAdapter?.Description ?? string.Empty;
 
-                databaseFileProvider = InitializeAssetDatabase();
+                databaseFileProvider = InitializeAssetDatabase(AssetBundleName);
                 ((DatabaseFileProviderService)Services.GetService<IDatabaseFileProviderService>()).FileProvider = databaseFileProvider;
 
                 var renderingSettings = new RenderingSettings();

--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -261,8 +261,9 @@ namespace Stride.Engine
             // Init assets
             if (Context.InitializeDatabase)
             {
-                PlatformConfigurations.RendererName = GraphicsAdapterFactory.DefaultAdapter?.Name ?? string.Empty;
-                databaseFileProvider = InitializeAssetDatabase(AssetBundleName);
+                PlatformConfigurations.RendererName = GraphicsAdapterFactory.DefaultAdapter?.Description ?? string.Empty;
+
+                databaseFileProvider = InitializeAssetDatabase();
                 ((DatabaseFileProviderService)Services.GetService<IDatabaseFileProviderService>()).FileProvider = databaseFileProvider;
 
                 var renderingSettings = new RenderingSettings();

--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -11,6 +11,7 @@ using Stride.Core.Diagnostics;
 using Stride.Core.IO;
 using Stride.Core.Mathematics;
 using Stride.Core.Storage;
+using Stride.Data;
 using Stride.Engine.Design;
 using Stride.Engine.Processors;
 using Stride.Games;
@@ -260,6 +261,7 @@ namespace Stride.Engine
             // Init assets
             if (Context.InitializeDatabase)
             {
+                PlatformConfigurations.RendererName = GraphicsAdapterFactory.DefaultAdapter?.Name ?? string.Empty;
                 databaseFileProvider = InitializeAssetDatabase(AssetBundleName);
                 ((DatabaseFileProviderService)Services.GetService<IDatabaseFileProviderService>()).FileProvider = databaseFileProvider;
 

--- a/sources/engine/Stride.Foundation/Data/PlatformConfigurations.cs
+++ b/sources/engine/Stride.Foundation/Data/PlatformConfigurations.cs
@@ -12,9 +12,7 @@ namespace Stride.Data
     [DataContract]
     public class PlatformConfigurations
     {
-        public static string RendererName = string.Empty;
-
-        public static string DeviceModel = string.Empty;
+        public static string RendererName { get; set; } = string.Empty;
 
         [DataMember]
         public List<ConfigurationOverride> Configurations = [];
@@ -25,7 +23,7 @@ namespace Stride.Data
         public T Get<T>() where T : Configuration, new()
         {
             //find default
-            var config = Configurations.Where(x => x.Platforms == ConfigPlatforms.None).FirstOrDefault(x => x.Configuration is T);
+            var config = Configurations.Where(x => x.Platforms == ConfigPlatforms.None).LastOrDefault(x => x.Configuration is T);
 
             //perform logic by platform and if required even gpu/cpu/specs
 
@@ -57,21 +55,14 @@ namespace Stride.Data
             }
 
             //find per platform if available
-            var platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter == -1).FirstOrDefault(x => x.Configuration is T);
+            var platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter == -1).LastOrDefault(x => x.Configuration is T);
             if (platformConfig != null)
             {
                 config = platformConfig;
             }
 
             //find per specific renderer settings
-            platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter != -1 && new Regex(PlatformFilters[x.SpecificFilter], RegexOptions.IgnoreCase).IsMatch(RendererName)).FirstOrDefault(x => x.Configuration is T);
-            if (platformConfig != null)
-            {
-                config = platformConfig;
-            }
-
-            //find per specific device settings
-            platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter != -1 && new Regex(PlatformFilters[x.SpecificFilter], RegexOptions.IgnoreCase).IsMatch(DeviceModel)).FirstOrDefault(x => x.Configuration is T);
+            platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter != -1 && new Regex(PlatformFilters[x.SpecificFilter], RegexOptions.IgnoreCase).IsMatch(RendererName)).LastOrDefault(x => x.Configuration is T);
             if (platformConfig != null)
             {
                 config = platformConfig;
@@ -79,7 +70,13 @@ namespace Stride.Data
 
             if (config == null)
             {
-                return new T();
+                var newInstance = new T();
+                Configurations.Add(new()
+                {
+                    Configuration = newInstance,
+                });
+
+                return newInstance;
             }
 
             return (T)config.Configuration;

--- a/sources/engine/Stride.Foundation/Data/PlatformConfigurations.cs
+++ b/sources/engine/Stride.Foundation/Data/PlatformConfigurations.cs
@@ -12,6 +12,7 @@ namespace Stride.Data
     [DataContract]
     public class PlatformConfigurations
     {
+        /// <summary>String identifying the rendering device, used for configuration overrides.</summary>
         public static string RendererName { get; set; } = string.Empty;
 
         [DataMember]
@@ -22,54 +23,40 @@ namespace Stride.Data
 
         public T Get<T>() where T : Configuration, new()
         {
-            //find default
+            // Find the default for all platforms and devices
             var config = Configurations.Where(x => x.Platforms == ConfigPlatforms.None).LastOrDefault(x => x.Configuration is T);
 
-            //perform logic by platform and if required even gpu/cpu/specs
+            // Try finding one for the specific platform or hardware configuration
 
-            var platform = ConfigPlatforms.None;
-            switch (Platform.Type)
+            var platform = Platform.Type switch
             {
-                case PlatformType.Shared:
-                    break;
-                case PlatformType.Windows:
-                    platform = ConfigPlatforms.Windows;
-                    break;
-                case PlatformType.Android:
-                    platform = ConfigPlatforms.Android;
-                    break;
-                case PlatformType.iOS:
-                    platform = ConfigPlatforms.iOS;
-                    break;
-                case PlatformType.UWP:
-                    platform = ConfigPlatforms.UWP;
-                    break;
-                case PlatformType.Linux:
-                    platform = ConfigPlatforms.Linux;
-                    break;
-                case PlatformType.macOS:
-                    platform = ConfigPlatforms.macOS;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+                PlatformType.Shared => ConfigPlatforms.None,
+                PlatformType.Windows => ConfigPlatforms.Windows,
+                PlatformType.Android => ConfigPlatforms.Android,
+                PlatformType.iOS => ConfigPlatforms.iOS,
+                PlatformType.UWP => ConfigPlatforms.UWP,
+                PlatformType.Linux => ConfigPlatforms.Linux,
+                PlatformType.macOS => ConfigPlatforms.macOS,
+                _ => throw new ArgumentOutOfRangeException(),
+            };
 
-            //find per platform if available
-            var platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter == -1).LastOrDefault(x => x.Configuration is T);
-            if (platformConfig != null)
+            // Find per platform if available
+            if (Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter == -1)
+                .LastOrDefault(x => x.Configuration is T) is { } platformConfig)
             {
                 config = platformConfig;
             }
 
-            //find per specific renderer settings
-            platformConfig = Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter != -1 && new Regex(PlatformFilters[x.SpecificFilter], RegexOptions.IgnoreCase).IsMatch(RendererName)).LastOrDefault(x => x.Configuration is T);
-            if (platformConfig != null)
+            // Find per specific renderer
+            if (Configurations.Where(x => x.Platforms.HasFlag(platform) && x.SpecificFilter != -1 && new Regex(PlatformFilters[x.SpecificFilter], RegexOptions.IgnoreCase).IsMatch(RendererName))
+                .LastOrDefault(x => x.Configuration is T) is { } rendererConfig)
             {
-                config = platformConfig;
+                config = rendererConfig;
             }
 
             if (config == null)
             {
+                // If the requested configuration doesn't exist, create and add a new one
                 var newInstance = new T();
                 Configurations.Add(new()
                 {

--- a/sources/engine/Stride.Foundation/Data/PlatformConfigurations.cs
+++ b/sources/engine/Stride.Foundation/Data/PlatformConfigurations.cs
@@ -24,7 +24,7 @@ namespace Stride.Data
         public T Get<T>() where T : Configuration, new()
         {
             // Find the default for all platforms and devices
-            var config = Configurations.Where(x => x.Platforms == ConfigPlatforms.None).LastOrDefault(x => x.Configuration is T);
+            var config = Configurations.Where(x => x.Platforms == ConfigPlatforms.None && x.SpecificFilter == -1).LastOrDefault(x => x.Configuration is T);
 
             // Try finding one for the specific platform or hardware configuration
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

Currently there is an issue with using [config overrides](https://doc.stride3d.net/latest/en/manual/game-studio/game-settings.html#overrides), where the `Specific Filter` field doesn't actually do anything. This is because `PlatformConfiguration` has two static fields that are never set which are used to determine the user's graphics card and cpu model.

This PR fixes this and changes some of the logic that is used when choosing the correct configuration:
* Specific filter can now be used to filter the gpu, but not the cpu because I'm not sure if Stride even stores that property anywhere.
* Configuration overrides are now prioritized from last to first, so that the behavior is more intuitive.
* Overrides with specific filters remain prioritized over those without one.

Sidenote, this feature is extremely useless. Aside from setting a different graphics level, there is almost never a need to use a different config based on the user's platform or gpu. I could alternatively close this PR and open a different one to remove the feature altogether.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->