### PR TITLE
docs: Fix invalid XML docs references reported by docfx

### DIFF
--- a/sources/assets/Stride.Core.Assets/AssetRegistry.cs
+++ b/sources/assets/Stride.Core.Assets/AssetRegistry.cs
@@ -328,7 +328,7 @@ public static class AssetRegistry
     /// <remarks>
     /// The difference between this one and <see cref="CanPropertyHandleAssets"/> is that this one returns the content types,
     /// meaning the concrete types that are types that would be compiled into 'content' to be used at runtime.
-    /// The types contained in <see cref="contentTypes"/> are not guaranteed to be assignable to <paramref name="propertyType"/>
+    /// The types contained in <paramref name="contentTypes"/> are not guaranteed to be assignable to <paramref name="propertyType"/>
     /// </remarks>
     public static bool CanPropertyHandleContent(Type propertyType, [MaybeNullWhen(false)] out IReadOnlyList<Type> contentTypes)
     {

--- a/sources/assets/Stride.Core.Assets/Yaml/YamlAssetPath.cs
+++ b/sources/assets/Stride.Core.Assets/Yaml/YamlAssetPath.cs
@@ -44,7 +44,7 @@ public sealed class YamlAssetPath
         /// </summary>
         public readonly ElementType Type;
         /// <summary>
-        /// The value of the element, corresonding to its <see cref="Type"/>.
+        /// The value of the element, corresponding to its <see cref="Type"/>.
         /// </summary>
         public readonly object Value;
 
@@ -161,7 +161,7 @@ public sealed class YamlAssetPath
     /// Adds an additional element to the path representing an access to an item of a collection or a value of a dictionary that does not use <see cref="ItemId"/>.
     /// </summary>
     /// <param name="index">The index of the item.</param>
-    /// <seealso cref="NonIdentifiableCollectionItemsAttribute"/>
+    /// <seealso cref="Core.Annotations.NonIdentifiableCollectionItemsAttribute"/>
     /// <seealso cref="ItemId"/>
     public void PushIndex(object index)
     {
@@ -190,7 +190,7 @@ public sealed class YamlAssetPath
     /// Appends the given <see cref="YamlAssetPath"/> to this instance.
     /// </summary>
     /// <param name="other">The <see cref="YamlAssetPath"/></param>
-    /// <returns>A new instance of <see cref="YamlAssetPath"/> corresonding to the given instance appended to this instance.</returns>
+    /// <returns>A new instance of <see cref="YamlAssetPath"/> corresponding to the given instance appended to this instance.</returns>
     [Pure]
     public YamlAssetPath Append(YamlAssetPath? other)
     {

--- a/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
+++ b/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
@@ -98,8 +98,8 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
 
     /// <inheritdoc />
     /// <param name="url">The url (without preceding slash).</param>
-    /// <param name="searchPattern"></param>
-    /// <param name="searchOption"></param>
+    /// <param name="searchPattern">The search pattern.</param>
+    /// <param name="searchOption">The search option.</param>
     /// <remarks>
     /// Example: to get all files within a directory <c>ListFiles("path/to/folder", "*", VirtualSearchOption.TopDirectoryOnly)</c>
     /// </remarks>

--- a/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
+++ b/sources/core/Stride.Core.Serialization/IO/DatabaseFileProvider.cs
@@ -98,8 +98,6 @@ public sealed class DatabaseFileProvider : VirtualFileProviderBase
 
     /// <inheritdoc />
     /// <param name="url">The url (without preceding slash).</param>
-    /// <param name="searchPattern">The search pattern.</param>
-    /// <param name="searchOption">The search option.</param>
     /// <remarks>
     /// Example: to get all files within a directory <c>ListFiles("path/to/folder", "*", VirtualSearchOption.TopDirectoryOnly)</c>
     /// </remarks>

--- a/sources/engine/Stride.Engine/Engine/Network/ClientRouterMessage.cs
+++ b/sources/engine/Stride.Engine/Engine/Network/ClientRouterMessage.cs
@@ -4,7 +4,7 @@ namespace Stride.Engine.Network
 {
     /// <summary>
     /// Message exchanged between client and router.
-    /// Note: shouldn't collide with <see cref="RouterMessage"/>.
+    /// Note: shouldn't collide with <c>RouterMessage</c>.
     /// </summary>
     public enum ClientRouterMessage : ushort
     {

--- a/sources/engine/Stride.Games/GameContextFactory.cs
+++ b/sources/engine/Stride.Games/GameContextFactory.cs
@@ -14,7 +14,7 @@ namespace Stride.Games
     {
         /// <summary>
         /// Whether the Windows Forms windowing backend is available. Set the "Stride.Games.WinFormsBackendEnabled"
-        /// feature switch to <c>false</c> to let trimming/AOT drop <c>GameContextWinforms</c> and System.Windows.Forms.
+        /// feature switch to <c>false</c> to let trimming/AOT drop <see cref="GameContextWinforms"/> and System.Windows.Forms.
         /// </summary>
         [FeatureSwitchDefinition("Stride.Games.WinFormsBackendEnabled")]
         public static bool WinFormsBackendEnabled

--- a/sources/engine/Stride.Games/GameContextFactory.cs
+++ b/sources/engine/Stride.Games/GameContextFactory.cs
@@ -14,7 +14,7 @@ namespace Stride.Games
     {
         /// <summary>
         /// Whether the Windows Forms windowing backend is available. Set the "Stride.Games.WinFormsBackendEnabled"
-        /// feature switch to <c>false</c> to let trimming/AOT drop <see cref="GameContextWinforms"/> and System.Windows.Forms.
+        /// feature switch to <c>false</c> to let trimming/AOT drop <c>GameContextWinforms</c> and System.Windows.Forms.
         /// </summary>
         [FeatureSwitchDefinition("Stride.Games.WinFormsBackendEnabled")]
         public static bool WinFormsBackendEnabled

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
@@ -65,7 +65,7 @@ namespace Stride.Graphics
         ///   Gets the native DXGI adapter.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<IDXGIAdapter1> NativeAdapter => ComPtrHelpers.ToComPtr(dxgiAdapter);

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
@@ -65,7 +65,7 @@ namespace Stride.Graphics
         ///   Gets the native DXGI adapter.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<IDXGIAdapter1> NativeAdapter => ComPtrHelpers.ToComPtr(dxgiAdapter);

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapterFactory.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapterFactory.Direct3D.cs
@@ -22,7 +22,7 @@ namespace Stride.Graphics
         ///   Gets the native DXGI factory object.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal static ComPtr<IDXGIFactory1> NativeFactory

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapterFactory.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapterFactory.Direct3D.cs
@@ -22,7 +22,7 @@ namespace Stride.Graphics
         ///   Gets the native DXGI factory object.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal static ComPtr<IDXGIFactory1> NativeFactory

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
@@ -51,7 +51,7 @@ public sealed unsafe partial class GraphicsOutput
     ///   Gets the native DXGI output.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     internal ComPtr<IDXGIOutput> NativeOutput => ComPtrHelpers.ToComPtr(dxgiOutput);

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsOutput.Direct3D.cs
@@ -51,7 +51,7 @@ public sealed unsafe partial class GraphicsOutput
     ///   Gets the native DXGI output.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     internal ComPtr<IDXGIOutput> NativeOutput => ComPtrHelpers.ToComPtr(dxgiOutput);

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -80,7 +80,7 @@ namespace Stride.Graphics
         ///   Gets the internal DXGI Swap-Chain.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<IDXGISwapChain1> NativeSwapChain => ToComPtr(swapChain);

--- a/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/SwapChainGraphicsPresenter.Direct3D.cs
@@ -80,7 +80,7 @@ namespace Stride.Graphics
         ///   Gets the internal DXGI Swap-Chain.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<IDXGISwapChain1> NativeSwapChain => ToComPtr(swapChain);

--- a/sources/engine/Stride.Graphics/Direct3D11/Buffer.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/Buffer.Direct3D11.cs
@@ -26,7 +26,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Buffer.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11Buffer> NativeBuffer => ToComPtr(nativeBuffer);

--- a/sources/engine/Stride.Graphics/Direct3D11/Buffer.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/Buffer.Direct3D11.cs
@@ -26,7 +26,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Buffer.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11Buffer> NativeBuffer => ToComPtr(nativeBuffer);

--- a/sources/engine/Stride.Graphics/Direct3D11/CommandList.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/CommandList.Direct3D11.cs
@@ -52,7 +52,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Device Context.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11DeviceContext> NativeDeviceContext => ToComPtr(nativeDeviceContext);

--- a/sources/engine/Stride.Graphics/Direct3D11/CommandList.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/CommandList.Direct3D11.cs
@@ -52,7 +52,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Device Context.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11DeviceContext> NativeDeviceContext => ToComPtr(nativeDeviceContext);

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsDevice.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsDevice.Direct3D11.cs
@@ -61,7 +61,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Device.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         public ComPtr<ID3D11Device> NativeDevice => ToComPtr(nativeDevice);
@@ -79,7 +79,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Device Context.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11DeviceContext> NativeDeviceContext => ToComPtr(nativeDeviceContext);

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsDevice.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsDevice.Direct3D11.cs
@@ -61,7 +61,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Device.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         public ComPtr<ID3D11Device> NativeDevice => ToComPtr(nativeDevice);
@@ -79,7 +79,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Device Context.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11DeviceContext> NativeDeviceContext => ToComPtr(nativeDeviceContext);

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsResource.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsResource.Direct3D11.cs
@@ -46,7 +46,7 @@ public abstract unsafe partial class GraphicsResource
     /// <remarks>
     ///   Only <see cref="Texture"/>s are using this Shader Resource View.
     ///   <para>
-    ///     If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///     If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///     reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     ///   </para>
     /// </remarks>
@@ -85,7 +85,7 @@ public abstract unsafe partial class GraphicsResource
     /// </summary>
     /// <value>The Unordered Access View associated with the Graphics Resource.</value>
     /// <remarks>
-    ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected internal ComPtr<ID3D11UnorderedAccessView> NativeUnorderedAccessView

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsResource.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsResource.Direct3D11.cs
@@ -46,7 +46,7 @@ public abstract unsafe partial class GraphicsResource
     /// <remarks>
     ///   Only <see cref="Texture"/>s are using this Shader Resource View.
     ///   <para>
-    ///     If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///     If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///     reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     ///   </para>
     /// </remarks>
@@ -85,7 +85,7 @@ public abstract unsafe partial class GraphicsResource
     /// </summary>
     /// <value>The Unordered Access View associated with the Graphics Resource.</value>
     /// <remarks>
-    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected internal ComPtr<ID3D11UnorderedAccessView> NativeUnorderedAccessView

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsResourceBase.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsResourceBase.Direct3D11.cs
@@ -21,7 +21,7 @@ public abstract unsafe partial class GraphicsResourceBase
     ///   Gets the internal Direct3D 11 Resource.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected internal ComPtr<ID3D11Resource> NativeResource => ToComPtr(nativeResource);
@@ -30,7 +30,7 @@ public abstract unsafe partial class GraphicsResourceBase
     ///   Gets or sets the internal <see cref="ID3D11DeviceChild"/>.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected internal ComPtr<ID3D11DeviceChild> NativeDeviceChild
@@ -125,7 +125,7 @@ public abstract unsafe partial class GraphicsResourceBase
     ///   a <see cref="Graphics.GraphicsDevice"/>, or <see langword="null"/> if not.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected ComPtr<ID3D11Device> NativeDevice => GraphicsDevice?.NativeDevice ?? default;

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsResourceBase.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsResourceBase.Direct3D11.cs
@@ -21,7 +21,7 @@ public abstract unsafe partial class GraphicsResourceBase
     ///   Gets the internal Direct3D 11 Resource.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected internal ComPtr<ID3D11Resource> NativeResource => ToComPtr(nativeResource);
@@ -30,7 +30,7 @@ public abstract unsafe partial class GraphicsResourceBase
     ///   Gets or sets the internal <see cref="ID3D11DeviceChild"/>.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected internal ComPtr<ID3D11DeviceChild> NativeDeviceChild
@@ -125,7 +125,7 @@ public abstract unsafe partial class GraphicsResourceBase
     ///   a <see cref="Graphics.GraphicsDevice"/>, or <see langword="null"/> if not.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     protected ComPtr<ID3D11Device> NativeDevice => GraphicsDevice?.NativeDevice ?? default;

--- a/sources/engine/Stride.Graphics/Direct3D11/QueryPool.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/QueryPool.Direct3D11.cs
@@ -18,7 +18,7 @@ public unsafe partial class QueryPool
     ///   Gets the internal Direct3D 11 Queries.
     /// </summary>
     /// <remarks>
-    ///   If any of the references is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If any of the references is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     internal ReadOnlySpan<ComPtr<ID3D11Query>> NativeQueries => nativeQueries;

--- a/sources/engine/Stride.Graphics/Direct3D11/QueryPool.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/QueryPool.Direct3D11.cs
@@ -18,7 +18,7 @@ public unsafe partial class QueryPool
     ///   Gets the internal Direct3D 11 Queries.
     /// </summary>
     /// <remarks>
-    ///   If any of the references is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If any of the references is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     internal ReadOnlySpan<ComPtr<ID3D11Query>> NativeQueries => nativeQueries;

--- a/sources/engine/Stride.Graphics/Direct3D11/SamplerState.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/SamplerState.Direct3D11.cs
@@ -21,7 +21,7 @@ public unsafe partial class SamplerState
     ///   Gets the internal Direct3D 11 Sampler State object.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     internal ComPtr<ID3D11SamplerState> NativeSamplerState => ComPtrHelpers.ToComPtr(samplerState);

--- a/sources/engine/Stride.Graphics/Direct3D11/SamplerState.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/SamplerState.Direct3D11.cs
@@ -21,7 +21,7 @@ public unsafe partial class SamplerState
     ///   Gets the internal Direct3D 11 Sampler State object.
     /// </summary>
     /// <remarks>
-    ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+    ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
     ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
     /// </remarks>
     internal ComPtr<ID3D11SamplerState> NativeSamplerState => ComPtrHelpers.ToComPtr(samplerState);

--- a/sources/engine/Stride.Graphics/Direct3D11/Texture.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/Texture.Direct3D11.cs
@@ -56,7 +56,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Depth-Stencil View attached to this Texture resource.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11DepthStencilView> NativeDepthStencilView
@@ -86,7 +86,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Render Target View attached to this Texture resource.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11RenderTargetView> NativeRenderTargetView

--- a/sources/engine/Stride.Graphics/Direct3D11/Texture.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/Texture.Direct3D11.cs
@@ -56,7 +56,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Depth-Stencil View attached to this Texture resource.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11DepthStencilView> NativeDepthStencilView
@@ -86,7 +86,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Render Target View attached to this Texture resource.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D11RenderTargetView> NativeRenderTargetView

--- a/sources/engine/Stride.Graphics/Direct3D12/DescriptorPool.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/DescriptorPool.Direct3D12.cs
@@ -21,7 +21,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Descriptor Heap for Shader Resource Views.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12DescriptorHeap> SrvHeap => ToComPtr(nativeSrvHeap);
@@ -30,7 +30,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Descriptor Heap for Samplers.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12DescriptorHeap> SamplerHeap => ToComPtr(nativeSamplerHeap);

--- a/sources/engine/Stride.Graphics/Direct3D12/DescriptorPool.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/DescriptorPool.Direct3D12.cs
@@ -21,7 +21,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Descriptor Heap for Shader Resource Views.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12DescriptorHeap> SrvHeap => ToComPtr(nativeSrvHeap);
@@ -30,7 +30,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Descriptor Heap for Samplers.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12DescriptorHeap> SamplerHeap => ToComPtr(nativeSamplerHeap);

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.Fence.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.Fence.cs
@@ -35,7 +35,7 @@ public unsafe partial class GraphicsDevice
         ///   Gets the internal Direct3D 12 Fence.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         public readonly ComPtr<ID3D12Fence> Fence => ToComPtr(fence);

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.Fence.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.Fence.cs
@@ -35,7 +35,7 @@ public unsafe partial class GraphicsDevice
         ///   Gets the internal Direct3D 12 Fence.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         public readonly ComPtr<ID3D12Fence> Fence => ToComPtr(fence);

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
@@ -81,7 +81,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Device.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         public ComPtr<ID3D12Device> NativeDevice => ToComPtr(nativeDevice);
@@ -90,7 +90,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command Queue.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12CommandQueue> NativeCommandQueue => ToComPtr(nativeCommandQueue);
@@ -122,7 +122,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command Queue used for copy commands.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12CommandQueue> NativeCopyCommandQueue => ToComPtr(nativeCopyCommandQueue);
@@ -133,7 +133,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command Allocator used for copy commands.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12CommandAllocator> NativeCopyCommandAllocator => ToComPtr(nativeCopyCommandAllocator);
@@ -144,7 +144,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command List used for copy commands.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12GraphicsCommandList7> NativeCopyCommandList => ToComPtr(nativeCopyCommandList);

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsDevice.Direct3D12.cs
@@ -81,7 +81,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Device.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         public ComPtr<ID3D12Device> NativeDevice => ToComPtr(nativeDevice);
@@ -90,7 +90,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command Queue.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12CommandQueue> NativeCommandQueue => ToComPtr(nativeCommandQueue);
@@ -122,7 +122,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command Queue used for copy commands.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12CommandQueue> NativeCopyCommandQueue => ToComPtr(nativeCopyCommandQueue);
@@ -133,7 +133,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command Allocator used for copy commands.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12CommandAllocator> NativeCopyCommandAllocator => ToComPtr(nativeCopyCommandAllocator);
@@ -144,7 +144,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Command List used for copy commands.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12GraphicsCommandList7> NativeCopyCommandList => ToComPtr(nativeCopyCommandList);

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsResourceBase.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsResourceBase.Direct3D12.cs
@@ -29,7 +29,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Resource.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12Resource> NativeResource => ToComPtr(nativeResource);
@@ -38,7 +38,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Device Child.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12DeviceChild> NativeDeviceChild
@@ -136,7 +136,7 @@ namespace Stride.Graphics
         ///   a <see cref="Graphics.GraphicsDevice"/>, or <see langword="null"/> if not.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected ComPtr<ID3D12Device> NativeDevice => GraphicsDevice?.NativeDevice ?? default;

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsResourceBase.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsResourceBase.Direct3D12.cs
@@ -29,7 +29,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 11 Resource.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12Resource> NativeResource => ToComPtr(nativeResource);
@@ -38,7 +38,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Device Child.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected internal ComPtr<ID3D12DeviceChild> NativeDeviceChild
@@ -136,7 +136,7 @@ namespace Stride.Graphics
         ///   a <see cref="Graphics.GraphicsDevice"/>, or <see langword="null"/> if not.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         protected ComPtr<ID3D12Device> NativeDevice => GraphicsDevice?.NativeDevice ?? default;

--- a/sources/engine/Stride.Graphics/Direct3D12/PipelineState.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/PipelineState.Direct3D12.cs
@@ -35,7 +35,7 @@ namespace Stride.Graphics
         ///   <see cref="PipelineStateDescription"/>.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12PipelineState> CompiledState => ToComPtr(compiledPipelineState);
@@ -44,7 +44,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Root Signature.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12RootSignature> RootSignature => ToComPtr(nativeRootSignature);

--- a/sources/engine/Stride.Graphics/Direct3D12/PipelineState.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/PipelineState.Direct3D12.cs
@@ -35,7 +35,7 @@ namespace Stride.Graphics
         ///   <see cref="PipelineStateDescription"/>.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12PipelineState> CompiledState => ToComPtr(compiledPipelineState);
@@ -44,7 +44,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Root Signature.
         /// </summary>
         /// <remarks>
-        ///   If the reference is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If the reference is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12RootSignature> RootSignature => ToComPtr(nativeRootSignature);

--- a/sources/engine/Stride.Graphics/Direct3D12/QueryPool.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/QueryPool.Direct3D12.cs
@@ -28,7 +28,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Query Heap.
         /// </summary>
         /// <remarks>
-        ///   If any of the references is going to be kept, use <c>AddRef()</c> to increment the internal
+        ///   If any of the references is going to be kept, use <c>AddRef()</c> on the COM pointer to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12QueryHeap> NativeQueryHeap => ToComPtr(nativeQueryHeap);

--- a/sources/engine/Stride.Graphics/Direct3D12/QueryPool.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/QueryPool.Direct3D12.cs
@@ -28,7 +28,7 @@ namespace Stride.Graphics
         ///   Gets the internal Direct3D 12 Query Heap.
         /// </summary>
         /// <remarks>
-        ///   If any of the references is going to be kept, use <see cref="ComPtr{T}.AddRef()"/> to increment the internal
+        ///   If any of the references is going to be kept, use <c>AddRef()</c> to increment the internal
         ///   reference count, and <see cref="ComPtr{T}.Dispose()"/> when no longer needed to release the object.
         /// </remarks>
         internal ComPtr<ID3D12QueryHeap> NativeQueryHeap => ToComPtr(nativeQueryHeap);

--- a/sources/engine/Stride.Graphics/GraphicsPresenter.cs
+++ b/sources/engine/Stride.Graphics/GraphicsPresenter.cs
@@ -258,14 +258,14 @@ public abstract class GraphicsPresenter : ComponentBase
     ///       <item>
     ///         <term>For rendering to a SDR display with gamma 2.2</term>
     ///         <description>
-    ///           Set a color space of <see cref="ColorSpaceType.RgbFullG22NoneP709"/> with a Back-Buffer format <see cref="PixelFormat.R8G8B8A8_UNorm"/>,
+    ///           Set a color space of <see cref="ColorSpaceType.Rgb_Full_G22_None_P709"/> with a Back-Buffer format <see cref="PixelFormat.R8G8B8A8_UNorm"/>,
     ///           <see cref="PixelFormat.R8G8B8A8_UNorm_SRgb"/>, <see cref="PixelFormat.B8G8R8A8_UNorm"/>, or <see cref="PixelFormat.B8G8R8A8_UNorm"/>.
     ///         </description>
     ///       </item>
     ///       <item>
     ///         <term>For rendering to a HDR display in scRGB (standard linear), and letting the Windows DWM do the color conversion</term>
     ///         <description>
-    ///           Set a color space of <see cref="ColorSpaceType.RgbFullG10NoneP709"/> with a Back-Buffer format <see cref="PixelFormat.R16G16B16A16_Float"/>.
+    ///           Set a color space of <see cref="ColorSpaceType.Rgb_Full_G10_None_P709"/> with a Back-Buffer format <see cref="PixelFormat.R16G16B16A16_Float"/>.
     ///         </description>
     ///       </item>
     ///       <item>
@@ -274,7 +274,7 @@ public abstract class GraphicsPresenter : ComponentBase
     ///           same color space as the display.
     ///         </term>
     ///         <description>
-    ///           Set a color space of <see cref="ColorSpaceType.RgbFullG2084NoneP2020"/> with a Back-Buffer format <see cref="PixelFormat.R10G10B10A2_UNorm"/>.
+    ///           Set a color space of <see cref="ColorSpaceType.Rgb_Full_G2084_None_P2020"/> with a Back-Buffer format <see cref="PixelFormat.R10G10B10A2_UNorm"/>.
     ///         </description>
     ///       </item>
     ///     </list>

--- a/sources/engine/Stride.Graphics/GraphicsResourceState.cs
+++ b/sources/engine/Stride.Graphics/GraphicsResourceState.cs
@@ -10,7 +10,7 @@ namespace Stride.Graphics;
 /// </summary>
 /// <remarks>
 ///   This enum is being replaced by <see cref="BarrierLayout"/> for cross-platform barrier transitions.
-///   New code should use <see cref="CommandList.ResourceBarrierTransition(GraphicsResource, BarrierLayout)"/> instead.
+///   New code should use <see cref="CommandList.ResourceBarrierTransition(GraphicsResource, BarrierLayout, uint)"/> instead.
 /// </remarks>
 [Obsolete("Use BarrierLayout instead for cross-platform barrier transitions.")]
 [Flags]

--- a/sources/engine/Stride.Graphics/PresentationParameters.cs
+++ b/sources/engine/Stride.Graphics/PresentationParameters.cs
@@ -234,7 +234,7 @@ public sealed class PresentationParameters : IEquatable<PresentationParameters>
     ///     <item>No multi-sampling.</item>
     ///     <item>
     ///       Assuming a linear color space (<see cref="ColorSpace.Linear"/>) and an output color space
-    ///       <see cref="ColorSpaceType.RgbFullG22NoneP709"/>, which is the default RGB output for monitors
+    ///       <see cref="ColorSpaceType.Rgb_Full_G22_None_P709"/>, which is the default RGB output for monitors
     ///       with a standard gamma of 2.2.
     ///     </item>
     ///     <item>

--- a/sources/engine/Stride.Graphics/Texture.Extensions1D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions1D.cs
@@ -104,7 +104,7 @@ public partial class Texture
     ///     It must have a size (in bytes, not elements) equal to the size of the <paramref name="format"/> times the <paramref name="width"/>.
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     /// </param>
     /// <param name="textureFlags">

--- a/sources/engine/Stride.Graphics/Texture.Extensions2D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions2D.cs
@@ -114,7 +114,7 @@ public partial class Texture
     ///     (<paramref name="width"/> * <paramref name="height"/>).
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.Extensions2D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions2D.cs
@@ -114,7 +114,7 @@ public partial class Texture
     ///     (<paramref name="width"/> * <paramref name="height"/>).
     ///   </para>
     ///   <para>
-    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
+    ///     See <see cref="PixelFormatExtensions.get_SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.Extensions2D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions2D.cs
@@ -114,7 +114,7 @@ public partial class Texture
     ///     (<paramref name="width"/> * <paramref name="height"/>).
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.get_SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.Extensions3D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions3D.cs
@@ -102,7 +102,7 @@ public partial class Texture
     ///     (<paramref name="width"/> * <paramref name="height"/> * <paramref name="depth"/>).
     ///   </para>
     ///   <para>
-    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
+    ///     See <see cref="PixelFormatExtensions.get_SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.Extensions3D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions3D.cs
@@ -102,7 +102,7 @@ public partial class Texture
     ///     (<paramref name="width"/> * <paramref name="height"/> * <paramref name="depth"/>).
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.Extensions3D.cs
+++ b/sources/engine/Stride.Graphics/Texture.Extensions3D.cs
@@ -102,7 +102,7 @@ public partial class Texture
     ///     (<paramref name="width"/> * <paramref name="height"/> * <paramref name="depth"/>).
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.get_SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.ExtensionsCube.cs
+++ b/sources/engine/Stride.Graphics/Texture.ExtensionsCube.cs
@@ -111,7 +111,7 @@ public partial class Texture
     ///     </list>
     ///   </para>
     ///   <para>
-    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
+    ///     See <see cref="PixelFormatExtensions.get_SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array of each of the cube faces will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.ExtensionsCube.cs
+++ b/sources/engine/Stride.Graphics/Texture.ExtensionsCube.cs
@@ -111,7 +111,7 @@ public partial class Texture
     ///     </list>
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.get_SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array of each of the cube faces will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/Texture.ExtensionsCube.cs
+++ b/sources/engine/Stride.Graphics/Texture.ExtensionsCube.cs
@@ -111,7 +111,7 @@ public partial class Texture
     ///     </list>
     ///   </para>
     ///   <para>
-    ///     See <see cref="PixelFormatExtensions.SizeInBytes(PixelFormat)"/> for calculating the size of a pixel format.
+    ///     See the <c>SizeInBytes</c> extension member in <see cref="PixelFormatExtensions"/> for calculating the size of a pixel format.
     ///   </para>
     ///   <para>
     ///     Each value in the data array of each of the cube faces will be a texel in the destination Texture.

--- a/sources/engine/Stride.Graphics/VertexElement.cs
+++ b/sources/engine/Stride.Graphics/VertexElement.cs
@@ -33,14 +33,15 @@ using Half = Stride.Core.Mathematics.Half;
 namespace Stride.Graphics;
 
 /// <summary>
-/// A description of a single element for the input-assembler stage. This structure is related to <see cref="SharpDX.Direct3D11.InputElement"/>.
+/// A description of a single element for the input-assembler stage. This structure is related to the native
+/// input element description (<c>D3D11_INPUT_ELEMENT_DESC</c> in Direct3D).
 /// </summary>
 /// <remarks>
-/// Because <see cref="SharpDX.Direct3D11.InputElement"/> requires to have the same <see cref="VertexBufferLayout.SlotIndex"/>, <see cref="VertexBufferLayout.VertexClassification"/> and <see cref="VertexBufferLayout.instanceDataStepRate"/>,
-/// the <see cref="VertexBufferLayout"/> structure encapsulates a set of <see cref="VertexElement"/> for a particular slot, classification and instance data step rate.
-/// Unlike the default <see cref="SharpDX.Direct3D11.InputElement"/>, this structure accepts a semantic name with a postfix number that will be automatically extracted to the semantic index.
+/// Because a native input element description requires to have the same slot index, vertex classification and instance data step rate,
+/// the <see cref="VertexDeclaration"/> structure encapsulates a set of <see cref="VertexElement"/> for a particular slot, classification and instance data step rate.
+/// Unlike the native input element description, this structure accepts a semantic name with a postfix number that will be automatically extracted to the semantic index.
 /// </remarks>
-/// <seealso cref="VertexBufferLayout"/>
+/// <seealso cref="VertexDeclaration"/>
 [DataContract]
 [DataSerializer(typeof(Serializer))]
 public partial struct VertexElement : IEquatable<VertexElement>

--- a/sources/engine/Stride.Rendering/Rendering/IEffectMixinProvider.cs
+++ b/sources/engine/Stride.Rendering/Rendering/IEffectMixinProvider.cs
@@ -7,7 +7,7 @@ using Stride.Shaders;
 namespace Stride.Rendering
 {
     /// <summary>
-    /// Defines the interface to provide an effect mixin for a <c>CameraRendererMode</c>.
+    /// Defines the interface to provide an effect mixin.
     /// </summary>
     public interface IEffectMixinProvider
     {

--- a/sources/engine/Stride.Rendering/Rendering/IEffectMixinProvider.cs
+++ b/sources/engine/Stride.Rendering/Rendering/IEffectMixinProvider.cs
@@ -7,7 +7,7 @@ using Stride.Shaders;
 namespace Stride.Rendering
 {
     /// <summary>
-    /// Defines the interface to provide an effect mixin for a <see cref="CameraRendererMode"/>.
+    /// Defines the interface to provide an effect mixin for a <c>CameraRendererMode</c>.
     /// </summary>
     public interface IEffectMixinProvider
     {

--- a/sources/engine/Stride.Rendering/Rendering/IImageEffectRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/IImageEffectRenderer.cs
@@ -7,7 +7,7 @@ using Stride.Rendering.Images;
 namespace Stride.Rendering
 {
     /// <summary>
-    /// Renderer interface for a end-user <see cref="ImageEffect"/>.
+    /// Renderer interface for an end-user <see cref="ImageEffect"/>.
     /// </summary>
     /// <remarks>
     /// An <see cref="IImageEffectRenderer"/> expect an input texture on slot 0, possibly a depth texture on slot 1 and a single

--- a/sources/engine/Stride.Rendering/Rendering/IImageEffectRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/IImageEffectRenderer.cs
@@ -7,7 +7,7 @@ using Stride.Rendering.Images;
 namespace Stride.Rendering
 {
     /// <summary>
-    /// Renderer interface for a end-user <see cref="ImageEffect"/> accessible from <c>SceneEffectRenderer</c>. See remarks.
+    /// Renderer interface for a end-user <see cref="ImageEffect"/>.
     /// </summary>
     /// <remarks>
     /// An <see cref="IImageEffectRenderer"/> expect an input texture on slot 0, possibly a depth texture on slot 1 and a single

--- a/sources/engine/Stride.Rendering/Rendering/IImageEffectRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/IImageEffectRenderer.cs
@@ -7,7 +7,7 @@ using Stride.Rendering.Images;
 namespace Stride.Rendering
 {
     /// <summary>
-    /// Renderer interface for a end-user <see cref="ImageEffect"/> accessible from <see cref="SceneEffectRenderer"/>. See remarks.
+    /// Renderer interface for a end-user <see cref="ImageEffect"/> accessible from <c>SceneEffectRenderer</c>. See remarks.
     /// </summary>
     /// <remarks>
     /// An <see cref="IImageEffectRenderer"/> expect an input texture on slot 0, possibly a depth texture on slot 1 and a single

--- a/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilter.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilter.cs
@@ -40,7 +40,7 @@ namespace Stride.Rendering.Images
         }
 
         /// <summary>
-        /// Gets or sets the threshold relative to the <see cref="WhitePoint"/>.
+        /// Gets or sets the threshold relative to the white point.
         /// </summary>
         /// <value>The threshold.</value>
         /// <userdoc>The value of the intensity threshold used to identify bright areas</userdoc>

--- a/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilter.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilter.cs
@@ -40,7 +40,7 @@ namespace Stride.Rendering.Images
         }
 
         /// <summary>
-        /// Gets or sets the threshold relative to the white point.
+        /// Gets or sets the threshold relative to the <see cref="WhitePoint"/>.
         /// </summary>
         /// <value>The threshold.</value>
         /// <userdoc>The value of the intensity threshold used to identify bright areas</userdoc>

--- a/sources/engine/Stride.Rendering/Rendering/PipelinePluginContext.cs
+++ b/sources/engine/Stride.Rendering/Rendering/PipelinePluginContext.cs
@@ -3,7 +3,7 @@
 namespace Stride.Rendering
 {
     /// <summary>
-    /// Context used by <see cref="PipelinePluginManager"/>.
+    /// Context used by <c>PipelinePluginManager</c>.
     /// </summary>
     public struct PipelinePluginContext
     {

--- a/sources/engine/Stride.Rendering/Rendering/PipelinePluginContext.cs
+++ b/sources/engine/Stride.Rendering/Rendering/PipelinePluginContext.cs
@@ -2,9 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 namespace Stride.Rendering
 {
-    /// <summary>
-    /// Context used by <c>PipelinePluginManager</c>.
-    /// </summary>
     public struct PipelinePluginContext
     {
         public readonly RenderContext RenderContext;

--- a/sources/engine/Stride.Rendering/Rendering/RenderContext.cs
+++ b/sources/engine/Stride.Rendering/Rendering/RenderContext.cs
@@ -89,7 +89,7 @@ namespace Stride.Rendering
         public RenderSystem RenderSystem { get; set; }
 
         /// <summary>
-        /// The current visibility group from the <see cref="Stride.Engine.SceneInstance"/> and <see cref="RenderSystem"/>.
+        /// The current visibility group from the <c>SceneInstance</c> and <see cref="RenderSystem"/>.
         /// </summary>
         public VisibilityGroup VisibilityGroup { get; set; }
 

--- a/sources/engine/Stride.Rendering/Rendering/Shaders/RenderTargetKeys.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shaders/RenderTargetKeys.cs
@@ -33,7 +33,7 @@ namespace Stride.Rendering
         public static readonly ObjectParameterKey<Buffer> StreamTarget = ParameterKeys.NewObject<Buffer>();
 
         /// <summary>
-        /// Used by <c>RenderTargetPlugin</c> to notify that the plugin requires support for depth stencil as shader resource
+        /// Used to notify that the plugin requires support for depth stencil as shader resource
         /// </summary>
         public static readonly PropertyKey<bool> RequireDepthStencilShaderResource = new PropertyKey<bool>("RequireDepthStencilShaderResource", typeof(RenderTargetKeys));
     }

--- a/sources/engine/Stride.Rendering/Rendering/Shaders/RenderTargetKeys.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shaders/RenderTargetKeys.cs
@@ -33,7 +33,7 @@ namespace Stride.Rendering
         public static readonly ObjectParameterKey<Buffer> StreamTarget = ParameterKeys.NewObject<Buffer>();
 
         /// <summary>
-        /// Used to notify that the plugin requires support for depth stencil as shader resource
+        /// Used to notify that a renderer requires support for depth stencil as shader resource
         /// </summary>
         public static readonly PropertyKey<bool> RequireDepthStencilShaderResource = new PropertyKey<bool>("RequireDepthStencilShaderResource", typeof(RenderTargetKeys));
     }

--- a/sources/engine/Stride.Rendering/Rendering/Shaders/RenderTargetKeys.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Shaders/RenderTargetKeys.cs
@@ -33,7 +33,7 @@ namespace Stride.Rendering
         public static readonly ObjectParameterKey<Buffer> StreamTarget = ParameterKeys.NewObject<Buffer>();
 
         /// <summary>
-        /// Used by <see cref="RenderTargetPlugin"/> to notify that the plugin requires support for depth stencil as shader resource
+        /// Used by <c>RenderTargetPlugin</c> to notify that the plugin requires support for depth stencil as shader resource
         /// </summary>
         public static readonly PropertyKey<bool> RequireDepthStencilShaderResource = new PropertyKey<bool>("RequireDepthStencilShaderResource", typeof(RenderTargetKeys));
     }

--- a/sources/engine/Stride.Video/FFmpeg/FFmpegMedia.cs
+++ b/sources/engine/Stride.Video/FFmpeg/FFmpegMedia.cs
@@ -18,7 +18,7 @@ namespace Stride.Video.FFmpeg
     /// <summary>
     /// Represents a media, i.e. a context with a collection of streams and associated codecs from a unique source.
     /// </summary>
-    /// <seealso cref="FFmpeg.AutoGen.AVFormatContext"/>
+    /// <seealso cref="global::FFmpeg.AutoGen.AVFormatContext"/>
     public sealed unsafe class FFmpegMedia : IDisposable
     {
         public static Logger Logger = GlobalLogger.GetLogger(nameof(FFmpegMedia));


### PR DESCRIPTION
# PR Details

Documentation update to improve clarity, accuracy, and consistency of XML comments across the codebase.

#### PR Summary
This pull request refines XML documentation by correcting type references, fixing typographical errors, and enhancing clarity in remarks and summaries.
- Updates `<see cref="..."/>` tags to use `<c>...</c>` or correct type/member names, especially for native or external types.
- Fixes typographical and grammatical errors in documentation comments.
- Clarifies remarks and summaries, including proper usage of class names and enum values.
- Replaces references to legacy or external types (e.g., SharpDX) with generic or native descriptions.
- Updates `<seealso>` tags and parameter documentation for accuracy and consistency.


<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

https://github.com/stride3d/stride/issues/1681

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->

