### PR TITLE
fix: map GraphicsProfile.Level_11_2 to a valid Direct3D feature level

### DIFF
--- a/sources/engine/Stride.Graphics.Tests/Stride.Graphics.Tests.csproj
+++ b/sources/engine/Stride.Graphics.Tests/Stride.Graphics.Tests.csproj
@@ -15,6 +15,9 @@
     <Compile Remove="Compiler\CubemapEffect.sdfx.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Silk.NET.Direct3D11" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />
     <ProjectReference Include="..\Stride.Engine\Stride.Engine.csproj" />
     <ProjectReference Include="..\Stride.Graphics.Regression\Stride.Graphics.Regression.csproj" />

--- a/sources/engine/Stride.Graphics.Tests/Stride.Graphics.Tests.csproj
+++ b/sources/engine/Stride.Graphics.Tests/Stride.Graphics.Tests.csproj
@@ -15,7 +15,10 @@
     <Compile Remove="Compiler\CubemapEffect.sdfx.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Silk.NET.Direct3D11" />
+    <!-- Stride.Graphics references Silk.NET with PrivateAssets="compile", so D3DFeatureLevel does not
+         flow to consumers; TestGraphicsProfileHelper needs its own reference to name it. Desktop-only,
+         matching the Direct3D references in Stride.Graphics.csproj. -->
+    <PackageReference Include="Silk.NET.Direct3D11" Condition="'$(StrideTargetFramework)' == '$(StrideFramework)' Or '$(StrideTargetFramework)' == '$(StrideFrameworkWindows)'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\tests\xunit.runner.stride\xunit.runner.stride.csproj" />

--- a/sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#if STRIDE_GRAPHICS_API_DIRECT3D
+
+using System;
+
+using Xunit;
+
+using Silk.NET.Core.Native;
+
+namespace Stride.Graphics.Tests;
+
+/// <summary>
+/// Regression tests for the GraphicsProfile -> D3DFeatureLevel mapping in GraphicsProfileHelper.
+/// Direct3D-only: the helper and D3DFeatureLevel exist only under STRIDE_GRAPHICS_API_DIRECT3D.
+/// </summary>
+public class TestGraphicsProfileHelper
+{
+    [Fact]
+    public void Level_11_2_MapsTo_Level_11_1()
+    {
+        // 0xB200 has no native D3D feature level; it must resolve to the real 11_1 (0xB100),
+        // matching Vulkan, instead of the raw-cast 0xB200 that fails CreateDevice on D3D11/D3D12.
+        Assert.Equal(GraphicsProfile.Level_11_1.ToFeatureLevel(), GraphicsProfile.Level_11_2.ToFeatureLevel());
+        Assert.NotEqual((D3DFeatureLevel)0xB200, GraphicsProfile.Level_11_2.ToFeatureLevel());
+    }
+
+    [Fact]
+    public void EveryProfile_MapsToADefinedFeatureLevel()
+    {
+        // Guards against any profile (now or future) mapping to a value with no native feature level.
+        foreach (GraphicsProfile profile in Enum.GetValues<GraphicsProfile>())
+        {
+            var featureLevel = profile.ToFeatureLevel();
+            Assert.True(Enum.IsDefined(featureLevel),
+                $"{profile} (0x{(int)profile:X4}) maps to undefined D3DFeatureLevel 0x{(int)featureLevel:X4}");
+        }
+    }
+}
+
+#endif

--- a/sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs
@@ -48,6 +48,41 @@ public class TestGraphicsProfileHelper
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => ((GraphicsProfile)0x1234).ToFeatureLevel());
     }
