### PR TITLE
fix: Local Reflections causes Vulkan device loss (surplus MRT targets bound in transparent stage)

### DIFF
--- a/sources/engine/Stride.Engine.Tests/ForwardRendererTransparentTargetsTest.cs
+++ b/sources/engine/Stride.Engine.Tests/ForwardRendererTransparentTargetsTest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Xunit;
+
+using Stride.Graphics;
+using Stride.Graphics.Regression;
+using Stride.Rendering;
+using Stride.Rendering.Compositing;
+
+namespace Stride.Engine.Tests
+{
+    public class ForwardRendererTransparentTargetsTest : GameTestBase
+    {
+        /// <summary>
+        /// Verifies the ForwardRenderer binds only as many render targets as the transparent stage declares it
+        /// outputs, dropping surplus opaque MRT targets (e.g. those Local Reflections adds). See #3251.
+        /// </summary>
+        [Fact]
+        public void BindsOnlyTransparentStageDeclaredTargets()
+        {
+            PerformDrawTest((game, context) =>
+            {
+                var device = game.GraphicsDevice;
+                var commandList = context.CommandList;
+
+                var transparentStage = new RenderStage("Transparent", "Main")
+                {
+                    Output = new RenderOutputDescription(PixelFormat.R8G8B8A8_UNorm, PixelFormat.D24_UNorm_S8_UInt),
+                };
+                var forwardRenderer = new ForwardRenderer { TransparentRenderStage = transparentStage };
+
+                // Formats are irrelevant here (only the target count matters); use a widely supported one.
+                var color = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
+                var normal = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
+                var specular = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
+                var depth = Texture.New2D(device, 16, 16, PixelFormat.D24_UNorm_S8_UInt, TextureFlags.DepthStencil);
+
+                // Opaque stage left 3 color targets + depth bound, as SSLR would.
+                commandList.SetRenderTargets(depth, color, normal, specular);
+                Assert.Equal(3, commandList.RenderTargetCount);
+
+                forwardRenderer.SetTransparentStageRenderTargets(context);
+
+                Assert.Equal(1, commandList.RenderTargetCount);
+                Assert.Equal(color, commandList.RenderTargets[0]);
+                Assert.Equal(depth, commandList.DepthStencilBuffer);
+
+                // Already matching the declared count: no change.
+                forwardRenderer.SetTransparentStageRenderTargets(context);
+                Assert.Equal(1, commandList.RenderTargetCount);
+
+                color.Dispose();
+                normal.Dispose();
+                specular.Dispose();
+                depth.Dispose();
+            }, takeSnapshot: false);
+        }
+    }
+}

--- a/sources/engine/Stride.Engine.Tests/ForwardRendererTransparentTargetsTest.cs
+++ b/sources/engine/Stride.Engine.Tests/ForwardRendererTransparentTargetsTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Xunit;
@@ -8,53 +8,52 @@ using Stride.Graphics.Regression;
 using Stride.Rendering;
 using Stride.Rendering.Compositing;
 
