### PR TITLE
fix: correct unordered access binding, storage image formats and subresource copies on Vulkan

### DIFF
--- a/sources/engine/Stride.Graphics.Tests.11_0/Assets/UnorderedAccessOnlyTextureShader.sdsl
+++ b/sources/engine/Stride.Graphics.Tests.11_0/Assets/UnorderedAccessOnlyTextureShader.sdsl
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Graphics.Tests
+{
+    /// <summary>
+    /// Writes each thread's dispatch coordinates into an unordered access texture.
+    /// </summary>
+    internal shader UnorderedAccessOnlyTextureShader : ComputeShaderBase
+    {
+        stage RWTexture2D<float4> Output;
+
+        override void Compute()
+        {
+            Output[streams.DispatchThreadId.xy] = float4(streams.DispatchThreadId.x, streams.DispatchThreadId.y, 0, 1);
+        }
+    };
+}

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestHammersley.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestHammersley.cs
@@ -83,8 +83,6 @@ namespace Stride.Graphics.Tests
         [SkippableFact]
         public void RunImageLoad()
         {
-            SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan);
-
             RunGameTest(new TestHammersley());
         }
     }

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestHammersley.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestHammersley.cs
@@ -80,7 +80,7 @@ namespace Stride.Graphics.Tests
         /// <summary>
         /// Run the test
         /// </summary>
-        [SkippableFact]
+        [Fact]
         public void RunImageLoad()
         {
             RunGameTest(new TestHammersley());

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestLambertPrefilteringSHPass2.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestLambertPrefilteringSHPass2.cs
@@ -136,8 +136,6 @@ namespace Stride.Graphics.Tests
         [SkippableFact]
         public void RunTestPass2()
         {
-            SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan);
-
             RunGameTest(new TestLambertPrefilteringSHPass2());
         }
     }

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestLambertPrefilteringSHPass2.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestLambertPrefilteringSHPass2.cs
@@ -133,7 +133,7 @@ namespace Stride.Graphics.Tests
         }
 
 
-        [SkippableFact]
+        [Fact]
         public void RunTestPass2()
         {
             RunGameTest(new TestLambertPrefilteringSHPass2());

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgx.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgx.cs
@@ -239,7 +239,7 @@ namespace Stride.Graphics.Tests
         [SkippableFact]
         public void RunTest()
         {
-            SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan);
+            SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan, "Lavapipe renders mip 1 of the non-compute prefilter path differently from the D3D reference");
 
             RunGameTest(new TestRadiancePrefilteringGgx());
         }

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgx.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgx.cs
@@ -236,11 +236,9 @@ namespace Stride.Graphics.Tests
             }
         }
 
