### PR TITLE
Improve the documentation for BrightFilter

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilter.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilter.cs
@@ -7,91 +7,132 @@ using Stride.Core;
 using Stride.Core.Mathematics;
 using Stride.Graphics;
 
-namespace Stride.Rendering.Images
+namespace Stride.Rendering.Images;
+
+/// <summary>
+///   An image effect that extracts the brightest parts of an input image to produce a bright-pass result.
+/// </summary>
+/// <remarks>
+///   This effect is typically used as a pre-pass for post-processing effects such as bloom or light streaks.
+///   It computes the relative luminance of each pixel, builds a smooth selection mask from
+///   <see cref="Threshold"/> and <see cref="Steepness"/>, and multiplies the original color by that mask.
+/// </remarks>
+[DataContract("BrightFilter")]
+public class BrightFilter : ImageEffect
 {
+    // TODO: Add Brightpass filters based on average luminance and key value, taking into account the tonemap
+    private readonly ImageEffectShader brightPassFilter;
+
+
     /// <summary>
-    /// A bright pass filter.
+    ///   Initializes a new instance of the <see cref="BrightFilter"/> class.
     /// </summary>
-    [DataContract("BrightFilter")]
-    public class BrightFilter : ImageEffect
+    public BrightFilter()
+        : this("BrightFilterShader")
     {
-        // TODO: Add Brightpass filters based on average luminance and key value, taking into account the tonemap
-        private readonly ImageEffectShader brightPassFilter;
+        Threshold = 0.2f;
+        Steepness = 1.0f;
+        Color = new Color3(1.0f);
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BrightFilter"/> class.
-        /// </summary>
-        public BrightFilter()
-            : this("BrightFilterShader")
-        {
-            Threshold = 0.2f;
-            Steepness = 1.0f;
-            Color = new Color3(1.0f);
-        }
+    /// <summary>
+    ///   Initializes a new instance of the <see cref="BrightFilter"/> class.
+    /// </summary>
+    /// <param name="brightPassShaderName">The name of the bright pass shader.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="brightPassShaderName"/> is <see langword="null"/>.</exception>
+    public BrightFilter(string brightPassShaderName) : base(brightPassShaderName)
+    {
+        ArgumentNullException.ThrowIfNull(brightPassShaderName);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BrightFilter"/> class.
-        /// </summary>
-        /// <param name="brightPassShaderName">Name of the bright pass shader.</param>
-        public BrightFilter(string brightPassShaderName) : base(brightPassShaderName)
-        {
-            if (brightPassShaderName == null) throw new ArgumentNullException("brightPassShaderName");
-            brightPassFilter = new ImageEffectShader(brightPassShaderName);
-        }
+        brightPassFilter = new ImageEffectShader(brightPassShaderName);
+    }
 
-        /// <summary>
-        /// Gets or sets the threshold relative to the <see cref="WhitePoint"/>.
-        /// </summary>
-        /// <value>The threshold.</value>
-        /// <userdoc>The value of the intensity threshold used to identify bright areas</userdoc>
-        [DataMember(10)]
-        [DefaultValue(0.2f)]
-        public float Threshold { get; set; }
 
-        /// <summary>
-        /// Gets or sets the smoothstep steepness for bright pass filtering
-        /// </summary>
-        [DataMember(15)]
-        [DefaultValue(1.0f)]
-        public float Steepness { get; set; }
+    /// <summary>
+    ///   Gets or sets the brightness threshold used to decide when a pixel
+    ///   starts contributing to the bright-pass result.
+    /// </summary>
+    /// <value>
+    ///   The bright-pass threshold.
+    ///   Lower values allow more pixels to pass through the filter.
+    ///   Higher values restrict the result to only the brightest parts of the image.
+    /// </value>
+    /// <remarks>
+    ///   This value is best understood relative to the HDR intensity range of the image and, conceptually,
+    ///   to the scene white point used by the tone-mapping pipeline.
+    ///   <para/>
+    ///   The term <em>white point</em> refers to the scene intensity that is considered reference white
+    ///   in the HDR pipeline, usually after exposure has been taken into account.
+    ///   In this effect, <see cref="Threshold"/> should be understood relative to that expected intensity range.
+    /// </remarks>
+    /// <userdoc>
+    ///   The intensity threshold used to identify bright areas.
+    ///   Lower values keep more pixels; higher values isolate only the brightest ones.
+    /// </userdoc>
+    [DataMember(10)]
+    [DefaultValue(0.2f)]
+    public float Threshold { get; set; }
 
-        /// <summary>
-        /// Modulate the bloom by a certain color.
-        /// </summary>
-        /// <value>The color.</value>
-        /// <userdoc>Modulates bright areas with the provided color. It affects the color of sub-sequent bloom, light-streak effects.</userdoc>
-        [DataMember(20)]
-        public Color3 Color { get; set; }
+    /// <summary>
+    ///   Gets or sets how selectively the filter responds around the threshold.
+    /// </summary>
+    /// <value>
+    ///   This value affects the luminance remapping used before the smooth threshold is applied.
+    ///   Higher values make the filter more selective and reduce the contribution of mid-bright pixels.
+    ///   Lower values make the transition start earlier and allow more near-threshold pixels to contribute.
+    /// </value>
+    /// <userdoc>
+    ///   The steepness of the threshold curve.
+    ///   Higher values isolate only the brightest pixels;
+    ///   lower values allow more near-threshold pixels to contribute.
+    /// </userdoc>
+    [DataMember(15)]
+    [DefaultValue(1.0f)]
+    public float Steepness { get; set; }
 
-        protected override void InitializeCore()
-        {
-            base.InitializeCore();
-            ToLoadAndUnload(brightPassFilter);
-        }
+    /// <summary>
+    ///   Gets or sets the color used to modulate the extracted bright areas.
+    /// </summary>
+    /// <value>The modulation color applied to the filtered result.</value>
+    /// <remarks>
+    ///   This is commonly used to tint the contribution that will later feed bloom, glare, or streak effects.
+    /// </remarks>
+    /// <userdoc>
+    ///   Modulates the extracted bright areas with the provided color.
+    ///   This affects the color of subsequent bloom or light-streak effects.
+    /// </userdoc>
+    [DataMember(20)]
+    public Color3 Color { get; set; }
 
-        protected override void SetDefaultParameters()
-        {
-            Color = new Color3(1.0f);
 
-            base.SetDefaultParameters();
-        }
+    protected override void InitializeCore()
+    {
+        base.InitializeCore();
 
-        protected override void DrawCore(RenderDrawContext context)
-        {
-            var input = GetInput(0);
-            var output = GetOutput(0);
-            if (input == null || output == null)
-            {
-                return;
-            }
+        ToLoadAndUnload(brightPassFilter);
+    }
+
+    protected override void SetDefaultParameters()
+    {
+        Color = new Color3(1.0f);
+
+        base.SetDefaultParameters();
+    }
+
+    protected override void DrawCore(RenderDrawContext context)
+    {
+        var input = GetInput(0);
+        var output = GetOutput(0);
+
+        if (input is null || output is null)
+            return;
+    
+        brightPassFilter.Parameters.Set(BrightFilterShaderKeys.ThresholdOffset, Threshold);
+        brightPassFilter.Parameters.Set(BrightFilterShaderKeys.BrightPassSteepness, Steepness);
+        brightPassFilter.Parameters.Set(BrightFilterShaderKeys.ColorModulator, Color.ToColorSpace(GraphicsDevice.ColorSpace));
         
-            brightPassFilter.Parameters.Set(BrightFilterShaderKeys.ThresholdOffset, Threshold);
-            brightPassFilter.Parameters.Set(BrightFilterShaderKeys.BrightPassSteepness, Steepness);
-            brightPassFilter.Parameters.Set(BrightFilterShaderKeys.ColorModulator, Color.ToColorSpace(GraphicsDevice.ColorSpace));
-            
-            brightPassFilter.SetInput(input);
-            brightPassFilter.SetOutput(output);
-            ((RendererBase)brightPassFilter).Draw(context);
-        }
+        brightPassFilter.SetInput(input);
+        brightPassFilter.SetOutput(output);
+        brightPassFilter.Draw(context);
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilterShader.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Images/BrightFilter/BrightFilterShader.sdsl
@@ -4,7 +4,11 @@
 namespace Stride.Rendering.Images
 {
     /// <summary>
-    /// A bright filter shader
+    ///   A bright filter shader:
+    ///   Builds a soft bright-pass mask from pixel luminance, then keeps only the bright contribution.
+    ///
+    ///   `ThresholdOffset` shifts the point where pixels start contributing.
+    ///   `BrightPassSteepness` makes the filter more selective by requiring stronger luminance to reach full contribution.
     /// </summary>
     internal shader BrightFilterShader : ImageEffectShader
     {


### PR DESCRIPTION
# PR Details

As discussed in PR #3291 this is a rewrite of the XML comments in the `BrightFilter` image effect to better explain what it does and what the parameters are for. It also adds a little explanation to the shader.

I took the opportunity to modernize the file with newer C# syntax (it is a small and simple file).

## Related Issue

PR #3291

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