-namespace Stride.Engine.Tests
+namespace Stride.Engine.Tests;
+
+public class ForwardRendererTransparentTargetsTest : GameTestBase
 {
-    public class ForwardRendererTransparentTargetsTest : GameTestBase
+    /// <summary>
+    /// Verifies the ForwardRenderer binds only as many render targets as the transparent stage declares it
+    /// outputs, dropping surplus opaque MRT targets (e.g. those Local Reflections adds). See #3251.
+    /// </summary>
+    [Fact]
+    public void BindsOnlyTransparentStageDeclaredTargets()
     {
-        /// <summary>
-        /// Verifies the ForwardRenderer binds only as many render targets as the transparent stage declares it
-        /// outputs, dropping surplus opaque MRT targets (e.g. those Local Reflections adds). See #3251.
-        /// </summary>
-        [Fact]
-        public void BindsOnlyTransparentStageDeclaredTargets()
+        PerformDrawTest((game, context) =>
         {
-            PerformDrawTest((game, context) =>
+            var device = game.GraphicsDevice;
+            var commandList = context.CommandList;
+
+            var transparentStage = new RenderStage("Transparent", "Main")
             {
-                var device = game.GraphicsDevice;
-                var commandList = context.CommandList;
+                Output = new RenderOutputDescription(PixelFormat.R8G8B8A8_UNorm, PixelFormat.D24_UNorm_S8_UInt),
+            };
+            var forwardRenderer = new ForwardRenderer { TransparentRenderStage = transparentStage };
 
-                var transparentStage = new RenderStage("Transparent", "Main")
-                {
-                    Output = new RenderOutputDescription(PixelFormat.R8G8B8A8_UNorm, PixelFormat.D24_UNorm_S8_UInt),
-                };
-                var forwardRenderer = new ForwardRenderer { TransparentRenderStage = transparentStage };
+            // Formats are irrelevant here (only the target count matters); use a widely supported one.
+            var color = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
+            var normal = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
+            var specular = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
+            var depth = Texture.New2D(device, 16, 16, PixelFormat.D24_UNorm_S8_UInt, TextureFlags.DepthStencil);
 
-                // Formats are irrelevant here (only the target count matters); use a widely supported one.
-                var color = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
-                var normal = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
-                var specular = Texture.New2D(device, 16, 16, PixelFormat.R8G8B8A8_UNorm, TextureFlags.RenderTarget);
-                var depth = Texture.New2D(device, 16, 16, PixelFormat.D24_UNorm_S8_UInt, TextureFlags.DepthStencil);
+            // Opaque stage left 3 color targets + depth bound, as SSLR would.
+            commandList.SetRenderTargets(depth, color, normal, specular);
+            Assert.Equal(3, commandList.RenderTargetCount);
 
-                // Opaque stage left 3 color targets + depth bound, as SSLR would.
-                commandList.SetRenderTargets(depth, color, normal, specular);
-                Assert.Equal(3, commandList.RenderTargetCount);
+            forwardRenderer.SetTransparentStageRenderTargets(context);
 
-                forwardRenderer.SetTransparentStageRenderTargets(context);
+            Assert.Equal(1, commandList.RenderTargetCount);
+            Assert.Equal(color, commandList.RenderTargets[0]);
+            Assert.Equal(depth, commandList.DepthStencilBuffer);
 
-                Assert.Equal(1, commandList.RenderTargetCount);
-                Assert.Equal(color, commandList.RenderTargets[0]);
-                Assert.Equal(depth, commandList.DepthStencilBuffer);
+            // Already matching the declared count: no change.
+            forwardRenderer.SetTransparentStageRenderTargets(context);
+            Assert.Equal(1, commandList.RenderTargetCount);
 
-                // Already matching the declared count: no change.
-                forwardRenderer.SetTransparentStageRenderTargets(context);
-                Assert.Equal(1, commandList.RenderTargetCount);
-
-                color.Dispose();
-                normal.Dispose();
-                specular.Dispose();
-                depth.Dispose();
-            }, takeSnapshot: false);
-        }
+            color.Dispose();
+            normal.Dispose();
+            specular.Dispose();
+            depth.Dispose();
+        }, takeSnapshot: false);
     }
 }

--- a/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.csproj
+++ b/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="XunitAttributes.cs" />
     <Compile Include="Build\TestBuilder.cs" />
     <Compile Include="EngineTestBase.cs" />
+    <Compile Include="ForwardRendererTransparentTargetsTest.cs" />
     <Compile Include="ParameterCollectionUpdateEngineTest.cs" />
     <Compile Include="EntityUpdateEngineTest.cs" />
     <Compile Include="AnimatedModelTests.cs" />

--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -809,8 +809,10 @@ namespace Stride.Rendering.Compositing
             return depthStencilSRV;
         }
 