+
+    [Fact]
+    public void Level_11_1_And_11_2_ShareAFeatureLevel()
+    {
+        // 11.2 is an API revision on 11_1 hardware, so the two profiles are the same capability tier.
+        // Anything that probes a device with them (GraphicsAdapter.IsProfileSupported) answers alike.
+        Assert.Equal(GraphicsProfile.Level_11_1.ToFeatureLevel(), GraphicsProfile.Level_11_2.ToFeatureLevel());
+    }
+
+    [Fact]
+    public void Profiles_MapElementWise_NotByReinterpretingTheSpan()
+    {
+        GraphicsProfile[] profiles = [GraphicsProfile.Level_11_2, GraphicsProfile.Level_11_1, GraphicsProfile.Level_10_0];
+
+        var featureLevels = GraphicsProfileHelper.ToFeatureLevels(profiles);
+
+        D3DFeatureLevel[] expected = [D3DFeatureLevel.Level111, D3DFeatureLevel.Level111, D3DFeatureLevel.Level100];
+        Assert.Equal(expected, featureLevels);
+        // A bulk reinterpretation of the span would leak 0xB200 through as a feature level.
+        Assert.All(featureLevels, featureLevel => Assert.True(Enum.IsDefined(featureLevel)));
+    }
+
+    [Fact]
+    public void NoProfiles_MapToNoFeatureLevels()
+    {
+        Assert.Empty(GraphicsProfileHelper.ToFeatureLevels([]));
+    }
+
+    [Fact]
+    public void UnknownProfileInASequence_Throws()
+    {
+        GraphicsProfile[] profiles = [GraphicsProfile.Level_11_0, (GraphicsProfile)0x1234];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => GraphicsProfileHelper.ToFeatureLevels(profiles));
+    }
 }
 
 #endif

--- a/sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs
@@ -17,25 +17,36 @@ namespace Stride.Graphics.Tests;
 /// </summary>
 public class TestGraphicsProfileHelper
 {
-    [Fact]
-    public void Level_11_2_MapsTo_Level_11_1()
+    [Theory]
+    [InlineData(GraphicsProfile.Level_9_1, D3DFeatureLevel.Level91)]
+    [InlineData(GraphicsProfile.Level_9_2, D3DFeatureLevel.Level92)]
+    [InlineData(GraphicsProfile.Level_9_3, D3DFeatureLevel.Level93)]
+    [InlineData(GraphicsProfile.Level_10_0, D3DFeatureLevel.Level100)]
+    [InlineData(GraphicsProfile.Level_10_1, D3DFeatureLevel.Level101)]
+    [InlineData(GraphicsProfile.Level_11_0, D3DFeatureLevel.Level110)]
+    [InlineData(GraphicsProfile.Level_11_1, D3DFeatureLevel.Level111)]
+    [InlineData(GraphicsProfile.Level_11_2, D3DFeatureLevel.Level111)]
+    public void Profile_MapsToExpectedFeatureLevel(GraphicsProfile profile, D3DFeatureLevel expected)
     {
-        // 0xB200 has no native D3D feature level; it must resolve to the real 11_1 (0xB100),
-        // matching Vulkan, instead of the raw-cast 0xB200 that fails CreateDevice on D3D11/D3D12.
-        Assert.Equal(GraphicsProfile.Level_11_1.ToFeatureLevel(), GraphicsProfile.Level_11_2.ToFeatureLevel());
-        Assert.NotEqual((D3DFeatureLevel)0xB200, GraphicsProfile.Level_11_2.ToFeatureLevel());
+        Assert.Equal(expected, profile.ToFeatureLevel());
     }
 
     [Fact]
     public void EveryProfile_MapsToADefinedFeatureLevel()
     {
-        // Guards against any profile (now or future) mapping to a value with no native feature level.
+        // Guards against a profile added later without a matching entry in the mapping.
         foreach (GraphicsProfile profile in Enum.GetValues<GraphicsProfile>())
         {
             var featureLevel = profile.ToFeatureLevel();
             Assert.True(Enum.IsDefined(featureLevel),
                 $"{profile} (0x{(int)profile:X4}) maps to undefined D3DFeatureLevel 0x{(int)featureLevel:X4}");
         }
+    }
+
+    [Fact]
+    public void UnknownProfile_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ((GraphicsProfile)0x1234).ToFeatureLevel());
     }
 }
 

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
@@ -269,7 +269,11 @@ namespace Stride.Graphics
             ID3D11DeviceContext* deviceContext = null;
 
             D3DFeatureLevel matchedFeatureLevel = 0;
