### PR TITLE
perf: Have bepu rely on stride's own dispatcher

### DIFF
--- a/sources/core/Stride.Core/Threading/Dispatcher.cs
+++ b/sources/core/Stride.Core/Threading/Dispatcher.cs
@@ -20,15 +20,23 @@ public static class Dispatcher
 #if STRIDE_PLATFORM_IOS || STRIDE_PLATFORM_ANDROID
     public static readonly int MaxDegreeOfParallelism = 1;
 #else
-    public static int MaxDegreeOfParallelism { get; set; } =
-        int.TryParse(Environment.GetEnvironmentVariable("STRIDE_MAX_PARALLELISM"), out var envValue) && envValue > 0
-            ? envValue
-            : Environment.ProcessorCount;
+    public static int MaxDegreeOfParallelism
+    {
+        get;
+        set
+        {
+            field = value;
+            OnMaxDegreeOfParallelismChanged?.Invoke();
+        }
+    } = int.TryParse(Environment.GetEnvironmentVariable("STRIDE_MAX_PARALLELISM"), out var envValue) && envValue > 0 
+        ? envValue
+        : Environment.ProcessorCount;
 #endif
 
     private static readonly ProfilingKey DispatcherSortKey = new("Dispatcher.Sort");
     private static readonly ProfilingKey DispatcherBatched = new("Dispatcher.Batched");
 
+    public static event Action? OnMaxDegreeOfParallelismChanged;
     public delegate void ValueAction<T>(ref T obj);
 
     /// <summary>

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/BepuSimulation.cs
@@ -40,7 +40,7 @@ public sealed class BepuSimulation : IDisposable
     private TimeSpan _fixedTimeStep = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / 60);
     private readonly Dictionary<Type, Elider> _simulationUpdateComponents = new();
     private readonly List<BodyComponent> _interpolatedBodies = new();
-    private readonly ThreadDispatcher _threadDispatcher;
+    private DispatcherWrapper _threadDispatcher;
     private TimeSpan _remainingUpdateTime;
     private TimeSpan _softStartRemainingDuration;
     private bool _softStartScheduled = false;
@@ -93,13 +93,22 @@ public sealed class BepuSimulation : IDisposable
     }
 
     /// <summary>
-    /// The number of threads the simulation runs on.
+    /// The number of threads the simulation may use.
     /// </summary>
     /// <remarks>
-    /// A negative value results in automatic thread selection.
+    /// <see cref="Dispatcher.MaxDegreeOfParallelism"/> is the upper bound, -1 will default to that value.
+    /// A value greater than <see cref="Dispatcher.MaxDegreeOfParallelism"/> will further split the work, potentially improving throughput depending on the context and simulation.
     /// </remarks>
     [Display(-1, "Thread Count")]
-    public int ThreadCount { get; set; } = -1;
+    public int ThreadCount
+    {
+        get;
+        set
+        {
+            field = value;
+            RefreshWorkerCount();
+        }
+    } = -1;
 
     /// <summary>
     /// Whether to update the simulation.
