### PR TITLE
feat: Moved to generics

### DIFF
--- a/sources/core/Stride.Core.Tests/Collections/TrackingDictionaryTests.cs
+++ b/sources/core/Stride.Core.Tests/Collections/TrackingDictionaryTests.cs
@@ -18,7 +18,7 @@ public class TrackingDictionaryTests
     public void Add_AddsItemAndTriggersEvent()
     {
         var dict = new TrackingDictionary<string, int>();
-        TrackingCollectionChangedEventArgs? eventArgs = null;
+        TrackingKeyedCollectionChangedEventArgs<string, int>? eventArgs = null;
         dict.CollectionChanged += (sender, args) => eventArgs = args;
 
         dict.Add("key1", 10);
@@ -34,7 +34,7 @@ public class TrackingDictionaryTests
     public void Remove_RemovesItemAndTriggersEvent()
     {
         var dict = new TrackingDictionary<string, int> { { "key1", 10 } };
-        TrackingCollectionChangedEventArgs? eventArgs = null;
+        TrackingKeyedCollectionChangedEventArgs<string, int>? eventArgs = null;
         dict.CollectionChanged += (sender, args) =>
         {
             if (args.Action == NotifyCollectionChangedAction.Remove)
@@ -218,7 +218,7 @@ public class TrackingDictionaryTests
     {
         var dict = new TrackingDictionary<string, int>();
         var eventCount = 0;
-        EventHandler<TrackingCollectionChangedEventArgs> handler = (s, e) => eventCount++;
+        EventHandler<TrackingKeyedCollectionChangedEventArgs<string, int>> handler = (s, e) => eventCount++;
 
         dict.CollectionChanged += handler;
         dict.Add("key1", 10);

--- a/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
+++ b/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
+++ b/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
@@ -1,13 +1,15 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
-// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Stride.Core.Collections;
-
-public interface ITrackingCollectionChanged<TKey, TValue>
+public interface ITrackingCollectionChanged<TValue>
 {
     /// <summary>
     /// Occurs when [collection changed].
     /// </summary>
     /// Called as is when adding an item, and in reverse-order when removing an item.
-    event EventHandler<TrackingCollectionChangedEventArgs<TKey, TValue>> CollectionChanged;
+    event EventHandler<TrackingCollectionChangedEventArgs<TValue>> CollectionChanged;
 }

--- a/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
+++ b/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
@@ -9,6 +9,5 @@ public interface ITrackingCollectionChanged<TKey, TValue>
     /// Occurs when [collection changed].
     /// </summary>
     /// Called as is when adding an item, and in reverse-order when removing an item.
-    [Obsolete]
     event EventHandler<TrackingCollectionChangedEventArgs<TKey, TValue>> CollectionChanged;
 }

--- a/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
+++ b/sources/core/Stride.Core/Collections/ITrackingCollectionChanged.cs
@@ -3,11 +3,12 @@
 
 namespace Stride.Core.Collections;
 
-public interface ITrackingCollectionChanged
+public interface ITrackingCollectionChanged<TKey, TValue>
 {
     /// <summary>
     /// Occurs when [collection changed].
     /// </summary>
     /// Called as is when adding an item, and in reverse-order when removing an item.
-    event EventHandler<TrackingCollectionChangedEventArgs> CollectionChanged;
+    [Obsolete]
+    event EventHandler<TrackingCollectionChangedEventArgs<TKey, TValue>> CollectionChanged;
 }

--- a/sources/core/Stride.Core/Collections/ITrackingKeyedCollectionChanged.cs
+++ b/sources/core/Stride.Core/Collections/ITrackingKeyedCollectionChanged.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Core.Collections;
+
+public interface ITrackingKeyedCollectionChanged<TKey, TValue>
+{
+    /// <summary>
+    /// Occurs when [collection changed].
+    /// </summary>
+    /// Called as is when adding an item, and in reverse-order when removing an item.
+    event EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>> CollectionChanged;
+}

--- a/sources/core/Stride.Core/Collections/TrackingCollection.cs
+++ b/sources/core/Stride.Core/Collections/TrackingCollection.cs
@@ -12,24 +12,24 @@ namespace Stride.Core.Collections;
 /// </summary>
 /// <typeparam name="T">The type of elements in the collection.</typeparam>
 [DataSerializer(typeof(ListAllSerializer<,>), Mode = DataSerializerGenericMode.TypeAndGenericArguments)]
-public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChanged<T, T>
+public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChanged<T>
 {
-    private EventHandler<TrackingCollectionChangedEventArgs<T, T>>? _itemAdded;
-    private EventHandler<TrackingCollectionChangedEventArgs<T, T>>? _itemRemoved;
+    private EventHandler<TrackingCollectionChangedEventArgs<T>>? _itemAdded;
+    private EventHandler<TrackingCollectionChangedEventArgs<T>>? _itemRemoved;
 
     /// <inheritdoc/>
-    public event EventHandler<TrackingCollectionChangedEventArgs<T, T>> CollectionChanged
+    public event EventHandler<TrackingCollectionChangedEventArgs<T>> CollectionChanged
     {
         add
         {
             // We keep a list in reverse order for removal, so that we can easily have multiple handlers depending on each others
-            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>)Delegate.Combine(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>)Delegate.Combine(value, _itemRemoved);
+            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(_itemAdded, value);
+            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(value, _itemRemoved);
         }
         remove
         {
-            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>?)Delegate.Remove(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>?)Delegate.Remove(_itemRemoved, value);
+            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(_itemAdded, value);
+            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(_itemRemoved, value);
         }
     }
 
@@ -37,13 +37,13 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
     protected override void InsertItem(int index, T item)
     {
         base.InsertItem(index, item);
-        _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Add, item, default, index, true));
+        _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Add, item, default, index, true));
     }
 
     /// <inheritdoc/>
     protected override void RemoveItem(int index)
     {
-        _itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, this[index], default, index, true));
+        _itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Remove, this[index], default, index, true));
         base.RemoveItem(index);
     }
 
@@ -61,7 +61,7 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
         if (collectionChanged != null)
         {
             for (var i = Count - 1; i >= 0; --i)
-                collectionChanged(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, this[i], default, i, true));
+                collectionChanged(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Remove, this[i], default, i, true));
         }
     }
 
@@ -72,10 +72,10 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
         var collectionChangedRemoved = _itemRemoved;
 
         T? oldItem = collectionChangedRemoved != null ? this[index] : default;
-        collectionChangedRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, oldItem, default, index, false));
+        collectionChangedRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Remove, oldItem, default, index, false));
 
         base.SetItem(index, item);
 
-        _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Add, item, oldItem, index, false));
+        _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Add, item, oldItem, index, false));
     }
 }

--- a/sources/core/Stride.Core/Collections/TrackingCollection.cs
+++ b/sources/core/Stride.Core/Collections/TrackingCollection.cs
@@ -12,24 +12,24 @@ namespace Stride.Core.Collections;
 /// </summary>
 /// <typeparam name="T">The type of elements in the collection.</typeparam>
 [DataSerializer(typeof(ListAllSerializer<,>), Mode = DataSerializerGenericMode.TypeAndGenericArguments)]
-public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChanged
+public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChanged<T, T>
 {
-    private EventHandler<TrackingCollectionChangedEventArgs>? itemAdded;
-    private EventHandler<TrackingCollectionChangedEventArgs>? itemRemoved;
+    private EventHandler<TrackingCollectionChangedEventArgs<T, T>>? _itemAdded;
+    private EventHandler<TrackingCollectionChangedEventArgs<T, T>>? _itemRemoved;
 
     /// <inheritdoc/>
-    public event EventHandler<TrackingCollectionChangedEventArgs> CollectionChanged
+    public event EventHandler<TrackingCollectionChangedEventArgs<T, T>> CollectionChanged
     {
         add
         {
             // We keep a list in reverse order for removal, so that we can easily have multiple handlers depending on each others
-            itemAdded = (EventHandler<TrackingCollectionChangedEventArgs>)Delegate.Combine(itemAdded, value);
-            itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs>)Delegate.Combine(value, itemRemoved);
+            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>)Delegate.Combine(_itemAdded, value);
+            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>)Delegate.Combine(value, _itemRemoved);
         }
         remove
         {
-            itemAdded = (EventHandler<TrackingCollectionChangedEventArgs>?)Delegate.Remove(itemAdded, value);
-            itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs>?)Delegate.Remove(itemRemoved, value);
+            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>?)Delegate.Remove(_itemAdded, value);
+            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>?)Delegate.Remove(_itemRemoved, value);
         }
     }
 