-            var featureLevel = (D3DFeatureLevel) graphicsProfile;
+            // Use ToFeatureLevel (not a raw cast) so Level_11_2 resolves to the real FL 11_1 it maps
+            // to; a raw cast would ask CreateDevice for the non-existent 0xB200, which can never match
+            // and would wrongly report the profile as unsupported on every adapter. The exact-match
+            // check below still legitimately rejects real capability gaps (e.g. FL10-only hardware).
+            var featureLevel = graphicsProfile.ToFeatureLevel();
             var featureLevels = stackalloc D3DFeatureLevel[] { featureLevel };
 
             HResult result = d3d11.CreateDevice(pAdapter: null, D3DDriverType.Hardware, Software: IntPtr.Zero,

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsAdapter.Direct3D.cs
@@ -269,10 +269,6 @@ namespace Stride.Graphics
             ID3D11DeviceContext* deviceContext = null;
 
             D3DFeatureLevel matchedFeatureLevel = 0;
-            // Use ToFeatureLevel (not a raw cast) so Level_11_2 resolves to the real FL 11_1 it maps
-            // to; a raw cast would ask CreateDevice for the non-existent 0xB200, which can never match
-            // and would wrongly report the profile as unsupported on every adapter. The exact-match
-            // check below still legitimately rejects real capability gaps (e.g. FL10-only hardware).
             var featureLevel = graphicsProfile.ToFeatureLevel();
             var featureLevels = stackalloc D3DFeatureLevel[] { featureLevel };
 

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsProfileHelper.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsProfileHelper.cs
@@ -38,6 +38,28 @@ internal static class GraphicsProfileHelper
     };
 
     /// <summary>
+    ///   Converts a sequence of <see cref="GraphicsProfile"/>s to the corresponding <see cref="D3DFeatureLevel"/>s.
+    /// </summary>
+    /// <param name="profiles">The <see cref="GraphicsProfile"/>s to convert.</param>
+    /// <returns>An array of Direct3D <see cref="D3DFeatureLevel"/>s, in the same order.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">One of the <paramref name="profiles"/> is not a known profile.</exception>
+    /// <remarks>
+    ///   The profiles are mapped one by one through <see cref="ToFeatureLevel(GraphicsProfile)"/>. The two enums must
+    ///   not be reinterpreted in bulk: not every <see cref="GraphicsProfile"/> has a feature level of the same value.
+    /// </remarks>
+    public static D3DFeatureLevel[] ToFeatureLevels(this ReadOnlySpan<GraphicsProfile> profiles)
+    {
+        if (profiles.IsEmpty)
+            return [];
+
+        var featureLevels = new D3DFeatureLevel[profiles.Length];
+        for (int index = 0; index < profiles.Length; index++)
+            featureLevels[index] = profiles[index].ToFeatureLevel();
+
+        return featureLevels;
+    }
+
+    /// <summary>
     ///   Converts a <see cref="D3DFeatureLevel"/> to its corresponding <see cref="GraphicsProfile"/>.
     /// </summary>
     /// <param name="level">A <see cref="D3DFeatureLevel"/> to convert.</param>

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsProfileHelper.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsProfileHelper.cs
@@ -3,9 +3,9 @@
 
 #if STRIDE_GRAPHICS_API_DIRECT3D
 
-using Silk.NET.Core.Native;
+using System;
 
-using Stride.Core.UnsafeExtensions;
+using Silk.NET.Core.Native;
 
 namespace Stride.Graphics;
 
