### PR TITLE
Make Asset.Replaces a proper reference + editor UX

### DIFF
--- a/sources/assets/Stride.Core.Assets.Tests/TestAssetReplacement.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestAssetReplacement.cs
@@ -2,9 +2,11 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using Stride.Core;
 using Stride.Core.Assets.Analysis;
+using Stride.Core.Assets.Compiler;
 using Stride.Core.Diagnostics;
 using Stride.Core.IO;
 
@@ -69,6 +71,52 @@ namespace Stride.Core.Assets.Tests
             var replacementItem = game.FindAsset(new UFile("/MyGame/Overrides/Logo"));
             Assert.NotNull(replacementItem);
             Assert.Equal(replacement.Id, replacementItem.Id);
+        }
+
+        [Fact]
+        public void TestReplacementShipsWhenTargetIsRoot()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var target = new AssetItem("Logo", new AssetObjectTest { Name = "Original" });
+            plugin.Assets.Add(target);
+            var replacer = new AssetItem("Overrides/Logo", new AssetObjectTest { Name = "Replacement", Replaces = target.ToReference() });
+            game.Assets.Add(replacer);
+
+            // The target is a build root, so its content is substituted and shipped.
+            game.RootAssets.Add(target.ToReference());
+
+            var logger = new LoggerResult();
+            Assert.True(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out var replacements));
+            AssetReplacementAnalysis.Substitute(replacements);
+
+            var included = new RootPackageAssetEnumerator(game).GetAssets(new AssetCompilerResult()).ToList();
+
+            // The target slot ships with the replacement content...
+            var shipped = Assert.Single(included, i => i.Id == target.Id);
+            Assert.Equal("Replacement", ((AssetObjectTest)shipped.Asset).Name);
+            // ...and the replacer is not compiled a second time (it is no longer force-rooted).
+            Assert.DoesNotContain(included, i => i.Id == replacer.Id);
+        }
+
+        [Fact]
+        public void TestReplacementDoesNotShipWhenTargetUnreachable()
+        {
+            var (_, game, plugin) = CreateSessionWithPlugin();
+            var target = new AssetItem("Logo", new AssetObjectTest { Name = "Original" });
+            plugin.Assets.Add(target);
+            var replacer = new AssetItem("Overrides/Logo", new AssetObjectTest { Name = "Replacement", Replaces = target.ToReference() });
+            game.Assets.Add(replacer);
+
+            // No roots: the target is unreachable, so neither it nor the replacer ships (declaring
+            // a replacement no longer force-roots the replacing asset).
+            var logger = new LoggerResult();
+            Assert.True(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out var replacements));
+            AssetReplacementAnalysis.Substitute(replacements);
+
+            var included = new RootPackageAssetEnumerator(game).GetAssets(new AssetCompilerResult()).ToList();
+
+            Assert.DoesNotContain(included, i => i.Id == target.Id);
+            Assert.DoesNotContain(included, i => i.Id == replacer.Id);
         }
 
         [Fact]

--- a/sources/assets/Stride.Core.Assets.Tests/TestAssetReplacement.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestAssetReplacement.cs
@@ -44,7 +44,7 @@ namespace Stride.Core.Assets.Tests
             var target = new AssetItem("Logo", new AssetObjectTest { Name = "Original" });
             plugin.Assets.Add(target);
             var targetId = target.Id;
-            var replacement = new AssetItem("Overrides/Logo", new AssetObjectTest { Name = "Replacement", Replaces = new UFile("/Plugin/Logo") });
+            var replacement = new AssetItem("Overrides/Logo", new AssetObjectTest { Name = "Replacement", Replaces = target.ToReference() });
             game.Assets.Add(replacement);
 
             var logger = new LoggerResult();
@@ -72,10 +72,34 @@ namespace Stride.Core.Assets.Tests
         }
 
         [Fact]
+        public void TestReplacesIsNotABuildDependency()
+        {
+            var (session, game, plugin) = CreateSessionWithPlugin();
+            var archetypeTarget = new AssetItem("Base", new AssetObjectTest());
+            plugin.Assets.Add(archetypeTarget);
+            var replaceTarget = new AssetItem("Logo", new AssetObjectTest());
+            plugin.Assets.Add(replaceTarget);
+
+            // The replacer derives from one asset (archetype) and replaces another.
+            var derived = archetypeTarget.CreateDerivedAsset();
+            derived.Replaces = replaceTarget.ToReference();
+            var replacer = new AssetItem("Overrides/Logo", derived);
+            game.Assets.Add(replacer);
+
+            var deps = session.DependencyManager.ComputeDependencies(replacer.Id, AssetDependencySearchOptions.Out);
+            Assert.NotNull(deps);
+            // Archetype is a real dependency link (control: proves the graph is populated)...
+            Assert.Contains(deps.LinksOut, l => l.Item.Id == archetypeTarget.Id);
+            // ...but Replaces must NOT be a dependency (it is substituted at build time, not consumed).
+            Assert.DoesNotContain(deps.LinksOut, l => l.Item.Id == replaceTarget.Id);
+        }
+
+        [Fact]
         public void TestReplacementMissingTargetFails()
         {
             var (_, game, _) = CreateSessionWithPlugin();
-            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/DoesNotExist") }));
+            // Neither the id nor the location resolves to an existing asset.
+            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new AssetReference(AssetId.New(), "/Plugin/DoesNotExist") }));
 
             var logger = new LoggerResult();
             Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