@@ -37,13 +37,13 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
     protected override void InsertItem(int index, T item)
     {
         base.InsertItem(index, item);
-        itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, null, index, true));
+        _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Add, item, default, index, true));
     }
 
     /// <inheritdoc/>
     protected override void RemoveItem(int index)
     {
-        itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, this[index], null, index, true));
+        _itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, this[index], default, index, true));
         base.RemoveItem(index);
     }
 
@@ -57,11 +57,11 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
     protected void ClearItemsEvents()
     {
         // Note: Changing CollectionChanged is not thread-safe
-        var collectionChanged = itemRemoved;
+        var collectionChanged = _itemRemoved;
         if (collectionChanged != null)
         {
             for (var i = Count - 1; i >= 0; --i)
-                collectionChanged(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, this[i], null, i, true));
+                collectionChanged(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, this[i], default, i, true));
         }
     }
 
@@ -69,13 +69,13 @@ public class TrackingCollection<T> : FastCollection<T>, ITrackingCollectionChang
     protected override void SetItem(int index, T item)
     {
         // Note: Changing CollectionChanged is not thread-safe
-        var collectionChangedRemoved = itemRemoved;
+        var collectionChangedRemoved = _itemRemoved;
 
-        object? oldItem = collectionChangedRemoved != null ? this[index] : null;
-        collectionChangedRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, oldItem, null, index, false));
+        T? oldItem = collectionChangedRemoved != null ? this[index] : default;
+        collectionChangedRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, oldItem, default, index, false));
 
         base.SetItem(index, item);
 
-        itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, oldItem, index, false));
+        _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Add, item, oldItem, index, false));
     }
 }

--- a/sources/core/Stride.Core/Collections/TrackingCollectionChangedEventArgs.cs
+++ b/sources/core/Stride.Core/Collections/TrackingCollectionChangedEventArgs.cs
@@ -5,62 +5,7 @@ using System.Collections.Specialized;
 
 namespace Stride.Core.Collections;
 
-public class TrackingCollectionChangedEventArgs : EventArgs
-{
-    public TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction action, object? item, object? oldItem, int index, bool collectionChanged)
-    {
-        Action = action;
-        Item = item;
-        OldItem = oldItem;
-        Key = null;
-        Index = index;
-        CollectionChanged = collectionChanged;
-    }
-
-    public TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction action, object key, object? item, object? oldItem, bool collectionChanged)
-    {
-        Action = action;
-        Item = item;
-        OldItem = oldItem;
-        Key = key;
-        Index = -1;
-        CollectionChanged = collectionChanged;
-    }
-
-    /// <summary>
-    /// Gets the type of action performed.
-    /// Allowed values are <see cref="NotifyCollectionChangedAction.Add"/> and <see cref="NotifyCollectionChangedAction.Remove"/>.
-    /// </summary>
-    public NotifyCollectionChangedAction Action { get; }
-
-    /// <summary>
-    /// Gets the added or removed item (if dictionary, value only).
-    /// </summary>
-    public object? Item { get; }
-
-    /// <summary>
-    /// Gets the previous value. Only valid if <see cref="Action"/> is <see cref="NotifyCollectionChangedAction.Add"/> and <see cref="NotifyCollectionChangedAction.Remove"/>
-    /// </summary>
-    public object? OldItem { get; }
-
-    /// <summary>Gets the added or removed key (if dictionary).</summary>
-    public object? Key { get; }
-
-    /// <summary>
-    /// Gets the index in the collection (if applicable).
-    /// </summary>
-    public int Index { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether [collection changed (not a replacement but real insertion/removal)].
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if [collection changed]; otherwise, <c>false</c>.
-    /// </value>
-    public bool CollectionChanged { get; }
-}
-
-public class TrackingCollectionChangedEventArgs<TKey, TValue>
+public sealed class TrackingCollectionChangedEventArgs<TKey, TValue> : EventArgs
 {
     public TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction action, TValue? item, TValue? oldItem, int index, bool collectionChanged)
     {

--- a/sources/core/Stride.Core/Collections/TrackingCollectionChangedEventArgs.cs
+++ b/sources/core/Stride.Core/Collections/TrackingCollectionChangedEventArgs.cs
@@ -59,3 +59,58 @@ public class TrackingCollectionChangedEventArgs : EventArgs
     /// </value>
     public bool CollectionChanged { get; }
 }
+
+public class TrackingCollectionChangedEventArgs<TKey, TValue>
+{
+    public TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction action, TValue? item, TValue? oldItem, int index, bool collectionChanged)
+    {
+        Action = action;
+        Item = item;
+        OldItem = oldItem;
+        Key = default;
+        Index = index;
+        CollectionChanged = collectionChanged;
+    }
+
+    public TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction action, TKey key, TValue? item, TValue? oldItem, bool collectionChanged)
+    {
+        Action = action;
+        Item = item;
+        OldItem = oldItem;
+        Key = key;
+        Index = -1;
+        CollectionChanged = collectionChanged;
+    }
+
+    /// <summary>
+    /// Gets the type of action performed.
+    /// Allowed values are <see cref="NotifyCollectionChangedAction.Add"/> and <see cref="NotifyCollectionChangedAction.Remove"/>.
+    /// </summary>
+    public NotifyCollectionChangedAction Action { get; }
+
+    /// <summary>
+    /// Gets the added or removed item (if dictionary, value only).
+    /// </summary>
+    public TValue? Item { get; }
+
+    /// <summary>
+    /// Gets the previous value. Only valid if <see cref="Action"/> is <see cref="NotifyCollectionChangedAction.Add"/> and <see cref="NotifyCollectionChangedAction.Remove"/>
+    /// </summary>
+    public TValue? OldItem { get; }
+
+    /// <summary>Gets the added or removed key (if dictionary).</summary>
+    public TKey? Key { get; }
+
+    /// <summary>
+    /// Gets the index in the collection (if applicable).
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether [collection changed (not a replacement but real insertion/removal)].
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if [collection changed]; otherwise, <c>false</c>.
+    /// </value>
+    public bool CollectionChanged { get; }
+}

--- a/sources/core/Stride.Core/Collections/TrackingCollectionChangedEventArgs.cs
+++ b/sources/core/Stride.Core/Collections/TrackingCollectionChangedEventArgs.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using System.Collections.Specialized;
 
 namespace Stride.Core.Collections;

--- a/sources/core/Stride.Core/Collections/TrackingDictionary.cs
+++ b/sources/core/Stride.Core/Collections/TrackingDictionary.cs
@@ -23,8 +23,8 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
 {
     private readonly Dictionary<TKey, TValue> innerDictionary;
 
-    private EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>? _itemAdded;
-    private EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>? _itemRemoved;
+    private EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>? itemAdded;
+    private EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>? itemRemoved;
 
     /// <inheritdoc/>
     public event EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>> CollectionChanged
@@ -32,13 +32,13 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
         add
         {
             // We keep a list in reverse order for removal, so that we can easily have multiple handlers depending on each others
-            _itemAdded = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>)Delegate.Combine(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>)Delegate.Combine(value, _itemRemoved);
+            itemAdded = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>)Delegate.Combine(itemAdded, value);
+            itemRemoved = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>)Delegate.Combine(value, itemRemoved);
         }
         remove
         {
-            _itemAdded = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>?)Delegate.Remove(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>?)Delegate.Remove(_itemRemoved, value);
+            itemAdded = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>?)Delegate.Remove(itemAdded, value);
+            itemRemoved = (EventHandler<TrackingKeyedCollectionChangedEventArgs<TKey, TValue>>?)Delegate.Remove(itemRemoved, value);
         }
     }
 
@@ -54,7 +54,7 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
     public void Add(TKey key, TValue value)
     {
         innerDictionary.Add(key, value);
-        _itemAdded?.Invoke(this, new TrackingKeyedCollectionChangedEventArgs<TKey, TValue>(NotifyCollectionChangedAction.Add, key, value, default, true));
+        itemAdded?.Invoke(this, new TrackingKeyedCollectionChangedEventArgs<TKey, TValue>(NotifyCollectionChangedAction.Add, key, value, default, true));
     }
 
     /// <inheritdoc/>
