### PR TITLE
feat: Skybox light fog

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/Editor/LightConstantWhite.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Editor/LightConstantWhite.sdsl
@@ -13,6 +13,7 @@ namespace Stride.Rendering.Lights
 
             streams.envLightDiffuseColor = 1;
             streams.envLightSpecularColor = 1;
+            streams.envLightDistFog = 0;
         }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/EnvironmentLight.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/EnvironmentLight.sdsl
@@ -11,6 +11,12 @@ namespace Stride.Rendering.Lights
         {
             streams.envLightDiffuseColor = 0;
             streams.envLightSpecularColor = 0;
+            streams.envLightDistFog = 0;
+        }
+        
+        float4 GetEnvLightDistFog()
+        {
+            return streams.envLightDistFog;
         }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSimpleAmbient.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSimpleAmbient.sdsl
@@ -20,6 +20,7 @@ namespace Stride.Rendering.Lights
             float3 lightColor = AmbientLight * streams.matAmbientOcclusion;
             streams.envLightDiffuseColor = lightColor;
             streams.envLightSpecularColor = lightColor;
+            streams.envLightDistFog = 0;
         }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkybox.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkybox.cs
@@ -21,7 +21,7 @@ namespace Stride.Rendering.Lights
         [DataMember(0)]
         public Skybox Skybox { get; set; }
 
-        public float Distance = 250f, Curve = 0.5f, NearMip = 6.87f, FarMip = 0f;
+        public float Distance = 250f, Curve = 0.5f, CurveMip = 1.0f, NearMip = 6.87f, FarMip = 0f;
 
         [DataMemberIgnore]
         internal Quaternion Rotation;

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkybox.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkybox.cs
@@ -21,6 +21,8 @@ namespace Stride.Rendering.Lights
         [DataMember(0)]
         public Skybox Skybox { get; set; }
 
+        public float AA = 250f, AB = 0.5f, AC = 0.32f, AD = 6.87f;
+
         [DataMemberIgnore]
         internal Quaternion Rotation;
 

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkybox.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkybox.cs
@@ -21,7 +21,7 @@ namespace Stride.Rendering.Lights
         [DataMember(0)]
         public Skybox Skybox { get; set; }
 
-        public float AA = 250f, AB = 0.5f, AC = 0.32f, AD = 6.87f;
+        public float Distance = 250f, Curve = 0.5f, NearMip = 6.87f, FarMip = 0f;
 
         [DataMemberIgnore]
         internal Quaternion Rotation;

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
@@ -83,10 +83,10 @@ namespace Stride.Rendering.Lights
             private static readonly ShaderClassSource EmptyComputeEnvironmentColorSource = new ShaderClassSource("IComputeEnvironmentColor");
 
             private ValueParameterKey<float> intensityKey;
-            private ValueParameterKey<float> aaKey;
-            private ValueParameterKey<float> abKey;
-            private ValueParameterKey<float> acKey;
-            private ValueParameterKey<float> adKey;
+            private ValueParameterKey<float> distanceKey;
+            private ValueParameterKey<float> curveKey;
+            private ValueParameterKey<float> farMipKey;
+            private ValueParameterKey<float> nearMipKey;
             private ValueParameterKey<Matrix> skyMatrixKey;
             private PermutationParameterKey<ShaderSource> lightDiffuseColorKey;
             private PermutationParameterKey<ShaderSource> lightSpecularColorKey;
@@ -106,10 +106,10 @@ namespace Stride.Rendering.Lights
                 base.UpdateLayout(compositionName);
 
                 intensityKey = LightSkyboxShaderKeys.Intensity.ComposeWith(compositionName);
-                aaKey = LightSkyboxShaderKeys.AA.ComposeWith(compositionName);
-                abKey = LightSkyboxShaderKeys.AB.ComposeWith(compositionName);
-                acKey = LightSkyboxShaderKeys.AC.ComposeWith(compositionName);
-                adKey = LightSkyboxShaderKeys.AD.ComposeWith(compositionName);
+                distanceKey = LightSkyboxShaderKeys.Distance.ComposeWith(compositionName);
+                curveKey = LightSkyboxShaderKeys.Curve.ComposeWith(compositionName);
+                farMipKey = LightSkyboxShaderKeys.FarMip.ComposeWith(compositionName);
+                nearMipKey = LightSkyboxShaderKeys.NearMip.ComposeWith(compositionName);
                 skyMatrixKey = LightSkyboxShaderKeys.SkyMatrix.ComposeWith(compositionName);
                 lightDiffuseColorKey = LightSkyboxShaderKeys.LightDiffuseColor.ComposeWith(compositionName);
                 lightSpecularColorKey = LightSkyboxShaderKeys.LightSpecularColor.ComposeWith(compositionName);