-        // Binds only as many targets as the transparent stage outputs; extra opaque MRT targets left bound by
-        // post-effects (e.g. SSLR) would exceed its render pass' attachment count and lose the device (#3251).
+        /// <summary>
+        /// Binds only the render targets the transparent stage outputs, dropping any surplus opaque targets left
+        /// bound by post-effects (e.g. Local Reflections) so the framebuffer matches the transparent render pass.
+        /// </summary>
         internal void SetTransparentStageRenderTargets(RenderDrawContext drawContext)
         {
             if (TransparentRenderStage == null)

--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.cs
@@ -555,6 +555,8 @@ namespace Stride.Rendering.Compositing
 
                         var renderTargetSRV = ResolveRenderTargetAsSRV(drawContext);
 
+                        SetTransparentStageRenderTargets(drawContext);
+
                         renderSystem.Draw(drawContext, context.RenderView, TransparentRenderStage);
 
                         Context.Allocator.ReleaseReference(renderTargetSRV);
@@ -805,6 +807,19 @@ namespace Stride.Rendering.Compositing
             commandList.SetRenderTargets(depthStencilROCached, commandList.RenderTargets);
 
             return depthStencilSRV;
+        }
+
+        // Binds only as many targets as the transparent stage outputs; extra opaque MRT targets left bound by
+        // post-effects (e.g. SSLR) would exceed its render pass' attachment count and lose the device (#3251).
+        internal void SetTransparentStageRenderTargets(RenderDrawContext drawContext)
+        {
+            if (TransparentRenderStage == null)
+                return;
+
+            var commandList = drawContext.CommandList;
+            var declaredCount = TransparentRenderStage.Output.RenderTargetCount;
+            if (declaredCount >= 1 && commandList.RenderTargetCount > declaredCount)
+                commandList.SetRenderTargets(commandList.DepthStencilBuffer, commandList.RenderTargets.Slice(0, declaredCount));
         }
 
         private Texture ResolveRenderTargetAsSRV(RenderDrawContext drawContext)

--- a/sources/engine/Stride.Graphics.Tests/TestFramebufferAttachmentGuard.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestFramebufferAttachmentGuard.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+using Xunit;
+
+using Stride.Core.Mathematics;
+using Stride.Rendering;
+
+namespace Stride.Graphics.Tests
+{
+    public class TestFramebufferAttachmentGuard : GraphicTestGameBase
+    {
+        private struct Vertex
+        {
+            public Vector3 Position;
+            public Vector2 TexCoords;
+        }
+
+        /// <summary>
+        /// The Vulkan backend's debug guard turns a framebuffer/render-pass attachment-count mismatch into a clear
+        /// exception instead of a device loss. Verify it fires when more render targets are bound than the active
+        /// pipeline's render pass declares.
+        /// </summary>
+        [SkippableFact]
+        public void ThrowsWhenBoundTargetsExceedPipelineRenderPass()
+        {
+            PerformTest(game =>
+            {
+                // The guard lives in the Vulkan backend (and needs the debug device, which GraphicTestGameBase sets).
+                Skip.IfNot(GraphicsDevice.Platform == GraphicsPlatform.Vulkan, "Attachment guard is Vulkan-only.");
+
+                var device = game.GraphicsDevice;
+                var commandList = game.GraphicsContext.CommandList;
+
+                var backBuffer = device.Presenter.BackBuffer;
+                var depth = device.Presenter.DepthStencilBuffer;
+                var extraTarget = Texture.New2D(device, backBuffer.Width, backBuffer.Height, backBuffer.Format, TextureFlags.RenderTarget);
+
+                var declaration = new VertexDeclaration(VertexElement.Position<Vector3>(), VertexElement.TextureCoordinate<Vector2>());
+                var vertexBuffer = Buffer.Vertex.New(device, new Vertex[3], GraphicsResourceUsage.Default);
+                var sampledTexture = Texture.New2D(device, 4, 4, PixelFormat.R8G8B8A8_UNorm, TextureFlags.ShaderResource);
+
+                var effect = new EffectInstance(new Effect(device, SpriteEffect.Bytecode));
+                effect.Parameters.Set(TexturingKeys.Texture0, sampledTexture);
+                effect.Parameters.Set(TexturingKeys.Sampler, device.SamplerStates.LinearClamp);
+                effect.UpdateEffect(device);
+
+                var pipelineState = new MutablePipelineState(device);
+                pipelineState.State.SetDefaults();
+                pipelineState.State.RootSignature = effect.RootSignature;
+                pipelineState.State.EffectBytecode = effect.Effect.Bytecode;
+                pipelineState.State.InputElements = declaration.CreateInputElements();
+                pipelineState.State.PrimitiveType = PrimitiveType.TriangleList;
+
+                // Capture the pipeline Output with a single color + depth bound: its render pass declares 2 attachments.
+                commandList.SetRenderTargetAndViewport(depth, backBuffer);
+                pipelineState.State.Output.CaptureState(commandList);
+                pipelineState.Update();
+
+                // Now bind two color targets + depth: the framebuffer would have 3 attachments, mismatching the pass.
+                commandList.SetRenderTargets(depth, backBuffer, extraTarget);
+                commandList.SetPipelineState(pipelineState.CurrentState);
+                commandList.SetVertexBuffer(0, vertexBuffer, 0, declaration.VertexStride);
+                effect.Apply(game.GraphicsContext);
+
+                var exception = Assert.Throws<InvalidOperationException>(() => commandList.Draw(3));
+                Assert.Contains("render pass", exception.Message);
+
+                sampledTexture.Dispose();
+                extraTarget.Dispose();
+            });
+        }
+    }
+}