@@ -15,34 +15,26 @@ namespace Stride.Graphics;
 internal static class GraphicsProfileHelper
 {
     /// <summary>
-    ///   Converts an array of <see cref="GraphicsProfile"/>s to an array of corresponding <see cref="D3DFeatureLevel"/>s.
-    /// </summary>
-    /// <param name="profiles">An array of <see cref="GraphicsProfile"/>s to convert.</param>
-    /// <returns>An array of Direct3D <see cref="D3DFeatureLevel"/>s.</returns>
-    public static D3DFeatureLevel[] ToFeatureLevel(this GraphicsProfile[] profiles)
-    {
-        if (profiles is null or [])
-            return null;
-
-        var featureLevels = profiles.AsReadOnlySpan<GraphicsProfile, D3DFeatureLevel>().ToArray();
-        return featureLevels;
-    }
-
-    /// <summary>
     ///   Converts a <see cref="GraphicsProfile"/> to its corresponding <see cref="D3DFeatureLevel"/>.
     /// </summary>
     /// <param name="profile">A <see cref="GraphicsProfile"/> to convert.</param>
     /// <returns>A Direct3D <see cref="D3DFeatureLevel"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="profile"/> is not a known profile.</exception>
+    /// <remarks>
+    ///   Direct3D has no feature level 11.2, as 11.2 was an API revision running on 11_1 hardware, so
+    ///   <see cref="GraphicsProfile.Level_11_2"/> maps to 11_1, its real capability tier.
+    /// </remarks>
     public static D3DFeatureLevel ToFeatureLevel(this GraphicsProfile profile) => profile switch
     {
-        // Direct3D has no feature level 11.2: D3D 11.2 was an API revision that runs on FL 11_1
-        // hardware, not a new feature level (real levels jump 11_1 (0xB100) -> 12_0 (0xC000)). Map it
-        // to its real capability tier (11_1) so device creation succeeds and the backend runs,
-        // matching Vulkan; a raw cast would emit the non-existent 0xB200 and fail CreateDevice on
-        // both D3D11 and D3D12. Every other GraphicsProfile value equals a real D3DFeatureLevel, so a
-        // direct cast is correct for them.
-        GraphicsProfile.Level_11_2 => (D3DFeatureLevel) GraphicsProfile.Level_11_1,
-        _ => (D3DFeatureLevel) profile,
+        GraphicsProfile.Level_9_1 => D3DFeatureLevel.Level91,
+        GraphicsProfile.Level_9_2 => D3DFeatureLevel.Level92,
+        GraphicsProfile.Level_9_3 => D3DFeatureLevel.Level93,
+        GraphicsProfile.Level_10_0 => D3DFeatureLevel.Level100,
+        GraphicsProfile.Level_10_1 => D3DFeatureLevel.Level101,
+        GraphicsProfile.Level_11_0 => D3DFeatureLevel.Level110,
+        GraphicsProfile.Level_11_1 or GraphicsProfile.Level_11_2 => D3DFeatureLevel.Level111,
+
+        _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unknown graphics profile.")
     };
 
     /// <summary>

--- a/sources/engine/Stride.Graphics/Direct3D/GraphicsProfileHelper.cs
+++ b/sources/engine/Stride.Graphics/Direct3D/GraphicsProfileHelper.cs
@@ -33,7 +33,17 @@ internal static class GraphicsProfileHelper
     /// </summary>
     /// <param name="profile">A <see cref="GraphicsProfile"/> to convert.</param>
     /// <returns>A Direct3D <see cref="D3DFeatureLevel"/>.</returns>
-    public static D3DFeatureLevel ToFeatureLevel(this GraphicsProfile profile) => (D3DFeatureLevel) profile;
+    public static D3DFeatureLevel ToFeatureLevel(this GraphicsProfile profile) => profile switch
+    {
+        // Direct3D has no feature level 11.2: D3D 11.2 was an API revision that runs on FL 11_1
+        // hardware, not a new feature level (real levels jump 11_1 (0xB100) -> 12_0 (0xC000)). Map it
+        // to its real capability tier (11_1) so device creation succeeds and the backend runs,
+        // matching Vulkan; a raw cast would emit the non-existent 0xB200 and fail CreateDevice on
+        // both D3D11 and D3D12. Every other GraphicsProfile value equals a real D3DFeatureLevel, so a
+        // direct cast is correct for them.
+        GraphicsProfile.Level_11_2 => (D3DFeatureLevel) GraphicsProfile.Level_11_1,
+        _ => (D3DFeatureLevel) profile,
+    };
 
     /// <summary>
     ///   Converts a <see cref="D3DFeatureLevel"/> to its corresponding <see cref="GraphicsProfile"/>.

--- a/sources/engine/Stride.Graphics/Direct3D11/GraphicsOutput.Direct3D11.cs
+++ b/sources/engine/Stride.Graphics/Direct3D11/GraphicsOutput.Direct3D11.cs
@@ -24,7 +24,6 @@
 // THE SOFTWARE.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -32,8 +31,6 @@ using System.Runtime.InteropServices;
 using Silk.NET.Core.Native;
 using Silk.NET.DXGI;
 using Silk.NET.Direct3D11;
-
-using Stride.Core.UnsafeExtensions;
 
 namespace Stride.Graphics;
 
@@ -92,24 +89,25 @@ public sealed unsafe partial class GraphicsOutput
 
         var d3d11 = D3D11.GetApi(window: null);
 
-        // NOTE: Assume the same underlying integer type
-        Debug.Assert(sizeof(GraphicsProfile) == sizeof(D3DFeatureLevel));
-        var featureLevels = targetProfiles.As<GraphicsProfile, D3DFeatureLevel>();
+        var featureLevels = targetProfiles.ToFeatureLevels();
 
         IDXGIAdapter* nativeAdapter = (IDXGIAdapter*) Adapter.NativeAdapter.Handle;
         ID3D11Device* deviceTemp = null;
         ID3D11DeviceContext* deviceContext = null;
         D3DFeatureLevel createdFeatureLevel = default;
 
-        d3d11.CreateDevice(nativeAdapter, D3DDriverType.Unknown, Software: 0, Flags: 0,
-                           in featureLevels.GetReference(), (uint) featureLevels.Length,
-                           D3D11.SdkVersion,
-                           ref deviceTemp, ref createdFeatureLevel, ref deviceContext);
+        HResult result = d3d11.CreateDevice(nativeAdapter, D3DDriverType.Unknown, Software: 0, Flags: 0,
+                                            in featureLevels[0], (uint) featureLevels.Length,
+                                            D3D11.SdkVersion,
+                                            ref deviceTemp, ref createdFeatureLevel, ref deviceContext);
+
+        if (result.IsFailure)
+            ThrowNoCompatibleProfile(result, Adapter, targetProfiles);
 
         ModeDesc modeDescription = modeToMatch.ToDescription();
 
         Unsafe.SkipInit(out ModeDesc closestDescription);
-        HResult result = dxgiOutput->FindClosestMatchingMode(in modeDescription, ref closestDescription, (IUnknown*) deviceTemp);
+        result = dxgiOutput->FindClosestMatchingMode(in modeDescription, ref closestDescription, (IUnknown*) deviceTemp);
 
         if (result.IsFailure)
             ThrowNoCompatibleProfile(result, Adapter, targetProfiles);

--- a/sources/engine/Stride.Graphics/Direct3D12/GraphicsOutput.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/GraphicsOutput.Direct3D12.cs
@@ -24,7 +24,6 @@
 // THE SOFTWARE.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -32,8 +31,6 @@ using System.Runtime.InteropServices;
 using Silk.NET.Core.Native;
 using Silk.NET.DXGI;
 using Silk.NET.Direct3D12;
-
-using Stride.Core.UnsafeExtensions;
 
 namespace Stride.Graphics;
 
@@ -95,9 +92,7 @@ public unsafe partial class GraphicsOutput
 
         var d3d12 = D3D12.GetApi();
 
-        // NOTE: Assume the same underlying integer type
-        Debug.Assert(sizeof(GraphicsProfile) == sizeof(D3DFeatureLevel));
-        var featureLevels = targetProfiles.As<GraphicsProfile, D3DFeatureLevel>();
+        var featureLevels = targetProfiles.ToFeatureLevels();
 
         HResult result = default;
 

--- a/sources/shaders/Stride.Shaders.Compilers/Direct3D/ShaderCompiler.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/Direct3D/ShaderCompiler.cs
@@ -161,7 +161,9 @@ namespace Stride.Shaders.Compiler.Direct3D
                     GraphicsProfile.Level_9_3 => "4_0_level_9_3",
                     GraphicsProfile.Level_10_0 => "4_0",
                     GraphicsProfile.Level_10_1 => "4_1",
-                    GraphicsProfile.Level_11_0 or GraphicsProfile.Level_11_1 => "5_0",
+                    // Level_11_2 shares shader model 5_0 with 11_0/11_1 (it maps to FL 11_1); listing
+                    // it here keeps it from hitting the throw below when used as the compile target.
+                    GraphicsProfile.Level_11_0 or GraphicsProfile.Level_11_1 or GraphicsProfile.Level_11_2 => "5_0",
 
                     _ => throw new ArgumentException("Graphics Profile not supported.", nameof(graphicsProfile))
                 };