@@ -86,8 +110,9 @@ namespace Stride.Core.Assets.Tests
         public void TestReplacementTypeMismatchFails()
         {
             var (_, game, plugin) = CreateSessionWithPlugin();
-            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
-            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTestSub { Replaces = new UFile("/Plugin/Logo") }));
+            var target = new AssetItem("Logo", new AssetObjectTest());
+            plugin.Assets.Add(target);
+            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTestSub { Replaces = target.ToReference() }));
 
             var logger = new LoggerResult();
             Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
@@ -98,7 +123,9 @@ namespace Stride.Core.Assets.Tests
         public void TestReplacementOfSelfFails()
         {
             var (_, game, _) = CreateSessionWithPlugin();
-            game.Assets.Add(new AssetItem("Logo", new AssetObjectTest { Replaces = new UFile("/MyGame/Logo") }));
+            var self = new AssetItem("Logo", new AssetObjectTest());
+            game.Assets.Add(self);
+            self.Asset.Replaces = self.ToReference();
 
             var logger = new LoggerResult();
             Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
@@ -109,8 +136,9 @@ namespace Stride.Core.Assets.Tests
         public void TestReplacementOfSourceCodeAssetFails()
         {
             var (_, game, plugin) = CreateSessionWithPlugin();
-            plugin.Assets.Add(new AssetItem("Effect", new SourceCodeAssetTest()));
-            game.Assets.Add(new AssetItem("Overrides/Effect", new SourceCodeAssetTest { Replaces = new UFile("/Plugin/Effect") }));
+            var target = new AssetItem("Effect", new SourceCodeAssetTest());
+            plugin.Assets.Add(target);
+            game.Assets.Add(new AssetItem("Overrides/Effect", new SourceCodeAssetTest { Replaces = target.ToReference() }));
 
             var logger = new LoggerResult();
             Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
@@ -126,7 +154,7 @@ namespace Stride.Core.Assets.Tests
 
             // The editor's "Create replacing asset" derives from the target (archetype -> target)
             var derived = target.CreateDerivedAsset();
-            derived.Replaces = new UFile("/Plugin/Logo");
+            derived.Replaces = target.ToReference();
             var replacement = new AssetItem("Overrides/Logo", derived);
             game.Assets.Add(replacement);
 
@@ -149,9 +177,12 @@ namespace Stride.Core.Assets.Tests
         {
             var (_, game, plugin) = CreateSessionWithPlugin();
             var plugin2 = AddPlugin(game, "Plugin2");
-            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
-            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
-            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin2/Fixups/Logo") }));
+            var pluginLogo = new AssetItem("Logo", new AssetObjectTest());
+            plugin.Assets.Add(pluginLogo);
+            var plugin2Logo = new AssetItem("Fixups/Logo", new AssetObjectTest());
+            plugin2.Assets.Add(plugin2Logo);
+            plugin2Logo.Asset.Replaces = pluginLogo.ToReference();
+            game.Assets.Add(new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = plugin2Logo.ToReference() }));
 
             var logger = new LoggerResult();
             Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));
@@ -163,10 +194,11 @@ namespace Stride.Core.Assets.Tests
         {
             var (_, game, plugin) = CreateSessionWithPlugin();
             var plugin2 = AddPlugin(game, "Plugin2");
-            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
-            var gameReplacement = new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") });
+            var pluginLogo = new AssetItem("Logo", new AssetObjectTest());
+            plugin.Assets.Add(pluginLogo);
+            var gameReplacement = new AssetItem("Overrides/Logo", new AssetObjectTest { Replaces = pluginLogo.ToReference() });
             game.Assets.Add(gameReplacement);
-            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
+            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = pluginLogo.ToReference() }));
 
             var logger = new LoggerResult();
             Assert.True(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out var replacements));
@@ -180,9 +212,10 @@ namespace Stride.Core.Assets.Tests
             var (_, game, plugin) = CreateSessionWithPlugin();
             var plugin2 = AddPlugin(game, "Plugin2");
             var plugin3 = AddPlugin(game, "Plugin3");
-            plugin.Assets.Add(new AssetItem("Logo", new AssetObjectTest()));
-            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
-            plugin3.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = new UFile("/Plugin/Logo") }));
+            var pluginLogo = new AssetItem("Logo", new AssetObjectTest());
+            plugin.Assets.Add(pluginLogo);
+            plugin2.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = pluginLogo.ToReference() }));
+            plugin3.Assets.Add(new AssetItem("Fixups/Logo", new AssetObjectTest { Replaces = pluginLogo.ToReference() }));
 
             var logger = new LoggerResult();
             Assert.False(AssetReplacementAnalysis.TryCollect(game, new HashSet<Package> { game }, logger, out _));

--- a/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
+++ b/sources/assets/Stride.Core.Assets.Tests/TestPackage.cs
@@ -196,6 +196,39 @@ namespace Stride.Core.Assets.Tests
         }
 
         [Fact]