--- a/sources/engine/Stride.Graphics.Tests/TestFramebufferAttachmentGuard.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestFramebufferAttachmentGuard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
@@ -8,69 +8,68 @@ using Xunit;
 using Stride.Core.Mathematics;
 using Stride.Rendering;
 
-namespace Stride.Graphics.Tests
+namespace Stride.Graphics.Tests;
+
+public class TestFramebufferAttachmentGuard : GraphicTestGameBase
 {
-    public class TestFramebufferAttachmentGuard : GraphicTestGameBase
+    private struct Vertex
     {
-        private struct Vertex
+        public Vector3 Position;
+        public Vector2 TexCoords;
+    }
+
+    /// <summary>
+    /// The Vulkan backend's debug guard turns a framebuffer/render-pass attachment-count mismatch into a clear
+    /// exception instead of a device loss. Verify it fires when more render targets are bound than the active
+    /// pipeline's render pass declares.
+    /// </summary>
+    [SkippableFact]
+    public void ThrowsWhenBoundTargetsExceedPipelineRenderPass()
+    {
+        PerformTest(game =>
         {
-            public Vector3 Position;
-            public Vector2 TexCoords;
-        }
+            // The guard lives in the Vulkan backend (and needs the debug device, which GraphicTestGameBase sets).
+            Skip.IfNot(GraphicsDevice.Platform == GraphicsPlatform.Vulkan, "Attachment guard is Vulkan-only.");
 
-        /// <summary>
-        /// The Vulkan backend's debug guard turns a framebuffer/render-pass attachment-count mismatch into a clear
-        /// exception instead of a device loss. Verify it fires when more render targets are bound than the active
-        /// pipeline's render pass declares.
-        /// </summary>
-        [SkippableFact]
-        public void ThrowsWhenBoundTargetsExceedPipelineRenderPass()
-        {
-            PerformTest(game =>
-            {
-                // The guard lives in the Vulkan backend (and needs the debug device, which GraphicTestGameBase sets).
-                Skip.IfNot(GraphicsDevice.Platform == GraphicsPlatform.Vulkan, "Attachment guard is Vulkan-only.");
+            var device = game.GraphicsDevice;
+            var commandList = game.GraphicsContext.CommandList;
 
-                var device = game.GraphicsDevice;
-                var commandList = game.GraphicsContext.CommandList;
+            var backBuffer = device.Presenter.BackBuffer;
+            var depth = device.Presenter.DepthStencilBuffer;
+            var extraTarget = Texture.New2D(device, backBuffer.Width, backBuffer.Height, backBuffer.Format, TextureFlags.RenderTarget);
 
-                var backBuffer = device.Presenter.BackBuffer;
-                var depth = device.Presenter.DepthStencilBuffer;
-                var extraTarget = Texture.New2D(device, backBuffer.Width, backBuffer.Height, backBuffer.Format, TextureFlags.RenderTarget);
+            var declaration = new VertexDeclaration(VertexElement.Position<Vector3>(), VertexElement.TextureCoordinate<Vector2>());
+            var vertexBuffer = Buffer.Vertex.New(device, new Vertex[3], GraphicsResourceUsage.Default);
+            var sampledTexture = Texture.New2D(device, 4, 4, PixelFormat.R8G8B8A8_UNorm, TextureFlags.ShaderResource);
 
-                var declaration = new VertexDeclaration(VertexElement.Position<Vector3>(), VertexElement.TextureCoordinate<Vector2>());
-                var vertexBuffer = Buffer.Vertex.New(device, new Vertex[3], GraphicsResourceUsage.Default);
-                var sampledTexture = Texture.New2D(device, 4, 4, PixelFormat.R8G8B8A8_UNorm, TextureFlags.ShaderResource);
+            var effect = new EffectInstance(new Effect(device, SpriteEffect.Bytecode));
+            effect.Parameters.Set(TexturingKeys.Texture0, sampledTexture);
+            effect.Parameters.Set(TexturingKeys.Sampler, device.SamplerStates.LinearClamp);
+            effect.UpdateEffect(device);
 
-                var effect = new EffectInstance(new Effect(device, SpriteEffect.Bytecode));
-                effect.Parameters.Set(TexturingKeys.Texture0, sampledTexture);
-                effect.Parameters.Set(TexturingKeys.Sampler, device.SamplerStates.LinearClamp);
-                effect.UpdateEffect(device);
+            var pipelineState = new MutablePipelineState(device);
+            pipelineState.State.SetDefaults();
+            pipelineState.State.RootSignature = effect.RootSignature;
+            pipelineState.State.EffectBytecode = effect.Effect.Bytecode;
+            pipelineState.State.InputElements = declaration.CreateInputElements();
+            pipelineState.State.PrimitiveType = PrimitiveType.TriangleList;
 
-                var pipelineState = new MutablePipelineState(device);
-                pipelineState.State.SetDefaults();
-                pipelineState.State.RootSignature = effect.RootSignature;
-                pipelineState.State.EffectBytecode = effect.Effect.Bytecode;
-                pipelineState.State.InputElements = declaration.CreateInputElements();
-                pipelineState.State.PrimitiveType = PrimitiveType.TriangleList;
+            // Capture the pipeline Output with a single color + depth bound: its render pass declares 2 attachments.
+            commandList.SetRenderTargetAndViewport(depth, backBuffer);
+            pipelineState.State.Output.CaptureState(commandList);
+            pipelineState.Update();
 
-                // Capture the pipeline Output with a single color + depth bound: its render pass declares 2 attachments.
-                commandList.SetRenderTargetAndViewport(depth, backBuffer);
-                pipelineState.State.Output.CaptureState(commandList);
-                pipelineState.Update();
+            // Now bind two color targets + depth: the framebuffer would have 3 attachments, mismatching the pass.
+            commandList.SetRenderTargets(depth, backBuffer, extraTarget);
+            commandList.SetPipelineState(pipelineState.CurrentState);
+            commandList.SetVertexBuffer(0, vertexBuffer, 0, declaration.VertexStride);
+            effect.Apply(game.GraphicsContext);
 
-                // Now bind two color targets + depth: the framebuffer would have 3 attachments, mismatching the pass.
-                commandList.SetRenderTargets(depth, backBuffer, extraTarget);
-                commandList.SetPipelineState(pipelineState.CurrentState);
-                commandList.SetVertexBuffer(0, vertexBuffer, 0, declaration.VertexStride);
-                effect.Apply(game.GraphicsContext);
+            var exception = Assert.Throws<InvalidOperationException>(() => commandList.Draw(3));
+            Assert.Contains("render pass", exception.Message);
 
-                var exception = Assert.Throws<InvalidOperationException>(() => commandList.Draw(3));
-                Assert.Contains("render pass", exception.Message);
-
-                sampledTexture.Dispose();
-                extraTarget.Dispose();
-            });
-        }
+            sampledTexture.Dispose();
+            extraTarget.Dispose();
+        });
     }
 }

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -1760,6 +1760,18 @@ namespace Stride.Graphics
 
                 if (framebufferDirty)
                 {
+                    // A framebuffer/render-pass attachment mismatch is undefined behavior that loses the device on
+                    // strict drivers; fail loud in debug (only, to not break drivers that tolerate it) instead.
+                    if (GraphicsDevice.IsDebugMode)
+                    {
+                        var output = activePipeline.Description.Output;
+                        var expectedAttachmentCount = output.RenderTargetCount + (output.DepthStencilFormat != PixelFormat.None ? 1 : 0);
+                        if (framebufferAttachmentCount != expectedAttachmentCount)
+                            throw new InvalidOperationException(
+                                $"Bound render targets ({framebufferAttachmentCount}) do not match the active pipeline's render pass " +
+                                $"({expectedAttachmentCount} attachments). The render targets bound on the command list must match the pipeline's Output description.");
+                    }
+
                     // Create new frame buffer
                     fixed (VkImageView* attachmentsPointer = &framebufferAttachments[0])
                     {


### PR DESCRIPTION
# PR Details

Enabling a post-effect that needs the normal / specular-roughness buffers (most visibly **Local Reflections / SSLR**) crashes the **Vulkan** backend with `VK_ERROR_DEVICE_LOST` on NVIDIA GPUs (works on AMD). Reported in #3251 as a crash "when shooting" in the FPS template.

### Root cause

`ForwardRenderer.ValidateOpaqueStageOutput` adds `Normal` + `SpecularColorRoughness` color targets for the Opaque stage when a post-effect requires them. Those extra targets stay bound through the **Transparent** stage, whose pipelines are built for a single color + depth output. On Vulkan the framebuffer is assembled from the bound targets while the render pass comes from the pipeline, so it ends up with more attachments than the render pass (e.g. **4 vs 2**) — undefined behavior that NVIDIA faults on and D3D11/12 + AMD tolerate.

### Fix (`ForwardRenderer.cs`)

Before the transparent draw, bind only as many targets as the transparent stage declares it outputs (`TransparentRenderStage.Output.RenderTargetCount`) — the color target, keeping depth — so the framebuffer matches the transparent render pass. The extra targets are only needed for the Opaque GBuffer fill and are restored afterwards by the existing `PushRenderTargetsAndRestore`, so SSLR still receives them. Acts only when surplus targets are bound; no effect on the non-SSLR path or on D3D11/12.

### Backend guard (`CommandList.Vulkan.cs`, second commit)

Complementary hardening, not the fix: `EnsureRenderPass` never cross-checked the framebuffer attachment count against the pipeline's render pass. Added a **debug-only** (`IsDebugMode`) assertion that throws a clear, localized exception on a mismatch instead of a cryptic device loss. Debug-gated so it doesn't break drivers that tolerate a mismatch.

### Validation

Reproduced on an **RTX 3080 Ti** (different NVIDIA GPU than the reporter's, so not Optimus/laptop-specific) with the FPS template + Local Reflections + continuous fire. A/B on the same compiled project, swapping only the engine DLL:

| Engine | Result |
| --- | --- |
| unpatched (4.4.0-beta4) | `ErrorDeviceLost` within ~10s |
| this fix | runs clean; the `4 vs 2` validation errors are gone |

With the guard on the unpatched engine, the device loss becomes an immediate `InvalidOperationException` naming the mismatch (`Bound render targets (4) do not match the active pipeline's render pass (2 attachments)`).

### Tests

- `ForwardRendererTransparentTargetsTest` (`Stride.Engine.Tests`, all backends): asserts the transparent stage binds only its declared target count, dropping surplus opaque targets. Fails without the fix.
- `TestFramebufferAttachmentGuard` (`Stride.Graphics.Tests`, Vulkan-gated): asserts the guard throws on an attachment-count mismatch.

## Related Issue

Closes #3251.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes. <!-- The device-loss itself isn't reproducible in CI (lavapipe tolerates the mismatch), so the tests assert the invariant that prevents it: the transparent stage binds only its declared targets, and the guard throws on a mismatch. -->
- [ ] All new and existing tests passed. <!-- New tests pass locally on D3D11 + Vulkan (real NVIDIA); full suite relies on CI. -->
- [ ] **I have built and run the editor to try this change out.** <!-- Runtime-only compositor change; validated via a standalone Vulkan game A/B on real NVIDIA hardware rather than the editor. -->