@@ -72,7 +72,7 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
     /// <inheritdoc/>
     public bool Remove(TKey key)
     {
-        var collectionChanged = _itemRemoved;
+        var collectionChanged = itemRemoved;
         if (collectionChanged != null && innerDictionary.TryGetValue(key, out var dictValue))
             collectionChanged(this, new TrackingKeyedCollectionChangedEventArgs<TKey, TValue>(NotifyCollectionChangedAction.Remove, key, dictValue, default, true));
 
@@ -100,7 +100,7 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
         }
         set
         {
-            var collectionChangedRemoved = _itemRemoved;
+            var collectionChangedRemoved = itemRemoved;
             if (collectionChangedRemoved != null)
             {
                 var alreadyExisting = innerDictionary.TryGetValue(key, out var oldValue);
@@ -110,7 +110,7 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
                 innerDictionary[key] = value;
 
                 // Note: CollectionChanged is considered not thread-safe, so no need to skip if null here, shouldn't happen
-                _itemAdded?.Invoke(this, new TrackingKeyedCollectionChangedEventArgs<TKey, TValue>(NotifyCollectionChangedAction.Add, key, innerDictionary[key], oldValue, !alreadyExisting));
+                itemAdded?.Invoke(this, new TrackingKeyedCollectionChangedEventArgs<TKey, TValue>(NotifyCollectionChangedAction.Add, key, innerDictionary[key], oldValue, !alreadyExisting));
             }
             else
             {
@@ -128,7 +128,7 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
     /// <inheritdoc/>
     public void Clear()
     {
-        var collectionChanged = _itemRemoved;
+        var collectionChanged = itemRemoved;
         if (collectionChanged != null)
         {
             foreach (var key in innerDictionary.Keys.ToArray())
@@ -169,7 +169,7 @@ public class TrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDict
     /// <inheritdoc/>
     public bool Remove(KeyValuePair<TKey, TValue> item)
     {
-        var collectionChanged = _itemRemoved;
+        var collectionChanged = itemRemoved;
         if (collectionChanged != null && innerDictionary.Contains(item))
             return innerDictionary.Remove(item.Key);
 

--- a/sources/core/Stride.Core/Collections/TrackingHashSet.cs
+++ b/sources/core/Stride.Core/Collections/TrackingHashSet.cs
@@ -16,8 +16,8 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
 {
     private readonly HashSet<T> innerHashSet = [];
 
-    private EventHandler<TrackingCollectionChangedEventArgs<T>>? _itemAdded;
-    private EventHandler<TrackingCollectionChangedEventArgs<T>>? _itemRemoved;
+    private EventHandler<TrackingCollectionChangedEventArgs<T>>? itemAdded;
+    private EventHandler<TrackingCollectionChangedEventArgs<T>>? itemRemoved;
 
     /// <inheritdoc/>
     public event EventHandler<TrackingCollectionChangedEventArgs<T>> CollectionChanged
@@ -25,13 +25,13 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
         add
         {
             // We keep a list in reverse order for removal, so that we can easily have multiple handlers depending on each others
-            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(value, _itemRemoved);
+            itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(itemAdded, value);
+            itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(value, itemRemoved);
         }
         remove
         {
-            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(_itemRemoved, value);
+            itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(itemAdded, value);
+            itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(itemRemoved, value);
         }
     }
 
@@ -40,7 +40,7 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
     {
         if (innerHashSet.Add(item))
         {
-            _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Add, item, default, -1, true));
+            itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Add, item, default, -1, true));
             return true;
         }
 
@@ -116,7 +116,7 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
     /// <inheritdoc/>
     public void Clear()
     {
-        if (_itemRemoved != null)
+        if (itemRemoved != null)
         {
             foreach (var item in innerHashSet.ToArray())
             {
@@ -153,7 +153,7 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
         if (!innerHashSet.Remove(item))
             return false;
 
-        _itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Remove, item, default, -1, true));
+        itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Remove, item, default, -1, true));
         return true;
     }
 

--- a/sources/core/Stride.Core/Collections/TrackingHashSet.cs
+++ b/sources/core/Stride.Core/Collections/TrackingHashSet.cs
@@ -12,26 +12,26 @@ namespace Stride.Core.Collections;
 /// Underlying storage is done with a <see cref="HashSet{T}"/>.
 /// </remarks>
 /// <typeparam name="T">The type of elements in the hash set.</typeparam>
-public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionChanged<T, T>
+public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionChanged<T>
 {
     private readonly HashSet<T> innerHashSet = [];
 
-    private EventHandler<TrackingCollectionChangedEventArgs<T, T>>? _itemAdded;
-    private EventHandler<TrackingCollectionChangedEventArgs<T, T>>? _itemRemoved;
+    private EventHandler<TrackingCollectionChangedEventArgs<T>>? _itemAdded;
+    private EventHandler<TrackingCollectionChangedEventArgs<T>>? _itemRemoved;
 
     /// <inheritdoc/>
-    public event EventHandler<TrackingCollectionChangedEventArgs<T, T>> CollectionChanged
+    public event EventHandler<TrackingCollectionChangedEventArgs<T>> CollectionChanged
     {
         add
         {
             // We keep a list in reverse order for removal, so that we can easily have multiple handlers depending on each others
-            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>)Delegate.Combine(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>)Delegate.Combine(value, _itemRemoved);
+            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(_itemAdded, value);
+            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>)Delegate.Combine(value, _itemRemoved);
         }
         remove
         {
-            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>?)Delegate.Remove(_itemAdded, value);
-            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T, T>>?)Delegate.Remove(_itemRemoved, value);
+            _itemAdded = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(_itemAdded, value);
+            _itemRemoved = (EventHandler<TrackingCollectionChangedEventArgs<T>>?)Delegate.Remove(_itemRemoved, value);
         }
     }
 
@@ -40,7 +40,7 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
     {
         if (innerHashSet.Add(item))
         {
-            _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Add, item, default, -1, true));
+            _itemAdded?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Add, item, default, -1, true));
             return true;
         }
 
@@ -153,7 +153,7 @@ public class TrackingHashSet<T> : ISet<T>, IReadOnlySet<T>, ITrackingCollectionC
         if (!innerHashSet.Remove(item))
             return false;
 
-        _itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T, T>(NotifyCollectionChangedAction.Remove, item, default, -1, true));
+        _itemRemoved?.Invoke(this, new TrackingCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Remove, item, default, -1, true));
         return true;
     }
 

--- a/sources/core/Stride.Core/Collections/TrackingKeyedCollectionChangedEventArgs.cs
+++ b/sources/core/Stride.Core/Collections/TrackingKeyedCollectionChangedEventArgs.cs
@@ -1,14 +1,29 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using System.Collections.Specialized;
 
 namespace Stride.Core.Collections;