@@ -289,10 +298,10 @@ public sealed class BepuSimulation : IDisposable
 
     public BepuSimulation()
     {
-        var targetThreadCount = ThreadCount > -1 ? ThreadCount : Math.Max(1, Environment.ProcessorCount > 4 ? Environment.ProcessorCount - 2 : Environment.ProcessorCount - 1);
+        var targetThreadCount = ThreadCount > -1 ? ThreadCount : Dispatcher.MaxDegreeOfParallelism;
 
         #warning Consider wrapping stride's threadpool/dispatcher into an IThreadDispatcher and passing that over to bepu instead of using their dispatcher
-        _threadDispatcher = new ThreadDispatcher(targetThreadCount);
+        _threadDispatcher = new DispatcherWrapper(targetThreadCount);
         BufferPool = new BufferPool();
         ContactEvents = new ContactEventsManager(BufferPool, this, targetThreadCount);
 
@@ -307,14 +316,24 @@ public sealed class BepuSimulation : IDisposable
 
         Characters = new CharacterControllers(BufferPool);
         Characters.Initialize(Simulation);
-        //CollisionBatcher = new CollisionBatcher<BatcherCallbacks>(BufferPool, Simulation.Shapes, Simulation.NarrowPhase.CollisionTaskRegistry, 0, DefaultBatcherCallbacks);
+
+        Dispatcher.OnMaxDegreeOfParallelismChanged += RefreshWorkerCount;
     }
 
     public void Dispose()
     {
-        Characters.Dispose();
+        Dispatcher.OnMaxDegreeOfParallelismChanged -= RefreshWorkerCount;
         _threadDispatcher.Dispose();
+        Characters.Dispose();
         BufferPool.Clear();
+    }
+
+    private void RefreshWorkerCount()
+    {
+        var targetThreadCount = ThreadCount > -1 ? ThreadCount : Dispatcher.MaxDegreeOfParallelism;
+        ContactEvents.ResizeWorkerCount(targetThreadCount);
+        _threadDispatcher.Dispose();
+        _threadDispatcher = new DispatcherWrapper(targetThreadCount);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1053,6 +1072,133 @@ public sealed class BepuSimulation : IDisposable
                     body.PreviousAngularVelocity = body.AngularVelocity;
                     body.PreviousLinearVelocity = body.LinearVelocity;
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Based on Bepu's <see cref="BepuUtilities.ThreadDispatcher"/>, does away with the orchestrator thread
+    /// and relies on <see cref="Stride.Core.Threading.Dispatcher"/> for scheduling
+    /// </summary>
+    private unsafe class DispatcherWrapper : IThreadDispatcher, IDisposable
+    {
+        private readonly int _threadCount;
+        /// <summary>
+        /// Gets the number of threads to dispatch work on.
+        /// </summary>
+        public int ThreadCount => _threadCount;
+
+        private volatile WorkerType _workerType;
+        private volatile Action<int>? _managedWorker;
+        private volatile delegate*<int, IThreadDispatcher, void> _unmanagedWorker;
+        private volatile void* _unmanagedContext;
+        private volatile object? _managedContext;
+
+        private volatile bool _disposed;
+
+        /// <inheritdoc/>
+        public WorkerBufferPools WorkerPools { get; private set; }
+        /// <inheritdoc/>
+        public void* UnmanagedContext => _unmanagedContext;
+        /// <inheritdoc/>
+        public object? ManagedContext => _managedContext;
+
+        /// <summary>
+        /// Creates a new thread dispatcher with the given number of threads.
+        /// </summary>
+        /// <param name="threadCount">Number of threads to dispatch on each invocation.</param>
+        /// <param name="threadPoolBlockAllocationSize">Size of memory blocks to allocate for thread pools.</param>
+        public DispatcherWrapper(int threadCount, int threadPoolBlockAllocationSize = 16384)
+        {
+            if (threadCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(threadCount), "Thread count must be positive.");
+            _threadCount = threadCount;
+            WorkerPools = new WorkerBufferPools(threadCount, threadPoolBlockAllocationSize);
+        }
+
+        private void DispatchThread(int workerIndex)
+        {
+            switch (_workerType)
+            {
+                case WorkerType.Managed: _managedWorker!(workerIndex); break;
+                case WorkerType.Unmanaged: _unmanagedWorker(workerIndex, this); break;
+            }
+        }
+
+        private void SignalThreads(int maximumWorkerCount)
+        {
+            int workersToSignal = maximumWorkerCount < _threadCount ? maximumWorkerCount : _threadCount;
+            Dispatcher.ForBatched(workersToSignal, new Job(this));
+        }
+
+        /// <inheritdoc/>
+        public void DispatchWorkers(delegate*<int, IThreadDispatcher, void> workerBody, int maximumWorkerCount = int.MaxValue, void* unmanagedContext = null, object? managedContext = null)
+        {
+            Debug.Assert(_managedWorker == null && _unmanagedWorker == null && _managedContext == null && _unmanagedContext == null);
+            _unmanagedContext = unmanagedContext;
+            _managedContext = managedContext;
+            if (maximumWorkerCount > 1)
+            {
+                _workerType = WorkerType.Unmanaged;
+                _unmanagedWorker = workerBody;
+                SignalThreads(maximumWorkerCount);
+                _unmanagedWorker = null;
+            }
+            else if (maximumWorkerCount == 1)
+            {
+                workerBody(0, this);
+            }
+            _unmanagedContext = null;
+            _managedContext = null;
+        }
+
+        //While we *could* pass in the IThreadDispatcher for the managed side of things, it is typically best to just expect closures. Simplifies some stuff.
+        //(The fact that we supply context at all is a bit of a shrug.)
+        /// <inheritdoc/>
+        public void DispatchWorkers(Action<int> workerBody, int maximumWorkerCount = int.MaxValue, void* unmanagedContext = null, object? managedContext = null)
+        {
+            Debug.Assert(_managedWorker == null && _unmanagedWorker == null && _managedContext == null && _unmanagedContext == null);
+            _unmanagedContext = unmanagedContext;
+            _managedContext = managedContext;
+            if (maximumWorkerCount > 1)
+            {
+                _workerType = WorkerType.Managed;
+                _managedWorker = workerBody;
+                SignalThreads(maximumWorkerCount);
+                _managedWorker = null;
+            }
+            else if (maximumWorkerCount == 1)
+            {
+                workerBody(0);
+            }
+            _unmanagedContext = null;
+            _managedContext = null;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                if (_managedContext is not null || _unmanagedContext is not null)
+                    throw new InvalidOperationException("Cannot dispose while a job is in flight");
+
+                _disposed = true;
+                WorkerPools.Dispose();
+            }
+        }
+
+        private enum WorkerType
+        {
+            Managed,
+            Unmanaged,
+        }
+
+        private readonly struct Job(DispatcherWrapper wrapper) : Dispatcher.IBatchJob
+        {
+            public void Process(int start, int endExclusive)
+            {
+                for (int i = start; i < endExclusive; i++)
+                    wrapper.DispatchThread(i);
             }
         }
     }

