### PR TITLE
fix: Incorrect bounding box for sprites with non-default Center

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Sprites/RenderSprite.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Sprites/RenderSprite.cs
@@ -51,6 +51,7 @@ namespace Stride.Rendering.Sprites
         private Matrix lastWorldMatrix;
         private Vector2 lastHalfSpriteSize;
         private SpriteType lastSpriteType;
+        private Vector2 lastSpriteCenter;
 
         public Matrix WorldMatrix;
         public float RotationEulerZ;
@@ -71,7 +72,10 @@ namespace Stride.Rendering.Sprites
             var halfSpriteSize = Sprite?.Size / 2 ?? Vector2.Zero;
 
             // Only calculate if we've changed...
-            if (lastWorldMatrix != WorldMatrix || lastHalfSpriteSize != halfSpriteSize || lastSpriteType != SpriteType)
+            if (lastWorldMatrix != WorldMatrix || lastHalfSpriteSize != halfSpriteSize 
+            || lastSpriteType != SpriteType
++           || lastSpriteCenter != (Sprite?.Center ?? Vector2.Zero))
+
             {
                 Vector3 halfBoxSize;
                 var boxWorldPosition = WorldMatrix.TranslationVector;
@@ -91,6 +95,28 @@ namespace Stride.Rendering.Sprites
                         Math.Abs(WorldMatrix.M13 * halfSpriteSize.X) + Math.Abs(WorldMatrix.M23 * halfSpriteSize.Y));
                 }
 
+                // Account for Sprite.Center (pivot offset) — same logic as SpriteRenderFeature.Draw()
+                if (Sprite != null)
+                {
+                    var sourceRegion = Sprite.Region;
+                    var normalizedCenter = new Vector2(
+                        Sprite.Center.X / sourceRegion.Width - 0.5f,
+                        0.5f - Sprite.Center.Y / sourceRegion.Height);
+
+                    if (Sprite.Orientation == ImageOrientation.Rotated90)
+                    {
+                        var oldCenterX = normalizedCenter.X;
+                        normalizedCenter.X = -normalizedCenter.Y;
+                        normalizedCenter.Y = oldCenterX;
+                    }
+
+                    var centerOffset = Vector2.Modulate(normalizedCenter, Sprite.SizeInternal);
+                    boxWorldPosition -= new Vector3(
+                        centerOffset.X * WorldMatrix.M11 + centerOffset.Y * WorldMatrix.M21,
+                        centerOffset.X * WorldMatrix.M12 + centerOffset.Y * WorldMatrix.M22,
+                        centerOffset.X * WorldMatrix.M13 + centerOffset.Y * WorldMatrix.M23);
+                }
+
                 // Update bounding box
                 BoundingBox = new BoundingBoxExt(boxWorldPosition - halfBoxSize, boxWorldPosition + halfBoxSize);
 
@@ -98,6 +124,7 @@ namespace Stride.Rendering.Sprites
                 lastWorldMatrix = WorldMatrix;
                 lastHalfSpriteSize = halfSpriteSize;
                 lastSpriteType = SpriteType;
+                lastSpriteCenter = Sprite?.Center ?? Vector2.Zero;
             }
         }
     }


### PR DESCRIPTION
# PR Details

When a sprite's pivot is offset from the geometric center of the texture (e.g. anchoring the sprite to its bottom edge so it sits on the ground), the sprite is rendered visually shifted relative to the entity's position — but the bounding box used for frustum culling stays centered on the entity itself.

## Related Issue

fixes: #3227

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->