-public sealed class TrackingCollectionChangedEventArgs<TValue> : EventArgs
+
+public sealed class TrackingKeyedCollectionChangedEventArgs<TKey, TValue> : EventArgs
 {
-    public TrackingCollectionChangedEventArgs(NotifyCollectionChangedAction action, TValue? item, TValue? oldItem, int index, bool collectionChanged)
+    public TrackingKeyedCollectionChangedEventArgs(NotifyCollectionChangedAction action, TValue? item, TValue? oldItem, int index, bool collectionChanged)
     {
         Action = action;
         Item = item;
         OldItem = oldItem;
+        Key = default;
         Index = index;
+        CollectionChanged = collectionChanged;
+    }
+
+    public TrackingKeyedCollectionChangedEventArgs(NotifyCollectionChangedAction action, TKey key, TValue? item, TValue? oldItem, bool collectionChanged)
+    {
+        Action = action;
+        Item = item;
+        OldItem = oldItem;
+        Key = key;
+        Index = -1;
         CollectionChanged = collectionChanged;
     }
 
@@ -27,6 +42,9 @@ public sealed class TrackingCollectionChangedEventArgs<TValue> : EventArgs
     /// Gets the previous value. Only valid if <see cref="Action"/> is <see cref="NotifyCollectionChangedAction.Add"/> and <see cref="NotifyCollectionChangedAction.Remove"/>
     /// </summary>
     public TValue? OldItem { get; }
+
+    /// <summary>Gets the added or removed key (if dictionary).</summary>
+    public TKey? Key { get; }
 
     /// <summary>
     /// Gets the index in the collection (if applicable).

--- a/sources/core/Stride.Core/Collections/TrackingKeyedCollectionChangedEventArgs.cs
+++ b/sources/core/Stride.Core/Collections/TrackingKeyedCollectionChangedEventArgs.cs
@@ -7,16 +7,6 @@ namespace Stride.Core.Collections;
 
 public sealed class TrackingKeyedCollectionChangedEventArgs<TKey, TValue> : EventArgs
 {
-    public TrackingKeyedCollectionChangedEventArgs(NotifyCollectionChangedAction action, TValue? item, TValue? oldItem, int index, bool collectionChanged)
-    {
-        Action = action;
-        Item = item;
-        OldItem = oldItem;
-        Key = default;
-        Index = index;
-        CollectionChanged = collectionChanged;
-    }
-
     public TrackingKeyedCollectionChangedEventArgs(NotifyCollectionChangedAction action, TKey key, TValue? item, TValue? oldItem, bool collectionChanged)
     {
         Action = action;
@@ -44,7 +34,7 @@ public sealed class TrackingKeyedCollectionChangedEventArgs<TKey, TValue> : Even
     public TValue? OldItem { get; }
 
     /// <summary>Gets the added or removed key (if dictionary).</summary>
-    public TKey? Key { get; }
+    public TKey Key { get; }
 
     /// <summary>
     /// Gets the index in the collection (if applicable).

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameNavigationMeshService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameNavigationMeshService.cs
@@ -365,7 +365,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             return ret;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
+        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase> e)
         {
             if (dynamicNavigationMeshSystem != null)
                 return;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameNavigationMeshService.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/Game/EditorGameNavigationMeshService.cs
@@ -365,7 +365,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.Game
             return ret;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
         {
             if (dynamicNavigationMeshSystem != null)
                 return;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/BlockNodeVertex.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/BlockNodeVertex.cs
@@ -51,7 +51,7 @@ namespace Stride.Assets.Presentation.AssetEditors.VisualScriptEditor
             {
                 case NotifyCollectionChangedAction.Add:
                 {
-                    var slot = (Slot)e.Item;
+                    var slot = e.Item;
                     var slots = slot.Direction == SlotDirection.Input ? InputSlots : OutputSlots;
                     var slotViewModel = new VisualScriptSlotViewModel(ViewModel, slot);
                     slots.Add(slotViewModel);

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/BlockNodeVertex.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/BlockNodeVertex.cs
@@ -45,7 +45,7 @@ namespace Stride.Assets.Presentation.AssetEditors.VisualScriptEditor
             viewModel.Block.Slots.CollectionChanged += Slots_CollectionChanged;
         }
 
-        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Slot, Slot> e)
+        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Slot> e)
         {
             switch (e.Action)
             {

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/BlockNodeVertex.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/VisualScriptEditor/BlockNodeVertex.cs
@@ -45,7 +45,7 @@ namespace Stride.Assets.Presentation.AssetEditors.VisualScriptEditor
             viewModel.Block.Slots.CollectionChanged += Slots_CollectionChanged;
         }
 
-        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Slot, Slot> e)
         {
             switch (e.Action)
             {

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -84,7 +84,7 @@ namespace Stride.Assets.Presentation.ViewModel
 
             void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly, ProjectWatcher.TrackedAssembly> e)
             {
-                if (((ProjectWatcher.TrackedAssembly)e.Item).Project is { } project)
+                if ((e.Item).Project is { } project)
                 {
                     switch (e.Action)
                     {

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -82,7 +82,7 @@ namespace Stride.Assets.Presentation.ViewModel
             projectWatcherCompletion.SetResult(projectWatcher);
             workspaceCompletion.SetResult(workspace);
 
-            void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly, ProjectWatcher.TrackedAssembly> e)
+            void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly> e)
             {
                 if ((e.Item).Project is { } project)
                 {

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -82,7 +82,7 @@ namespace Stride.Assets.Presentation.ViewModel
             projectWatcherCompletion.SetResult(projectWatcher);
             workspaceCompletion.SetResult(workspace);
 
-            void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs e)
+            void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly, ProjectWatcher.TrackedAssembly> e)
             {
                 if (((ProjectWatcher.TrackedAssembly)e.Item).Project is { } project)
                 {

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -105,12 +105,12 @@ namespace Stride.Assets.Presentation.ViewModel
             }
         }
 
-        private void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs e)
+        private void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly, ProjectWatcher.TrackedAssembly> e)
         {
             if (roslynWorkspace == null)
                 return;
 
-            if (((ProjectWatcher.TrackedAssembly)e.Item).Project is { } project)
+            if (e.Item.Project is { } project)
             {
                 switch (e.Action)
                 {

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -105,23 +105,21 @@ namespace Stride.Assets.Presentation.ViewModel
             }
         }
 
-            void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly> e)
+        private void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly> e)
+        {
+            if (roslynWorkspace == null)
+                return;
+
+            if (e.Item.Project is { } project)
             {
-                if ((e.Item).Project is { } project)
+                switch (e.Action)
                 {
-                    switch (e.Action)
-                    {
-                        case NotifyCollectionChangedAction.Add:
-                            {
-                                workspace.AddOrUpdateProject(project);
-                                break;
-                            }
-                        case NotifyCollectionChangedAction.Remove:
-                            {
-                                workspace.RemoveProject(project.Id);
-                                break;
-                            }
-                    }
+                    case NotifyCollectionChangedAction.Add:
+                        roslynWorkspace.AddOrUpdateProject(project);
+                        break;
+                    case NotifyCollectionChangedAction.Remove:
+                        roslynWorkspace.RemoveProject(project.Id);
+                        break;
                 }
             }
         }

--- a/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/CodeViewModel.cs
@@ -105,7 +105,7 @@ namespace Stride.Assets.Presentation.ViewModel
             }
         }
 
-        private void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly, ProjectWatcher.TrackedAssembly> e)
+        private void TrackedAssembliesCollectionChanged(object sender, Core.Collections.TrackingCollectionChangedEventArgs<ProjectWatcher.TrackedAssembly> e)
         {
             if (roslynWorkspace == null)
                 return;

--- a/sources/engine/Stride.Assets/Scripts/Block.cs
+++ b/sources/engine/Stride.Assets/Scripts/Block.cs
@@ -107,7 +107,7 @@ namespace Stride.Assets.Scripts
             slot.Owner = null;
         }
 
-        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Slot, Slot> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Assets/Scripts/Block.cs
+++ b/sources/engine/Stride.Assets/Scripts/Block.cs
@@ -112,10 +112,10 @@ namespace Stride.Assets.Scripts
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    OnSlotAdd((Slot)e.Item);
+                    OnSlotAdd(e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    OnSlotRemove((Slot)e.Item);
+                    OnSlotRemove(e.Item);
                     break;
                 default:
                     throw new NotSupportedException();

--- a/sources/engine/Stride.Assets/Scripts/Block.cs
+++ b/sources/engine/Stride.Assets/Scripts/Block.cs
@@ -107,7 +107,7 @@ namespace Stride.Assets.Scripts
             slot.Owner = null;
         }
 
-        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Slot, Slot> e)
+        private void Slots_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Slot> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Engine/Audio/AudioEmitterProcessor.cs
+++ b/sources/engine/Stride.Engine/Audio/AudioEmitterProcessor.cs
@@ -233,7 +233,7 @@ namespace Stride.Audio
             data.AudioEmitterComponent.ControllerCollectionChanged -= OnSoundControllerListChanged;
         }
 
-        private void OnListenerCollectionChanged(object o, TrackingCollectionChangedEventArgs<AudioListenerComponent, AudioListener> args)
+        private void OnListenerCollectionChanged(object o, TrackingKeyedCollectionChangedEventArgs<AudioListenerComponent, AudioListener> args)
         {
             if (!args.CollectionChanged) // no keys have been added or removed, only one of the values changed
                 return;

--- a/sources/engine/Stride.Engine/Audio/AudioEmitterProcessor.cs
+++ b/sources/engine/Stride.Engine/Audio/AudioEmitterProcessor.cs
@@ -233,7 +233,7 @@ namespace Stride.Audio
             data.AudioEmitterComponent.ControllerCollectionChanged -= OnSoundControllerListChanged;
         }
 
-        private void OnListenerCollectionChanged(object o, TrackingCollectionChangedEventArgs args)
+        private void OnListenerCollectionChanged(object o, TrackingCollectionChangedEventArgs<AudioListenerComponent, AudioListener> args)
         {
             if (!args.CollectionChanged) // no keys have been added or removed, only one of the values changed
                 return;

--- a/sources/engine/Stride.Engine/Audio/AudioEmitterProcessor.cs
+++ b/sources/engine/Stride.Engine/Audio/AudioEmitterProcessor.cs
@@ -249,11 +249,11 @@ namespace Stride.Audio
                 {
                     if (args.Action == NotifyCollectionChangedAction.Add) // A new listener have been added
                     {
-                        soundController.CreateSoundInstance((AudioListenerComponent)args.Key, false);
+                        soundController.CreateSoundInstance(args.Key, false);
                     }
                     else if (args.Action == NotifyCollectionChangedAction.Remove) // A listener have been removed
                     {
-                        soundController.DestroySoundInstances((AudioListenerComponent)args.Key);
+                        soundController.DestroySoundInstances(args.Key);
                     }
                 }
             }

--- a/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
@@ -49,7 +49,7 @@ namespace Stride.Engine
             PlayingAnimations.CollectionChanged += PlayingAnimations_CollectionChanged;
         }
 