--- a/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Contacts/ContactEventsManager.cs
+++ b/sources/engine/Stride.BepuPhysics/Stride.BepuPhysics/Definitions/Contacts/ContactEventsManager.cs
@@ -49,6 +49,22 @@ internal class ContactEventsManager : IDisposable
             _staticListenerFlags.Dispose(_pool);
     }
 
+    public void ResizeWorkerCount(int newWorkerCount)
+    {
+        foreach (var workerStore in _manifoldStoresPerWorker)
+        {
+            foreach (var typeStore in workerStore)
+            {
+                if (typeStore.IsEmpty() == false)
+                    throw new InvalidOperationException("Cannot resize the manifold store, manifolds have not been flushed yet");
+            }
+        }
+
+        _manifoldStoresPerWorker = new IPerTypeManifoldStore[newWorkerCount][];
+        for (int i = 0; i < _manifoldStoresPerWorker.Length; i++)
+            _manifoldStoresPerWorker[i] = [];
+    }
+
     /// <summary>
     /// Begins listening for events related to the given collidable.
     /// </summary>
@@ -309,6 +325,8 @@ internal class ContactEventsManager : IDisposable
 
     private interface IPerTypeManifoldStore
     {
+        bool IsEmpty();
+
         void RunEvents(ContactEventsManager eventsManager);
 
         void ClearEventsOf(uint packed);
@@ -379,6 +397,8 @@ internal class ContactEventsManager : IDisposable
 
         private class ListOf<TManifold> : List<ContactGroup<TManifold>>, IPerTypeManifoldStore where TManifold : unmanaged, IContactManifold<TManifold>
         {
+            public bool IsEmpty() => Count == 0;
+
             public void RunEvents(ContactEventsManager eventsManager)
             {
                 for (int i = Count - 1; i >= 0; i--) // reverse as the scope may end up calling ClearRelatedContacts


### PR DESCRIPTION
# PR Details
Title. 
- Reduces memory footprint by re-using strides' threads instead of creating additional sets per simulations.
- Reduces overhead related to keeping our threadpool's threads warm.
- May slightly improve bepu's throughput in scenarios where the work provided benefits from being split further.

## Related Issue
Not specifically targeted at fixing #3269 but does so none the less. Lucky you @bj-rn :P

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**