### PR TITLE
fix: Bepu, illegal write when performing overlap queries

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
@@ -604,6 +604,9 @@ public sealed class BepuSimulation : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool AllowCollisionTesting(int pairId, int childA, int childB)
         {
+            if (Collector.Full)
+                return false;
+
             var matA = CollidableMaterials[References[pairId]];
             return CollisionMask.IsSet(matA.Layer);
         }
@@ -641,14 +644,15 @@ public sealed class BepuSimulation : IDisposable
             {
                 Simulation.BroadPhase.GetOverlaps(boundingBoxMin, boundingBoxMax, BufferPool, ref broadPhaseEnumerator);
 
-                var batcher = new CollisionBatcher<BatcherCallbacks<TCollector>>(BufferPool, Simulation.Shapes, Simulation.NarrowPhase.CollisionTaskRegistry, 0, new()
+                var batcherCallbacks = new BatcherCallbacks<TCollector>
                 {
                     CollisionMask = collisionMask,
                     References = broadPhaseEnumerator.References,
                     CollidableMaterials = CollidableMaterials,
                     Collector = collector,
                     Simulation = this
-                });
+                };
+                var batcher = new CollisionBatcher<BatcherCallbacks<TCollector>>(BufferPool, Simulation.Shapes, Simulation.NarrowPhase.CollisionTaskRegistry, 0, batcherCallbacks);
 
                 int i = 0;
                 foreach (CollidableReference reference in broadPhaseEnumerator.References)
@@ -672,7 +676,6 @@ public sealed class BepuSimulation : IDisposable
                     Simulation.Shapes[shapeIndexOther.Type].GetShapeData(shapeIndexOther.Index, out var shapeData, out _);
                     //In this path, we assume that the incoming shape data is ephemeral. The collision batcher may last longer than the data pointer.
                     //To avoid undefined access, we cache the query data into the collision batcher and use a pointer to the cache instead.
-                    batcher.Callbacks.References.Add(reference, BufferPool);
                     batcher.CacheShapeB(shapeIndexOther.Type, TShape.TypeId, queryShapeData, queryShapeSize, out var cachedQueryShapeData);
                     batcher.AddDirectly(shapeIndexOther.Type, TShape.TypeId, shapeData, cachedQueryShapeData,
                         //Because we're using this as a boolean query, we use a speculative margin of 0. Don't care about negative depths.

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/SimTests/Collectors.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/SimTests/Collectors.cs
@@ -10,6 +10,8 @@ namespace Stride.BepuPhysics.Definitions.SimTests;
 
 interface IOverlapCollector
 {
+    public bool Full { get; }
+
     public void OnPairCompleted<TManifold>(BepuSimulation simulation, CollidableReference reference, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>;
 }
 
@@ -17,13 +19,14 @@ internal unsafe struct SpanManifoldCollector(OverlapInfoStack* Ptr, int Length, 
 {
     public int Head;
 
+    public bool Full => Head == Length;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnPairCompleted<TManifold>(BepuSimulation simulation, CollidableReference reference, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
     {
         if (Head >= Length)
             return;
 
-#warning should short circuit the whole overlap test in the caller as soon as head is filled
         CollidableComponent? collidable = null;
         for (int i = 0; i < manifold.Count; ++i)
         {
@@ -42,13 +45,14 @@ internal unsafe struct SpanCollidableCollector(CollidableStack* Ptr, int Length,
 {
     public int Head;
 
+    public bool Full => Head == Length;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnPairCompleted<TManifold>(BepuSimulation simulation, CollidableReference reference, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
     {
         if (Head >= Length)
             return;
 
-#warning should short circuit the whole overlap test in the caller as soon as head is filled
         for (int i = 0; i < manifold.Count; ++i)
         {
             if (manifold.GetDepth(i) < 0)
@@ -62,6 +66,8 @@ internal unsafe struct SpanCollidableCollector(CollidableStack* Ptr, int Length,
 
 internal readonly struct CollectionCollector(ICollection<OverlapInfo> Collection) : IOverlapCollector
 {
+    public bool Full => false;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnPairCompleted<TManifold>(BepuSimulation simulation, CollidableReference reference, ref TManifold manifold) where TManifold : unmanaged, IContactManifold<TManifold>
     {


### PR DESCRIPTION
# PR Details
A line of the initial overlap implementation was left in, creating an illegal write when feeding the collision batcher. Removed the offending line and took care of a todo.

## Related Issue
None logged, reported through [discord](https://discord.com/channels/500285081265635328/1173235382356299897/1527326573869531366)

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**