+        public void TestNamespacedSaveWithReplacesDoesNotCrash()
+        {
+            var dirPath = Path.Combine(DirectoryTestBase, "TestNamespacedSaveWithReplacesDoesNotCrash");
+            if (Directory.Exists(dirPath))
+                Directory.Delete(dirPath, true);
+            Directory.CreateDirectory(dirPath);
+
+            var package = new Package { FullPath = Path.Combine(dirPath, "MyGame.sdpkg") };
+            package.AssetFolders.Add(new AssetFolder("Assets"));
+            var project = new SolutionProject(package, Guid.NewGuid(), Path.Combine(dirPath, "MyGame.csproj")) { AssetNamespace = "MyGame" };
+            var session = new PackageSession();
+            session.Projects.Add(project);
+
+            var target = new AssetItem("Target", new AssetObjectTest());
+            package.Assets.Add(target);
+            // A "replacing" asset references the asset it replaces (Asset.Replaces).
+            var replacement = new AssetObjectTest { Replaces = target.ToReference() };
+            var replacementItem = new AssetItem("Replacement", replacement);
+            package.Assets.Add(replacementItem);
+            replacementItem.IsDirty = true;
+
+            // Replaces is an asset reference, not a disk path: saving must not treat it as a UPath to
+            // relativize (which threw on the drive-consistency check when it was a UFile).
+            var result = new LoggerResult();
+            session.Save(result);
+            Assert.False(result.HasErrors, string.Join("\n", result.Messages));
+
+            // Same-package reference saves bare and re-qualifies on load, still resolving to the target.
+            var loaded = (AssetObjectTest)AssetFileSerializer.Load<Asset>(Path.Combine(dirPath, "Assets", "Replacement.sdtest"), result, "MyGame").Asset;
+            Assert.Equal("/MyGame/Target", loaded.Replaces?.Location);
+        }
+
+        [Fact]
         public void TestSaveKeepsAuthoredPackageName()
         {
             var dirPath = Path.Combine(DirectoryTestBase, "TestSaveKeepsAuthoredPackageName");

--- a/sources/assets/Stride.Core.Assets/Analysis/AssetDependencyManager.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/AssetDependencyManager.cs
@@ -730,6 +730,12 @@ public sealed class AssetDependencyManager : IAssetDependencyManager, IDisposabl
                 return;
             }
 
+            // Replaces is substituted at build time (AssetReplacementAnalysis): the target is superseded,
+            // not consumed, so it must never become a build dependency. Keep it out of the graph entirely
+            // (reference fixup still runs via AssetReferenceAnalysis).
+            if (typeof(Asset).IsAssignableFrom(member.DeclaringType) && member.Name == nameof(Asset.Replaces) && value is not null)
+                return;
+
             base.VisitObjectMember(container, containerDescriptor, member, value);
         }
     }

--- a/sources/assets/Stride.Core.Assets/Analysis/AssetDependencyManager.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/AssetDependencyManager.cs
@@ -730,11 +730,13 @@ public sealed class AssetDependencyManager : IAssetDependencyManager, IDisposabl
                 return;
             }
 
-            // Replaces is substituted at build time (AssetReplacementAnalysis): the target is superseded,
-            // not consumed, so it must never become a build dependency. Keep it out of the graph entirely
-            // (reference fixup still runs via AssetReferenceAnalysis).
+            // Replaces is substituted at build time, not consumed. Record it as a Replace link so the
+            // editor can see it, but keep it out of the default Reference queries so it is never a build dependency.
             if (typeof(Asset).IsAssignableFrom(member.DeclaringType) && member.Name == nameof(Asset.Replaces) && value is not null)
+            {
+                dependencies!.AddBrokenLinkOut((AssetReference)value, ContentLinkType.Replace);
                 return;
+            }
 
             base.VisitObjectMember(container, containerDescriptor, member, value);
         }

--- a/sources/assets/Stride.Core.Assets/Analysis/AssetReplacementAnalysis.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/AssetReplacementAnalysis.cs
@@ -34,6 +34,7 @@ public static class AssetReplacementAnalysis
                 if (assetItem.Asset.Replaces is not { } target)
                     continue;
 
+                // Resolve by id (rename-safe) with the location as fallback (see PackageExtensions.FindAsset).
                 var targetItem = rootPackage.FindAsset(target);
                 if (ValidateDeclaration(assetItem, targetItem) is { } error)
                 {
@@ -81,11 +82,11 @@ public static class AssetReplacementAnalysis
     public static string? ValidateDeclaration(AssetItem replacer, AssetItem? target)
     {
         if (target is null)
-            return $"Asset [{replacer.Location}] replaces [{replacer.Asset.Replaces}], which does not exist in the package or its dependencies.";
+            return $"Asset [{replacer.Location}] replaces [{replacer.Asset.Replaces?.Location}], which does not exist in the package or its dependencies.";
         if (target.Id == replacer.Id)
             return $"Asset [{replacer.Location}] cannot replace itself.";
         if (target.Asset.Replaces is not null)
-            return $"Asset [{replacer.Location}] cannot replace [{target.Location}], which itself replaces [{target.Asset.Replaces}]; chained replacements are not supported.";
+            return $"Asset [{replacer.Location}] cannot replace [{target.Location}], which itself replaces [{target.Asset.Replaces.Location}]; chained replacements are not supported.";
         if (!target.Asset.GetType().IsAssignableFrom(replacer.Asset.GetType()))
             return $"Asset [{replacer.Location}] of type [{replacer.Asset.GetType().Name}] cannot replace [{target.Location}] of type [{target.Asset.GetType().Name}].";
         if (target.Asset is SourceCodeAsset)
@@ -113,7 +114,7 @@ public static class AssetReplacementAnalysis
                 if (item.Asset.Replaces is { } target)
                 {
                     replacements ??= new Dictionary<string, AssetItem>(StringComparer.OrdinalIgnoreCase);
-                    replacements.TryAdd(target.FullPath, item);
+                    replacements.TryAdd(target.Location, item);
                 }
             }
         }