--- a/sources/shaders/Stride.Shaders.Compilers/Direct3D/ShaderCompiler.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/Direct3D/ShaderCompiler.cs
@@ -161,8 +161,6 @@ namespace Stride.Shaders.Compiler.Direct3D
                     GraphicsProfile.Level_9_3 => "4_0_level_9_3",
                     GraphicsProfile.Level_10_0 => "4_0",
                     GraphicsProfile.Level_10_1 => "4_1",
-                    // Level_11_2 shares shader model 5_0 with 11_0/11_1 (it maps to FL 11_1); listing
-                    // it here keeps it from hitting the throw below when used as the compile target.
                     GraphicsProfile.Level_11_0 or GraphicsProfile.Level_11_1 or GraphicsProfile.Level_11_2 => "5_0",
 
                     _ => throw new ArgumentException("Graphics Profile not supported.", nameof(graphicsProfile))


### PR DESCRIPTION
# PR Details

**Summary** — `GraphicsProfile.Level_11_2` does not work on the Direct3D backends. This PR maps it to
the feature level it represents (FL 11_1), so it behaves like every other profile.

**This PR unlocks no Direct3D 11.2 capabilities.** There is no feature level 11_2. Direct3D 11.2 was a
runtime revision for Windows 8.1, and the level enum goes from `11_1 (0xB100)` to `12_0 (0xC000)`. Its
headline feature, tiled resources, is an optional capability. The application queries it after device
creation with `CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS1)` → `TiledResourcesTier`, and Tier 1
needs FL 11_0 hardware plus a WDDM 1.3 driver. This PR only stops an enum value that we already ship
from failing.