-        private void PlayingAnimations_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<PlayingAnimation, PlayingAnimation> e)
+        private void PlayingAnimations_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<PlayingAnimation> e)
         {
             var item = e.Item;
             switch (e.Action)

--- a/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
@@ -51,7 +51,7 @@ namespace Stride.Engine
 
         private void PlayingAnimations_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<PlayingAnimation, PlayingAnimation> e)
         {
-            var item = (PlayingAnimation)e.Item;
+            var item = e.Item;
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Remove:

--- a/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AnimationComponent.cs
@@ -49,7 +49,7 @@ namespace Stride.Engine
             PlayingAnimations.CollectionChanged += PlayingAnimations_CollectionChanged;
         }
 
-        private void PlayingAnimations_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void PlayingAnimations_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<PlayingAnimation, PlayingAnimation> e)
         {
             var item = (PlayingAnimation)e.Item;
             switch (e.Action)

--- a/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
@@ -189,7 +189,7 @@ namespace Stride.Engine
             }
         }
 
-        private void OnSoundsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<string, Sound> args)
+        private void OnSoundsOnCollectionChanged(object sender, TrackingKeyedCollectionChangedEventArgs<string, Sound> args)
         {
             switch (args.Action)
             {

--- a/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
@@ -194,10 +194,10 @@ namespace Stride.Engine
             switch (args.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    SoundAdded((SoundBase)args.Item);
+                    SoundAdded(args.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    SoundRemoved((SoundBase)args.Item);
+                    SoundRemoved(args.Item);
                     break;
             }
         }

--- a/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
+++ b/sources/engine/Stride.Engine/Engine/AudioEmitterComponent.cs
@@ -189,7 +189,7 @@ namespace Stride.Engine
             }
         }
 
-        private void OnSoundsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs args)
+        private void OnSoundsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<string, Sound> args)
         {
             switch (args.Action)
             {

--- a/sources/engine/Stride.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneInstance.cs
@@ -151,7 +151,7 @@ namespace Stride.Engine
                 }
                 scene.Entities.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
                 {
                     Entity entity = (Entity)e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -182,7 +182,7 @@ namespace Stride.Engine
                 }
                 scene.Children.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
                 {
                     Scene subScene = (Scene)e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -222,7 +222,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
         {
             switch (e.Action)
             {
@@ -235,7 +235,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
         {
             switch (e.Action)
             {
@@ -271,7 +271,7 @@ namespace Stride.Engine
             registeredRenderProcessorTypes.Clear();
         }
 
-        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup, VisibilityGroup> e)
         {
             var visibilityGroup = (VisibilityGroup)e.Item;
 

--- a/sources/engine/Stride.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneInstance.cs
@@ -153,7 +153,7 @@ namespace Stride.Engine
 
                 void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
                 {
-                    Entity entity = (Entity)e.Item;
+                    Entity entity = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
                     {
                         if (entitiesToAdd.Remove(entity) == false)
@@ -184,7 +184,7 @@ namespace Stride.Engine
 
                 void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
                 {
-                    Scene subScene = (Scene)e.Item;
+                    Scene subScene = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
                     {
                         if (scenesToAdd.Remove(subScene) == false)
@@ -227,10 +227,10 @@ namespace Stride.Engine
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    Add((Entity)e.Item);
+                    Add(e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    Remove((Entity)e.Item);
+                    Remove(e.Item);
                     break;
             }
         }
@@ -240,10 +240,10 @@ namespace Stride.Engine
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    Add((Scene)e.Item);
+                    Add(e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    Remove((Scene)e.Item);
+                    Remove(e.Item);
                     break;
             }
         }
@@ -273,7 +273,7 @@ namespace Stride.Engine
 
         private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup, VisibilityGroup> e)
         {
-            var visibilityGroup = (VisibilityGroup)e.Item;
+            var visibilityGroup = e.Item;
 
             switch (e.Action)
             {

--- a/sources/engine/Stride.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneInstance.cs
@@ -151,7 +151,7 @@ namespace Stride.Engine
                 }
                 scene.Entities.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity> e)
                 {
                     Entity entity = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -182,7 +182,7 @@ namespace Stride.Engine
                 }
                 scene.Children.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene> e)
                 {
                     Scene subScene = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -222,7 +222,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
+        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Entity> e)
         {
             switch (e.Action)
             {
@@ -235,7 +235,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
+        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Scene> e)
         {
             switch (e.Action)
             {
@@ -271,7 +271,7 @@ namespace Stride.Engine
             registeredRenderProcessorTypes.Clear();
         }
 
-        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup, VisibilityGroup> e)
+        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup> e)
         {
             var visibilityGroup = e.Item;
 

--- a/sources/engine/Stride.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneInstance.cs
@@ -154,7 +154,7 @@ namespace Stride.Engine
 
                 void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
                 {
-                    Entity entity = (Entity)e.Item;
+                    Entity entity = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
                     {
                         if (entitiesToAdd.Remove(entity) == false)
@@ -185,7 +185,7 @@ namespace Stride.Engine
 
                 void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
                 {
-                    Scene subScene = (Scene)e.Item;
+                    Scene subScene = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
                     {
                         if (scenesToAdd.Remove(subScene) == false)
@@ -228,10 +228,10 @@ namespace Stride.Engine
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    Add((Entity)e.Item);
+                    Add(e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    Remove((Entity)e.Item);
+                    Remove(e.Item);
                     break;
             }
         }
@@ -241,10 +241,10 @@ namespace Stride.Engine
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    Add((Scene)e.Item);
+                    Add(e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    Remove((Scene)e.Item);
+                    Remove(e.Item);
                     break;
             }
         }
@@ -274,7 +274,7 @@ namespace Stride.Engine
 
         private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup, VisibilityGroup> e)
         {
-            var visibilityGroup = (VisibilityGroup)e.Item;
+            var visibilityGroup = e.Item;
 
             switch (e.Action)
             {

--- a/sources/engine/Stride.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneInstance.cs
@@ -152,7 +152,7 @@ namespace Stride.Engine
                 }
                 scene.Entities.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity> e)
                 {
                     Entity entity = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -183,7 +183,7 @@ namespace Stride.Engine
                 }
                 scene.Children.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene> e)
                 {
                     Scene subScene = e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -223,7 +223,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
+        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Entity> e)
         {
             switch (e.Action)
             {
@@ -236,7 +236,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
+        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Scene> e)
         {
             switch (e.Action)
             {
@@ -272,7 +272,7 @@ namespace Stride.Engine
             registeredRenderProcessorTypes.Clear();
         }
 
-        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup, VisibilityGroup> e)
+        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup> e)
         {
             var visibilityGroup = e.Item;
 

--- a/sources/engine/Stride.Engine/Engine/SceneInstance.cs
+++ b/sources/engine/Stride.Engine/Engine/SceneInstance.cs
@@ -152,7 +152,7 @@ namespace Stride.Engine
                 }
                 scene.Entities.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
                 {
                     Entity entity = (Entity)e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -183,7 +183,7 @@ namespace Stride.Engine
                 }
                 scene.Children.CollectionChanged -= DealWithTempChanges;
 
-                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs e)
+                void DealWithTempChanges(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
                 {
                     Scene subScene = (Scene)e.Item;
                     if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -223,7 +223,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Entities_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Entity, Entity> e)
         {
             switch (e.Action)
             {
@@ -236,7 +236,7 @@ namespace Stride.Engine
             }
         }
 
-        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Scene, Scene> e)
         {
             switch (e.Action)
             {
@@ -272,7 +272,7 @@ namespace Stride.Engine
             registeredRenderProcessorTypes.Clear();
         }
 
-        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void VisibilityGroups_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VisibilityGroup, VisibilityGroup> e)
         {
             var visibilityGroup = (VisibilityGroup)e.Item;
 

--- a/sources/engine/Stride.Games/GameSystemCollection.cs
+++ b/sources/engine/Stride.Games/GameSystemCollection.cs
@@ -238,7 +238,7 @@ namespace Stride.Games
             }
         }
 
-        private void GameSystems_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
+        private void GameSystems_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase> e)
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
@@ -250,7 +250,7 @@ namespace Stride.Games
             }
         }
 
-        private void GameSystems_ItemAdded(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
+        private void GameSystems_ItemAdded(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase> e)
         {
             var gameSystem = e.Item;
 
@@ -298,7 +298,7 @@ namespace Stride.Games
             }
         }
 
-        private void GameSystems_ItemRemoved(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
+        private void GameSystems_ItemRemoved(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase> e)
         {
             var gameSystem = e.Item;
 

--- a/sources/engine/Stride.Games/GameSystemCollection.cs
+++ b/sources/engine/Stride.Games/GameSystemCollection.cs
@@ -252,7 +252,7 @@ namespace Stride.Games
 
         private void GameSystems_ItemAdded(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
         {
-            var gameSystem = (IGameSystemBase)e.Item;
+            var gameSystem = e.Item;
 
             // If the game is already running, then we can initialize the game system now
             if (State >= GameSystemState.Initialized)
@@ -300,7 +300,7 @@ namespace Stride.Games
 
         private void GameSystems_ItemRemoved(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
         {
-            var gameSystem = (IGameSystemBase)e.Item;
+            var gameSystem = e.Item;
 
             if (State == GameSystemState.None)
             {

--- a/sources/engine/Stride.Games/GameSystemCollection.cs
+++ b/sources/engine/Stride.Games/GameSystemCollection.cs
@@ -238,7 +238,7 @@ namespace Stride.Games
             }
         }
 
-        private void GameSystems_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void GameSystems_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
@@ -250,7 +250,7 @@ namespace Stride.Games
             }
         }
 
-        private void GameSystems_ItemAdded(object sender, TrackingCollectionChangedEventArgs e)
+        private void GameSystems_ItemAdded(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
         {
             var gameSystem = (IGameSystemBase)e.Item;
 
@@ -298,7 +298,7 @@ namespace Stride.Games
             }
         }
 
-        private void GameSystems_ItemRemoved(object sender, TrackingCollectionChangedEventArgs e)
+        private void GameSystems_ItemRemoved(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> e)
         {
             var gameSystem = (IGameSystemBase)e.Item;
 

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -72,7 +72,7 @@ namespace Stride.Input
 
         private GameContext gameContext;
 
-        private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs>> devicesCollectionChangedActions = new Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs>>();
+        private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>>> devicesCollectionChangedActions = [];
 
 #if STRIDE_INPUT_RAWINPUT
         private bool rawInputEnabled = false;
@@ -584,7 +584,7 @@ namespace Stride.Input
             }
         }
 
-        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs e)
+        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource,IInputSource> e)
         {
             var source = (IInputSource)e.Item;
             switch (e.Action)
@@ -593,7 +593,7 @@ namespace Stride.Input
                     if (Sources.Count(x => x == source) > 1)
                         throw new InvalidOperationException("Input Source already added");
 
-                    EventHandler<TrackingCollectionChangedEventArgs> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
+                    EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
                     devicesCollectionChangedActions.Add(source, eventHandler);
                     source.Devices.CollectionChanged += eventHandler;
                     source.Initialize(this);
@@ -722,7 +722,7 @@ namespace Stride.Input
             }
         }
 