--- a/sources/assets/Stride.Core.Assets/Analysis/ContentLinkType.cs
+++ b/sources/assets/Stride.Core.Assets/Analysis/ContentLinkType.cs
@@ -16,7 +16,13 @@ public enum ContentLinkType
     Reference = 1,
 
     /// <summary>
+    /// The source asset replaces the target (<see cref="Asset.Replaces"/>). A design-time link only:
+    /// it is excluded from the default <see cref="Reference"/> queries, so it is never a build dependency.
+    /// </summary>
+    Replace = 2,
+
+    /// <summary>
     /// All type of links.
     /// </summary>
-    All = Reference,
+    All = Reference | Replace,
 }

--- a/sources/assets/Stride.Core.Assets/Asset.cs
+++ b/sources/assets/Stride.Core.Assets/Asset.cs
@@ -90,15 +90,15 @@ public abstract class Asset
     public TagCollection Tags { get; private set; }
 
     /// <summary>
-    /// Gets or sets the URL of an asset this asset replaces: at build time, the replaced asset's
-    /// content is substituted with this asset's, so everything resolving the replaced asset
-    /// (including references inside dependency packages) gets this asset instead.
+    /// Gets or sets a reference to an asset this asset replaces: at build time, the replaced asset's
+    /// content is substituted with this asset's, so anything resolving the replaced asset gets this
+    /// one instead. Resolved by id, so it survives the target being renamed or moved.
     /// </summary>
     [DataMember(-600)]
     [Display(Browsable = false)]
     [NonOverridable]
     [DefaultValue(null)]
-    public UFile? Replaces { get; set; }
+    public AssetReference? Replaces { get; set; }
 
     [DataMember(-500)]
     [Display(Browsable = false)]

--- a/sources/assets/Stride.Core.Assets/Compiler/RootPackageAssetEnumerator.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/RootPackageAssetEnumerator.cs
@@ -78,11 +78,10 @@ public class RootPackageAssetEnumerator : IPackageCompilerSource
             CollectReferences(dependency, assetsReferenced, packagesProcessed);
         }
 