**Description** — `GraphicsProfile.Level_11_2 = 0xB200` has no native Direct3D feature level.
`GraphicsProfileHelper.ToFeatureLevel` cast the profile to the non-existent `0xB200`. Direct3D11 then
rejected **Level 11.2** in `GraphicsAdapter.IsProfileSupported`. Direct3D12 passed its unconditional
`IsProfileSupported` and then failed at `CreateDevice(0xB200)`. Vulkan ignores the profile, so Vulkan
ran.

`Level_11_2` reaches those paths from disk, not only from code. `GraphicsProfile` is a `[DataContract]`
and `Level_11_2` has a `[Display]` name. It is therefore a selectable value for
`RenderingSettings.DefaultGraphicsProfile` in Game Settings, and `Game.cs` feeds that value into both
`deviceManager.ShaderProfile` and `PreferredGraphicsProfile`.

Five Direct3D files change. The `GraphicsProfile` enum stays as it is, so this PR breaks nothing and
changes no serialized data.

- **`GraphicsProfileHelper.cs`** — `ToFeatureLevel` maps `Level_11_2` to `11_1` with an explicit
  table, instead of a cast that depends on the two enums sharing values. `ToFeatureLevels` maps a
  sequence one element at a time. It replaces the array overload, whose span reinterpretation skipped
  the mapping.
- **`GraphicsAdapter.Direct3D.cs`** (Direct3D11 `IsProfileSupported`) resolves the feature level with
  `ToFeatureLevel()` instead of a cast, so the exact-match check tests the real FL 11_1.
- **`GraphicsOutput.Direct3D11.cs`** and **`GraphicsOutput.Direct3D12.cs`**
  (`FindClosestMatchingDisplayMode`) map the caller's profile span instead of reinterpreting it. See
  the next section.
- **`ShaderCompiler.cs`** (`ShaderProfileFromGraphicsProfile`) lists `Level_11_2` with `11_0` and
  `11_1` in the shader-model `5_0` case, so it no longer throws.

## The display-mode path was a second crash

`FindClosestMatchingDisplayMode` exists once per backend. Both copies reinterpreted the whole profile
span as feature levels. `GamePlatform` passes the game's own `PreferredGraphicsProfile` to that method
when `IsFullScreen` is set. With 11.2 selected, the fullscreen path carried `0xB200` into device
creation.

- *Direct3D12* tried each level in turn and failed every attempt. It then threw from
  `ThrowNoCompatibleProfile`. Fullscreen therefore still rejected the profile, even with the mapping
  fixed elsewhere.