-        [SkippableFact]
+        [Fact]
         public void RunTest()
         {
-            SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan, "Lavapipe renders mip 1 of the non-compute prefilter path differently from the D3D reference");
-
             RunGameTest(new TestRadiancePrefilteringGgx());
         }
     }

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestUnorderedAccessOnlyTexture.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestUnorderedAccessOnlyTexture.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+
+using Xunit;
+
+using Stride.Core;
+using Stride.Core.Mathematics;
+using Stride.Rendering;
+using Stride.Rendering.ComputeEffect;
+
+namespace Stride.Graphics.Tests;
+
+public class TestUnorderedAccessOnlyTexture : GraphicTestGameBase
+{
+    private const int TextureSize = 4;
+
+    private ComputeEffectShader computeEffect;
+    private Texture outputTexture;
+
+    protected override void RegisterTests()
+    {
+        base.RegisterTests();
+
+        FrameGameSystem.Draw(ComputeShaderWritesToUnorderedAccessOnlyTexture);
+    }
+
+    protected override async Task LoadContent()
+    {
+        await base.LoadContent();
+
+        // Deliberately no ShaderResource flag: this is the case where the Vulkan backend used to
+        // produce no image view and silently bind the empty texture instead.
+        outputTexture = Texture.New2D(GraphicsDevice, TextureSize, TextureSize, PixelFormat.R32G32B32A32_Float, TextureFlags.UnorderedAccess).DisposeBy(this);
+
+        computeEffect = new ComputeEffectShader(RenderContext.GetShared(Services))
+        {
+            ShaderSourceName = "UnorderedAccessOnlyTextureShader",
+            ThreadNumbers = new Int3(TextureSize, TextureSize, 1),
+            ThreadGroupCounts = new Int3(1, 1, 1),
+        };
+        computeEffect.DisposeBy(this);
+    }
+
+    private void ComputeShaderWritesToUnorderedAccessOnlyTexture()
+    {
+        var commandList = GraphicsContext.CommandList;
+        var renderDrawContext = new RenderDrawContext(Services, RenderContext.GetShared(Services), GraphicsContext);
+
+        commandList.ResourceBarrierTransition(outputTexture, BarrierLayout.UnorderedAccess);
+
+        computeEffect.Parameters.Set(UnorderedAccessOnlyTextureShaderKeys.Output, outputTexture);
+        ((RendererBase)computeEffect).Draw(renderDrawContext);
+
+        var pixels = outputTexture.GetData<Vector4>(commandList);
+
+        Assert.Equal(TextureSize * TextureSize, pixels.Length);
+        for (int y = 0; y < TextureSize; y++)
+        {
+            for (int x = 0; x < TextureSize; x++)
+            {
+                Assert.Equal(new Vector4(x, y, 0, 1), pixels[(y * TextureSize) + x]);
+            }
+        }
+    }
+
+    [SkippableFact]
+    public void ComputeShaderCanWriteToUnorderedAccessOnlyTexture()
+    {
+        RunGameTest(new TestUnorderedAccessOnlyTexture());
+    }
+}

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestUnorderedAccessOnlyTexture.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestUnorderedAccessOnlyTexture.cs
@@ -65,7 +65,7 @@ public class TestUnorderedAccessOnlyTexture : GraphicTestGameBase
         }
     }
 