-        // 3. Some types are marked with AlwaysMarkAsRoot; assets replacing another asset are
-        //    typically referenced by nothing, so they must be roots to get compiled
+        // 3. Some types are marked with AlwaysMarkAsRoot
         foreach (var assetItem in package.Assets)
         {
-            if (AssetRegistry.IsAssetTypeAlwaysMarkAsRoot(assetItem.Asset.GetType()) || assetItem.Asset.Replaces is not null)
+            if (AssetRegistry.IsAssetTypeAlwaysMarkAsRoot(assetItem.Asset.GetType()))
             {
                 assetsReferenced.Add(assetItem);
             }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AssetReplacesNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AssetReplacesNodeUpdater.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Stride.Core.Assets.Analysis;
 using Stride.Core.Assets.Editor.Services;
 using Stride.Core.Assets.Editor.ViewModel;
 
@@ -8,16 +9,21 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
     public sealed class AssetReplacesNodeUpdater : AssetNodePresenterUpdaterBase
     {
         public const string ReplacesNodeName = "ReplacesVirtual";
+        public const string ReplacedByNodeName = "ReplacedByVirtual";
 
         protected override void UpdateNode(IAssetNodePresenter node)
         {
             if (!(node.PropertyProvider is AssetViewModel) || node.Asset == null)
                 return;
 
-            // Add a link to the replaced asset in the root node, if this asset replaces one.
-            if (typeof(Asset).IsAssignableFrom(node.Type) && node.Asset.Asset.Replaces is { } replaces)
+            if (!typeof(Asset).IsAssignableFrom(node.Type))
+                return;
+
+            var session = node.Asset.Session;
+
+            // Forward: if this asset replaces another, add a link to the replaced asset.
+            if (node.Asset.Asset.Replaces is { } replaces)
             {
-                var session = node.Asset.Session;
                 var target = session.GetAssetById(replaces.Id);
                 // An unresolved target renders as a broken reference, which is the diagnostic we want
                 var assetReference = target != null ? ContentReferenceHelper.CreateReference<AssetReference>(target) : replaces;
@@ -25,6 +31,32 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
                 replacesNode.DisplayName = nameof(Asset.Replaces);
                 replacesNode.IsReadOnly = true;
             }
+
+            // Reverse: if another asset replaces this one, add a link to that replacing asset.
+            if (FindReplacer(session, node.Asset.Id) is { } replacer)
+            {
+                var replacerReference = ContentReferenceHelper.CreateReference<AssetReference>(replacer);
+                var replacedByNode = node.Factory.CreateVirtualNodePresenter(node, ReplacedByNodeName, typeof(AssetReference), int.MinValue + 2, () => replacerReference);
+                replacedByNode.DisplayName = "Replaced by";
+                replacedByNode.IsReadOnly = true;
+            }
+        }
+
+        /// <summary>
+        /// Finds the asset that replaces <paramref name="targetId"/> via the incoming Replace links.
+        /// At most one replacement per asset is valid.
+        /// </summary>
+        private static AssetViewModel FindReplacer(SessionViewModel session, AssetId targetId)
+        {
+            var dependencies = session.DependencyManager.ComputeDependencies(targetId, AssetDependencySearchOptions.In, ContentLinkType.Replace);
+            if (dependencies == null)
+                return null;
+            foreach (var link in dependencies.LinksIn)
+            {
+                if (session.GetAssetById(link.Item.Id) is { } replacer)
+                    return replacer;
+            }
+            return null;
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AssetReplacesNodeUpdater.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Quantum/NodePresenters/Updaters/AssetReplacesNodeUpdater.cs
@@ -18,9 +18,9 @@ namespace Stride.Core.Assets.Editor.Quantum.NodePresenters.Updaters
             if (typeof(Asset).IsAssignableFrom(node.Type) && node.Asset.Asset.Replaces is { } replaces)
             {
                 var session = node.Asset.Session;
-                var target = session.GetAssetByUrl(replaces.FullPath);
+                var target = session.GetAssetById(replaces.Id);
                 // An unresolved target renders as a broken reference, which is the diagnostic we want
-                var assetReference = target != null ? ContentReferenceHelper.CreateReference<AssetReference>(target) : new AssetReference(AssetId.Empty, replaces);
+                var assetReference = target != null ? ContentReferenceHelper.CreateReference<AssetReference>(target) : replaces;
                 var replacesNode = node.Factory.CreateVirtualNodePresenter(node, ReplacesNodeName, typeof(AssetReference), int.MinValue + 1, () => assetReference);
                 replacesNode.DisplayName = nameof(Asset.Replaces);
                 replacesNode.IsReadOnly = true;

--- a/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
@@ -57,6 +57,10 @@
                           HorizontalAlignment="Right" VerticalAlignment="Bottom" Visibility="{Binding IsReplacing, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}">
                       <Image Source="{StaticResource ImageAssetOverride}" Width="12" Height="12" Margin="5" ToolTip="{Binding ReplacesUrl, StringFormat={sd:Localize Replaces {0}}}"/>
                     </Border>
+                    <Border BorderBrush="{StaticResource NormalBorderBrush}" BorderThickness="2" CornerRadius="3" Background="{StaticResource NormalBrush}"
+                          HorizontalAlignment="Left" VerticalAlignment="Bottom" Visibility="{Binding IsReplaced, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}">
+                      <Image Source="{StaticResource ImageAssetOverride}" Width="12" Height="12" Margin="5" ToolTip="{Binding ReplacedByUrl, StringFormat={sd:Localize Replaced by {0}}}"/>
+                    </Border>
                     <Button HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,3" Command="{Binding Dependencies.ToggleIsRootOnSelectedAssetCommand, FallbackValue={x:Null}}">
                       <Button.Style>
                         <Style TargetType="Button">
@@ -104,6 +108,10 @@
                           <StackPanel Orientation="Horizontal" Visibility="{Binding IsReplacing, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetOverride}" Width="16" Height="16" Margin="0,2,0,0"/>
                             <TextBlock Text="{Binding ReplacesUrl, StringFormat={sd:Localize Replaces {0}}}"/>
+                          </StackPanel>
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding IsReplaced, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
+                            <Image Source="{StaticResource ImageAssetOverride}" Width="16" Height="16" Margin="0,2,0,0"/>
+                            <TextBlock Text="{Binding ReplacedByUrl, StringFormat={sd:Localize Replaced by {0}}}"/>
                           </StackPanel>
                           <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsRoot, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Margin="0,2,0,0"/>

--- a/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/AssetViewUserControl.xaml
@@ -74,8 +74,9 @@
                         </Style>
                       </Button.Style>
                       <Grid Background="Transparent">
-                        <Image Source="{StaticResource ImageAssetIsRoot}" Width="12" Height="12" Margin ="5" Visibility="{Binding Dependencies.IsRoot, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}"/>
-                        <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="12" Height="12" Margin ="5" Visibility="{Binding Dependencies.IsIndirectlyIncluded, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}"/>
+                        <Image Source="{StaticResource ImageAssetIsRoot}" Width="12" Height="12" Margin ="5" Visibility="{Binding Dependencies.IsBuiltAsRoot, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}"/>
+                        <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="12" Height="12" Margin ="5" Visibility="{Binding Dependencies.IsBuiltAsDependency, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}"/>
+                        <Image Source="{StaticResource ImageAssetIsOverridden}" Width="12" Height="12" Margin ="5" Visibility="{Binding Dependencies.IsOverridden, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}"/>
                         <Image Source="{StaticResource ImageAssetIsExcluded}" Width="12" Height="12" Margin ="5" Visibility="{Binding Dependencies.IsExcluded, Converter={sd:VisibleOrHidden}, FallbackValue={sd:Hidden}}"/>
                       </Grid>
                     </Button>
@@ -113,13 +114,17 @@
                             <Image Source="{StaticResource ImageAssetOverride}" Width="16" Height="16" Margin="0,2,0,0"/>
                             <TextBlock Text="{Binding ReplacedByUrl, StringFormat={sd:Localize Replaced by {0}}}"/>
                           </StackPanel>
-                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsRoot, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsBuiltAsRoot, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsRoot}" Width="16" Height="16" Margin="0,2,0,0"/>
                             <TextBlock Text="{sd:Localize Included in build as root}"/>
                           </StackPanel>
-                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsIndirectlyIncluded, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsBuiltAsDependency, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsIndirectlyIncluded}" Width="16" Height="16" Margin="0,2,0,0"/>
                             <TextBlock Text="{sd:Localize Included in build as dependency}"/>
+                          </StackPanel>
+                          <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsOverridden, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
+                            <Image Source="{StaticResource ImageAssetIsOverridden}" Width="16" Height="16" Margin="0,2,0,0"/>
+                            <TextBlock Text="{sd:Localize Overridden in build (content not used)}"/>
                           </StackPanel>
                           <StackPanel Orientation="Horizontal" Visibility="{Binding Dependencies.IsExcluded, Converter={sd:VisibleOrCollapsed}, FallbackValue={sd:Collapsed}}">
                             <Image Source="{StaticResource ImageAssetIsExcluded}" Width="16" Height="16" Margin="0,2,0,0"/>

--- a/sources/editor/Stride.Core.Assets.Editor/View/ImageDictionary.xaml
+++ b/sources/editor/Stride.Core.Assets.Editor/View/ImageDictionary.xaml
@@ -1027,6 +1027,19 @@
       </DrawingGroup>
     </DrawingImage.Drawing>
   </DrawingImage>
+  <DrawingImage x:Key="ImageAssetIsOverridden">
+    <DrawingImage.Drawing>
+      <DrawingGroup>
+        <DrawingGroup.Children>
+          <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+          <GeometryDrawing Brush="#FFF6F6F6"
+                           Geometry="F1M8,15C4.14,15 1,11.859 1,8 1,4.14 4.14,1 8,1 11.861,1 15,4.14 15,8 15,11.859 11.861,15 8,15" />
+          <GeometryDrawing Brush="#F0A30A"
+                           Geometry="F1M14,8C14,11.314 11.314,14 8,14 4.687,14 2,11.314 2,8 2,4.687 4.687,2 8,2 11.314,2 14,4.687 14,8" />
+        </DrawingGroup.Children>
+      </DrawingGroup>
+    </DrawingImage.Drawing>
+  </DrawingImage>
   <DrawingImage x:Key="ImageAssetOverride">
     <DrawingImage.Drawing>
       <DrawingGroup>

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetDependenciesViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetDependenciesViewModel.cs
@@ -84,7 +84,23 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// <summary>
         /// Gets whether this asset will be compiled as a dependency of an asset that has <see cref="IsRoot"/> set to <c>true</c>.
         /// </summary>
-        public bool IsIndirectlyIncluded => !IsRoot && !Asset.IsDeleted && RecursiveReferencerAssets.Any(x => x.Dependencies.IsRoot);
+        public bool IsIndirectlyIncluded => !IsRoot && !Asset.IsDeleted && (RecursiveReferencerAssets.Any(x => x.Dependencies.IsRoot) || ReplacesIncludedTarget);
+
+        /// <summary>
+        /// Gets whether this asset replaces (<see cref="Asset.Replaces"/>) an asset that is itself included.
+        /// A replacing asset ships its content through the asset it replaces, so it follows that target's
+        /// inclusion (it is never a root on its own).
+        /// </summary>
+        private bool ReplacesIncludedTarget
+        {
+            get
+            {
+                if (Asset.Asset.Replaces is not { } replaces)
+                    return false;
+                var target = Session.GetAssetById(replaces.Id);
+                return target != null && (target.Dependencies.IsRoot || target.Dependencies.IsIndirectlyIncluded);
+            }
+        }
 
         /// <summary>
         /// Gets whether this asset will be excluded from compilation.
@@ -136,6 +152,27 @@ namespace Stride.Core.Assets.Editor.ViewModel
                     referencedAsset.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
                     referencedAsset.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
                 }
+            }
+            // A replacing asset's dot follows this asset's inclusion, so refresh it too.
+            NotifyReplacerInclusionChange();
+        }
+
+        /// <summary>
+        /// Refreshes the inclusion dot of the asset that replaces this one, if any: its state mirrors
+        /// this asset's inclusion (see <see cref="ReplacesIncludedTarget"/>).
+        /// </summary>
+        private void NotifyReplacerInclusionChange()
+        {
+            var dependencies = Session.DependencyManager.ComputeDependencies(Asset.Id, AssetDependencySearchOptions.In, ContentLinkType.Replace);
+            if (dependencies == null)
+                return;
+            foreach (var link in dependencies.LinksIn)
+            {
+                var replacer = Session.GetAssetById(link.Item.Id);
+                if (replacer == null)
+                    continue;
+                replacer.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                replacer.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
             }
         }
 
