### PR TITLE
fix: Update required components to build the engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
    - **In the 'Individual Components' Tab**
      - **MSVC Build Tools for ARM64/ARM64EC (Latest)** *(currently v14.5x in VS 2026)*
 
-> See [docs/build/README.md](docs/build/README.md) for detailed prerequisites for iOS/Android/VSIX components, specific MSVC toolset versions, command-line builds without VS, and troubleshooting.
+> See [docs/build/README.md](docs/build/README.md) for iOS/Android/VSIX prerequisites, specific MSVC toolset versions, command-line builds without VS, and troubleshooting.
 
 ### Build Stride
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ Our [Roadmap](https://doc.stride3d.net/latest/en/contributors/roadmap.html) comm
 2. **[Visual Studio 2026](https://visualstudio.microsoft.com/downloads/)** (Community edition is free), with these two workloads:
    - **.NET desktop development** (bundles the .NET 10 SDK)
    - **Desktop development with C++**
+   - **In the 'Individual Components' Tab**
+     - **MSVC Build Tools for ARM64/ARM64EC (Latest)** *(currently v14.5x in VS 2026)*
 
-> See [docs/build/README.md](docs/build/README.md) for detailed prerequisites (specific MSVC toolset versions, optional iOS/Android/ARM64/VSIX components, command-line builds without VS, and troubleshooting).
+> See [docs/build/README.md](docs/build/README.md) for detailed prerequisites for iOS/Android/VSIX components, specific MSVC toolset versions, command-line builds without VS, and troubleshooting.
 
 ### Build Stride
 

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -12,10 +12,12 @@ When installing VS 2026, make sure these are selected:
 
 **Desktop development with C++ workload** — defaults are sufficient. Specific components used:
 - **Windows 11 SDK (10.0.22621.0 or later)** *(default)*
-- **MSVC Build Tools for x64/x86 (Latest)** *(default — currently v145.x in VS 2026)*
+- **MSVC Build Tools for x64/x86 (Latest)** *(default — currently v14.5x in VS 2026)*
+
+**In the 'Individual Components' Tab**
+- **MSVC Build Tools for ARM64/ARM64EC (Latest)** *(currently v14.5x in VS 2026)*
 
 **Optional components:**
-- **MSVC Build Tools for ARM64/ARM64EC (Latest)** — only needed if you actively develop or package for Windows ARM64. If missing, the ARM64 native build is **automatically skipped with a warning** (the rest of the build still succeeds).
 - **.NET Multi-platform App UI development** + **Android NDK 20.1+** (via *Tools > Android > Android SDK Manager*) — to target iOS/Android.
 - **Visual Studio extension development** + **.NET Framework 4.7.2 targeting pack** — to build the VSIX package.
 


### PR DESCRIPTION
# PR Details
MSVC Build Tools for ARM64/ARM64EC is required as of latest changes, tested out on a clean VS. Build probes and fails to find MSVC.dll in VS ARM64 directory.

## Related Issue
None logged

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**