### PR TITLE
docs: Fixed incorrect markdown formatting

### DIFF
--- a/docs/asset-system/asset-class.md
+++ b/docs/asset-system/asset-class.md
@@ -102,5 +102,5 @@ public sealed class %%AssetName%%Asset : Asset          // or AssetWithSource
 }
 ```
 
-> [!NOTE] Game projects
-> Replace `StrideConfig.PackageName` with a string literal matching your game's package name (e.g. `"MyGame"`). The rest of the pattern is identical.
+> [!NOTE]
+> **For game projects:** replace `StrideConfig.PackageName` with a string literal matching your game's package name (e.g. `"MyGame"`). The rest of the pattern is identical.

--- a/docs/asset-system/compiler.md
+++ b/docs/asset-system/compiler.md
@@ -126,5 +126,5 @@ Compiler classes live in the same assembly as the asset class. For engine assets
 
 The `Prepare` method and build command shown above form the complete starting template for a new compiler. Copy both blocks, replace `%%AssetName%%` with your asset's PascalCase name, and fill in the property mapping inside `DoCommandOverride`.
 
-> [!NOTE] Game projects
-> For game-project custom assets, the compiler class lives in the game project itself. Add `<PackageReference Include="Stride.AssetCompiler" IncludeAssets="build;buildTransitive" />` to the game project's `.csproj` — this brings in the infrastructure that discovers and invokes the compiler; it does not change where the compiler class lives.
+> [!NOTE]
+> **For game project custom assets:** the compiler class lives in the game project itself. Add `<PackageReference Include="Stride.AssetCompiler" IncludeAssets="build;buildTransitive" />` to the game project's `.csproj` — this brings in the infrastructure that discovers and invokes the compiler; it does not change where the compiler class lives.

--- a/docs/asset-system/compiler.md
+++ b/docs/asset-system/compiler.md
@@ -127,4 +127,4 @@ Compiler classes live in the same assembly as the asset class. For engine assets
 The `Prepare` method and build command shown above form the complete starting template for a new compiler. Copy both blocks, replace `%%AssetName%%` with your asset's PascalCase name, and fill in the property mapping inside `DoCommandOverride`.
 
 > [!NOTE]
-> **For game project custom assets:** the compiler class lives in the game project itself. Add `<PackageReference Include="Stride.AssetCompiler" IncludeAssets="build;buildTransitive" />` to the game project's `.csproj` — this brings in the infrastructure that discovers and invokes the compiler; it does not change where the compiler class lives.
+> **For game-project custom assets:** the compiler class lives in the game project itself. Add `<PackageReference Include="Stride.AssetCompiler" IncludeAssets="build;buildTransitive" />` to the game project's `.csproj` — this brings in the infrastructure that discovers and invokes the compiler; it does not change where the compiler class lives.

--- a/docs/asset-system/registration.md
+++ b/docs/asset-system/registration.md
@@ -89,7 +89,7 @@ sources/editor/Stride.Assets.Presentation/Templates/Assets/%%Group%%/%%AssetName
 The directory name under `Assets/` does not have to match the `Group` string exactly — the directory is just for organisation. The file is embedded automatically via the wildcard include already present in `Stride.Assets.Presentation.csproj` — no manual `.csproj` edit is needed for engine assets.
 
 > [!NOTE]
-> For game-project custom assets, place the `.sdtpl` file anywhere under the project's `Templates/` folder, then register it in the `.sdpkg` file:
+> **For game-project custom assets:** place the `.sdtpl` file anywhere under the project's `Templates/` folder, then register it in the `.sdpkg` file:
 >
 > ```yaml
 > TemplateFolders:

--- a/docs/asset-system/registration.md
+++ b/docs/asset-system/registration.md
@@ -88,7 +88,7 @@ sources/editor/Stride.Assets.Presentation/Templates/Assets/%%Group%%/%%AssetName
 
 The directory name under `Assets/` does not have to match the `Group` string exactly — the directory is just for organisation. The file is embedded automatically via the wildcard include already present in `Stride.Assets.Presentation.csproj` — no manual `.csproj` edit is needed for engine assets.
 