@@ -213,6 +250,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 asset.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
                 asset.Dependencies.UpdateRecursiveReferencerAssets();
                 asset.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                // A replacing asset's dot follows its target's inclusion, so refresh it when the target changes.
+                asset.Dependencies.NotifyReplacerInclusionChange();
             }
             foreach (var asset in dirtyReferencers)
             {

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetDependenciesViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetDependenciesViewModel.cs
@@ -108,9 +108,46 @@ namespace Stride.Core.Assets.Editor.ViewModel
         public bool IsExcluded => !IsRoot && !IsIndirectlyIncluded;
 
         /// <summary>
+        /// Gets whether this asset is replaced by another one while still being reachable: its slot ships,
+        /// but with the replacement's content, so its own content is not used. Shown as "overridden".
+        /// </summary>
+        public bool IsOverridden => !Asset.IsDeleted && Asset.IsReplaced && (IsRoot || IsIndirectlyIncluded);
+
+        /// <summary>
+        /// Gets whether the inclusion dot should show this asset as a build root (root and not overridden).
+        /// </summary>
+        public bool IsBuiltAsRoot => IsRoot && !IsOverridden;
+
+        /// <summary>
+        /// Gets whether the inclusion dot should show this asset as included as a dependency (and not overridden).
+        /// </summary>
+        public bool IsBuiltAsDependency => IsIndirectlyIncluded && !IsOverridden;
+
+        /// <summary>
         /// Gets whether this asset is forced to be a root asset.
         /// </summary>
         public bool ForcedRoot { get; }
+
+        // The inclusion dot and its tooltip derive from these together, so they are always notified as a set.
+        private static readonly string[] InclusionPropertyNames =
+        {
+            nameof(IsRoot), nameof(IsIndirectlyIncluded), nameof(IsExcluded),
+            nameof(IsOverridden), nameof(IsBuiltAsRoot), nameof(IsBuiltAsDependency),
+        };
+
+        private void NotifyInclusionChanging() => OnPropertyChanging(InclusionPropertyNames);
+
+        private void NotifyInclusionChanged() => OnPropertyChanged(InclusionPropertyNames);
+
+        /// <summary>
+        /// Refreshes the inclusion dot after the asset's replaced state (<see cref="AssetViewModel.IsReplaced"/>)
+        /// changed, which flips <see cref="IsOverridden"/>.
+        /// </summary>
+        internal void NotifyReplacedStateChanged()
+        {
+            NotifyInclusionChanging();
+            NotifyInclusionChanged();
+        }
 
         /// <summary>
         /// Gets a command that will toggle the <see cref="IsRoot"/> property.
@@ -143,14 +180,14 @@ namespace Stride.Core.Assets.Editor.ViewModel
 
         internal void NotifyRootAssetChange(bool notifyReferencedAssets)
         {
-            OnPropertyChanging(nameof(IsRoot), nameof(IsIndirectlyIncluded), nameof(IsExcluded));
-            OnPropertyChanged(nameof(IsRoot), nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+            NotifyInclusionChanging();
+            NotifyInclusionChanged();
             if (notifyReferencedAssets)
             {
                 foreach (var referencedAsset in RecursiveReferencedAssets)
                 {
-                    referencedAsset.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
-                    referencedAsset.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                    referencedAsset.Dependencies.NotifyInclusionChanging();
+                    referencedAsset.Dependencies.NotifyInclusionChanged();
                 }
             }
             // A replacing asset's dot follows this asset's inclusion, so refresh it too.
@@ -171,8 +208,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 var replacer = Session.GetAssetById(link.Item.Id);
                 if (replacer == null)
                     continue;
-                replacer.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
-                replacer.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                replacer.Dependencies.NotifyInclusionChanging();
+                replacer.Dependencies.NotifyInclusionChanged();
             }
         }
 
@@ -247,9 +284,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
             // Update recursive lists of referenced/referenced assets for assets affected by the changes
             foreach (var asset in dirtyReferenced)
             {
-                asset.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                asset.Dependencies.NotifyInclusionChanging();
                 asset.Dependencies.UpdateRecursiveReferencerAssets();
-                asset.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                asset.Dependencies.NotifyInclusionChanged();
                 // A replacing asset's dot follows its target's inclusion, so refresh it when the target changes.
                 asset.Dependencies.NotifyReplacerInclusionChange();
             }
@@ -259,8 +296,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
             }
             foreach (var asset in dirtyAssets)
             {
-                asset.Dependencies.OnPropertyChanging(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
-                asset.Dependencies.OnPropertyChanged(nameof(IsIndirectlyIncluded), nameof(IsExcluded));
+                asset.Dependencies.NotifyInclusionChanging();
+                asset.Dependencies.NotifyInclusionChanged();
             }
 
             // Job is completed, notify anything awaiting on it

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
@@ -271,6 +271,8 @@ namespace Stride.Core.Assets.Editor.ViewModel
                 return;
             replacedBy = replacer;
             OnPropertyChanged(nameof(IsReplaced), nameof(ReplacedByUrl));
+            // IsReplaced flips IsOverridden, so refresh the inclusion dot.
+            Dependencies.NotifyReplacedStateChanged();
         }
 
         public IReadOnlyObservableCollection<MenuCommandInfo> AssetCommands => assetCommands;

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
@@ -83,6 +83,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         private ThumbnailData thumbnailData;
         private AssetItem assetItem;
         private IAssetEditorViewModel editor;
