### PR TITLE
fix: Validate translation and rotation data fed to bepu for collidables

### DIFF
--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BodyComponent.cs
@@ -454,17 +454,13 @@ public class BodyComponent : CollidableComponent
     /// <exception cref="ArgumentException"><paramref name="orientation"/> must be normalized; <paramref name="position"/> must be finite</exception>
     public void Teleport(Vector3 position, Quaternion orientation)
     {
-        if (orientation.IsNormalized == false)
-            throw new ArgumentException($"{nameof(orientation)} must be normalized");
-
-        var positionNumerics = position.ToNumeric();
-        if (System.Numerics.Vector3.AllWhereAllBitsSet(System.Numerics.Vector3.IsFinite(positionNumerics)) == false)
-            throw new ArgumentException($"{nameof(position)} must be finite");
+        position.ValidateRange(nameof(Teleport), nameof(position));
+        orientation.ValidateRange(nameof(Teleport), nameof(orientation));
 
         if (BodyReference is { } bodyRef)
         {
             bodyRef.Pose.Orientation = orientation.ToNumeric();
-            bodyRef.Pose.Position = positionNumerics;
+            bodyRef.Pose.Position = position;
             bodyRef.UpdateBounds();
             PreviousPose = CurrentPose = bodyRef.Pose; // Update interpolation data as well
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -301,7 +301,9 @@ public abstract class CollidableComponent : EntityComponent
         Entity.Transform.UpdateWorldMatrix();
         Entity.Transform.WorldMatrix.Decompose(out _, out Quaternion collidableWorldRotation, out Vector3 collidableWorldTranslation);
 
+        // ReSharper disable once ExplicitCallerInfoArgument
         collidableWorldTranslation.ValidateRange(Entity, "World Position");
+        // ReSharper disable once ExplicitCallerInfoArgument
         collidableWorldRotation.ValidateRange(Entity, "World Rotation");
 
         var pose = new NRigidPose((collidableWorldTranslation + collidableWorldRotation * CenterOfMass).ToNumeric(), collidableWorldRotation.ToNumeric());

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/CollidableComponent.cs
@@ -301,12 +301,8 @@ public abstract class CollidableComponent : EntityComponent
         Entity.Transform.UpdateWorldMatrix();
         Entity.Transform.WorldMatrix.Decompose(out _, out Quaternion collidableWorldRotation, out Vector3 collidableWorldTranslation);
 
-        if (collidableWorldRotation.IsNormalized == false)
-            throw new ArgumentException($"{nameof(collidableWorldRotation)} must be normalized");
-
-        var positionNumerics = collidableWorldTranslation.ToNumeric();
-        if (System.Numerics.Vector3.AllWhereAllBitsSet(System.Numerics.Vector3.IsFinite(positionNumerics)) == false)
-            throw new ArgumentException($"{nameof(collidableWorldTranslation)} must be finite");
+        collidableWorldTranslation.ValidateRange(Entity, "World Position");
+        collidableWorldRotation.ValidateRange(Entity, "World Rotation");
 
         var pose = new NRigidPose((collidableWorldTranslation + collidableWorldRotation * CenterOfMass).ToNumeric(), collidableWorldRotation.ToNumeric());
 

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/BepuAndStrideExtensions.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/BepuAndStrideExtensions.cs
@@ -34,4 +34,25 @@ internal static class BepuAndStrideExtensions
     public static NQuaternion ToNumeric(this SQuaternion qua) => Unsafe.As<SQuaternion, NQuaternion>(ref qua);
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SQuaternion ToStride(this NQuaternion qua) => Unsafe.As<NQuaternion, SQuaternion>(ref qua);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ValidateRange<T>(this SVector3 vec, T val, string field)
+    {
+        if (NVector3.AllWhereAllBitsSet(NVector3.IsFinite(vec)) == false)
+            throw new ArgumentOutOfRangeException($"{val}'s {field} must be finite");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ValidateRange<T>(this SQuaternion quat, T val, string field)
+    {
+        if (quat.IsNormalized == false)
+            throw new ArgumentOutOfRangeException($"{val}'s {field} must be normalized");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ValidateGreaterThanZeroFinite<T>(this float fp, T val, string field)
+    {
+        if (fp > 0 && float.IsFinite(fp))
+            throw new ArgumentOutOfRangeException($"{val}'s {field} must be finite and greater than zero");
+    }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/BepuAndStrideExtensions.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/BepuAndStrideExtensions.cs
@@ -36,23 +36,23 @@ internal static class BepuAndStrideExtensions
     public static SQuaternion ToStride(this NQuaternion qua) => Unsafe.As<NQuaternion, SQuaternion>(ref qua);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ValidateRange<T>(this SVector3 vec, T val, [CallerMemberName] string? fieldName = null)
+    public static void ValidateRange<T>(this SVector3 vec, T owner, [CallerMemberName] string? fieldName = null)
     {
         if (NVector3.AllWhereAllBitsSet(NVector3.IsFinite(vec)) == false)
-            throw new ArgumentOutOfRangeException($"{val}'s {fieldName} must be finite");
+            throw new ArgumentOutOfRangeException($"{owner}'s {fieldName} must be finite");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ValidateRange<T>(this SQuaternion quat, T val, [CallerMemberName] string? fieldName = null)
+    public static void ValidateRange<T>(this SQuaternion quat, T owner, [CallerMemberName] string? fieldName = null)
     {
         if (quat.IsNormalized == false)
-            throw new ArgumentOutOfRangeException($"{val}'s {fieldName} must be normalized");
+            throw new ArgumentOutOfRangeException($"{owner}'s {fieldName} must be normalized");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ValidateGreaterThanZeroFinite<T>(this float fp, T val, [CallerMemberName] string? fieldName = null)
+    public static void ValidateGreaterThanZeroFinite<T>(this float fp, T owner, [CallerMemberName] string? fieldName = null)
     {
         if (fp > 0 && float.IsFinite(fp))
-            throw new ArgumentOutOfRangeException($"{val}'s {fieldName} must be finite and greater than zero");
+            throw new ArgumentOutOfRangeException($"{owner}'s {fieldName} must be finite and greater than zero");
     }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/BepuAndStrideExtensions.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/BepuAndStrideExtensions.cs
@@ -36,23 +36,23 @@ internal static class BepuAndStrideExtensions
     public static SQuaternion ToStride(this NQuaternion qua) => Unsafe.As<NQuaternion, SQuaternion>(ref qua);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ValidateRange<T>(this SVector3 vec, T val, string field)
+    public static void ValidateRange<T>(this SVector3 vec, T val, [CallerMemberName] string? fieldName = null)
     {
         if (NVector3.AllWhereAllBitsSet(NVector3.IsFinite(vec)) == false)
-            throw new ArgumentOutOfRangeException($"{val}'s {field} must be finite");
+            throw new ArgumentOutOfRangeException($"{val}'s {fieldName} must be finite");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ValidateRange<T>(this SQuaternion quat, T val, string field)
+    public static void ValidateRange<T>(this SQuaternion quat, T val, [CallerMemberName] string? fieldName = null)
     {
         if (quat.IsNormalized == false)
-            throw new ArgumentOutOfRangeException($"{val}'s {field} must be normalized");
+            throw new ArgumentOutOfRangeException($"{val}'s {fieldName} must be normalized");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ValidateGreaterThanZeroFinite<T>(this float fp, T val, string field)
+    public static void ValidateGreaterThanZeroFinite<T>(this float fp, T val, [CallerMemberName] string? fieldName = null)
     {
         if (fp > 0 && float.IsFinite(fp))
-            throw new ArgumentOutOfRangeException($"{val}'s {field} must be finite and greater than zero");
+            throw new ArgumentOutOfRangeException($"{val}'s {fieldName} must be finite and greater than zero");
     }
 }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/BoxCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/BoxCollider.cs
@@ -25,6 +25,7 @@ public sealed class BoxCollider : ColliderBase
         get => _size;
         set
         {
+            value.ValidateRange(this, nameof(Size));
             _size = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/BoxCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/BoxCollider.cs
@@ -25,7 +25,7 @@ public sealed class BoxCollider : ColliderBase
         get => _size;
         set
         {
-            value.ValidateRange(this, nameof(Size));
+            value.ValidateRange(this);
             _size = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CapsuleCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CapsuleCollider.cs
@@ -24,7 +24,7 @@ public sealed class CapsuleCollider : ColliderBase
         get => _radius;
         set
         {
-            value.ValidateGreaterThanZeroFinite(this, nameof(Radius));
+            value.ValidateGreaterThanZeroFinite(this);
             _radius = value;
             TryUpdateFeatures();
         }
@@ -38,7 +38,7 @@ public sealed class CapsuleCollider : ColliderBase
         get => _length;
         set
         {
-            value.ValidateGreaterThanZeroFinite(this, nameof(Length));
+            value.ValidateGreaterThanZeroFinite(this);
             _length = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CapsuleCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CapsuleCollider.cs
@@ -24,6 +24,7 @@ public sealed class CapsuleCollider : ColliderBase
         get => _radius;
         set
         {
+            value.ValidateGreaterThanZeroFinite(this, nameof(Radius));
             _radius = value;
             TryUpdateFeatures();
         }
@@ -37,6 +38,7 @@ public sealed class CapsuleCollider : ColliderBase
         get => _length;
         set
         {
+            value.ValidateGreaterThanZeroFinite(this, nameof(Length));
             _length = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CylinderCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CylinderCollider.cs
@@ -24,6 +24,7 @@ public sealed class CylinderCollider : ColliderBase
         get => _radius;
         set
         {
+            value.ValidateGreaterThanZeroFinite(this, nameof(Radius));
             _radius = value;
             TryUpdateFeatures();
         }
@@ -37,6 +38,7 @@ public sealed class CylinderCollider : ColliderBase
         get => _length;
         set
         {
+            value.ValidateGreaterThanZeroFinite(this, nameof(Length));
             _length = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CylinderCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/CylinderCollider.cs
@@ -24,7 +24,7 @@ public sealed class CylinderCollider : ColliderBase
         get => _radius;
         set
         {
-            value.ValidateGreaterThanZeroFinite(this, nameof(Radius));
+            value.ValidateGreaterThanZeroFinite(this);
             _radius = value;
             TryUpdateFeatures();
         }
@@ -38,7 +38,7 @@ public sealed class CylinderCollider : ColliderBase
         get => _length;
         set
         {
-            value.ValidateGreaterThanZeroFinite(this, nameof(Length));
+            value.ValidateGreaterThanZeroFinite(this);
             _length = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/MeshCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/MeshCollider.cs
@@ -45,7 +45,7 @@ public sealed class MeshCollider : ICollider
         {
             if (_mass != value)
             {
-                value.ValidateGreaterThanZeroFinite(this, nameof(Mass));
+                value.ValidateGreaterThanZeroFinite(this);
                 _mass = value;
                 _component?.TryUpdateFeatures();
             }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/MeshCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/MeshCollider.cs
@@ -45,6 +45,7 @@ public sealed class MeshCollider : ICollider
         {
             if (_mass != value)
             {
+                value.ValidateGreaterThanZeroFinite(this, nameof(Mass));
                 _mass = value;
                 _component?.TryUpdateFeatures();
             }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/SphereCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/SphereCollider.cs
@@ -23,7 +23,7 @@ public sealed class SphereCollider : ColliderBase
         get => _radius;
         set
         {
-            value.ValidateGreaterThanZeroFinite(this, nameof(Radius));
+            value.ValidateGreaterThanZeroFinite(this);
             _radius = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/SphereCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/SphereCollider.cs
@@ -23,6 +23,7 @@ public sealed class SphereCollider : ColliderBase
         get => _radius;
         set
         {
+            value.ValidateGreaterThanZeroFinite(this, nameof(Radius));
             _radius = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/TriangleCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/TriangleCollider.cs
@@ -25,6 +25,7 @@ public sealed class TriangleCollider : ColliderBase
         get => _a;
         set
         {
+            value.ValidateRange(this, nameof(A));
             _a = value;
             TryUpdateFeatures();
         }
@@ -38,6 +39,7 @@ public sealed class TriangleCollider : ColliderBase
         get => _b;
         set
         {
+            value.ValidateRange(this, nameof(B));
             _b = value;
             TryUpdateFeatures();
         }
@@ -51,6 +53,7 @@ public sealed class TriangleCollider : ColliderBase
         get => _c;
         set
         {
+            value.ValidateRange(this, nameof(C));
             _c = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/TriangleCollider.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/TriangleCollider.cs
@@ -25,7 +25,7 @@ public sealed class TriangleCollider : ColliderBase
         get => _a;
         set
         {
-            value.ValidateRange(this, nameof(A));
+            value.ValidateRange(this);
             _a = value;
             TryUpdateFeatures();
         }
@@ -39,7 +39,7 @@ public sealed class TriangleCollider : ColliderBase
         get => _b;
         set
         {
-            value.ValidateRange(this, nameof(B));
+            value.ValidateRange(this);
             _b = value;
             TryUpdateFeatures();
         }
@@ -53,7 +53,7 @@ public sealed class TriangleCollider : ColliderBase
         get => _c;
         set
         {
-            value.ValidateRange(this, nameof(C));
+            value.ValidateRange(this);
             _c = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/_ColliderBase.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/_ColliderBase.cs
@@ -25,6 +25,7 @@ public abstract class ColliderBase
         get => _mass;
         set
         {
+            value.ValidateGreaterThanZeroFinite(this, nameof(Mass));
             _mass = value;
             TryUpdateFeatures();
         }
@@ -42,6 +43,7 @@ public abstract class ColliderBase
         get => _positionLocal;
         set
         {
+            value.ValidateRange(this, nameof(PositionLocal));
             _positionLocal = value;
             TryUpdateFeatures();
         }
@@ -58,6 +60,7 @@ public abstract class ColliderBase
         get => _rotationLocal;
         set
         {
+            value.ValidateRange(this, nameof(RotationLocal));
             _rotationLocal = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/_ColliderBase.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Colliders/_ColliderBase.cs
@@ -25,7 +25,7 @@ public abstract class ColliderBase
         get => _mass;
         set
         {
-            value.ValidateGreaterThanZeroFinite(this, nameof(Mass));
+            value.ValidateGreaterThanZeroFinite(this);
             _mass = value;
             TryUpdateFeatures();
         }
@@ -43,7 +43,7 @@ public abstract class ColliderBase
         get => _positionLocal;
         set
         {
-            value.ValidateRange(this, nameof(PositionLocal));
+            value.ValidateRange(this);
             _positionLocal = value;
             TryUpdateFeatures();
         }
@@ -60,7 +60,7 @@ public abstract class ColliderBase
         get => _rotationLocal;
         set
         {
-            value.ValidateRange(this, nameof(RotationLocal));
+            value.ValidateRange(this);
             _rotationLocal = value;
             TryUpdateFeatures();
         }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/StaticComponent.cs
@@ -146,17 +146,13 @@ public class StaticComponent : CollidableComponent
     /// <inheritdoc cref="Teleport"/>
     internal void TeleportNoTransformUpdate(Vector3 position, Quaternion orientation)
     {
-        if (orientation.IsNormalized == false)
-            throw new ArgumentException($"{nameof(orientation)} must be normalized");
-
-        var positionNumerics = position.ToNumeric();
-        if (System.Numerics.Vector3.AllWhereAllBitsSet(System.Numerics.Vector3.IsFinite(positionNumerics)) == false)
-            throw new ArgumentException($"{nameof(position)} must be finite");
+        position.ValidateRange(nameof(TeleportNoTransformUpdate), nameof(position));
+        orientation.ValidateRange(nameof(TeleportNoTransformUpdate), nameof(orientation));
 
         if (StaticReference is { } staticRef)
         {
             staticRef.Pose.Orientation = orientation.ToNumeric();
-            staticRef.Pose.Position = positionNumerics + CenterOfMass;
+            staticRef.Pose.Position = position + CenterOfMass;
             staticRef.UpdateBounds();
         }
     }


### PR DESCRIPTION
# PR Details
Bepu does very little validation on their end; sending nans or zeroed quaternion causes memory corruption, this PR places a couple of exception to notify users of their invalid data.

There's also some very minor cleanup and summaries added in. Haven't had any time to test this yet, but let's see if automation catches anything before I find the time to do so.

Was previously opened in PR #3166

## Related Issue
fix: #3163

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**