@@ -142,10 +142,10 @@ namespace Stride.Rendering.Lights
                 var skybox = lightSkybox.Skybox;
 
                 var intensity = Light.Intensity;
-                var aa = lightSkybox.AA;
-                var ab = lightSkybox.AB;
-                var ac = lightSkybox.AC;
-                var ad = lightSkybox.AD;
+                var distance = lightSkybox.Distance;
+                var curve = lightSkybox.Curve;
+                var nearMip = lightSkybox.NearMip;
+                var farMip = lightSkybox.FarMip;
 
                 var skyMatrix = Matrix.Invert(Matrix.RotationQuaternion(lightSkybox.Rotation));
 
@@ -161,10 +161,10 @@ namespace Stride.Rendering.Lights
 
                 // global parameters
                 parameters.Set(intensityKey, intensity);
-                parameters.Set(aaKey, aa);
-                parameters.Set(abKey, ab);
-                parameters.Set(acKey, ac);
-                parameters.Set(adKey, ad);
+                parameters.Set(distanceKey, distance);
+                parameters.Set(curveKey, curve);
+                parameters.Set(nearMipKey, nearMip);
+                parameters.Set(farMipKey, farMip);
                 parameters.Set(skyMatrixKey, skyMatrix);
 
                 // This need to be working with new system

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
@@ -83,6 +83,10 @@ namespace Stride.Rendering.Lights
             private static readonly ShaderClassSource EmptyComputeEnvironmentColorSource = new ShaderClassSource("IComputeEnvironmentColor");
 
             private ValueParameterKey<float> intensityKey;
+            private ValueParameterKey<float> aaKey;
+            private ValueParameterKey<float> abKey;
+            private ValueParameterKey<float> acKey;
+            private ValueParameterKey<float> adKey;
             private ValueParameterKey<Matrix> skyMatrixKey;
             private PermutationParameterKey<ShaderSource> lightDiffuseColorKey;
             private PermutationParameterKey<ShaderSource> lightSpecularColorKey;
@@ -102,6 +106,10 @@ namespace Stride.Rendering.Lights
                 base.UpdateLayout(compositionName);
 
                 intensityKey = LightSkyboxShaderKeys.Intensity.ComposeWith(compositionName);
+                aaKey = LightSkyboxShaderKeys.AA.ComposeWith(compositionName);
+                abKey = LightSkyboxShaderKeys.AB.ComposeWith(compositionName);
+                acKey = LightSkyboxShaderKeys.AC.ComposeWith(compositionName);
+                adKey = LightSkyboxShaderKeys.AD.ComposeWith(compositionName);
                 skyMatrixKey = LightSkyboxShaderKeys.SkyMatrix.ComposeWith(compositionName);
                 lightDiffuseColorKey = LightSkyboxShaderKeys.LightDiffuseColor.ComposeWith(compositionName);
                 lightSpecularColorKey = LightSkyboxShaderKeys.LightSpecularColor.ComposeWith(compositionName);
@@ -134,6 +142,10 @@ namespace Stride.Rendering.Lights
                 var skybox = lightSkybox.Skybox;
 
                 var intensity = Light.Intensity;
+                var aa = lightSkybox.AA;
+                var ab = lightSkybox.AB;
+                var ac = lightSkybox.AC;
+                var ad = lightSkybox.AD;
 
                 var skyMatrix = Matrix.Invert(Matrix.RotationQuaternion(lightSkybox.Rotation));
 
@@ -149,6 +161,10 @@ namespace Stride.Rendering.Lights
 
                 // global parameters
                 parameters.Set(intensityKey, intensity);
+                parameters.Set(aaKey, aa);
+                parameters.Set(abKey, ab);
+                parameters.Set(acKey, ac);
+                parameters.Set(adKey, ad);
                 parameters.Set(skyMatrixKey, skyMatrix);
 
                 // This need to be working with new system

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
@@ -85,6 +85,7 @@ namespace Stride.Rendering.Lights
             private ValueParameterKey<float> intensityKey;
             private ValueParameterKey<float> distanceKey;
             private ValueParameterKey<float> curveKey;