+        private AssetViewModel replacedBy;
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetViewModel"/> class.
         /// </summary>
@@ -249,6 +250,28 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// The URL this asset replaces, or <c>null</c>.
         /// </summary>
         public string ReplacesUrl => Asset.Replaces?.Location;
+
+        /// <summary>
+        /// Gets whether another asset replaces this one in the built game.
+        /// </summary>
+        public bool IsReplaced => replacedBy != null;
+
+        /// <summary>
+        /// The URL of the asset that replaces this one, or <c>null</c>.
+        /// </summary>
+        public string ReplacedByUrl => replacedBy?.Url;
+
+        /// <summary>
+        /// Sets the asset that replaces this one (the reverse of <see cref="IsReplacing"/>), driven by
+        /// <see cref="SessionViewModel.CheckAssetReplacements"/> when the session's declarations change.
+        /// </summary>
+        internal void UpdateReplacedBy(AssetViewModel replacer)
+        {
+            if (replacedBy == replacer)
+                return;
+            replacedBy = replacer;
+            OnPropertyChanged(nameof(IsReplaced), nameof(ReplacedByUrl));
+        }
 
         public IReadOnlyObservableCollection<MenuCommandInfo> AssetCommands => assetCommands;
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/AssetViewModel.cs
@@ -248,7 +248,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// <summary>
         /// The URL this asset replaces, or <c>null</c>.
         /// </summary>
-        public string ReplacesUrl => Asset.Replaces?.FullPath;
+        public string ReplacesUrl => Asset.Replaces?.Location;
 
         public IReadOnlyObservableCollection<MenuCommandInfo> AssetCommands => assetCommands;
 
