### PR TITLE
Fix zero-sized window / crash after minimize and restore

### DIFF
--- a/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
@@ -1,0 +1,262 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+using Stride.Core;
+using Stride.Core.Mathematics;
+using Stride.Games;
+using Stride.Graphics;
+using Stride.Graphics.Regression;
+
+namespace Stride.Engine.Tests;
+
+/// <summary>
+/// Tests the <see cref="GameWindow"/> base logic around <see cref="GameWindow.ClientBounds"/>:
+/// an empty client area (e.g. minimized window) must not be treated as a valid size.
+/// </summary>
+public class GameWindowClientBoundsTest
+{
+    private class TestGameWindow : GameWindow
+    {
+        public Rectangle Bounds = new Rectangle(0, 0, 640, 480);
+
+        public override bool AllowUserResizing { get; set; }
+        public override Rectangle ClientBounds => Bounds;
+        public override DisplayOrientation CurrentOrientation => DisplayOrientation.Default;
+        public override bool IsMinimized => false;
+        public override bool Focused => true;
+        public override bool IsMouseVisible { get; set; }
+        public override WindowHandle NativeWindow => null;
+        public override bool Visible { get; set; }
+        public override double Opacity { get; set; }
+        public override bool IsBorderLess { get; set; }
+
+        public override void BeginScreenDeviceChange(bool willBeFullScreen) { }
+        public override void EndScreenDeviceChange(int clientWidth, int clientHeight) { }
+        protected internal override void Initialize(GameContext gameContext) { }
+        internal override void Run() { }
+        internal override void Resize(int width, int height) { }
+        protected internal override void SetSupportedOrientations(DisplayOrientation orientations) { }
+        protected override void SetTitle(string title) { }
+
+        public void RaiseClientSizeChanged() => OnClientSizeChanged(this, EventArgs.Empty);
+    }
+
+    [Fact]
+    public void EmptyClientBoundsSkipsClientSizeChanged()
+    {
+        var window = new TestGameWindow
+        {
+            Bounds = Rectangle.Empty,
+            PreferredWindowedSize = new Int2(640, 480),
+        };
+        var clientSizeChanged = false;
+        window.ClientSizeChanged += (sender, e) => clientSizeChanged = true;
+
+        window.RaiseClientSizeChanged();
+
+        Assert.False(clientSizeChanged);
+        Assert.Equal(new Int2(640, 480), window.PreferredWindowedSize);
+    }
+
+    [Fact]
+    public void ValidClientBoundsUpdatesPreferredWindowedSize()
+    {
+        var window = new TestGameWindow
+        {
+            Bounds = new Rectangle(0, 0, 800, 600),
+            PreferredWindowedSize = new Int2(640, 480),
+        };
+        var clientSizeChanged = false;
+        window.ClientSizeChanged += (sender, e) => clientSizeChanged = true;
+
+        window.RaiseClientSizeChanged();
+
+        Assert.True(clientSizeChanged);
+        Assert.Equal(new Int2(800, 600), window.PreferredWindowedSize);
+    }
+
+    [Fact]
+    public void FullscreenKeepsPreferredWindowedSize()
+    {
+        var window = new TestGameWindow
+        {
+            Bounds = new Rectangle(0, 0, 1920, 1080),
+            PreferredWindowedSize = new Int2(640, 480),
+            IsFullscreen = true,
+        };
+        var clientSizeChanged = false;
+        window.ClientSizeChanged += (sender, e) => clientSizeChanged = true;
+
+        window.RaiseClientSizeChanged();
+
+        Assert.True(clientSizeChanged);
+        Assert.Equal(new Int2(640, 480), window.PreferredWindowedSize);
+    }
+}
+
+/// <summary>
+/// Minimizes and restores a real window, checking that the minimized state never produces
+/// a valid-looking render size and that the window comes back at its original size.
+/// </summary>
+public class GameWindowMinimizeTest : GameTestBase
+{
+    [SkippableTheory]
+    [InlineData(AppContextType.DesktopWinForms)]
+    [InlineData(AppContextType.DesktopSDL)]
+    public void MinimizeRestore(AppContextType contextType)
+    {
+        Skip.If(Platform.Type != PlatformType.Windows, reason: "Programmatic minimize/restore needs a real window manager; this test drives it through Win32 ShowWindow");
+
+        PerformTest(game =>
+        {
+            var context = GameContextFactory.NewGameContext(contextType, isUserManagingRun: true);
+            var windowRenderer = new GameWindowRenderer(game.Services, context)
+            {
+                PreferredBackBufferWidth = 640,
+                PreferredBackBufferHeight = 480,
+            };
+            windowRenderer.Initialize();
+            ((IContentable)windowRenderer).LoadContent();
+
+            var window = windowRenderer.Window;
+            var messageLoop = window.CreateUserManagedMessageLoop();
+            messageLoop.NextFrame();
+
+            Assert.True(windowRenderer.BeginDraw());
+            game.GraphicsContext.CommandList.Clear(windowRenderer.Presenter.BackBuffer, Color.Blue);
+            windowRenderer.EndDraw();
+
+            Assert.Equal(new Int2(640, 480), ClientSize(window));
+            var preferredWindowedSize = window.PreferredWindowedSize;
+            var hwnd = window.NativeWindow.Handle;
+
+            ShowWindow(hwnd, SW_MINIMIZE);
+            PumpUntil(messageLoop, () => window.IsMinimized);
+
+            Assert.True(window.IsMinimized);
+            Assert.True(window.ClientBounds.IsEmpty);
+            Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+
+            // With the backbuffer size driven by the window, drawing must be skipped while minimized
+            windowRenderer.PreferredBackBufferWidth = 0;
+            windowRenderer.PreferredBackBufferHeight = 0;
+            Assert.False(windowRenderer.BeginDraw());
+
+            ShowWindow(hwnd, SW_RESTORE);
+            PumpUntil(messageLoop, () => !window.IsMinimized && window.ClientBounds.Width > 0);
+
+            Assert.False(window.IsMinimized);
+            Assert.Equal(new Int2(640, 480), ClientSize(window));
+            Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+
+            Assert.True(windowRenderer.BeginDraw());
+            game.GraphicsContext.CommandList.Clear(windowRenderer.Presenter.BackBuffer, Color.Green);
+            windowRenderer.EndDraw();
+
+            windowRenderer.Dispose();
+        });
+    }
+
+    /// <summary>
+    /// Same scenario on the main game window, exercising the <see cref="GraphicsDeviceManager"/>
+    /// resize path: minimizing must not corrupt the preferred windowed size or shrink the
+    /// backbuffer, and the window must come back at its original size.
+    /// </summary>
+    [SkippableFact]
+    public void MainWindowMinimizeRestore()
+    {
+        Skip.If(Platform.Type != PlatformType.Windows, reason: "Programmatic minimize/restore needs a real window manager; this test drives it through Win32 ShowWindow");
+
+        Exception failure = null;
+        var game = new GameWindowMinimizeTest();
+        game.Script.AddTask(async () =>
+        {
+            try
+            {
+                var window = game.Window;
+
+                // Let the window and device reach a steady state
+                for (int i = 0; i < 5; i++)
+                    await game.Script.NextFrame();
+
+                var initialSize = ClientSize(window);
+                Assert.True(initialSize.X > 1 && initialSize.Y > 1);
+                var preferredWindowedSize = window.PreferredWindowedSize;
+                var backBuffer = game.GraphicsDevice.Presenter.BackBuffer;
+                var initialBackBufferSize = new Int2(backBuffer.Width, backBuffer.Height);
+                var hwnd = window.NativeWindow.Handle;
+
+                ShowWindow(hwnd, SW_MINIMIZE);
+                await WaitUntil(game, () => window.IsMinimized);
+
+                Assert.True(window.IsMinimized);
+                Assert.True(window.ClientBounds.IsEmpty);
+                Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+
+                ShowWindow(hwnd, SW_RESTORE);
+                await WaitUntil(game, () => !window.IsMinimized && window.ClientBounds.Width > 0);
+
+                // Let any pending device changes apply
+                for (int i = 0; i < 5; i++)
+                    await game.Script.NextFrame();
+
+                Assert.False(window.IsMinimized);
+                Assert.Equal(initialSize, ClientSize(window));
+                Assert.Equal(preferredWindowedSize, window.PreferredWindowedSize);
+                backBuffer = game.GraphicsDevice.Presenter.BackBuffer;
+                Assert.Equal(initialBackBufferSize, new Int2(backBuffer.Width, backBuffer.Height));
+            }
+            catch (Exception e)
+            {
+                failure = e;
+            }
+            finally
+            {
+                game.Exit();
+            }
+        });
+
+        // Run directly through GameTester: with screenshot automation off it creates a real window
+        GameTester.RunGameTest(game);
+
+        if (failure != null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private static Int2 ClientSize(GameWindow window)
+    {
+        var bounds = window.ClientBounds;
+        return new Int2(bounds.Width, bounds.Height);
+    }
+
+    private static async Task WaitUntil(GameTestBase game, Func<bool> condition)
+    {
+        var timeout = Stopwatch.StartNew();
+        while (!condition() && timeout.Elapsed < TimeSpan.FromSeconds(10))
+            await game.Script.NextFrame();
+    }
+
+    private static void PumpUntil(IMessageLoop messageLoop, Func<bool> condition)
+    {
+        for (int i = 0; i < 200 && !condition(); i++)
+        {
+            messageLoop.NextFrame();
+            Thread.Sleep(10);
+        }
+    }
+
+    private const int SW_MINIMIZE = 6;
+    private const int SW_RESTORE = 9;
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+}

--- a/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
@@ -107,6 +107,7 @@ public class GameWindowClientBoundsTest
 /// Checks that <see cref="GameWindow.Position"/> and the <see cref="GameWindow.ClientBounds"/>
 /// origin both mean the client area origin on the screen.
 /// </summary>
+[Collection("Windowing")] // window tests pump global SDL/Win32 events, they cannot run in parallel
 public class GameWindowPositionTest : GameTestBase
 {
     [SkippableTheory]
@@ -152,6 +153,7 @@ public class GameWindowPositionTest : GameTestBase
 /// Minimizes and restores a real window, checking that the minimized state never produces
 /// a valid-looking render size and that the window comes back at its original size.
 /// </summary>
+[Collection("Windowing")] // window tests pump global SDL/Win32 events, they cannot run in parallel
 public class GameWindowMinimizeTest : GameTestBase
 {
     [SkippableTheory]

--- a/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowMinimizeTest.cs
@@ -104,6 +104,51 @@ public class GameWindowClientBoundsTest
 }
 
 /// <summary>
+/// Checks that <see cref="GameWindow.Position"/> and the <see cref="GameWindow.ClientBounds"/>
+/// origin both mean the client area origin on the screen.
+/// </summary>
+public class GameWindowPositionTest : GameTestBase
+{
+    [SkippableTheory]
+    [InlineData(AppContextType.DesktopWinForms)]
+    [InlineData(AppContextType.DesktopSDL)]
+    public void PositionIsClientAreaOrigin(AppContextType contextType)
+    {
+        Skip.If(Platform.Type != PlatformType.Windows, reason: "Window positioning needs a real window manager");
+
+        PerformTest(game =>
+        {
+            var context = GameContextFactory.NewGameContext(contextType, isUserManagingRun: true);
+            var windowRenderer = new GameWindowRenderer(game.Services, context)
+            {
+                PreferredBackBufferWidth = 320,
+                PreferredBackBufferHeight = 240,
+            };
+            windowRenderer.Initialize();
+            ((IContentable)windowRenderer).LoadContent();
+
+            var window = windowRenderer.Window;
+            var messageLoop = window.CreateUserManagedMessageLoop();
+            messageLoop.NextFrame();
+
+            var target = new Int2(160, 120);
+            window.Position = target;
+            for (int i = 0; i < 20 && window.Position != target; i++)
+            {
+                messageLoop.NextFrame();
+                Thread.Sleep(5);
+            }
+
+            Assert.Equal(target, window.Position);
+            var bounds = window.ClientBounds;
+            Assert.Equal(target, new Int2(bounds.X, bounds.Y));
+
+            windowRenderer.Dispose();
+        });
+    }
+}
+
+/// <summary>
 /// Minimizes and restores a real window, checking that the minimized state never produces
 /// a valid-looking render size and that the window comes back at its original size.
 /// </summary>

--- a/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowTest.cs
+++ b/sources/engine/Stride.Engine.NoAssets.Tests/GameWindowTest.cs
@@ -10,6 +10,7 @@ using Stride.Games;
 
 namespace Stride.Engine.Tests
 {
+    [Collection("Windowing")] // window tests pump global SDL/Win32 events, they cannot run in parallel
     public class GameWindowTest : GameTestBase
     {
         [SkippableTheory]

--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -310,17 +310,21 @@ namespace Stride.Engine
 
             var deviceManager = (GraphicsDeviceManager)graphicsDeviceManager;
 
-            if (gameCreation && !deviceManager.SkipBackBufferClampToWindow)
+            // Skip window-based adjustments when there is no usable client area (e.g. minimized)
+            var clientBounds = Window.ClientBounds;
+            var hasClientSize = clientBounds.Width > 0 && clientBounds.Height > 0;
+
+            if (gameCreation && !deviceManager.SkipBackBufferClampToWindow && hasClientSize)
             {
                 //if our device width or height is actually smaller then requested we use the device one
-                deviceManager.PreferredBackBufferWidth = Context.RequestedWidth = Math.Min(deviceManager.PreferredBackBufferWidth, Window.ClientBounds.Width);
-                deviceManager.PreferredBackBufferHeight = Context.RequestedHeight = Math.Min(deviceManager.PreferredBackBufferHeight, Window.ClientBounds.Height);
+                deviceManager.PreferredBackBufferWidth = Context.RequestedWidth = Math.Min(deviceManager.PreferredBackBufferWidth, clientBounds.Width);
+                deviceManager.PreferredBackBufferHeight = Context.RequestedHeight = Math.Min(deviceManager.PreferredBackBufferHeight, clientBounds.Height);
             }
 
             //these might get triggered even during game runtime, resize, orientation change
-            if (!deviceManager.SkipBackBufferClampToWindow && renderingSettings != null && renderingSettings.AdaptBackBufferToScreen)
+            if (!deviceManager.SkipBackBufferClampToWindow && renderingSettings != null && renderingSettings.AdaptBackBufferToScreen && hasClientSize)
             {
-                var deviceAr = Window.ClientBounds.Width / (float)Window.ClientBounds.Height;
+                var deviceAr = clientBounds.Width / (float)clientBounds.Height;
 
                 if (deviceManager.PreferredBackBufferHeight > deviceManager.PreferredBackBufferWidth)
                 {

--- a/sources/engine/Stride.Games/Android/GamePlatformAndroid.cs
+++ b/sources/engine/Stride.Games/Android/GamePlatformAndroid.cs
@@ -125,13 +125,13 @@ namespace Stride.Games
                     // Check if this profile is supported.
                     if (graphicsAdapter.IsProfileSupported(featureLevel))
                     {
-                        // Report the SDL window's actual size; formats stay caller-preferred (negotiated at swapchain creation).
-                        var clientBounds = gameWindowAndroid.ClientBounds;
+                        // Swapchain sizes are in pixels; formats stay caller-preferred (negotiated at swapchain creation).
+                        var drawableSize = gameWindowAndroid.DrawableSize;
                         var deviceInfo = new GraphicsDeviceInformation
                         {
                             Adapter = GraphicsAdapterFactory.DefaultAdapter,
                             GraphicsProfile = featureLevel,
-                            PresentationParameters = new PresentationParameters(clientBounds.Width, clientBounds.Height,
+                            PresentationParameters = new PresentationParameters(drawableSize.Width, drawableSize.Height,
                                 gameWindowAndroid.NativeWindow)
                             {
                                 BackBufferFormat = preferredParameters.PreferredBackBufferFormat,

--- a/sources/engine/Stride.Games/Desktop/GameForm.cs
+++ b/sources/engine/Stride.Games/Desktop/GameForm.cs
@@ -313,6 +313,13 @@ namespace Stride.Games
         protected override void OnClientSizeChanged(EventArgs e)
         {
             base.OnClientSizeChanged(e);
+
+            if (ClientSize.Width <= 0 || ClientSize.Height <= 0)
+            {
+                isSizeChangedWithoutResizeBegin = true;
+                return;
+            }
+
             if (!isUserResizing && (isSizeChangedWithoutResizeBegin || cachedSize != Size))
             {
                 isSizeChangedWithoutResizeBegin = false;
@@ -344,7 +351,7 @@ namespace Stride.Games
                         Rectangle rect;
 
                         GetClientRect(m.HWnd, out rect);
-                        if (rect.Bottom - rect.Top == 0)
+                        if (rect.Right - rect.Left <= 0 || rect.Bottom - rect.Top <= 0)
                         {
                             // Rapidly clicking the task bar to minimize and restore a window
                             // can cause a WM_SIZE message with SIZE_RESTORED when 

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -105,7 +105,10 @@ namespace Stride.Games
             if (deviceChangeChangedVisible)
                 Visible = oldVisible;
 
-            if (form != null)
+            if (form != null
+                && form.WindowState != FormWindowState.Minimized
+                && clientWidth > 0
+                && clientHeight > 0)
             {
                 form.ClientSize = new Size(clientWidth, clientHeight);
             }
@@ -371,8 +374,13 @@ namespace Stride.Games
         {
             get
             {
-                // Ensure width and height are at least 1 to avoid divisions by 0
-                return new Stride.Core.Mathematics.Rectangle(0, 0, Math.Max(Control.ClientSize.Width, 1), Math.Max(Control.ClientSize.Height, 1));
+                // A minimized form reports a bogus non-zero client area
+                if (Control == null || IsMinimized)
+                    return Stride.Core.Mathematics.Rectangle.Empty;
+
+                var location = Control.PointToScreen(Point.Empty);
+                var size = Control.ClientSize;
+                return new Stride.Core.Mathematics.Rectangle(location.X, location.Y, size.Width, size.Height);
             }
         }
 

--- a/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
+++ b/sources/engine/Stride.Games/Desktop/GameWindowWinforms.cs
@@ -299,12 +299,19 @@ namespace Stride.Games
                 if (Control == null)
                     return base.Position;
 
-                return new Int2(Control.Location.X, Control.Location.Y);
+                var location = Control.PointToScreen(Point.Empty);
+                return new Int2(location.X, location.Y);
             }
             set
             {
                 if (Control != null)
-                    Control.Location = new Point(value.X, value.Y);
+                {
+                    // Move so that the client area origin lands on the given position
+                    var clientOrigin = Control.PointToScreen(Point.Empty);
+                    Control.Location = new Point(
+                        Control.Location.X + value.X - clientOrigin.X,
+                        Control.Location.Y + value.Y - clientOrigin.Y);
+                }
 
                 base.Position = value;
             }

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -87,9 +87,16 @@ namespace Stride.Games
         public abstract bool AllowUserResizing { get; set; }
 
         /// <summary>
-        /// Gets the client bounds.
+        /// Gets the bounds of the client area, in window coordinates (points; equals pixels on Windows).
         /// </summary>
-        /// <value>The client bounds.</value>
+        /// <value>The client area bounds.</value>
+        /// <remarks>
+        /// X and Y are the client area origin in screen coordinates. On platforms where the window system
+        /// does not expose global window positions (Wayland, Android, iOS, headless), the origin is (0,0)
+        /// and coordinates are window-relative.
+        /// Returns an empty rectangle when the window is minimized or has no usable client area;
+        /// check for a positive size before using it for rendering or resize decisions.
+        /// </remarks>
         public abstract Rectangle ClientBounds { get; }
 
         /// <summary>
@@ -223,7 +230,11 @@ namespace Stride.Games
 
         public void EndScreenDeviceChange()
         {
-            EndScreenDeviceChange(ClientBounds.Width, ClientBounds.Height);
+            var bounds = ClientBounds;
+            if (bounds.Width > 0 && bounds.Height > 0)
+                EndScreenDeviceChange(bounds.Width, bounds.Height);
+            else
+                EndScreenDeviceChange(PreferredWindowedSize.X, PreferredWindowedSize.Y);
         }
 
         public abstract void EndScreenDeviceChange(int clientWidth, int clientHeight);
@@ -282,11 +293,15 @@ namespace Stride.Games
 
         protected void OnClientSizeChanged(object source, EventArgs e)
         {
+            // No usable client area (e.g. minimized): nothing to notify
+            var resizeSize = ClientBounds.Size;
+            if (resizeSize.Width <= 0 || resizeSize.Height <= 0)
+                return;
+
             if (!isFullscreen)
             {
-                // Update preferred windowed size in windowed mode 
-                var resizeSize = ClientBounds.Size;
-                PreferredWindowedSize = new Int2(resizeSize.Width, resizeSize.Height); 
+                // Update preferred windowed size in windowed mode
+                PreferredWindowedSize = new Int2(resizeSize.Width, resizeSize.Height);
             }
             var handler = ClientSizeChanged;
             handler?.Invoke(this, e);

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -143,8 +143,14 @@ namespace Stride.Games
         public abstract double Opacity { get; set; }
 
         /// <summary>
-        /// Gets or sets the position of the window on the screen.
+        /// Gets or sets the position of the window's client area origin on the screen,
+        /// in window coordinates (points; equals pixels on Windows).
         /// </summary>
+        /// <remarks>
+        /// Matches the origin of <see cref="ClientBounds"/>. On platforms where the window system
+        /// does not expose global window positions (Wayland, Android, iOS, headless), getting
+        /// returns (0,0) and setting has no effect.
+        /// </remarks>
         public virtual Int2 Position { get; set; }
 
         /// <summary>

--- a/sources/engine/Stride.Games/GameWindow.cs
+++ b/sources/engine/Stride.Games/GameWindow.cs
@@ -154,6 +154,12 @@ namespace Stride.Games
         public virtual Int2 Position { get; set; }
 
         /// <summary>
+        /// Gets the number of drawable pixels per window coordinate unit.
+        /// 1 on Windows; can be higher on high-DPI displays (e.g. 2 on macOS Retina).
+        /// </summary>
+        public virtual float ScaleFactor => 1.0f;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this window has a border
         /// </summary>
         /// <value><c>true</c> if this window has a border; otherwise, <c>false</c>.</value>
@@ -185,14 +191,16 @@ namespace Stride.Games
         }
 
         /// <summary>
-        /// The size the window should have when switching from fullscreen to windowed mode.
+        /// The size the window should have when switching from fullscreen to windowed mode,
+        /// in window coordinates (points; equals pixels on Windows).
         /// To get the current actual size use <see cref="ClientBounds"/>.
-        /// This gets overwritten when the user resizes the window. 
+        /// This gets overwritten when the user resizes the window.
         /// </summary>
         public Int2 PreferredWindowedSize { get; set; } = new Int2(768, 432);
 
         /// <summary>
-        /// The size the window should have when switching from windowed to fullscreen mode.
+        /// The size the window should have when switching from windowed to fullscreen mode,
+        /// in window coordinates (points; equals pixels on Windows).
         /// To get the current actual size use <see cref="ClientBounds"/>.
         /// </summary>
         public Int2 PreferredFullscreenSize { get; set; } = new Int2(1920, 1080);
@@ -234,6 +242,12 @@ namespace Stride.Games
 
         public abstract void BeginScreenDeviceChange(bool willBeFullScreen);
 
+        /// <summary>
+        /// Completes a screen device change, applying the given client size,
+        /// in window coordinates (points; equals pixels on Windows).
+        /// </summary>
+        public abstract void EndScreenDeviceChange(int clientWidth, int clientHeight);
+
         public void EndScreenDeviceChange()
         {
             var bounds = ClientBounds;
@@ -242,8 +256,6 @@ namespace Stride.Games
             else
                 EndScreenDeviceChange(PreferredWindowedSize.X, PreferredWindowedSize.Y);
         }
-
-        public abstract void EndScreenDeviceChange(int clientWidth, int clientHeight);
 
         #endregion
 
@@ -264,7 +276,8 @@ namespace Stride.Games
         internal abstract void Run();
 
         /// <summary>
-        /// Sets the size of the client area and triggers the <see cref="ClientSizeChanged"/> event.
+        /// Sets the size of the client area, in window coordinates (points; equals pixels on Windows),
+        /// and triggers the <see cref="ClientSizeChanged"/> event.
         /// This will trigger a backbuffer resize too.
         /// </summary>
         public void SetSize(Int2 size)

--- a/sources/engine/Stride.Games/GameWindowRenderer.cs
+++ b/sources/engine/Stride.Games/GameWindowRenderer.cs
@@ -196,25 +196,31 @@ namespace Stride.Games
         /// <summary>
         ///   Determines the requested size for the Back-Buffer based on the current window bounds and user preferences.
         /// </summary>
+        /// <param name="size">
+        ///   When this method returns, contains the width and height of the requested Back-Buffer size.
+        ///   If the preferred Back-Buffer dimensions are not set or the window has been resized by the user,
+        ///   the current window dimensions are used.
+        /// </param>
         /// <param name="format">
         ///   When this method returns, contains the pixel format to be used for the Back-Buffer.
         ///   This will be the preferred Back-Buffer format if specified;
         ///   otherwise, it defaults to <see cref="PixelFormat.R8G8B8A8_UNorm"/>.
         /// </param>
         /// <returns>
-        ///   An <see cref="Int2"/> structure representing the width and height of the requested Back-Buffer size.
-        ///   If the preferred Back-Buffer dimensions are not set or the window has been resized by the user,
-        ///   the current window dimensions are used.
+        ///   <see langword="true"/> when a valid size could be determined;
+        ///   <see langword="false"/> when the window has no usable client area (e.g. it is minimized).
         /// </returns>
-        private Int2 GetRequestedSize(out PixelFormat format)
+        private bool TryGetRequestedSize(out Int2 size, out PixelFormat format)
         {
             var bounds = Window.ClientBounds;
 
             format = PreferredBackBufferFormat == PixelFormat.None ? PixelFormat.R8G8B8A8_UNorm : PreferredBackBufferFormat;
 
-            return new Int2(
+            size = new Int2(
                 PreferredBackBufferWidth == 0 || windowUserResized ? bounds.Width : PreferredBackBufferWidth,
                 PreferredBackBufferHeight == 0 || windowUserResized ? bounds.Height : PreferredBackBufferHeight);
+
+            return size.X > 0 && size.Y > 0;
         }
 
         /// <summary>
@@ -225,11 +231,16 @@ namespace Stride.Games
         ///   using the requested size and format. It configures the presentation parameters,
         ///   including Depth-Stencil format and presentation interval.
         /// </remarks>
-        protected virtual void CreateOrUpdatePresenter()
+        /// <returns>
+        ///   <see langword="true"/> when the presenter exists or could be created; otherwise, <see langword="false"/>.
+        /// </returns>
+        protected virtual bool CreateOrUpdatePresenter()
         {
             if (Presenter is null || isColorSpaceToChange)
             {
-                var size = GetRequestedSize(out PixelFormat resizeFormat);
+                if (!TryGetRequestedSize(out var size, out PixelFormat resizeFormat))
+                    return false;
+
                 var presentationParameters = new PresentationParameters(size.X, size.Y, Window.NativeWindow, resizeFormat)
                 {
                     DepthStencilFormat = PreferredDepthStencilFormat,
@@ -251,6 +262,8 @@ namespace Stride.Games
                 isBackBufferToResize = false;
                 isColorSpaceToChange = false;
             }
+
+            return true;
         }
 
         /// <inheritdoc/>
@@ -260,11 +273,20 @@ namespace Stride.Games
             {
                 savedPresenter = GraphicsDevice.Presenter;
 
-                CreateOrUpdatePresenter();
+                if (!CreateOrUpdatePresenter())
+                {
+                    beginDrawOk = false;
+                    return false;
+                }
 
                 if (isBackBufferToResize || windowUserResized)
                 {
-                    var size = GetRequestedSize(out PixelFormat resizeFormat);
+                    if (!TryGetRequestedSize(out var size, out PixelFormat resizeFormat))
+                    {
+                        beginDrawOk = false;
+                        return false;
+                    }
+
                     Presenter.Resize(size.X, size.Y, resizeFormat);
 
                     isBackBufferToResize = false;

--- a/sources/engine/Stride.Games/GraphicsDeviceManager.cs
+++ b/sources/engine/Stride.Games/GraphicsDeviceManager.cs
@@ -1004,10 +1004,11 @@ namespace Stride.Games
         {
             // The client size can be zero in some cases (minimized window...)
             // We only process it when we have a valid size
-            if (game.Window.ClientBounds.Height != 0 || game.Window.ClientBounds.Width != 0)
+            var clientBounds = game.Window.ClientBounds;
+            if (clientBounds.Width > 0 && clientBounds.Height > 0)
             {
-                resizedBackBufferWidth = game.Window.ClientBounds.Width;
-                resizedBackBufferHeight = game.Window.ClientBounds.Height;
+                resizedBackBufferWidth = clientBounds.Width;
+                resizedBackBufferHeight = clientBounds.Height;
                 isBackBufferToResize = true;
                 deviceSettingsChanged = true;
 
@@ -1049,11 +1050,12 @@ namespace Stride.Games
         {
             // The client size can be zero in some cases (minimized window...)
             // We only process it when we have a valid size, and the orientation actually changed
-            if ((game.Window.ClientBounds.Height != 0 || game.Window.ClientBounds.Width != 0) &&
+            var clientBounds = game.Window.ClientBounds;
+            if ((clientBounds.Width > 0 && clientBounds.Height > 0) &&
                 game.Window.CurrentOrientation != currentWindowOrientation)
             {
-                if ((game.Window.ClientBounds.Height > game.Window.ClientBounds.Width && preferredBackBufferWidth > preferredBackBufferHeight) ||
-                    (game.Window.ClientBounds.Width > game.Window.ClientBounds.Height && preferredBackBufferHeight > preferredBackBufferWidth))
+                if ((clientBounds.Height > clientBounds.Width && preferredBackBufferWidth > preferredBackBufferHeight) ||
+                    (clientBounds.Width > clientBounds.Height && preferredBackBufferHeight > preferredBackBufferWidth))
                 {
                     // Client size and Back-Buffer size are different things
                     // In this case all we care is if orientation changed, if so we swap width and height
@@ -1167,15 +1169,17 @@ namespace Stride.Games
                 game.ConfirmRenderingSettings(GraphicsDevice is null); // If no device we assume we are still at game creation phase
 
                 isChangingDevice = true;
-                var width = game.Window.ClientBounds.Width;
-                var height = game.Window.ClientBounds.Height;
+                var clientBounds = game.Window.ClientBounds;
+                var hasClientSize = clientBounds.Width > 0 && clientBounds.Height > 0;
+                var width = hasClientSize ? clientBounds.Width : preferredBackBufferWidth;
+                var height = hasClientSize ? clientBounds.Height : preferredBackBufferHeight;
 
                 // If the orientation is free to be changed from portrait to landscape we actually need this check now,
                 // it is mostly useful only at initialization because `Window_OrientationChanged` does the same logic on runtime change
-                if (game.Window.CurrentOrientation != currentWindowOrientation)
+                if (hasClientSize && game.Window.CurrentOrientation != currentWindowOrientation)
                 {
-                    if ((game.Window.ClientBounds.Height > game.Window.ClientBounds.Width && preferredBackBufferWidth > preferredBackBufferHeight) ||
-                        (game.Window.ClientBounds.Width > game.Window.ClientBounds.Height && preferredBackBufferHeight > preferredBackBufferWidth))
+                    if ((clientBounds.Height > clientBounds.Width && preferredBackBufferWidth > preferredBackBufferHeight) ||
+                        (clientBounds.Width > clientBounds.Height && preferredBackBufferHeight > preferredBackBufferWidth))
                     {
                         // Client size and Back-Buffer size are different things
                         // In this case all we care is if orientation changed, if so we swap width and height

--- a/sources/engine/Stride.Games/Properties/AssemblyInfo.cs
+++ b/sources/engine/Stride.Games/Properties/AssemblyInfo.cs
@@ -11,4 +11,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Stride.UI" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Debugger" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.Graphics.Regression" + Stride.PublicKeys.Default)]
+[assembly: InternalsVisibleTo("Stride.Engine.NoAssets.Tests" + Stride.PublicKeys.Default)]
 [assembly: InternalsVisibleTo("Stride.VirtualReality" + Stride.PublicKeys.Default)]

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -360,6 +360,24 @@ namespace Stride.Games
             }
         }
 
+        /// <summary>
+        /// Size of the drawable surface, in pixels.
+        /// </summary>
+        internal Size2 DrawableSize => window?.DrawableSize ?? new Size2(0, 0);
+
+        /// <inheritdoc />
+        public override float ScaleFactor
+        {
+            get
+            {
+                if (window == null)
+                    return 1.0f;
+
+                var clientSize = window.ClientSize;
+                return clientSize.Width > 0 ? window.DrawableSize.Width / (float)clientSize.Width : 1.0f;
+            }
+        }
+
         public override DisplayOrientation CurrentOrientation
         {
             get

--- a/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
+++ b/sources/engine/Stride.Games/SDL/GameWindowSDL.cs
@@ -66,15 +66,18 @@ namespace Stride.Games
             if (window != null)
             {
                 window.FullscreenIsBorderlessWindow = FullscreenIsBorderlessWindow;
+                var canResize = clientWidth > 0 && clientHeight > 0 && window.WindowState != FormWindowState.Minimized;
                 if (deviceChangeWillBeFullScreen.Value) //windowed to fullscreen
                 {
-                    window.ClientSize = new Size2(clientWidth, clientHeight);
+                    if (canResize)
+                        window.ClientSize = new Size2(clientWidth, clientHeight);
                     window.IsFullScreen = true;
                 }
                 else //fullscreen to windowed or window resize
                 {
                     window.IsFullScreen = false;
-                    window.ClientSize = new Size2(clientWidth, clientHeight);
+                    if (canResize)
+                        window.ClientSize = new Size2(clientWidth, clientHeight);
                     // Only restore the windowed position when actually leaving fullscreen. On plain
                     // resizes the get/set round-trip is not symmetric about the decoration frame on
                     // X11 reparenting WMs, so restoring it every resize walks the window up-left.
@@ -347,8 +350,13 @@ namespace Stride.Games
         {
             get
             {
-                // Ensure width and height are at least 1 to avoid divisions by 0
-                return new Rectangle(0, 0, Math.Max(window.ClientSize.Width, 1), Math.Max(window.ClientSize.Height, 1));
+                // SDL keeps reporting the pre-minimize size while minimized
+                if (window == null || IsMinimized)
+                    return Rectangle.Empty;
+
+                var location = window.Location;
+                var size = window.ClientSize;
+                return new Rectangle(location.X, location.Y, size.Width, size.Height);
             }
         }
 

--- a/sources/engine/Stride.Games/iOS/GamePlatformiOS.cs
+++ b/sources/engine/Stride.Games/iOS/GamePlatformiOS.cs
@@ -88,14 +88,14 @@ namespace Stride.Games
                     // Check if this profile is supported.
                     if (graphicsAdapter.IsProfileSupported(featureLevel))
                     {
-                        // Report the SDL window's actual size; formats stay caller-preferred (negotiated at swapchain creation).
-                        var clientBounds = gameWindowiOS.ClientBounds;
+                        // Swapchain sizes are in pixels; formats stay caller-preferred (negotiated at swapchain creation).
+                        var drawableSize = gameWindowiOS.DrawableSize;
                         var deviceInfo = new GraphicsDeviceInformation
                         {
                             Adapter = GraphicsAdapterFactory.DefaultAdapter,
                             GraphicsProfile = featureLevel,
-                            PresentationParameters = new PresentationParameters(clientBounds.Width,
-                                                                                clientBounds.Height,
+                            PresentationParameters = new PresentationParameters(drawableSize.Width,
+                                                                                drawableSize.Height,
                                                                                 gameWindowiOS.NativeWindow)
                             {
                                 BackBufferFormat = preferredParameters.PreferredBackBufferFormat,

--- a/sources/engine/Stride.Graphics/SDL/Window.cs
+++ b/sources/engine/Stride.Graphics/SDL/Window.cs
@@ -367,9 +367,27 @@ namespace Stride.Graphics.SDL
         }
 
         /// <summary>
-        /// Size of the client area of a window.
+        /// Size of the client area of a window, in window coordinates (points; equals pixels on Windows).
         /// </summary>
         public unsafe Size2 ClientSize
+        {
+            get
+            {
+                int w, h;
+                SDL.GetWindowSize(sdlHandle, &w, &h);
+                return new Size2(w, h);
+            }
+            set
+            {
+                // From SDL documentation: Use this function to set the size of a window's client area.
+                SDL.SetWindowSize(sdlHandle, value.Width, value.Height);
+            }
+        }
+
+        /// <summary>
+        /// Size of the drawable surface, in pixels. Can be larger than <see cref="ClientSize"/> on high-DPI displays.
+        /// </summary>
+        public unsafe Size2 DrawableSize
         {
             get
             {
@@ -382,31 +400,20 @@ namespace Stride.Graphics.SDL
                 return new Size2(surface->W, surface->H);
 #endif
             }
-            set
-            {
-                // FIXME: We need to adapt the ClientSize to an actual Size to take into account borders.
-                // FIXME: On Windows you do this by using AdjustWindowRect.
-                // SDL.SDL_GetWindowBordersSize(sdlHandle, out var top, out var left, out var bottom, out var right);
-                // From SDL documentation: Use this function to set the size of a window's client area.
-                SDL.SetWindowSize(sdlHandle, value.Width, value.Height);
-            }
         }
 
         /// <summary>
-        /// Size of client area expressed as a rectangle.
+        /// Client area expressed as a rectangle: position on screen and size, in window coordinates
+        /// (points; equals pixels on Windows).
         /// </summary>
         public unsafe Rectangle ClientRectangle
         {
             get
             {
-#if STRIDE_GRAPHICS_API_VULKAN
-                int w, h;
-                SDL.GLGetDrawableSize(sdlHandle, &w, &h);
-                return new Rectangle(0, 0, w, h);
-#else
-                var surface = SDL.GetWindowSurface(sdlHandle);
-                return new Rectangle(0, 0, surface->W, surface->H);
-#endif
+                int w, h, x, y;
+                SDL.GetWindowSize(sdlHandle, &w, &h);
+                SDL.GetWindowPosition(sdlHandle, &x, &y);
+                return new Rectangle(x, y, w, h);
             }
             set
             {

--- a/sources/engine/Stride.Input/IPointerDevice.cs
+++ b/sources/engine/Stride.Input/IPointerDevice.cs
@@ -14,7 +14,8 @@ namespace Stride.Input
     public interface IPointerDevice : IInputDevice
     {
         /// <summary>
-        /// The size of the surface used by the pointer, for a mouse this is the size of the window, for a touch device, the size of the touch area, etc.
+        /// The size of the surface used by the pointer, in window coordinates (points; equals pixels on Windows).
+        /// For a mouse this is the size of the window, for a touch device, the size of the touch area, etc.
         /// </summary>
         Vector2 SurfaceSize { get; }
 


### PR DESCRIPTION
# PR Details

Fixes minimize/restore breaking the game window: after restoring, the window could come back tiny (or stuck), and post-processing would crash with `Input and output texture cannot have same size [(1,1,1)]`.

Fixes #3288 (supersedes #3230 and #3297, thanks @Redwarx008 for the initial investigation)

## Root cause

`ClientBounds` clamped its size to be at least 1x1.
A minimized window looked like a valid 1x1 window, so resize code saved and applied that bogus size.

## Changes

- `ClientBounds` now reports the real client area:
  - empty rectangle when minimized (no more fake 1x1)
  - X/Y is the client area position on screen (was always 0,0)
  - resize code now checks for a valid size before acting (this is the actual bug fix)
- `Position` now means the client area origin on all platforms (WinForms used the outer frame, SDL already used the client area; SDL/GLFW convention, and the only meaning that works on Wayland)
- Units are now explicit: window sizes/positions are in window coordinates (points; equals pixels on Windows), backbuffer sizes are in pixels
  - SDL `Window.ClientSize` getter returned pixels while its setter took points; it is now points both ways, with a new `DrawableSize` (pixels) for swapchain code
  - this also fixes mouse normalization and iOS swapchain size on high-DPI displays
  - new `GameWindow.ScaleFactor` (drawable pixels per window unit) for explicit conversions

## Why a different approach than #3230

#3230 added an internal `RawClientSize` next to the clamped `ClientBounds`.

This PR fixes `ClientBounds` itself instead:

- one property with proper meaning, instead of two properties with subtly different values
- the clamp only protected callers that never needed it; every real consumer wants the true size
- no risk of new code reading the wrong one later and reintroducing the bug

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->