-        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<GestureConfig, GestureConfig> trackingCollectionChangedEventArgs)
         {
             switch (trackingCollectionChangedEventArgs.Action)
             {
@@ -762,7 +762,7 @@ namespace Stride.Input
             }
         }
 
-        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingCollectionChangedEventArgs e)
+        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingCollectionChangedEventArgs<Guid, IInputDevice> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -72,7 +72,7 @@ namespace Stride.Input
 
         private GameContext gameContext;
 
-        private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>>> devicesCollectionChangedActions = [];
+        private Dictionary<IInputSource, EventHandler<TrackingKeyedCollectionChangedEventArgs<Guid, IInputDevice>>> devicesCollectionChangedActions = [];
 
 #if STRIDE_INPUT_RAWINPUT
         private bool rawInputEnabled = false;
@@ -584,7 +584,7 @@ namespace Stride.Input
             }
         }
 
-        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource,IInputSource> e)
+        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource> e)
         {
             var source = e.Item;
             switch (e.Action)
@@ -593,7 +593,7 @@ namespace Stride.Input
                     if (Sources.Count(x => x == source) > 1)
                         throw new InvalidOperationException("Input Source already added");
 
-                    EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
+                    EventHandler<TrackingKeyedCollectionChangedEventArgs<Guid, IInputDevice>> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
                     devicesCollectionChangedActions.Add(source, eventHandler);
                     source.Devices.CollectionChanged += eventHandler;
                     source.Initialize(this);
@@ -722,7 +722,7 @@ namespace Stride.Input
             }
         }
 
-        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<GestureConfig, GestureConfig> trackingCollectionChangedEventArgs)
+        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<GestureConfig> trackingCollectionChangedEventArgs)
         {
             switch (trackingCollectionChangedEventArgs.Action)
             {
@@ -762,7 +762,7 @@ namespace Stride.Input
             }
         }
 
-        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingCollectionChangedEventArgs<Guid, IInputDevice> e)
+        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingKeyedCollectionChangedEventArgs<Guid, IInputDevice> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -586,7 +586,7 @@ namespace Stride.Input
 
         private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource,IInputSource> e)
         {
-            var source = (IInputSource)e.Item;
+            var source = e.Item;
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
@@ -727,10 +727,10 @@ namespace Stride.Input
             switch (trackingCollectionChangedEventArgs.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    StartGestureRecognition((GestureConfig)trackingCollectionChangedEventArgs.Item);
+                    StartGestureRecognition(trackingCollectionChangedEventArgs.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    StopGestureRecognition((GestureConfig)trackingCollectionChangedEventArgs.Item);
+                    StopGestureRecognition(trackingCollectionChangedEventArgs.Item);
                     break;
                 case NotifyCollectionChangedAction.Replace:
                 case NotifyCollectionChangedAction.Reset:
@@ -767,10 +767,10 @@ namespace Stride.Input
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    OnInputDeviceAdded(source, (IInputDevice)e.Item);
+                    OnInputDeviceAdded(source, e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    OnInputDeviceRemoved((IInputDevice)e.Item);
+                    OnInputDeviceRemoved(e.Item);
                     break;
                 default:
                     throw new InvalidOperationException("Unsupported collection operation");

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -72,7 +72,7 @@ namespace Stride.Input
 
         private GameContext gameContext;
 
-        private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs>> devicesCollectionChangedActions = new Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs>>();
+        private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>>> devicesCollectionChangedActions = [];
 
 #if STRIDE_INPUT_RAWINPUT
         private bool rawInputEnabled = false;
@@ -587,7 +587,7 @@ namespace Stride.Input
             }
         }
 
-        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs e)
+        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource,IInputSource> e)
         {
             var source = (IInputSource)e.Item;
             switch (e.Action)
@@ -596,7 +596,7 @@ namespace Stride.Input
                     if (Sources.Count(x => x == source) > 1)
                         throw new InvalidOperationException("Input Source already added");
 
-                    EventHandler<TrackingCollectionChangedEventArgs> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
+                    EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
                     devicesCollectionChangedActions.Add(source, eventHandler);
                     source.Devices.CollectionChanged += eventHandler;
                     source.Initialize(this);
@@ -733,7 +733,7 @@ namespace Stride.Input
             }
         }
 
-        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<GestureConfig, GestureConfig> trackingCollectionChangedEventArgs)
         {
             switch (trackingCollectionChangedEventArgs.Action)
             {
@@ -773,7 +773,7 @@ namespace Stride.Input
             }
         }
 
-        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingCollectionChangedEventArgs e)
+        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingCollectionChangedEventArgs<Guid, IInputDevice> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -72,7 +72,7 @@ namespace Stride.Input
 
         private GameContext gameContext;
 
-        private Dictionary<IInputSource, EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>>> devicesCollectionChangedActions = [];
+        private Dictionary<IInputSource, EventHandler<TrackingKeyedCollectionChangedEventArgs<Guid, IInputDevice>>> devicesCollectionChangedActions = [];
 
 #if STRIDE_INPUT_RAWINPUT
         private bool rawInputEnabled = false;
@@ -587,7 +587,7 @@ namespace Stride.Input
             }
         }
 
-        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource,IInputSource> e)
+        private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource> e)
         {
             var source = e.Item;
             switch (e.Action)
@@ -596,7 +596,7 @@ namespace Stride.Input
                     if (Sources.Count(x => x == source) > 1)
                         throw new InvalidOperationException("Input Source already added");
 
-                    EventHandler<TrackingCollectionChangedEventArgs<Guid, IInputDevice>> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
+                    EventHandler<TrackingKeyedCollectionChangedEventArgs<Guid, IInputDevice>> eventHandler = (sender, args) => InputDevicesOnCollectionChanged(source, args);
                     devicesCollectionChangedActions.Add(source, eventHandler);
                     source.Devices.CollectionChanged += eventHandler;
                     source.Initialize(this);
@@ -733,7 +733,7 @@ namespace Stride.Input
             }
         }
 