-> [!NOTE] Game projects
+> [!NOTE]
 > For game-project custom assets, place the `.sdtpl` file anywhere under the project's `Templates/` folder, then register it in the `.sdpkg` file:
 >
 > ```yaml

--- a/docs/asset-system/runtime-type.md
+++ b/docs/asset-system/runtime-type.md
@@ -55,5 +55,5 @@ public class %%AssetName%%
 }
 ```
 
-> [!NOTE] Game projects
-> Game-project runtime types follow the same pattern. The assembly containing them is discovered automatically because the compiler app scans all assemblies referenced by the game project. No explicit `AssemblyRegistry.Register` call is required.
+> [!NOTE]
+> **For game projects:** game-project runtime types follow the same pattern. The assembly containing them is discovered automatically because the compiler app scans all assemblies referenced by the game project. No explicit `AssemblyRegistry.Register` call is required.

--- a/docs/build/SDK-GUIDE.md
+++ b/docs/build/SDK-GUIDE.md
@@ -374,7 +374,7 @@ Stride.Build.Sdk/Sdk/Sdk.targets (top)
 | Windows | Direct3D11 | Direct3D11, Direct3D12,Vulkan |
 | Linux | Vulkan | Vulkan |
 | macOS | Vulkan | Vulkan |
-| Android | VUlkan | Vulkan |
+| Android | Vulkan | Vulkan |
 | iOS | Vulkan | Vulkan |
 
 **Graphics API defines** (added to `DefineConstants`):

--- a/docs/quantum/asset-graph.md
+++ b/docs/quantum/asset-graph.md
@@ -35,9 +35,7 @@ A property in a derived asset is in one of three states:
 When a composite node (an object with children) is reset, all descendant nodes are also reset recursively.
 
 > [!NOTE]
-> **Just adding a new asset type**
-> 
-> If your asset has no base/derived relationship and you are not implementing archetypes or prefab composition, the override model is invisible to you. `IsInherited` will always be `false` and `HasBase` will always be `false`. You do not need to understand this layer to add a new asset type.
+> **When just adding a new asset type:** if your asset has no base/derived relationship and you are not implementing archetypes or prefab composition, the override model is invisible to you. `IsInherited` will always be `false` and `HasBase` will always be `false`. You do not need to understand this layer to add a new asset type.
 
 ## `AssetPropertyGraph`
 

--- a/docs/quantum/asset-graph.md
+++ b/docs/quantum/asset-graph.md
@@ -34,7 +34,9 @@ A property in a derived asset is in one of three states:
 
 When a composite node (an object with children) is reset, all descendant nodes are also reset recursively.
 
-> [!NOTE] Just adding a new asset type
+> [!NOTE]
+> **Just adding a new asset type**
+> 
 > If your asset has no base/derived relationship and you are not implementing archetypes or prefab composition, the override model is invisible to you. `IsInherited` will always be `false` and `HasBase` will always be `false`. You do not need to understand this layer to add a new asset type.
 
 ## `AssetPropertyGraph`
@@ -89,8 +91,8 @@ public class YourAssetPropertyGraphDefinition : AssetPropertyGraphDefinition
 
 The `[AssetPropertyGraphDefinition(typeof(YourAsset))]` attribute is discovered automatically when the assembly is registered. No manual registration is needed beyond `AssetQuantumRegistry.RegisterAssembly()` in `Module.cs`.
 
-> [!NOTE] Just adding a new asset type
-> If all your asset's properties are plain data values (numbers, strings, lists of structs), you do not need an `AssetPropertyGraphDefinition`. Only provide one when your asset class has members that hold references to other content objects (Prefabs, Textures, Materials, etc.) that should remain as references rather than be embedded inline.
+> [!NOTE]
+> **When just adding a new asset type:** if all your asset's properties are plain data values (numbers, strings, lists of structs), you do not need an `AssetPropertyGraphDefinition`. Only provide one when your asset class has members that hold references to other content objects (Prefabs, Textures, Materials, etc.) that should remain as references rather than be embedded inline.
 
 ## `AssetQuantumRegistry`
 


### PR DESCRIPTION
# PR Details

Some pages in `docs/` had issues with formatting, which produced warnings while building stride-docs when they were copied over to it. These errors also make the pages appear incorrectly on GitHub.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related PR

https://github.com/stride3d/stride-docs/pull/528

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->