+            private ValueParameterKey<float> curveMipKey;
             private ValueParameterKey<float> farMipKey;
             private ValueParameterKey<float> nearMipKey;
             private ValueParameterKey<Matrix> skyMatrixKey;
@@ -108,6 +109,7 @@ namespace Stride.Rendering.Lights
                 intensityKey = LightSkyboxShaderKeys.Intensity.ComposeWith(compositionName);
                 distanceKey = LightSkyboxShaderKeys.Distance.ComposeWith(compositionName);
                 curveKey = LightSkyboxShaderKeys.Curve.ComposeWith(compositionName);
+                curveMipKey = LightSkyboxShaderKeys.CurveMip.ComposeWith(compositionName);
                 farMipKey = LightSkyboxShaderKeys.FarMip.ComposeWith(compositionName);
                 nearMipKey = LightSkyboxShaderKeys.NearMip.ComposeWith(compositionName);
                 skyMatrixKey = LightSkyboxShaderKeys.SkyMatrix.ComposeWith(compositionName);
@@ -144,6 +146,7 @@ namespace Stride.Rendering.Lights
                 var intensity = Light.Intensity;
                 var distance = lightSkybox.Distance;
                 var curve = lightSkybox.Curve;
+                var curveMip = lightSkybox.CurveMip;
                 var nearMip = lightSkybox.NearMip;
                 var farMip = lightSkybox.FarMip;
 
@@ -163,6 +166,7 @@ namespace Stride.Rendering.Lights
                 parameters.Set(intensityKey, intensity);
                 parameters.Set(distanceKey, distance);
                 parameters.Set(curveKey, curve);
+                parameters.Set(curveMipKey, curveMip);
                 parameters.Set(nearMipKey, nearMip);
                 parameters.Set(farMipKey, farMip);
                 parameters.Set(skyMatrixKey, skyMatrix);

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxShader.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxShader.sdsl
@@ -11,10 +11,10 @@ namespace Stride.Rendering.Lights
         {
             float4x4 SkyMatrix;
             float Intensity;
-            float AA;
-            float AB;
-            float AC;
-            float AD;
+            float Distance;
+            float Curve;
+            float FarMip;
+            float NearMip;
         }
 
         compose IComputeEnvironmentColor lightDiffuseColor;
@@ -59,15 +59,12 @@ namespace Stride.Rendering.Lights
             viewVector = float3(viewVector.xy, -viewVector.z);
 
             float dist = length(viewVector);
-            dist = Remap(0, AA, 0, 1, dist);
+            dist = Remap(0, Distance, 0, 1, dist);
+            dist = saturate(dist);
 
-            float curve = pow(dist, AB);
-            curve = saturate(curve);
-            float alpha = saturate(curve);
+            float curve = pow(dist, Curve);
             
-            float skyboxBlur = Remap(0, 1, 0, AC, dist);
-            skyboxBlur = saturate(skyboxBlur);
-            skyboxBlur = Remap(0, 1, AD, 0, skyboxBlur);
+            float skyboxBlur = Remap(0, 1, NearMip, FarMip, curve);
             
             float f = floor(skyboxBlur);
             float3 colorA = lightSpecularColor.Compute(viewVector, f).rgb;
@@ -75,7 +72,7 @@ namespace Stride.Rendering.Lights
 
             float4 fog;
             fog.rgb = lerp(colorA, colorB, frac(skyboxBlur));
-            fog.a = alpha;
+            fog.a = curve;
         
             return fog;
         }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxShader.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxShader.sdsl
@@ -5,12 +5,16 @@ namespace Stride.Rendering.Lights
     /// <summary>
     /// Defines a skybox environment light
     /// </summary>