- *Direct3D11* discarded the `CreateDevice` HRESULT and then released the device and the context
  unconditionally. On failure both pointers are still `null`, so it faulted instead of reporting an
  unsupported profile. **This fault is not specific to 11.2.** Any unsupported profile in fullscreen
  reached the same null release, for example `Level_11_1` on FL10 hardware. Direct3D11 now checks the
  HRESULT before it uses the device, which is what Direct3D12 already did.

Direct3D11 and Direct3D12 now accept `Level_11_2` and run at FL 11_1, windowed and fullscreen, the
same as Vulkan. **The code still rejects what it must reject.** A profile that a device cannot provide
fails the capability check as before. Only the invalid-value failure goes away.

## Consequences to know about

- **The round trip loses information, by design.** `FromFeatureLevel` does not change, so a game that
  requests 11.2 reports `Features.CurrentProfile == Level_11_1`. `RequestedProfile` keeps the request.
  The `case Level_11_2:` arm in `GraphicsDeviceFeatures.Direct3D11.cs` is therefore unreachable. It is
  harmless, because it shares a row with `11_1` and `11_0`.
- **`IsProfileSupported(Level_11_2)` now succeeds on FL 11_1 hardware.**
  `IsPreferredProfileAvailable` walks every enum value, so the message *"the highest available profile
  is [...]"* can now name `Level_11_2`. This follows from treating 11.2 as the 11_1 tier. It is not a
  regression.
- **Shader macros still carry `0xB200`.** `EffectCompiler` emits `STRIDE_GRAPHICS_PROFILE` from the
  requested profile, plus one `GRAPHICS_PROFILE_LEVEL_*` macro per enum value. The ordered comparisons
  in `.sdsl` stay correct, because `0xB200` is above every other level. `Stride.Shaders.Tests` already
  pins those values. Shader-model resolution is the part that needed the fix.
- **The Null backend is the concrete reason the `ShaderCompiler` arm is necessary.**
  `Null/GraphicsDeviceFeatures.Null.cs` sets `RequestedProfile = CurrentProfile = Level_11_2`, and
  `EffectSystem` feeds `Features.RequestedProfile` into the compiler.
- **The test project takes its own `Silk.NET.Direct3D11` reference.** `Stride.Graphics` keeps Silk.NET
  at `PrivateAssets="compile"`, so `D3DFeatureLevel` does not flow to consumers. The reference is
  conditioned to the desktop frameworks, the same way `Stride.Graphics` conditions its own.

**Motivation and context** — see #3301. The failure does not depend on hardware. A WARP
software-renderer proof in the repro shows WARP reporting FL 12_1, rejecting `0xB200` with
`E_INVALIDARG`, and accepting `0xB100`. The mapping has been wrong since the 2018 open-source commit.
A June-2025 documentation pass added the `[Display("Level 11.2 ~ …")]` tooltip, which makes the broken
option look legitimate in Game Settings.

## Related Issue

Fixes #3301. Repro (minimal code-only game and WARP proof):
https://github.com/sasvdw/stride-graphicsprofile-level112-repro

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

**Validation status** (kept honest — check the boxes above as each one is satisfied):

- *Docs*: no documentation change is necessary. The profile works now, and the existing tooltip
  becomes accurate.
- *Tests*: `sources/engine/Stride.Graphics.Tests/TestGraphicsProfileHelper.cs` covers both mappings.
  `Level_11_2` resolves to FL 11_1 and not to `0xB200`. Every profile maps to a defined
  `D3DFeatureLevel`. A sequence maps one element at a time, so no entry can leak `0xB200`. Verified
  red and green: the sequence tests fail against a cast and pass with the mapping.
- *Build*: `Stride.Graphics` builds clean under `StrideGraphicsApi=Direct3D11` and under
  `=Direct3D12`. The two `GraphicsOutput` files sit behind mutually exclusive `#if` guards, so each
  backend needs its own build for full coverage. `Stride.Shaders.Compilers` builds clean. CI runs the
  full test suite.
- *Editor*: **outstanding**. Build and run the editor with a project set to Level 11.2, windowed and
  fullscreen, to confirm that it starts. This is the mandatory personal-testing step.