@@ -687,7 +687,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             var childUrl = UFile.Combine(targetDirectory.Path, childName);
             var childAsset = assetItem.CreateDerivedAsset();
             if (replaces)
-                childAsset.Replaces = assetItem.Location;
+                childAsset.Replaces = assetItem.ToReference();
             var childAssetItem = new AssetItem(childUrl, childAsset);
             targetDirectory.Package.CreateAsset(targetDirectory, childAssetItem, true, null);
             if (replaces)

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -1029,15 +1029,33 @@ namespace Stride.Core.Assets.Editor.ViewModel
         /// </summary>
         public void CheckAssetReplacements(AssetViewModel changedAsset = null)
         {
+            var newReplaced = new Dictionary<AssetId, AssetViewModel>();
             foreach (var asset in AllAssets)
             {
-                if (asset.Asset.Replaces != null)
+                if (asset.Asset.Replaces is { } target)
+                {
                     CheckAssetReplacement(asset);
+                    if (GetAssetById(target.Id) is { } targetVm)
+                        newReplaced.TryAdd(targetVm.Id, asset);
+                }
             }
+            // Refresh the reverse "Replaced by" indicator: clear targets that are no longer replaced,
+            // then set the current ones.
+            foreach (var id in replacedTargets.Keys)
+            {
+                if (!newReplaced.ContainsKey(id))
+                    GetAssetById(id)?.UpdateReplacedBy(null);
+            }
+            foreach (var (id, replacer) in newReplaced)
+                GetAssetById(id)?.UpdateReplacedBy(replacer);
+            replacedTargets = newReplaced;
+
             if (changedAsset != null && (changedAsset.IsDeleted || changedAsset.Asset.Replaces == null))
                 AssetLog.ClearMessages(LogKey.Get(changedAsset.Id, AssetReplacementLogName));
             AssetReplacementsChanged?.Invoke(this, EventArgs.Empty);
         }
+
+        private Dictionary<AssetId, AssetViewModel> replacedTargets = new();
 
         private const string AssetReplacementLogName = "AssetReplacement";
 

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -1052,9 +1052,9 @@ namespace Stride.Core.Assets.Editor.ViewModel
             var error = AssetReplacementAnalysis.ValidateDeclaration(asset.AssetItem, targetItem);
             if (error == null)
             {
-                var duplicate = AllAssets.FirstOrDefault(x => x != asset && x.Asset.Replaces is { } other && string.Equals(other.FullPath, target.FullPath, StringComparison.OrdinalIgnoreCase));
+                var duplicate = AllAssets.FirstOrDefault(x => x != asset && x.Asset.Replaces is { } other && string.Equals(other.Location, target.Location, StringComparison.OrdinalIgnoreCase));
                 if (duplicate != null)
-                    error = $"[{duplicate.Url}] also replaces [{target}]; only one replacement per URL is allowed.";
+                    error = $"[{duplicate.Url}] also replaces [{target.Location}]; only one replacement per URL is allowed.";
             }
 
             if (error != null)

--- a/sources/editor/Stride.Editor/EditorGame/ContentLoader/EditorContentLoader.cs
+++ b/sources/editor/Stride.Editor/EditorGame/ContentLoader/EditorContentLoader.cs
@@ -87,8 +87,8 @@ namespace Stride.Editor.EditorGame.ContentLoader
             Session = asset.Session;
             foreach (var sessionAsset in Session.AllAssets)
             {
-                if (sessionAsset.Asset.Replaces is { } replacedUrl)
-                    lastKnownReplaces[sessionAsset.Id] = replacedUrl;
+                if (sessionAsset.Asset.Replaces is { } replaces)
+                    lastKnownReplaces[sessionAsset.Id] = new UFile(replaces.Location);
             }
             Session.AssetPropertiesChanged += AssetPropertiesChanged;
             Game = game ?? throw new ArgumentNullException(nameof(game));
@@ -505,7 +505,7 @@ namespace Stride.Editor.EditorGame.ContentLoader
             foreach (var replacer in e.Assets)
             {
                 UFile previousUrl;
-                var replacedUrl = replacer.Asset.Replaces;
+                var replacedUrl = replacer.Asset.Replaces is { } replaces ? new UFile(replaces.Location) : null;
                 lock (lastKnownReplaces)
                 {
                     lastKnownReplaces.TryGetValue(replacer.Id, out previousUrl);


### PR DESCRIPTION
Turns `Asset.Replaces` from a URL into an `AssetReference` (id + location, like `Archetype`), and surfaces replacements in the editor.

### Core
- `Asset.Replaces` is now an `AssetReference`, resolved by id so it survives the target being renamed or moved. As a reference it skips path relativization, which also fixes the save-time crash.
- Recorded as a design-time `Replace` dependency link: visible to the editor, but excluded from the default `Reference` queries so it is never a build dependency.
- A replacing asset is included in the build only when its target is reachable (dropped the force-root), so the replacer is not compiled a second time.

### Editor
- "Replaced by" link on the replaced asset's property grid (mirror of the forward "Replaces:" node).
- "Replaced by" badge and tooltip on the replaced asset tile.
- Inclusion dots reflect what actually ships: a replacing asset's dot follows its target, and a replaced asset shows an orange "overridden" dot (its slot ships someone else's content).

<img width="1436" height="1516" alt="image" src="https://github.com/user-attachments/assets/c39a6c8a-f5ad-44f6-b071-4461bd358e50" />


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->