### PR TITLE
chore: remove SharpDX refs from core and GameStudio projects

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -30,12 +30,6 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="ServiceWire" Version="5.6.0" />
     <PackageVersion Include="System.Formats.Nrbf" Version="9.0.11" />
-    <PackageVersion Include="SharpDX" Version="4.2.0" />
-    <PackageVersion Include="SharpDX.D3DCompiler" Version="4.2.0" />
-    <PackageVersion Include="SharpDX.Direct2D1" Version="4.2.0" />
-    <PackageVersion Include="SharpDX.Direct3D11" Version="4.2.0" />
-    <PackageVersion Include="SharpDX.Direct3D12" Version="4.2.0" />
-    <PackageVersion Include="SharpDX.DXGI" Version="4.2.0" />
     <PackageVersion Include="SharpDX.DirectInput" Version="4.2.0" />
     <PackageVersion Include="SharpDX.RawInput" Version="4.2.0" />
     <PackageVersion Include="SharpDX.XInput" Version="4.2.0" />

--- a/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
+++ b/sources/core/Stride.Core.Design/Stride.Core.Design.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="NuGet.Configuration" />
-    <PackageReference Include="SharpDX" />
     <PackageReference Include="System.Management" />
   </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.Editor/Sdk/Sdk.targets" />

--- a/sources/core/Stride.Core.IO/Stride.Core.IO.csproj
+++ b/sources/core/Stride.Core.IO/Stride.Core.IO.csproj
@@ -26,7 +26,6 @@
     <ProjectReference Include="..\Stride.Core\Stride.Core.csproj">
       <PrivateAssets>contentfiles;analyzers</PrivateAssets>
     </ProjectReference>
-    <PackageReference Include="SharpDX" Condition="'$(TargetFramework)' == '$(StrideFrameworkUWP)'" />
   </ItemGroup>
 
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk/Sdk/Sdk.targets" />

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -41,7 +41,6 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="ServiceWire" />
-    <PackageReference Include="SharpDX" />
     <PackageReference Include="Stride.Metrics" />
     <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="SSH.NET" />


### PR DESCRIPTION
# PR Details

chore: remove SharpDX refs from core and GameStudio projects

Removed SharpDX package references from Directory.Packages.props, Stride.Core.Design.csproj, Stride.Core.IO.csproj, and Stride.GameStudio.csproj. This eliminates SharpDX as a dependency from these projects, except for specific subpackages (SharpDX.DirectInput, SharpDX.RawInput, SharpDX.XInput) which remain.

Discussed here https://github.com/stride3d/stride/pull/1715

https://github.com/stride3d/stride/pull/1715#issuecomment-4020067669

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->