-    shader LightSkyboxShader : EnvironmentLight, MaterialPixelShadingStream, NormalStream, Transformation
+    shader LightSkyboxShader : EnvironmentLight, MaterialPixelShadingStream, NormalStream, Transformation, PositionStream
     {
         cbuffer PerView.Lighting
         {
             float4x4 SkyMatrix;
             float Intensity;
+            float AA;
+            float AB;
+            float AC;
+            float AD;
         }
 
         compose IComputeEnvironmentColor lightDiffuseColor;
@@ -44,6 +48,41 @@ namespace Stride.Rendering.Lights
             sampleDirection = float3(sampleDirection.xy, -sampleDirection.z);
 
             streams.envLightSpecularColor = lightSpecularColor.Compute(sampleDirection).rgb * Intensity * ambientAccessibility * streams.matDiffuseSpecularAlphaBlend.y;
+
+            streams.envLightDistFog = Fog();
+        }
+        
+        float4 Fog()
+        {
+            float3 viewVector = streams.PositionWS.xyz - Eye.xyz;
+            viewVector = mul(viewVector, (float3x3)SkyMatrix);
+            viewVector = float3(viewVector.xy, -viewVector.z);
+
+            float dist = length(viewVector);
+            dist = Remap(0, AA, 0, 1, dist);
+
+            float curve = pow(dist, AB);
+            curve = saturate(curve);
+            float alpha = saturate(curve);
+            
+            float skyboxBlur = Remap(0, 1, 0, AC, dist);
+            skyboxBlur = saturate(skyboxBlur);
+            skyboxBlur = Remap(0, 1, AD, 0, skyboxBlur);
+            
+            float f = floor(skyboxBlur);
+            float3 colorA = lightSpecularColor.Compute(viewVector, f).rgb;
+            float3 colorB = lightSpecularColor.Compute(viewVector, f+1).rgb;
+
+            float4 fog;
+            fog.rgb = lerp(colorA, colorB, frac(skyboxBlur));
+            fog.a = alpha;
+        
+            return fog;
+        }
+
+        float Remap(float origFrom, float origTo, float targetFrom, float targetTo, float value)
+        {
+            return lerp(targetFrom, targetTo, (value - origFrom) / (origTo - origFrom));
         }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxShader.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightSkyboxShader.sdsl
@@ -13,6 +13,7 @@ namespace Stride.Rendering.Lights
             float Intensity;
             float Distance;
             float Curve;
+            float CurveMip;
             float FarMip;
             float NearMip;
         }
@@ -61,18 +62,12 @@ namespace Stride.Rendering.Lights
             float dist = length(viewVector);
             dist = Remap(0, Distance, 0, 1, dist);
             dist = saturate(dist);
-
-            float curve = pow(dist, Curve);
             
-            float skyboxBlur = Remap(0, 1, NearMip, FarMip, curve);
-            
-            float f = floor(skyboxBlur);
-            float3 colorA = lightSpecularColor.Compute(viewVector, f).rgb;
-            float3 colorB = lightSpecularColor.Compute(viewVector, f+1).rgb;
+            float skyboxMip = Remap(0, 1, NearMip, FarMip, pow(dist, CurveMip));
 
             float4 fog;
-            fog.rgb = lerp(colorA, colorB, frac(skyboxBlur));
-            fog.a = curve;
+            fog.rgb = lightSpecularColor.Compute(viewVector, skyboxMip).rgb;
+            fog.a = pow(dist, Curve);
         
             return fog;
         }

--- a/sources/engine/Stride.Rendering/Rendering/Lights/LightStream.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Lights/LightStream.sdsl
@@ -15,6 +15,7 @@ namespace Stride.Rendering.Lights
         stage stream float lightAttenuation;
         stage stream float3 envLightDiffuseColor;
         stage stream float3 envLightSpecularColor;
+        stage stream float4 envLightDistFog;
 
         // normal dot light
         stage stream float NdotL;
@@ -31,6 +32,7 @@ namespace Stride.Rendering.Lights
             streams.lightAttenuation = 1.0f;
             streams.envLightDiffuseColor = 0;
             streams.envLightSpecularColor = 0;
+            streams.envLightDistFog = 0;
             streams.lightDirectAmbientOcclusion = 1.0f;
             streams.NdotL = 0;
         }

--- a/sources/engine/Stride.Rendering/Rendering/Materials/Shaders/MaterialSurfaceLightingAndShading.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/Shaders/MaterialSurfaceLightingAndShading.sdsl
@@ -72,10 +72,12 @@ namespace Stride.Rendering.Materials
             // Compute Environment Lighting contribution
             // ---------------------------------------------------------------------------
             float3 environmentLightingContribution = 0;