-        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<GestureConfig, GestureConfig> trackingCollectionChangedEventArgs)
+        private void GesturesOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<GestureConfig> trackingCollectionChangedEventArgs)
         {
             switch (trackingCollectionChangedEventArgs.Action)
             {
@@ -773,7 +773,7 @@ namespace Stride.Input
             }
         }
 
-        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingCollectionChangedEventArgs<Guid, IInputDevice> e)
+        private void InputDevicesOnCollectionChanged(IInputSource source, TrackingKeyedCollectionChangedEventArgs<Guid, IInputDevice> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Input/InputManager.cs
+++ b/sources/engine/Stride.Input/InputManager.cs
@@ -589,7 +589,7 @@ namespace Stride.Input
 
         private void SourcesOnCollectionChanged(object o, TrackingCollectionChangedEventArgs<IInputSource,IInputSource> e)
         {
-            var source = (IInputSource)e.Item;
+            var source = e.Item;
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
@@ -738,10 +738,10 @@ namespace Stride.Input
             switch (trackingCollectionChangedEventArgs.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    StartGestureRecognition((GestureConfig)trackingCollectionChangedEventArgs.Item);
+                    StartGestureRecognition(trackingCollectionChangedEventArgs.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    StopGestureRecognition((GestureConfig)trackingCollectionChangedEventArgs.Item);
+                    StopGestureRecognition(trackingCollectionChangedEventArgs.Item);
                     break;
                 case NotifyCollectionChangedAction.Replace:
                 case NotifyCollectionChangedAction.Reset:
@@ -778,10 +778,10 @@ namespace Stride.Input
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    OnInputDeviceAdded(source, (IInputDevice)e.Item);
+                    OnInputDeviceAdded(source, e.Item);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    OnInputDeviceRemoved((IInputDevice)e.Item);
+                    OnInputDeviceRemoved(e.Item);
                     break;
                 default:
                     throw new InvalidOperationException("Unsupported collection operation");

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
@@ -119,7 +119,7 @@ namespace Stride.Input
 
         private void Bindings_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VirtualButtonBinding, VirtualButtonBinding> e)
         {
-            var virtualButtonBinding = (VirtualButtonBinding)e.Item;
+            var virtualButtonBinding = e.Item;
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
@@ -117,7 +117,7 @@ namespace Stride.Input
             return false;
         }
 
-        private void Bindings_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VirtualButtonBinding, VirtualButtonBinding> e)
+        private void Bindings_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VirtualButtonBinding> e)
         {
             var virtualButtonBinding = e.Item;
             switch (e.Action)

--- a/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
+++ b/sources/engine/Stride.Input/VirtualButton/VirtualButtonConfig.cs
@@ -117,7 +117,7 @@ namespace Stride.Input
             return false;
         }
 
-        private void Bindings_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Bindings_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<VirtualButtonBinding, VirtualButtonBinding> e)
         {
             var virtualButtonBinding = (VirtualButtonBinding)e.Item;
             switch (e.Action)

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -180,7 +180,7 @@ namespace Stride.Navigation.Processors
             data.Component.SceneOffset = data.Component.NavigationMesh != null ? data.Component.Entity.Scene.Offset : Vector3.Zero;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
         {
             TryRegisterDynamicNavigationMeshSystem();
         }

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -180,7 +180,7 @@ namespace Stride.Navigation.Processors
             data.Component.SceneOffset = data.Component.NavigationMesh != null ? data.Component.Entity.Scene.Offset : Vector3.Zero;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
+        private void GameSystemsOnCollectionChanged(object sender,  TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
         {
             TryRegisterDynamicNavigationMeshSystem();
         }

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -180,7 +180,7 @@ namespace Stride.Navigation.Processors
             data.Component.SceneOffset = data.Component.NavigationMesh != null ? data.Component.Entity.Scene.Offset : Vector3.Zero;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender,  TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
+        private void GameSystemsOnCollectionChanged(object sender,  TrackingCollectionChangedEventArgs<IGameSystemBase> trackingCollectionChangedEventArgs)
         {
             TryRegisterDynamicNavigationMeshSystem();
         }

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -178,7 +178,7 @@ namespace Stride.Navigation.Processors
             data.Component.SceneOffset = data.Component.NavigationMesh != null ? data.Component.Entity.Scene.Offset : Vector3.Zero;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
         {
             TryRegisterDynamicNavigationMeshSystem();
         }

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -178,7 +178,7 @@ namespace Stride.Navigation.Processors
             data.Component.SceneOffset = data.Component.NavigationMesh != null ? data.Component.Entity.Scene.Offset : Vector3.Zero;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender, TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
+        private void GameSystemsOnCollectionChanged(object sender,  TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
         {
             TryRegisterDynamicNavigationMeshSystem();
         }

--- a/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
+++ b/sources/engine/Stride.Navigation/Processors/NavigationProcessor.cs
@@ -178,7 +178,7 @@ namespace Stride.Navigation.Processors
             data.Component.SceneOffset = data.Component.NavigationMesh != null ? data.Component.Entity.Scene.Offset : Vector3.Zero;
         }
 
-        private void GameSystemsOnCollectionChanged(object sender,  TrackingCollectionChangedEventArgs<IGameSystemBase, IGameSystemBase> trackingCollectionChangedEventArgs)
+        private void GameSystemsOnCollectionChanged(object sender,  TrackingCollectionChangedEventArgs<IGameSystemBase> trackingCollectionChangedEventArgs)
         {
             TryRegisterDynamicNavigationMeshSystem();
         }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -686,7 +686,7 @@ namespace Stride.Rendering.Lights
             return lightGroup;
         }
 
-        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<LightGroupRendererBase, LightGroupRendererBase> e)
+        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<LightGroupRendererBase> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -686,7 +686,7 @@ namespace Stride.Rendering.Lights
             return lightGroup;
         }
 
-        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<LightGroupRendererBase, LightGroupRendererBase> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -692,13 +692,13 @@ namespace Stride.Rendering.Lights
             {
                 case NotifyCollectionChangedAction.Add:
                 {
-                    var item = e.Item as LightGroupRendererBase;
+                    var item = e.Item;
                     item?.Initialize(Context);
                     break;
                 }
                 case NotifyCollectionChangedAction.Remove:
                 {
-                    var item = e.OldItem as LightGroupRendererBase;
+                    var item = e.OldItem;
                     item?.Unload();
                     break;
                 }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -681,7 +681,7 @@ namespace Stride.Rendering.Lights
             return lightGroup;
         }
 
-        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<LightGroupRendererBase, LightGroupRendererBase> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -687,13 +687,13 @@ namespace Stride.Rendering.Lights
             {
                 case NotifyCollectionChangedAction.Add:
                 {
-                    var item = e.Item as LightGroupRendererBase;
+                    var item = e.Item;
                     item?.Initialize(Context);
                     break;
                 }
                 case NotifyCollectionChangedAction.Remove:
                 {
-                    var item = e.OldItem as LightGroupRendererBase;
+                    var item = e.OldItem;
                     item?.Unload();
                     break;
                 }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -681,7 +681,7 @@ namespace Stride.Rendering.Lights
             return lightGroup;
         }
 
-        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<LightGroupRendererBase, LightGroupRendererBase> e)
+        private void LightRenderers_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<LightGroupRendererBase> e)
         {
             switch (e.Action)
             {

--- a/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
@@ -255,7 +255,7 @@ namespace Stride.Rendering
             }
         }
 
-        private void RenderFeatures_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void RenderFeatures_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<SubRenderFeature, SubRenderFeature> e)
         {
             var renderFeature = (SubRenderFeature)e.Item;
 

--- a/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
@@ -255,7 +255,7 @@ namespace Stride.Rendering
             }
         }
 
-        private void RenderFeatures_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<SubRenderFeature, SubRenderFeature> e)
+        private void RenderFeatures_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<SubRenderFeature> e)
         {
             var renderFeature = e.Item;
 

--- a/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/MeshRenderFeature.cs
@@ -257,7 +257,7 @@ namespace Stride.Rendering
 
         private void RenderFeatures_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<SubRenderFeature, SubRenderFeature> e)
         {
-            var renderFeature = (SubRenderFeature)e.Item;
+            var renderFeature = e.Item;
 
             switch (e.Action)
             {

--- a/sources/engine/Stride.Rendering/Rendering/Model.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Model.cs
@@ -146,9 +146,9 @@ namespace Stride.Rendering
             return result;
         }
 
-        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs e)
+        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Model, Model> e)
         {
-            var child = (Model)e.Item;
+            var child = e.Item;
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:

--- a/sources/engine/Stride.Rendering/Rendering/Model.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Model.cs
@@ -146,7 +146,7 @@ namespace Stride.Rendering
             return result;
         }
 
