### PR TITLE
fix: SDSL multidimensional array dimensions emitted in reverse order

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Literals.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Literals.cs
@@ -787,8 +787,11 @@ public partial class TypeName(string name, TextLocation info) : Literal(info)
 
     public static SymbolType GenerateArrayType(SymbolTable table, SpirvContext context, SymbolType arraySymbolType, List<Expression> arraySizes)
     {
-        foreach (var arraySize in arraySizes)
+        // Wrap from the last declared dimension inward so the first dimension ends up outermost:
+        // for `T[a][b][c]` (arraySizes = [a, b, c]) this builds Array(a, Array(b, Array(c, T))).
+        for (var index = arraySizes.Count - 1; index >= 0; index--)
         {
+            var arraySize = arraySizes[index];
             if (!table.ResolveArraySizes || arraySize is EmptyExpression)
                 arraySymbolType = new ArrayType(arraySymbolType, -1);
             else

--- a/sources/shaders/Stride.Shaders.Tests/Stride.Shaders.Tests.csproj
+++ b/sources/shaders/Stride.Shaders.Tests/Stride.Shaders.Tests.csproj
@@ -41,9 +41,11 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <StrideShaderFiles Include="..\assets\SDSL\CompilerTests\**" LinkBase="assets\SDSL\CompilerTests\" />
     <StrideShaderFiles Include="..\assets\SDSL\RenderTests\**" LinkBase="assets\SDSL\RenderTests\" />
     <StrideShaderFiles Include="..\assets\SDSL\ComputeTests\**" LinkBase="assets\SDSL\ComputeTests\" />
     <StrideShaderFiles Include="..\assets\SDSL\StreamOutTests\**" LinkBase="assets\SDSL\StreamOutTests\" />
+    <Content Include="..\assets\SDSL\CompilerTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\CompilerTests\" />
     <Content Include="..\assets\SDSL\RenderTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\RenderTests\" />
     <Content Include="..\assets\SDSL\ComputeTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\ComputeTests\" />
     <Content Include="..\assets\SDSL\StreamOutTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\StreamOutTests\" />

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using CommunityToolkit.HighPerformance;
 using Silk.NET.SPIRV;
@@ -18,6 +19,35 @@ namespace Stride.Shaders.Parsers.Tests;
 
 public class StrideShaderTests
 {
+    // Regression: multidimensional array dimensions must be emitted in declaration order.
+    // GenerateArrayType used to wrap the dimensions such that the last bracket became outermost,
+    // so `float4 Data3D[2][3][5]` was emitted transposed as [5][3][2] (breaking indexing / fxc).
+    [Fact]
+    public void MultidimensionalArrayDimensionsKeepDeclarationOrder()
+    {
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var shaderMixer = new ShaderMixer(loader);
+        shaderMixer.ShaderLoader.LoadExternalBuffer("ArrayDims3D", [], out _, out _, out _);
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        Assert.True(shaderMixer.MergeSDSL(new ShaderClassSource("ArrayDims3D"), new ShaderMixer.Options(true), log, out var bytecode, out _, out _, out _),
+            string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
+
+        var translator = new SpirvTranslator(bytecode.ToArray().AsMemory().Cast<byte, uint>());
+        var entryPoint = translator.GetEntryPoints().First(x => x.ExecutionModel == ExecutionModel.GLCompute);
+        var hlsl = translator.Translate(Backend.Hlsl, entryPoint);
+
+        Assert.Equal("[2][3][5]", MatchArrayDimensions(hlsl, "Data3D"));
+        Assert.Equal("[7]", MatchArrayDimensions(hlsl, "Data1D")); // rank-1 control: unaffected
+    }
+
+    private static string MatchArrayDimensions(string hlsl, string arrayName)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(hlsl, $@"\b{arrayName}((?:\[\d+\])+)\s*;");
+        Assert.True(match.Success, $"'{arrayName}' declaration not found in emitted HLSL:{Environment.NewLine}{hlsl}");
+        return match.Groups[1].Value;
+    }
+
     // Regression: the MemberName re-instantiation path sets ShaderLoaderBase.SuppressSourceHash and
     // relies on LoadFromCode to clear it. When the load hits the shader cache instead, LoadFromCode
     // never runs, so the flag leaks into the next compiled shader and strips its OpSourceHashSDSL.

--- a/sources/shaders/assets/SDSL/CompilerTests/ArrayDims3D.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ArrayDims3D.sdsl
@@ -1,0 +1,22 @@
+// Compiler regression: multidimensional array dimensions must be emitted in declaration order.
+// Data3D[2][3][5] used to be reversed to [5][3][2] (see GenerateArrayType). Data1D is a rank-1 control.
+namespace Stride.Shaders.Tests;
+
+shader ArrayDims3D
+{
+    groupshared float4 Data3D[2][3][5];
+    groupshared float4 Data1D[7];
+
+    RWStructuredBuffer<float4> Output;
+
+    [numthreads(1, 1, 1)]
+    void CSMain()
+    {
+        // Indices are legal only under the declared order; out of bounds if transposed.
+        Data3D[1][2][4] = float4(1, 0, 0, 0);
+        Data1D[6] = float4(1, 0, 0, 0);
+
+        // Read the arrays back so they survive into the emitted code.
+        Output[0] = Data3D[1][2][4] + Data1D[6];
+    }
+}


### PR DESCRIPTION
# PR Details

The SDSL compiler emitted **multidimensional array dimensions in reverse order** — `float4 Data[2][3][5]` came out as `[5][3][2]` (reversed, not rotated; rank‑1 unaffected). This is the production 4.4 path (`EffectCompiler` → `MergeSDSL` → `SpirvTranslator` → fxc/dxc).

### Root cause

`GenerateArrayType` (`sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Literals.cs`) iterated the declared dimensions left‑to‑right and wrapped each around the accumulated type, so the last bracket became the outermost array. `arraySizes` is in declaration order and `RegisterArrayType` faithfully emits the nesting it's handed, so the reversal originated solely in that loop.

### Fix

Wrap from the last dimension inward, so the first‑declared dimension is outermost. One‑line change; rank‑1 behaviour unchanged. This unbreaks the stock compute shader `LambertianPrefilteringSHPass1` (`PartialSHCoeffs[4][4][9]`, previously emitted `[9][4][4]` → indexed out of bounds → fxc `X3504/X3696`).

### Test

`MultidimensionalArrayDimensionsKeepDeclarationOrder` (`Stride.Shaders.Tests`) compiles a small compute shader with `Data3D[2][3][5]` (+ a rank‑1 control) via `MergeSDSL` + `SpirvTranslator` and asserts the emitted HLSL keeps `[2][3][5]`. Compiler‑only (no GPU), so it's CI‑safe. Red before the fix (`Actual "[5][3][2]"`), green after; the rest of the suite is unchanged.

The shader asset lives in a new `assets/SDSL/CompilerTests/` folder rather than `ComputeTests/`, deliberately: `ComputeTest1` runs every `ComputeTests` shader through a D3D11 dispatch, which wouldn't be CI‑safe.

### Note

`Stride.Shaders.Tests` isn't currently referenced by any CI `.slnf`, so these shader unit tests are built but never run in CI — worth wiring in (the suite has a handful of pre‑existing, unrelated `ErrorUnsupportedSpirv` failures to triage first).

### Validation

Reproduced and verified with a standalone repro (`dotnet run`, no GPU): https://github.com/sasvdw/stride-sdsl-array-repro — all three cases correct after the fix, including the real `LambertianPrefilteringSHPass1`.

## Related Issue

Closes #3292.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. <!-- Stride.Shaders.Tests: new test + the previously-passing 512; the 11 pre-existing unrelated failures are unchanged. -->
- [ ] **I have built and run the editor to try this change out.** <!-- Compiler-only change; validated via the shader unit test + the standalone repro rather than the editor. -->