+            float4 environmentFogContribution = 0;
             foreach(var environmentLight in environmentLights)
             {
                 // Compute the environment light color (streams.lightColor)
                 environmentLight.PrepareEnvironmentLight();
+                environmentFogContribution += environmentLight.GetEnvLightDistFog();
 
                 // Iterate on shading models
                 foreach(var surface in surfaces)
@@ -86,6 +88,7 @@ namespace Stride.Rendering.Materials
 
             // Add Direct (*PI over hemisphere) and Environment Lighting
             streams.shadingColor += directLightingContribution * PI + environmentLightingContribution;
+            streams.shadingColor = lerp(streams.shadingColor, environmentFogContribution.rgb, saturate(environmentFogContribution.a));
             streams.shadingColorAlpha = streams.matDiffuse.a;
 
             // Do any computations after lighting and shading, like discarding pixels for example.

--- a/sources/engine/Stride.Rendering/Rendering/Skyboxes/IComputeEnvironmentColor.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Skyboxes/IComputeEnvironmentColor.sdsl
@@ -12,5 +12,10 @@ namespace Stride.Rendering.Skyboxes
         {
             return 0;
         }
+
+        float4 Compute(float3 direction, float blurriness)
+        {
+            return 0;
+        }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Skyboxes/LevelCubeMapEnvironmentColor.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Skyboxes/LevelCubeMapEnvironmentColor.sdsl
@@ -15,5 +15,10 @@ namespace Stride.Rendering.Skyboxes
         {
             return CubeMap.SampleLevel(LinearSampler, direction, MipLevel);
         }
+
+        override float4 Compute(float3 direction, float blurriness)
+        {
+            return CubeMap.SampleLevel(LinearSampler, direction, blurriness);
+        }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Skyboxes/RoughnessCubeMapEnvironmentColor.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Skyboxes/RoughnessCubeMapEnvironmentColor.sdsl
@@ -25,5 +25,10 @@ namespace Stride.Rendering.Skyboxes
 
             return CubeMap.SampleLevel(LinearSampler, direction, mipLevel);
         }
+
+        override float4 Compute(float3 direction, float blurriness)
+        {
+            return CubeMap.SampleLevel(LinearSampler, direction, blurriness);
+        }
     };
 }

--- a/sources/engine/Stride.Rendering/Rendering/Skyboxes/SphericalHarmonicsEnvironmentColor.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/Skyboxes/SphericalHarmonicsEnvironmentColor.sdsl
@@ -24,5 +24,10 @@ namespace Stride.Rendering.Skyboxes
 
             return EvaluateSphericalHarmonics(SphericalColors, direction);
         }
+
+        override float4 Compute(float3 direction, float blurriness)
+        {
+            return EvaluateSphericalHarmonics(SphericalColors, direction);
+        }
     };
 }


### PR DESCRIPTION
# PR Details
Adds a fog feature to the skybox light, this is different from the fog post process as it matches the skybox used instead of having a singular color used for the whole range.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/21217811-3311-43f4-a39c-f3ac33cb5251" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/bbab3f2b-b849-4c4c-b9c5-b0d9fb83d4ff" />
The idea is to sample the skybox over the surface, increase in mipmap res the further the surface is.

Mar Saba Monastery model belongs to [Andrea Spognetta](https://sketchfab.com/3d-models/mar-saba-monastery-rawscan-65cd2eee84544eea856c0215dd67bc3d)

## Related Issue
None.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**


The implementation is kind of hack-y. Hoping Xen2 or Youness could push me in the right direction. On that note, current questions regarding the implementation:
- Does this make sense as part of the Skybox light, we've had some back and forth with Ethereal about this and here's what we think
   - Ethereal is suggesting we move the implementation to be part of the graphics compositor, but with components and parameters still defined in the scene. 
   - This implementation is ultimately dependent on the `BackgroundComponent`'s skybox used, not the lights' parameters. So we could split it off of the light either as a new component or something else ?
   - But `BackgroundComponent` is not guaranteed to be set to a skybox, it could be a 2d texture. We could branch this implementation to handle the different parameters of the background appropriately. But I'm not seeing an obvious way to do so cleanly.
   - To work around the point above, we could create a new component that takes care of both the background and the fog at the same time. Users would remove their background component, and use this one instead. Does that make sense ?
- Should `Distance`, `Curve`, `NearMip`, etc. be generics or leave them as `PerView.Lighting` ? If they should, how would I set that up.