-        private void Children_CollectionChanged(object sender, TrackingCollectionChangedEventArgs<Model, Model> e)
+        private void Children_CollectionChanged(object sender, TrackingKeyedCollectionChangedEventArgs<Model, Model> e)
         {
             var child = e.Item;
             switch (e.Action)

--- a/sources/engine/Stride.UI/Panels/Grid.cs
+++ b/sources/engine/Stride.UI/Panels/Grid.cs
@@ -72,7 +72,7 @@ namespace Stride.UI.Panels
             LayerDefinitions.CollectionChanged += DefinitionCollectionChanged;
         }
 
-        private void DefinitionCollectionChanged(object sender, TrackingCollectionChangedEventArgs<StripDefinition, StripDefinition> trackingCollectionChangedEventArgs)
+        private void DefinitionCollectionChanged(object sender, TrackingCollectionChangedEventArgs<StripDefinition> trackingCollectionChangedEventArgs)
         {
             var modifiedElement = trackingCollectionChangedEventArgs.Item;
             switch (trackingCollectionChangedEventArgs.Action)

--- a/sources/engine/Stride.UI/Panels/Grid.cs
+++ b/sources/engine/Stride.UI/Panels/Grid.cs
@@ -72,7 +72,7 @@ namespace Stride.UI.Panels
             LayerDefinitions.CollectionChanged += DefinitionCollectionChanged;
         }
 
-        private void DefinitionCollectionChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        private void DefinitionCollectionChanged(object sender, TrackingCollectionChangedEventArgs<StripDefinition, StripDefinition> trackingCollectionChangedEventArgs)
         {
             var modifiedElement = (StripDefinition)trackingCollectionChangedEventArgs.Item;
             switch (trackingCollectionChangedEventArgs.Action)

--- a/sources/engine/Stride.UI/Panels/Grid.cs
+++ b/sources/engine/Stride.UI/Panels/Grid.cs
@@ -74,7 +74,7 @@ namespace Stride.UI.Panels
 
         private void DefinitionCollectionChanged(object sender, TrackingCollectionChangedEventArgs<StripDefinition, StripDefinition> trackingCollectionChangedEventArgs)
         {
-            var modifiedElement = (StripDefinition)trackingCollectionChangedEventArgs.Item;
+            var modifiedElement = trackingCollectionChangedEventArgs.Item;
             switch (trackingCollectionChangedEventArgs.Action)
             {
                 case NotifyCollectionChangedAction.Add:

--- a/sources/engine/Stride.UI/Panels/Panel.cs
+++ b/sources/engine/Stride.UI/Panels/Panel.cs
@@ -116,7 +116,7 @@ namespace Stride.UI.Panels
         /// <param name="trackingCollectionChangedEventArgs">Argument indicating what changed in the collection</param>
         protected void LogicalChildrenChanged(object sender, TrackingCollectionChangedEventArgs<UIElement, UIElement> trackingCollectionChangedEventArgs)
         {
-            var modifiedElement = (UIElement)trackingCollectionChangedEventArgs.Item;
+            var modifiedElement = trackingCollectionChangedEventArgs.Item;
             var elementIndex = trackingCollectionChangedEventArgs.Index;
             switch (trackingCollectionChangedEventArgs.Action)
             {

--- a/sources/engine/Stride.UI/Panels/Panel.cs
+++ b/sources/engine/Stride.UI/Panels/Panel.cs
@@ -114,7 +114,7 @@ namespace Stride.UI.Panels
         /// </summary>
         /// <param name="sender">Sender of the event</param>
         /// <param name="trackingCollectionChangedEventArgs">Argument indicating what changed in the collection</param>
-        protected void LogicalChildrenChanged(object sender, TrackingCollectionChangedEventArgs<UIElement, UIElement> trackingCollectionChangedEventArgs)
+        protected void LogicalChildrenChanged(object sender, TrackingCollectionChangedEventArgs<UIElement> trackingCollectionChangedEventArgs)
         {
             var modifiedElement = trackingCollectionChangedEventArgs.Item;
             var elementIndex = trackingCollectionChangedEventArgs.Index;

--- a/sources/engine/Stride.UI/Panels/Panel.cs
+++ b/sources/engine/Stride.UI/Panels/Panel.cs
@@ -114,7 +114,7 @@ namespace Stride.UI.Panels
         /// </summary>
         /// <param name="sender">Sender of the event</param>
         /// <param name="trackingCollectionChangedEventArgs">Argument indicating what changed in the collection</param>
-        protected void LogicalChildrenChanged(object sender, TrackingCollectionChangedEventArgs trackingCollectionChangedEventArgs)
+        protected void LogicalChildrenChanged(object sender, TrackingCollectionChangedEventArgs<UIElement, UIElement> trackingCollectionChangedEventArgs)
         {
             var modifiedElement = (UIElement)trackingCollectionChangedEventArgs.Item;
             var elementIndex = trackingCollectionChangedEventArgs.Index;

--- a/sources/presentation/Stride.Core.Presentation.Graph/Controls/NodeEdgeControl.cs
+++ b/sources/presentation/Stride.Core.Presentation.Graph/Controls/NodeEdgeControl.cs
@@ -214,7 +214,7 @@ namespace Stride.Core.Presentation.Graph.Controls
             Visibility = Visibility.Visible;
         }
 
-        private void UpdateSourceConnectors(object sender, TrackingCollectionChangedEventArgs e)
+        private void UpdateSourceConnectors(object sender, TrackingCollectionChangedEventArgs<object, DependencyObject> e)
         {
             // Unregister ourselves
             ((NodeVertexControl)Source).Connectors.CollectionChanged -= UpdateSourceConnectors;
@@ -223,7 +223,7 @@ namespace Stride.Core.Presentation.Graph.Controls
             UpdateEdge();
         }
 
-        private void UpdateTargetConnectors(object sender, TrackingCollectionChangedEventArgs e)
+        private void UpdateTargetConnectors(object sender, TrackingCollectionChangedEventArgs<object, DependencyObject> e)
         {
             // Unregister ourselves
             ((NodeVertexControl)Target).Connectors.CollectionChanged -= UpdateTargetConnectors;

--- a/sources/presentation/Stride.Core.Presentation.Graph/Controls/NodeEdgeControl.cs
+++ b/sources/presentation/Stride.Core.Presentation.Graph/Controls/NodeEdgeControl.cs
@@ -214,7 +214,7 @@ namespace Stride.Core.Presentation.Graph.Controls
             Visibility = Visibility.Visible;
         }
 
-        private void UpdateSourceConnectors(object sender, TrackingCollectionChangedEventArgs<object, DependencyObject> e)
+        private void UpdateSourceConnectors(object sender, TrackingKeyedCollectionChangedEventArgs<object, DependencyObject> e)
         {
             // Unregister ourselves
             ((NodeVertexControl)Source).Connectors.CollectionChanged -= UpdateSourceConnectors;
@@ -223,7 +223,7 @@ namespace Stride.Core.Presentation.Graph.Controls
             UpdateEdge();
         }
 
-        private void UpdateTargetConnectors(object sender, TrackingCollectionChangedEventArgs<object, DependencyObject> e)
+        private void UpdateTargetConnectors(object sender, TrackingKeyedCollectionChangedEventArgs<object, DependencyObject> e)
         {
             // Unregister ourselves
             ((NodeVertexControl)Target).Connectors.CollectionChanged -= UpdateTargetConnectors;


### PR DESCRIPTION
Reopening from https://github.com/stride3d/stride/pull/2866 as I think this was mostly agreed on but was on hold due to being a breaking change.

# PR Details

This PR shows a POC that would reduce the amount of required casts by users. I don't want to merge this but I was curious on what the thoughts would be on something like this as using object causes a ton of casting and required checks to be usable. Ideally I would redo this PR but with the `Obsolete` attribute. The only variable that gets in the way is `CollectionChanged` as I dont know what the non-obsolete variable would be called.

~I also still need to verify that there wont be weird checks in the GameStudio layers as I assume they may not like generics as much as objects.~ Works fine.

## Related Issue

No related issues. I ran into this today trying to use tracking collections for a modular system I am experimenting with as seen in the code snippet below:
```
    private void WornItemsChanged(object? sender, TrackingCollectionChangedEventArgs e)
    {
        if (e.Action == NotifyCollectionChangedAction.Add)
        {
            var newItem = e.Item;
            if (e.Item is GameItem item && !item.HasDescriptor<WearableDescriptor>())
            {
                _logger.Error($"Only wearable items can be worn. Item: {item.Name}");

                // Remove the item if it is not wearable
                var key = e.Key as string;
                var oldItem = e.OldItem == null ? null : e.OldItem as GameItem;
                WornItems[key] = oldItem;
            }
        }
    }
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
