### PR TITLE
Fix minimized window raw client size handling

### DIFF
--- a/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
@@ -1,0 +1,270 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+using Stride.Core;
+using Stride.Core.Mathematics;
+using Stride.Games;
+using Stride.Graphics;
+using Stride.Graphics.Regression;
+
+namespace Stride.Engine.Tests;
+
+/// <summary>
+/// Tests the <see cref="GameWindow"/> base logic around <see cref="GameWindow.RawClientSize"/>,
+/// which resize decisions rely on to reject minimized/zero-sized windows (see issue #3288).
+/// </summary>
+public class GameWindowRawClientSizeTest
+{
+    private class TestGameWindow : GameWindow
+    {
+        public Rectangle Bounds = new Rectangle(0, 0, 640, 480);
+        public Int2? RawSize;
+
+        public override bool AllowUserResizing { get; set; }
+        public override Rectangle ClientBounds => Bounds;
+        public override DisplayOrientation CurrentOrientation => DisplayOrientation.Default;
+        public override bool IsMinimized => false;
+        public override bool Focused => true;
+        public override bool IsMouseVisible { get; set; }
+        public override WindowHandle NativeWindow => null;
+        public override bool Visible { get; set; }
+        public override double Opacity { get; set; }
+        public override bool IsBorderLess { get; set; }
+
+        internal override Int2 RawClientSize => RawSize ?? base.RawClientSize;
+
+        public override void BeginScreenDeviceChange(bool willBeFullScreen) { }
+        public override void EndScreenDeviceChange(int clientWidth, int clientHeight) { }
+        protected internal override void Initialize(GameContext gameContext) { }
+        internal override void Run() { }
+        internal override void Resize(int width, int height) { }
+        protected internal override void SetSupportedOrientations(DisplayOrientation orientations) { }
+        protected override void SetTitle(string title) { }
+
+        public void RaiseClientSizeChanged() => OnClientSizeChanged(this, EventArgs.Empty);
+    }
+
+    [Fact]
+    public void RawClientSizeDefaultsToClientBounds()
+    {
+        var window = new TestGameWindow { Bounds = new Rectangle(0, 0, 321, 123) };
+
+        Assert.Equal(new Int2(321, 123), window.RawClientSize);
+    }
+
+    [Fact]
+    public void ZeroRawClientSizeIsIgnored()
+    {
+        // Simulates a minimized window: clamped bounds still report 1x1 while the native size is zero
+        var window = new TestGameWindow
+        {
+            Bounds = new Rectangle(0, 0, 1, 1),
+            RawSize = new Int2(0, 0),
+            PreferredWindowedSize = new Int2(640, 480),
+        };
+        var clientSizeChanged = false;
+        window.ClientSizeChanged += (sender, e) => clientSizeChanged = true;
+
+        window.RaiseClientSizeChanged();
+
+        Assert.False(clientSizeChanged);
+        Assert.Equal(new Int2(640, 480), window.PreferredWindowedSize);
+    }
+
+    [Fact]
+    public void ValidRawClientSizeUpdatesPreferredWindowedSize()
+    {
+        var window = new TestGameWindow
+        {
+            Bounds = new Rectangle(0, 0, 800, 600),
+            PreferredWindowedSize = new Int2(640, 480),
+        };
+        var clientSizeChanged = false;
+        window.ClientSizeChanged += (sender, e) => clientSizeChanged = true;
+
+        window.RaiseClientSizeChanged();
+
+        Assert.True(clientSizeChanged);
+        Assert.Equal(new Int2(800, 600), window.PreferredWindowedSize);
+    }
+
+    [Fact]
+    public void FullscreenKeepsPreferredWindowedSize()
+    {
+        var window = new TestGameWindow
+        {
+            Bounds = new Rectangle(0, 0, 1920, 1080),
+            PreferredWindowedSize = new Int2(640, 480),
+            IsFullscreen = true,
+        };
+        var clientSizeChanged = false;
+        window.ClientSizeChanged += (sender, e) => clientSizeChanged = true;
+
+        window.RaiseClientSizeChanged();
+
+        Assert.True(clientSizeChanged);
+        Assert.Equal(new Int2(640, 480), window.PreferredWindowedSize);
+    }
+}
+
+/// <summary>
+/// Minimizes and restores a real window, checking that the minimized state never produces
+/// a valid-looking render size and that the window comes back at its original size (issue #3288).
+/// </summary>
+public class GameWindowMinimizeTest : GameTestBase
+{
+    [SkippableTheory]
+    [InlineData(AppContextType.DesktopWinForms)]
+    [InlineData(AppContextType.DesktopSDL)]
+    public void MinimizeRestore(AppContextType contextType)
+    {
+        Skip.If(Platform.Type != PlatformType.Windows, reason: "Programmatic minimize/restore needs a real window manager; this test drives it through Win32 ShowWindow");
+
+        PerformTest(game =>
+        {
+            var context = GameContextFactory.NewGameContext(contextType, isUserManagingRun: true);
+            var windowRenderer = new GameWindowRenderer(game.Services, context)
+            {
+                PreferredBackBufferWidth = 640,
+                PreferredBackBufferHeight = 480,
+            };
+            windowRenderer.Initialize();
+            ((IContentable)windowRenderer).LoadContent();
+
+            var window = windowRenderer.Window;
+            var messageLoop = window.CreateUserManagedMessageLoop();
+            messageLoop.NextFrame();
+
+            Assert.True(windowRenderer.BeginDraw());
+            game.GraphicsContext.CommandList.Clear(windowRenderer.Presenter.BackBuffer, Color.Blue);
+            windowRenderer.EndDraw();
+
+            Assert.Equal(new Int2(640, 480), window.RawClientSize);
+            var preferredWindowedSize = window.PreferredWindowedSize;
+            var hwnd = window.NativeWindow.Handle;
+
+            ShowWindow(hwnd, SW_MINIMIZE);
+            PumpUntil(messageLoop, () => window.IsMinimized);
+
+            Assert.True(window.IsMinimized);
+            Assert.Equal(new Int2(0, 0), window.RawClientSize);
+            Assert.True(window.ClientBounds.Width >= 1 && window.ClientBounds.Height >= 1);
+            Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+
+            // With the backbuffer size driven by the window, drawing must be skipped while minimized
+            windowRenderer.PreferredBackBufferWidth = 0;
+            windowRenderer.PreferredBackBufferHeight = 0;
+            Assert.False(windowRenderer.BeginDraw());
+
+            ShowWindow(hwnd, SW_RESTORE);
+            PumpUntil(messageLoop, () => !window.IsMinimized && window.RawClientSize.X > 0);
+
+            Assert.False(window.IsMinimized);
+            Assert.Equal(new Int2(640, 480), window.RawClientSize);
+            Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+
+            Assert.True(windowRenderer.BeginDraw());
+            game.GraphicsContext.CommandList.Clear(windowRenderer.Presenter.BackBuffer, Color.Green);
+            windowRenderer.EndDraw();
+
+            windowRenderer.Dispose();
+        });
+    }
+
+    /// <summary>
+    /// Same scenario on the main game window, exercising the <see cref="GraphicsDeviceManager"/>
+    /// resize path reported in issue #3288: minimizing must not corrupt the preferred windowed size
+    /// or shrink the backbuffer, and the window must come back at its original size.
+    /// </summary>
+    [SkippableFact]
+    public void MainWindowMinimizeRestore()
+    {
+        Skip.If(Platform.Type != PlatformType.Windows, reason: "Programmatic minimize/restore needs a real window manager; this test drives it through Win32 ShowWindow");
+
+        Exception failure = null;
+        var game = new GameWindowMinimizeTest();
+        game.Script.AddTask(async () =>
+        {
+            try
+            {
+                var window = game.Window;
+
+                // Let the window and device reach a steady state
+                for (int i = 0; i < 5; i++)
+                    await game.Script.NextFrame();
+
+                var initialSize = window.RawClientSize;
+                Assert.True(initialSize.X > 1 && initialSize.Y > 1);
+                var preferredWindowedSize = window.PreferredWindowedSize;
+                var backBuffer = game.GraphicsDevice.Presenter.BackBuffer;
+                var initialBackBufferSize = new Int2(backBuffer.Width, backBuffer.Height);
+                var hwnd = window.NativeWindow.Handle;
+
+                ShowWindow(hwnd, SW_MINIMIZE);
+                await WaitUntil(game, () => window.IsMinimized);
+
+                Assert.True(window.IsMinimized);
+                Assert.Equal(new Int2(0, 0), window.RawClientSize);
+                Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+
+                ShowWindow(hwnd, SW_RESTORE);
+                await WaitUntil(game, () => !window.IsMinimized && window.RawClientSize.X > 0);
+
+                // Let any pending device changes apply
+                for (int i = 0; i < 5; i++)
+                    await game.Script.NextFrame();
+
+                Assert.False(window.IsMinimized);
+                Assert.Equal(initialSize, window.RawClientSize);
+                Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+                backBuffer = game.GraphicsDevice.Presenter.BackBuffer;
+                Assert.Equal(initialBackBufferSize, new Int2(backBuffer.Width, backBuffer.Height));
+            }
+            catch (Exception e)
+            {
+                failure = e;
+            }
+            finally
+            {
+                game.Exit();
+            }
+        });
+
+        // Run directly through GameTester: with screenshot automation off it creates a real window
+        GameTester.RunGameTest(game);
+
+        if (failure != null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private static async Task WaitUntil(GameTestBase game, Func<bool> condition)
+    {
+        var timeout = Stopwatch.StartNew();
+        while (!condition() && timeout.Elapsed < TimeSpan.FromSeconds(10))
+            await game.Script.NextFrame();
+    }
+
+    private static void PumpUntil(IMessageLoop messageLoop, Func<bool> condition)
+    {
+        for (int i = 0; i < 200 && !condition(); i++)
+        {
+            messageLoop.NextFrame();
+            Thread.Sleep(10);
+        }
+    }
+
+    private const int SW_MINIMIZE = 6;
+    private const int SW_RESTORE = 9;
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+}

--- a/sources/engine/Stride.Games/Desktop/GameForm.cs
+++ b/sources/engine/Stride.Games/Desktop/GameForm.cs
@@ -313,6 +313,13 @@ namespace Stride.Games
         protected override void OnClientSizeChanged(EventArgs e)
         {
             base.OnClientSizeChanged(e);
+
+            if (ClientSize.Width <= 0 || ClientSize.Height <= 0)
+            {
+                isSizeChangedWithoutResizeBegin = true;
+                return;
+            }
+
             if (!isUserResizing && (isSizeChangedWithoutResizeBegin || cachedSize != Size))
             {
                 isSizeChangedWithoutResizeBegin = false;
@@ -344,7 +351,7 @@ namespace Stride.Games
                         Rectangle rect;
 
                         GetClientRect(m.HWnd, out rect);
-                        if (rect.Bottom - rect.Top == 0)
+                        if (rect.Right - rect.Left <= 0 || rect.Bottom - rect.Top <= 0)
                         {
                             // Rapidly clicking the task bar to minimize and restore a window
                             // can cause a WM_SIZE message with SIZE_RESTORED when 

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -381,6 +381,7 @@ namespace Stride.Games
             }
         }
 
+        /// <inheritdoc />
         internal override Int2 RawClientSize
         {
             get

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -105,7 +105,12 @@ namespace Stride.Games
             if (deviceChangeChangedVisible)
                 Visible = oldVisible;
 
-            if (form != null)
+            if (form != null
+                && form.WindowState != FormWindowState.Minimized
+                && form.ClientSize.Width > 0
+                && form.ClientSize.Height > 0
+                && clientWidth > 0
+                && clientHeight > 0)
             {
                 form.ClientSize = new Size(clientWidth, clientHeight);
             }
@@ -373,6 +378,19 @@ namespace Stride.Games
             {
                 // Ensure width and height are at least 1 to avoid divisions by 0
                 return new Stride.Core.Mathematics.Rectangle(0, 0, Math.Max(Control.ClientSize.Width, 1), Math.Max(Control.ClientSize.Height, 1));
+            }
+        }
+
+        internal override Int2 RawClientSize
+        {
+            get
+            {
+                if (IsMinimized)
+                    return new Int2(0, 0);
+
+                return Control != null
+                    ? new Int2(Control.ClientSize.Width, Control.ClientSize.Height)
+                    : new Int2(0, 0);
             }
         }
 

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -93,6 +93,17 @@ namespace Stride.Games
         public abstract Rectangle ClientBounds { get; }
 
         /// <summary>
+        /// Gets the unclamped client size reported by the native window.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ClientBounds"/> can clamp its dimensions to keep rendering code away from zero-sized viewports.
+        /// Device and swap-chain resize decisions need the native size instead, otherwise minimized windows can be
+        /// mistaken for valid 1x1 render targets.
+        /// Platform implementations that can observe the native client size should override this property.
+        /// </remarks>
+        internal virtual Int2 RawClientSize => new Int2(ClientBounds.Width, ClientBounds.Height);
+
+        /// <summary>
         /// Gets the current orientation.
         /// </summary>
         /// <value>The current orientation.</value>
@@ -282,11 +293,16 @@ namespace Stride.Games
 
         protected void OnClientSizeChanged(object source, EventArgs e)
         {
+            var resizeSize = RawClientSize;
+            if (resizeSize.X <= 0 || resizeSize.Y <= 0)
+            {
+                return;
+            }
+
             if (!isFullscreen)
             {
                 // Update preferred windowed size in windowed mode 
-                var resizeSize = ClientBounds.Size;
-                PreferredWindowedSize = new Int2(resizeSize.Width, resizeSize.Height); 
+                PreferredWindowedSize = resizeSize;
             }
             var handler = ClientSizeChanged;
             handler?.Invoke(this, e);

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -234,7 +234,10 @@ namespace Stride.Games
 
         public void EndScreenDeviceChange()
         {
-            EndScreenDeviceChange(ClientBounds.Width, ClientBounds.Height);
+            var size = RawClientSize;
+            EndScreenDeviceChange(
+                size.X > 0 ? size.X : ClientBounds.Width,
+                size.Y > 0 ? size.Y : ClientBounds.Height);
         }
 
         public abstract void EndScreenDeviceChange(int clientWidth, int clientHeight);

--- a/sources/engine/Stride.Games/GameWindowRenderer.cs
+++ b/sources/engine/Stride.Games/GameWindowRenderer.cs
@@ -202,19 +202,19 @@ namespace Stride.Games
         ///   otherwise, it defaults to <see cref="PixelFormat.R8G8B8A8_UNorm"/>.
         /// </param>
         /// <returns>
-        ///   An <see cref="Int2"/> structure representing the width and height of the requested Back-Buffer size.
-        ///   If the preferred Back-Buffer dimensions are not set or the window has been resized by the user,
-        ///   the current window dimensions are used.
+        ///   <see langword="true"/> when a valid requested size could be determined; otherwise, <see langword="false"/>.
         /// </returns>
-        private Int2 GetRequestedSize(out PixelFormat format)
+        private bool TryGetRequestedSize(out Int2 size, out PixelFormat format)
         {
-            var bounds = Window.ClientBounds;
+            var rawClientSize = Window.RawClientSize;
 
             format = PreferredBackBufferFormat == PixelFormat.None ? PixelFormat.R8G8B8A8_UNorm : PreferredBackBufferFormat;
 
-            return new Int2(
-                PreferredBackBufferWidth == 0 || windowUserResized ? bounds.Width : PreferredBackBufferWidth,
-                PreferredBackBufferHeight == 0 || windowUserResized ? bounds.Height : PreferredBackBufferHeight);
+            size = new Int2(
+                PreferredBackBufferWidth == 0 || windowUserResized ? rawClientSize.X : PreferredBackBufferWidth,
+                PreferredBackBufferHeight == 0 || windowUserResized ? rawClientSize.Y : PreferredBackBufferHeight);
+
+            return size.X > 0 && size.Y > 0;
         }
 
         /// <summary>
@@ -225,11 +225,15 @@ namespace Stride.Games
         ///   using the requested size and format. It configures the presentation parameters,
         ///   including Depth-Stencil format and presentation interval.
         /// </remarks>
-        protected virtual void CreateOrUpdatePresenter()
+        protected virtual bool CreateOrUpdatePresenter()
         {
             if (Presenter is null || isColorSpaceToChange)
             {
-                var size = GetRequestedSize(out PixelFormat resizeFormat);
+                if (!TryGetRequestedSize(out var size, out PixelFormat resizeFormat))
+                {
+                    return false;
+                }
+
                 var presentationParameters = new PresentationParameters(size.X, size.Y, Window.NativeWindow, resizeFormat)
                 {
                     DepthStencilFormat = PreferredDepthStencilFormat,
@@ -251,6 +255,8 @@ namespace Stride.Games
                 isBackBufferToResize = false;
                 isColorSpaceToChange = false;
             }
+
+            return true;
         }
 
         /// <inheritdoc/>
@@ -260,11 +266,20 @@ namespace Stride.Games
             {
                 savedPresenter = GraphicsDevice.Presenter;
 
-                CreateOrUpdatePresenter();
+                if (!CreateOrUpdatePresenter())
+                {
+                    beginDrawOk = false;
+                    return false;
+                }
 
                 if (isBackBufferToResize || windowUserResized)
                 {
-                    var size = GetRequestedSize(out PixelFormat resizeFormat);
+                    if (!TryGetRequestedSize(out var size, out PixelFormat resizeFormat))
+                    {
+                        beginDrawOk = false;
+                        return false;
+                    }
+
                     Presenter.Resize(size.X, size.Y, resizeFormat);
 
                     isBackBufferToResize = false;

--- a/sources/engine/Stride.Games/GameWindowRenderer.cs
+++ b/sources/engine/Stride.Games/GameWindowRenderer.cs
@@ -196,6 +196,9 @@ namespace Stride.Games
         /// <summary>
         ///   Determines the requested size for the Back-Buffer based on the current window bounds and user preferences.
         /// </summary>
+        /// <param name="size">
+        ///   When this method returns, contains the requested size for the Back-Buffer.
+        /// </param>
         /// <param name="format">
         ///   When this method returns, contains the pixel format to be used for the Back-Buffer.
         ///   This will be the preferred Back-Buffer format if specified;
@@ -225,6 +228,9 @@ namespace Stride.Games
         ///   using the requested size and format. It configures the presentation parameters,
         ///   including Depth-Stencil format and presentation interval.
         /// </remarks>
+        /// <returns>
+        ///   <see langword="true"/> when the presenter exists or could be created; otherwise, <see langword="false"/>.
+        /// </returns>
         protected virtual bool CreateOrUpdatePresenter()
         {
             if (Presenter is null || isColorSpaceToChange)

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -1004,10 +1004,11 @@ namespace Stride.Games
         {
             // The client size can be zero in some cases (minimized window...)
             // We only process it when we have a valid size
-            if (game.Window.ClientBounds.Height != 0 || game.Window.ClientBounds.Width != 0)
+            var clientSize = game.Window.RawClientSize;
+            if (clientSize.X > 0 && clientSize.Y > 0)
             {
-                resizedBackBufferWidth = game.Window.ClientBounds.Width;
-                resizedBackBufferHeight = game.Window.ClientBounds.Height;
+                resizedBackBufferWidth = clientSize.X;
+                resizedBackBufferHeight = clientSize.Y;
                 isBackBufferToResize = true;
                 deviceSettingsChanged = true;
 
@@ -1049,11 +1050,12 @@ namespace Stride.Games
         {
             // The client size can be zero in some cases (minimized window...)
             // We only process it when we have a valid size, and the orientation actually changed
-            if ((game.Window.ClientBounds.Height != 0 || game.Window.ClientBounds.Width != 0) &&
+            var clientSize = game.Window.RawClientSize;
+            if ((clientSize.X > 0 && clientSize.Y > 0) &&
                 game.Window.CurrentOrientation != currentWindowOrientation)
             {
-                if ((game.Window.ClientBounds.Height > game.Window.ClientBounds.Width && preferredBackBufferWidth > preferredBackBufferHeight) ||
-                    (game.Window.ClientBounds.Width > game.Window.ClientBounds.Height && preferredBackBufferHeight > preferredBackBufferWidth))
+                if ((clientSize.Y > clientSize.X && preferredBackBufferWidth > preferredBackBufferHeight) ||
+                    (clientSize.X > clientSize.Y && preferredBackBufferHeight > preferredBackBufferWidth))
                 {
                     // Client size and Back-Buffer size are different things
                     // In this case all we care is if orientation changed, if so we swap width and height
@@ -1167,15 +1169,16 @@ namespace Stride.Games
                 game.ConfirmRenderingSettings(GraphicsDevice is null); // If no device we assume we are still at game creation phase
 
                 isChangingDevice = true;
-                var width = game.Window.ClientBounds.Width;
-                var height = game.Window.ClientBounds.Height;
+                var clientSize = game.Window.RawClientSize;
+                var width = clientSize.X > 0 ? clientSize.X : game.Window.ClientBounds.Width;
+                var height = clientSize.Y > 0 ? clientSize.Y : game.Window.ClientBounds.Height;
 
                 // If the orientation is free to be changed from portrait to landscape we actually need this check now,
                 // it is mostly useful only at initialization because `Window_OrientationChanged` does the same logic on runtime change
                 if (game.Window.CurrentOrientation != currentWindowOrientation)
                 {
-                    if ((game.Window.ClientBounds.Height > game.Window.ClientBounds.Width && preferredBackBufferWidth > preferredBackBufferHeight) ||
-                        (game.Window.ClientBounds.Width > game.Window.ClientBounds.Height && preferredBackBufferHeight > preferredBackBufferWidth))
+                    if ((clientSize.Y > 0 && clientSize.X > 0 && clientSize.Y > clientSize.X && preferredBackBufferWidth > preferredBackBufferHeight) ||
+                        (clientSize.X > 0 && clientSize.Y > 0 && clientSize.X > clientSize.Y && preferredBackBufferHeight > preferredBackBufferWidth))
                     {
                         // Client size and Back-Buffer size are different things
                         // In this case all we care is if orientation changed, if so we swap width and height

--- a/sources/engine/Stride.Games/Properties/AssemblyInfo.cs
+++ b/sources/engine/Stride.Games/Properties/AssemblyInfo.cs
@@ -11,4 +11,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Stride.UI" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Debugger" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Graphics.Regression" + Stride.PublicKeys.Default)]
+[assembly: InternalsVisibleTo("Stride.Engine.NoAssets.Tests" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.VirtualReality" + Stride.PublicKeys.Default)]

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -352,6 +352,7 @@ namespace Stride.Games
             }
         }
 
+        /// <inheritdoc />
         internal override Int2 RawClientSize
         {
             get

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -357,6 +357,9 @@ namespace Stride.Games
         {
             get
             {
+                if (IsMinimized)
+                    return new Int2(0, 0);
+
                 return window != null
                     ? new Int2(window.ClientSize.Width, window.ClientSize.Height)
                     : new Int2(0, 0);

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -352,6 +352,16 @@ namespace Stride.Games
             }
         }
 
+        internal override Int2 RawClientSize
+        {
+            get
+            {
+                return window != null
+                    ? new Int2(window.ClientSize.Width, window.ClientSize.Height)
+                    : new Int2(0, 0);
+            }
+        }
+
         public override DisplayOrientation CurrentOrientation
         {
             get


### PR DESCRIPTION
# PR Details

Revived PR #3230 from @Redwarx008 
Kudos to his work on this issue!

Please check that PR details for the actual description.
I have adjusted a few things (extra commits) and added a few unit tests as requested in [this comment](https://github.com/stride3d/stride/pull/3230#issuecomment-4827449484).

As an alternative approach, I was hesitating to go further and mark the old `ClientBounds` obsolete (nobody needs it as a `Rectangle`, that's XNA leftover when it was bounds on screen, we always pretend it's at corner 0,0).
Instead, we could simply add a proper `public Int2 ClientSize` (name TBD, or maybe even use nullable when undefined) without the Max(1) and then have call site dealing with rendering & expecting size 1 do the max themselves (or even skip rendering).

I am happy to do it if people agree.
What do you think?

## Related Issue

#3230
#3288 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->