-    [SkippableFact]
+    [Fact]
     public void ComputeShaderCanWriteToUnorderedAccessOnlyTexture()
     {
         RunGameTest(new TestUnorderedAccessOnlyTexture());

--- a/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Buffer.Vulkan.cs
@@ -122,14 +122,14 @@ namespace Stride.Graphics
                 {
                     createInfo.usage |= VkBufferUsageFlags.UniformBuffer;
                     NativeAccessMask |= VkAccessFlags.UniformRead;
-                    NativePipelineStageMask |= VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.FragmentShader;
+                    NativePipelineStageMask |= VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.FragmentShader | VkPipelineStageFlags.ComputeShader;
                 }
 
                 if ((ViewFlags & BufferFlags.StructuredBuffer) != 0)
                 {
                     createInfo.usage |= VkBufferUsageFlags.StorageBuffer;
-                    NativeAccessMask |= VkAccessFlags.UniformRead;
-                    NativePipelineStageMask |= VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.FragmentShader;
+                    NativeAccessMask |= VkAccessFlags.ShaderRead;
+                    NativePipelineStageMask |= VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.FragmentShader | VkPipelineStageFlags.ComputeShader;
 
                     if ((ViewFlags & BufferFlags.UnorderedAccess) != 0)
                     {
@@ -141,7 +141,7 @@ namespace Stride.Graphics
                 {
                     createInfo.usage |= VkBufferUsageFlags.UniformTexelBuffer;
                     NativeAccessMask |= VkAccessFlags.ShaderRead;
-                    NativePipelineStageMask |= VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.FragmentShader;
+                    NativePipelineStageMask |= VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.FragmentShader | VkPipelineStageFlags.ComputeShader;
 
                     if ((ViewFlags & BufferFlags.UnorderedAccess) != 0)
                     {

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -1242,6 +1242,23 @@ namespace Stride.Graphics
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        ///   Resolves a subresource index into the Vulkan subresource layers it addresses.
+        /// </summary>
+        /// <param name="texture">The Texture the index refers to.</param>
+        /// <param name="imageAspect">The image aspect to select.</param>
+        /// <param name="subresourceIndex">
+        ///   The subresource index, encoded as <c>arraySlice * MipLevelCount + mipLevel</c>
+        ///   (see <see cref="Texture.GetSubResourceIndex"/>).
+        /// </param>
+        private static VkImageSubresourceLayers GetSubresourceLayers(Texture texture, VkImageAspectFlags imageAspect, int subresourceIndex)
+        {
+            return new VkImageSubresourceLayers(imageAspect,
+                                                mipLevel: (uint) (subresourceIndex % texture.MipLevelCount),
+                                                baseArrayLayer: (uint) (subresourceIndex / texture.MipLevelCount),
+                                                layerCount: 1);
+        }
+
         public unsafe void CopyRegion(GraphicsResource source, int sourceSubresource, ResourceRegion? sourceRegion, GraphicsResource destination, int destinationSubResource, int dstX = 0, int dstY = 0, int dstZ = 0)
         {
             RecordDebugCounter(DebugCounterKind.Copy);
@@ -1307,8 +1324,7 @@ namespace Stride.Graphics
                             bufferOffset = (ulong)destinationTexture.ComputeBufferOffset(destinationSubResource, 0),
                             bufferImageHeight = (uint)destinationTexture.Height,
                             bufferRowLength = (uint)destinationTexture.Width,
-                            // Review: Method parameter is ignored, D3D12 doesn't do that and ignore texture view details
-                            imageSubresource = new VkImageSubresourceLayers(sourceParent.NativeImageAspect, (uint)sourceTexture.MipLevel, (uint)sourceTexture.ArraySlice, (uint)sourceTexture.ArraySize),
+                            imageSubresource = GetSubresourceLayers(sourceTexture, sourceParent.NativeImageAspect, sourceSubresource),
                             imageOffset = new VkOffset3D(region.Left, region.Top, region.Front),
                             imageExtent = new VkExtent3D((uint)(region.Right - region.Left), (uint)(region.Bottom - region.Top), (uint)(region.Back - region.Front))
                         };
@@ -1322,8 +1338,7 @@ namespace Stride.Graphics
                 }
                 else
                 {
-                    // Review: Method parameter is ignored, D3D12 doesn't do that and ignore texture view details
-                    var destinationSubresource = new VkImageSubresourceLayers(destinationParent.NativeImageAspect, (uint) destinationTexture.MipLevel, (uint) destinationTexture.ArraySlice, (uint) destinationTexture.ArraySize);
+                    var destinationSubresource = GetSubresourceLayers(destinationTexture, destinationParent.NativeImageAspect, destinationSubResource);
 
                     if (sourceTexture.Usage == GraphicsResourceUsage.Staging)
                     {
@@ -1346,7 +1361,7 @@ namespace Stride.Graphics
                     {
                         var copy = new VkImageCopy
                         {
-                            srcSubresource = new VkImageSubresourceLayers(sourceParent.NativeImageAspect, (uint) sourceTexture.MipLevel, (uint) sourceTexture.ArraySlice, (uint) sourceTexture.ArraySize),
+                            srcSubresource = GetSubresourceLayers(sourceTexture, sourceParent.NativeImageAspect, sourceSubresource),
                             srcOffset = new VkOffset3D(region.Left, region.Top, region.Front),
                             dstSubresource = destinationSubresource,
                             dstOffset = new VkOffset3D(dstX, dstY, dstZ),

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -508,6 +508,7 @@ namespace Stride.Graphics
                         break;
 
                     case VkDescriptorType.UniformTexelBuffer:
+                    case VkDescriptorType.StorageTexelBuffer:
                         buffer = heapObject.Value as Buffer;
                         descriptorData->BufferView = buffer?.NativeBufferView ?? (mapping.ResourceElementIsInteger ? GraphicsDevice.EmptyTexelBufferInt.NativeBufferView : GraphicsDevice.EmptyTexelBufferFloat.NativeBufferView);
                         write->pTexelBufferView = &descriptorData->BufferView;

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -1245,8 +1245,6 @@ namespace Stride.Graphics
         /// <summary>
         ///   Resolves a subresource index into the Vulkan subresource layers it addresses.
         /// </summary>
-        /// <param name="texture">The Texture the index refers to.</param>
-        /// <param name="imageAspect">The image aspect to select.</param>
         /// <param name="subresourceIndex">
         ///   The subresource index, encoded as <c>arraySlice * MipLevelCount + mipLevel</c>
         ///   (see <see cref="Texture.GetSubResourceIndex"/>).

--- a/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
@@ -182,7 +182,7 @@ namespace Stride.Graphics
                 NativePipelineStageMask =
                     IsRenderTarget ? VkPipelineStageFlags.ColorAttachmentOutput :
                     IsDepthStencil ? VkPipelineStageFlags.ColorAttachmentOutput | VkPipelineStageFlags.EarlyFragmentTests | VkPipelineStageFlags.LateFragmentTests :
-                    IsShaderResource ? VkPipelineStageFlags.VertexInput | VkPipelineStageFlags.FragmentShader :
+                    IsShaderResource || IsUnorderedAccess ? VkPipelineStageFlags.VertexInput | VkPipelineStageFlags.FragmentShader | VkPipelineStageFlags.ComputeShader :
                     VkPipelineStageFlags.None;
 
                 if (ParentTexture != null)
@@ -501,7 +501,7 @@ namespace Stride.Graphics
 
         private unsafe VkImageView GetImageView(ViewType viewType, int arrayOrDepthSlice, int mipIndex)
         {
-            if (!IsShaderResource)
+            if (!IsShaderResource && !IsUnorderedAccess)
                 return VkImageView.Null;
 
             if (viewType == ViewType.MipBand && IsRenderTarget)
@@ -512,7 +512,8 @@ namespace Stride.Graphics
             var layerCount = Dimension == TextureDimension.Texture3D ? 1 : arrayOrDepthCount;
 
             // Narrow view usage to what it's actually bound as (drops ColorAttachment etc.) — avoids MoltenVK's layered-render check on iOS sim.
-            var viewUsage = VkImageUsageFlags.Sampled;
+            var viewUsage = default(VkImageUsageFlags);
+            if (IsShaderResource) viewUsage |= VkImageUsageFlags.Sampled;
             if (IsUnorderedAccess) viewUsage |= VkImageUsageFlags.Storage;
             var viewUsageInfo = new VkImageViewUsageCreateInfo
             {

--- a/sources/engine/Stride.Graphics/Vulkan/VulkanConvertExtensions.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/VulkanConvertExtensions.cs
@@ -732,8 +732,10 @@ namespace Stride.Graphics
                         case EffectParameterType.RWTexture2D:
                         case EffectParameterType.RWTexture2DArray:
                         case EffectParameterType.RWTexture3D:
-                        case EffectParameterType.RWBuffer:
                             return VkDescriptorType.StorageImage;
+
+                        case EffectParameterType.RWBuffer:
+                            return VkDescriptorType.StorageTexelBuffer;
 
                         case EffectParameterType.Buffer:
                         case EffectParameterType.StructuredBuffer:

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
@@ -167,9 +167,9 @@ public partial class SpirvContext
             // SampledType stores the full return type (e.g. float4, not just float) so that
             // Texture<float> and Texture<float4> produce structurally distinct OpTypeImage during merge.
             // ShaderMixer normalizes SampledType back to scalar before final SPIR-V emission.
-            // The element type must not be used to infer a storage image format: RWTexture2D<float4>
-            // binds equally to R8G8B8A8_UNorm or R32G32B32A32_Float, and the view decides. Leaving the
-            // format Unknown makes ShaderMixer request StorageImage{Read,Write}WithoutFormat instead.
+            // Do not infer a storage image format from the element type. The view decides it:
+            // RWTexture2D<float4> binds equally to R8G8B8A8_UNorm and R32G32B32A32_Float. An
+            // Unknown format makes ShaderMixer request StorageImage{Read,Write}WithoutFormat.
             Texture1DType t => Buffer.AddData(new OpTypeImage(id, GetOrRegister(t.ReturnType), t.Dimension,
                 t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Format, null)).IdResult,
             Texture2DType t => Buffer.AddData(new OpTypeImage(id, GetOrRegister(t.ReturnType), t.Dimension,

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
@@ -167,14 +167,17 @@ public partial class SpirvContext
             // SampledType stores the full return type (e.g. float4, not just float) so that
             // Texture<float> and Texture<float4> produce structurally distinct OpTypeImage during merge.
             // ShaderMixer normalizes SampledType back to scalar before final SPIR-V emission.
+            // The element type must not be used to infer a storage image format: RWTexture2D<float4>
+            // binds equally to R8G8B8A8_UNorm or R32G32B32A32_Float, and the view decides. Leaving the
+            // format Unknown makes ShaderMixer request StorageImage{Read,Write}WithoutFormat instead.
             Texture1DType t => Buffer.AddData(new OpTypeImage(id, GetOrRegister(t.ReturnType), t.Dimension,
-                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Sampled == 2 ? GetStorageImageFormat(t.ReturnType) : t.Format, null)).IdResult,
+                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Format, null)).IdResult,
             Texture2DType t => Buffer.AddData(new OpTypeImage(id, GetOrRegister(t.ReturnType), t.Dimension,
-                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Sampled == 2 ? GetStorageImageFormat(t.ReturnType) : t.Format, null)).IdResult,
+                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Format, null)).IdResult,
             Texture3DType t => Buffer.AddData(new OpTypeImage(id, GetOrRegister(t.ReturnType), t.Dimension,
-                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Sampled == 2 ? GetStorageImageFormat(t.ReturnType) : t.Format, null)).IdResult,
+                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Format, null)).IdResult,
             TextureCubeType t => Buffer.AddData(new OpTypeImage(id, GetOrRegister(t.ReturnType), t.Dimension,
-                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Sampled == 2 ? GetStorageImageFormat(t.ReturnType) : t.Format, null)).IdResult,
+                t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Format, null)).IdResult,
             SamplerType st => Buffer.AddData(new OpTypeSampler(id)).IdResult,
             BufferType b => Buffer.AddData(new OpTypeImage(id, GetOrRegister(b.BaseType), Specification.Dim.Buffer,
                 2, 0, 0, b.WriteAllowed ? 2 : 1, Specification.ImageFormat.Unknown, null)).IdResult,
@@ -357,25 +360,4 @@ public partial class SpirvContext
         return id;
     }
 
-    // Derives the SPIR-V ImageFormat for a storage (RW) texture from its return type.
-    // Note: 3-component float/int/uint formats don't exist in SPIR-V (no Rgb32f etc.).
-    private static Specification.ImageFormat GetStorageImageFormat(SymbolType returnType)
-    {
-        var scalar = returnType.GetElementType();
-        int count = returnType.GetElementCount();
-        return (scalar.Type, count) switch
-        {
-            (Scalar.Float, 1) => Specification.ImageFormat.R32f,
-            (Scalar.Float, 2) => Specification.ImageFormat.Rg32f,
-            (Scalar.Float, 4) => Specification.ImageFormat.Rgba32f,
-            (Scalar.Float, 3) => Specification.ImageFormat.Unknown,
-            (Scalar.UInt, 1) => Specification.ImageFormat.R32ui,
-            (Scalar.UInt, 2) => Specification.ImageFormat.Rg32ui,
-            (Scalar.UInt, 4) => Specification.ImageFormat.Rgba32ui,
-            (Scalar.Int, 1) => Specification.ImageFormat.R32i,
-            (Scalar.Int, 2) => Specification.ImageFormat.Rg32i,
-            (Scalar.Int, 4) => Specification.ImageFormat.Rgba32i,
-            _ => Specification.ImageFormat.Unknown,
-        };
-    }
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f1.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f1.metadata.json
@@ -1,0 +1,14 @@
+{
+  "os": "Microsoft Windows 10.0.26100",
+  "cpu": "AMD EPYC 7763 64-Core Processor",
+  "gpu": "Mesa llvmpipe (LLVM 21.1.0, 256 bits)",
+  "gpuVendorId": "0x10005",
+  "gpuDeviceId": "0x0000",
+  "vendorName": "Mesa",
+  "driverId": "MesaLLVMPipe",
+  "driverName": "llvmpipe",
+  "driverInfo": "Mesa 26.2.0-devel (git-154d3b5812) (LLVM 21.1.0)",
+  "driverVersion": "26.1.99",
+  "apiName": "Vulkan",
+  "apiVersion": "1.4.352"
+}

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f1.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1c06b80ef756412e57c25f96cba10ef19ce89b6657128c159fb668e1c531468
+size 253030

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f2.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f2.metadata.json
@@ -1,0 +1,14 @@
+{
+  "os": "Microsoft Windows 10.0.26100",
+  "cpu": "AMD EPYC 7763 64-Core Processor",
+  "gpu": "Mesa llvmpipe (LLVM 21.1.0, 256 bits)",
+  "gpuVendorId": "0x10005",
+  "gpuDeviceId": "0x0000",
+  "vendorName": "Mesa",
+  "driverId": "MesaLLVMPipe",
+  "driverName": "llvmpipe",
+  "driverInfo": "Mesa 26.2.0-devel (git-154d3b5812) (LLVM 21.1.0)",
+  "driverVersion": "26.1.99",
+  "apiName": "Vulkan",
+  "apiVersion": "1.4.352"
+}

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f2.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Vulkan/Lavapipe/TestRadiancePrefilteringGgx.f2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02c2a5e9dde85ac4737b3b9450ead45032c54b884497d02ad138820a603fdfdc
+size 193517

--- a/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f1.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f1.metadata.json
@@ -1,0 +1,13 @@
+{
+  "os": "macOS 26.5.2",
+  "cpu": "Apple M1 (Virtual)",
+  "gpu": "Apple Paravirtual device",
+  "gpuVendorId": "0x106B",
+  "gpuDeviceId": "0x1A050205",
+  "driverId": "Moltenvk",
+  "driverName": "MoltenVK",
+  "driverInfo": "1.4.2",
+  "driverVersion": "0.2.2210",
+  "apiName": "Vulkan",
+  "apiVersion": "1.3.350"
+}

--- a/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f1.png
+++ b/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831911a5fa98583ead2d746de438007fa39b414fd636c8a0ec7cc81c14745fb7
+size 255818

--- a/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f2.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f2.metadata.json
@@ -1,0 +1,13 @@
+{
+  "os": "macOS 26.5.2",
+  "cpu": "Apple M1 (Virtual)",
+  "gpu": "Apple Paravirtual device",
+  "gpuVendorId": "0x106B",
+  "gpuDeviceId": "0x1A050205",
+  "driverId": "Moltenvk",
+  "driverName": "MoltenVK",
+  "driverInfo": "1.4.2",
+  "driverVersion": "0.2.2210",
+  "apiName": "Vulkan",
+  "apiVersion": "1.3.350"
+}

--- a/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f2.png
+++ b/tests/Stride.Graphics.Tests.11_0/macOS.Vulkan/Apple M1/TestRadiancePrefilteringGgx.f2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bfd9c03aa54f2db57f0a851baa190a691ef936eadac811d7eb4548fd397ffc3
+size 194643


### PR DESCRIPTION
# PR Details

Compute shaders that bind an unordered access view produced wrong results on Vulkan. Five separate defects caused this, and every one of them failed silently. The shader wrote to a harmless place, and the reads returned empty data.

Three tests that were disabled because of these defects now run again.

### 1. `RWBuffer<T>` bound as a storage image

`ConvertDescriptorType` mapped `EffectParameterType.RWBuffer` to `VkDescriptorType.StorageImage`. The bind path runs `heapObject.Value as Texture`, which returns null for a `Buffer`, and falls back to `GraphicsDevice.EmptyTexture`. Every dispatch wrote into a dummy image.

The type now maps to `StorageTexelBuffer`. The descriptor write joins the existing `UniformTexelBuffer` case, because both use `pTexelBufferView`. The two changes must land together, or the `default:` case throws.

### 2. Unordered-access-only textures produced no image view

`GetImageView` returned `VkImageView.Null` unless the texture had `IsShaderResource`. A texture created with only `TextureFlags.UnorderedAccess` therefore also bound `EmptyTexture`.

Relaxing that guard alone would add a second defect. The view usage was hardcoded to `Sampled`, and such an image never carries that flag. The view usage now comes from the flags the texture actually has.

### 3. Buffers and textures never advertised the compute stage

About twenty call sites pass `NativePipelineStageMask` to `vkCmdPipelineBarrier`, but the mask listed only vertex and fragment stages. Uploads and readbacks had no dependency edge against a dispatch. Storage buffers also reported `VkAccessFlags.UniformRead` instead of `ShaderRead`. An unordered-access-only texture fell through every branch to `VkPipelineStageFlags.None`, which is zero and is not a legal stage mask.

### 4. The SPIR-V emitter inferred a storage image format from the element type

`GetStorageImageFormat` mapped `float4` to `Rgba32f`. In HLSL the view decides the format, not the element type. `RWTexture2D<float4>` binds equally to `R8G8B8A8_UNorm` and `R32G32B32A32_Float`. The validation layer states the result plainly: *"Any loads or stores with the variable will produce undefined values to the whole image."*

The emitter now lets the `Unknown` format flow through. This matches `BufferType` and matches what DXC emits. `ShaderMixer` already requests `StorageImage{Read,Write}WithoutFormat` for an `Unknown` format, and the device already enables both features.

### 5. `CopyRegion` ignored both subresource indices

The method accepted `sourceSubresource` and `destinationSubResource` but used neither. It addressed the copy with the texture MipLevel and ArraySlice, and with a `layerCount` of `ArraySize`. Two `// Review:` comments in the file already recorded this. The copy extent still came from the index, so a copy of a non-zero mip read a correctly sized window out of mip 0. Direct3D11 and Direct3D12 pass both indices to the underlying API, and Vulkan now decodes them the same way.

Three callers pass a non-zero index:

- `RadiancePrefilteringGGX` and its non-compute variant copy mip 2 of a 1024 cubemap into a 256 output. They read the top-left corner of mip 0 instead.
- `CubemapRendererBase` addressed array layer 0 with a `layerCount` of 6 against a source that has one layer.
- `VoxelStorageTextureClipmap` landed every temporary mip on mip 0.

## How the fifth defect was found

@Ethereal77 asked whether the images looked similar enough, because a count of differing pixels is a poor indicator on its own. That question found the defect.

The images did not look similar. Every cube face showed the top-left cell of a 4x4 grid, which is a 1024 to 256 crop. The original skip reason was wrong in three ways:

- It named Lavapipe. The difference also reproduces on an NVIDIA discrete GPU.
- It named the non-compute path. The compute path fails the same way.
- It named mip 1. The affected level is mip 0.

`TestRadiancePrefilteringGgx` now runs on Vulkan with no skip. Mip 0 matches the Direct3D reference with a maximum channel difference of 1, against 249 before.

## Tests

`TestLambertPrefilteringSHPass2` and `TestHammersley` were skipped on Vulkan in 2020 with the reason *"compute shaders are not supported yet"* (19085cb65). That was a blanket disable, not a diagnosis. Both pass now.

`TestUnorderedAccessOnlyTexture` is new. It writes dispatch coordinates into an unordered-access-only texture and asserts every texel. Without these fixes it reads back all zeros.

Per @Ethereal77's review, a test with no skip condition now uses `[Fact]` instead of `[SkippableFact]`.

## Gold images

Vulkan output for the two filtered mip levels of `TestRadiancePrefilteringGgx` differs from the Direct3D reference by more than the default tolerance. The `test-gold-gen.yml` workflow generated gold for `Windows.Vulkan/Lavapipe` and `macOS.Vulkan/Apple M1`. Linux, Android and iOS needed none, because the runtime fallback covers them. Mip 0 needed none on any platform, because it now matches the existing Direct3D gold.

To answer the question about pixel counts directly, here is the divergence measured against a control that predates this work:

| Comparison | max diff | pixels differing | `[16+]` |
|---|---|---|---|
| D3D11-WARP against D3D12-WARP (control) | 1 | 0.1% | 0 |
| Vulkan-Lavapipe against D3D12-WARP | 3 | 15.1% | 0 |
| macOS-AppleM1 against D3D12-WARP | 6 | 3.1% | 0 |

The Vulkan difference is uniform across all six cube faces, and it shows no correlation with luminance. This is rounding at the final 8-bit conversion, not a rendering difference. For contrast, mip 0 before the fix measured a maximum difference of 249, with 288,150 pixels in the `[16+]` bucket.

## Verification

Debug build, so the validation layers load. Shader caches cleared between runs.

| Suite | Vulkan / Lavapipe | Direct3D11 / WARP | Direct3D12 / WARP |
|---|---|---|---|
| `Stride.Graphics.Tests.11_0` (6 tests) | 5 passed, 1 skipped | 5 passed, 1 skipped | 5 passed, 1 skipped |
| `Stride.Graphics.Tests.10_0` (48 tests) | 44 passed, 4 skipped | 44 passed, 4 skipped | 44 passed, 4 skipped |

All three backends now report the same result. The remaining skip in 11_0 is `TestComputeShader`, which has been disabled on every backend since 2018 and is untouched here.

The 10_0 suite is included because the shader compiler change affects every RW texture in the engine. That covers the sixteen `LightingTests` and the material gold images, across the native SPIR-V path and the SPIRV-Cross to HLSL path.

The GameStudio editor was also built and run from this branch, and the FPS sample renders correctly. On Windows the editor host uses Direct3D11, so this covers the shader compiler change through the SPIRV-Cross to HLSL path, including skybox prefiltering and PBR materials. It does not cover the four Vulkan defects, which the suites above cover.

One caveat, flagged because a reviewer may hit it: `TestHammersley` on Direct3D12 failed twice during this work. Both failures came on the first Direct3D12 run after another backend had run, and the signature was all 1024 sample points missing. It then passed 8 consecutive full-suite runs, 5 runs in isolation, and a run against cleared shader caches. I could not isolate a trigger, and I have not established whether it relates to the shader compiler change here.

## Notes

Two items found along the way. Both are out of scope, and each wants its own issue:

- `EffectCompilerCache` keys cached bytecode on the effect input hash, which excludes the shader compiler version. A compiler change silently reuses stale bytecode until `obj/stride/assetbuild` and the per-target `bin/**/cache` directories are cleared by hand.
- `RadiancePrefilteringGGX`, the compute prefilter, has no reference except a test that never enables it.

## Related Issue

No issue for the changes here. The Vulkan skips trace back to 19085cb65 (2020).

Review of this PR did surface a separate and older defect, now filed as #3328. @Ethereal77 spotted a seam across the bottom and back faces of the prefiltered cubemap in `TestRadiancePrefilteringGgx`, and found it in gold images back to 2018. Measurement puts most of it in the test display code rather than in the prefilter, and leaves a smaller residual that grows with roughness. Neither part is fixed here.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**


