### PR TITLE
fix: parse and format shader numbers with the invariant culture

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/LiteralParsers/NumberParsers.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/LiteralParsers/NumberParsers.cs
@@ -34,13 +34,13 @@ public struct NumberParser : IParser<Literal>
             var numPos = scanner.Position;
             if (suffix.Match(ref scanner, null!, out Suffix suf))
             {
-                parsed = new IntegerLiteral(suf, long.Parse(scanner.Span[position..numPos]), scanner[position..scanner.Position]);
+                parsed = new IntegerLiteral(suf, long.Parse(scanner.Span[position..numPos], CultureInfo.InvariantCulture), scanner[position..scanner.Position]);
                 return true;
             }
             else
             {
                 var memory = scanner.Memory[position..scanner.Position];
-                parsed = new IntegerLiteral(new(32, false, true), long.Parse(memory.Span), new(scanner.Memory, position..scanner.Position));
+                parsed = new IntegerLiteral(new(32, false, true), long.Parse(memory.Span, CultureInfo.InvariantCulture), new(scanner.Memory, position..scanner.Position));
                 return true;
             }
         }

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Builder.Class.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Builder.Class.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Buffers;
+using System.Globalization;
 using Stride.Shaders.Core;
 using Stride.Shaders.Parsing;
 using Stride.Shaders.Parsing.Analysis;
@@ -269,10 +270,10 @@ public partial class SpirvBuilder
             switch (genericParameterType)
             {
                 case ScalarType { Type: Scalar.Int }:
-                    value = int.Parse(genericValue);
+                    value = int.Parse(genericValue, CultureInfo.InvariantCulture);
                     return true;
                 case ScalarType { Type: Scalar.Float }:
-                    value = float.Parse(genericValue);
+                    value = float.Parse(genericValue, NumberStyles.Float, CultureInfo.InvariantCulture);
                     return true;
                 case ScalarType { Type: Scalar.Boolean }:
                     value = bool.Parse(genericValue);
@@ -581,7 +582,7 @@ public partial class SpirvBuilder
                 if (genericParameterType is GenericParameterType { Kind: GenericParameterKindSDSL.MemberName })
                 {
                     if (genericResolver.TryResolveGenericValue(genericParameterType, genericParameterName, genericParameterIndex, out var value))
-                        instantiatedGenericsMacros.Add((shaderBuffers.Context.Names[genericParameter], value.ToString()!));
+                        instantiatedGenericsMacros.Add((shaderBuffers.Context.Names[genericParameter], ShaderClassSource.ConvertGenericArgToString(value)));
                 }
                 genericParameterIndex++;
             }

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Context.Constants.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Context.Constants.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Numerics;
 using Stride.Shaders.Core;
 using Stride.Shaders.Parsing;
@@ -346,7 +347,7 @@ public partial class SpirvContext
         {
             BoolLiteral lit => $"{lit.Type}_{lit.Value}",
             IntegerLiteral lit => $"{lit.Type}_{lit.Value}",
-            FloatLiteral lit => $"{lit.Type}_{lit.Value}",
+            FloatLiteral lit => $"{lit.Type}_{lit.Value.ToString(CultureInfo.InvariantCulture)}",
             _ => throw new NotImplementedException()
         });
         return result;

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Analysis/SemanticAnalyzer.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Analysis/SemanticAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Stride.Shaders.Spirv.Processing.Interfaces.Analysis;
@@ -16,7 +17,7 @@ internal static class SemanticAnalyzer
         int value = 0;
         if (!string.IsNullOrEmpty(match.Groups[2].Value))
         {
-            value = int.Parse(match.Groups[2].Value);
+            value = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
         }
 
         return (baseName, value);

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Generation/BuiltinProcessor.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Generation/BuiltinProcessor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Stride.Shaders.Core;
 using Stride.Shaders.Spirv.Building;
 using Stride.Shaders.Spirv.Core;
@@ -27,7 +28,7 @@ internal static class BuiltinProcessor
     public static bool AddLocation(SpirvContext context, int variable, string location)
     {
         // If it fails, default is 0
-        int.TryParse(location, out var targetIndex);
+        int.TryParse(location, NumberStyles.Integer, CultureInfo.InvariantCulture, out var targetIndex);
         context.Add(new OpDecorate(variable, Decoration.Location, [targetIndex]));
         return true;
     }

--- a/sources/shaders/Stride.Shaders.Tests/FrameRenderer.D3D11.cs
+++ b/sources/shaders/Stride.Shaders.Tests/FrameRenderer.D3D11.cs
@@ -397,7 +397,7 @@ float4 main(vs_out input) : SV_TARGET {
                     });
 
                     // Also create the vertex and bind it right away
-                    var floatValues = parameter.Value.TrimStart('(').TrimEnd(')').Split(' ', StringSplitOptions.TrimEntries).Select(x => float.Parse(x)).ToArray();
+                    var floatValues = parameter.Value.TrimStart('(').TrimEnd(')').Split(' ', StringSplitOptions.TrimEntries).Select(x => float.Parse(x, NumberStyles.Float, CultureInfo.InvariantCulture)).ToArray();
                     bufferDesc = new BufferDesc
                     {
                         ByteWidth = (uint)(sizeof(float) * floatValues.Length), // up to 4 floats
@@ -948,17 +948,17 @@ float4 main(vs_out input) : SV_TARGET {
                 foreach (var comp in TestHeaderParser.SplitArgs(value))
                 {
                     if (type.Type == EffectParameterType.Float)
-                        *((float*)&cbufferDataPtr[offset + compIndex * sizeof(float)]) = float.Parse(comp, CultureInfo.InvariantCulture);
+                        *((float*)&cbufferDataPtr[offset + compIndex * sizeof(float)]) = float.Parse(comp, NumberStyles.Float, CultureInfo.InvariantCulture);
                     else if (type.Type == EffectParameterType.Int)
-                        *((int*)&cbufferDataPtr[offset + compIndex * sizeof(int)]) = int.Parse(comp, CultureInfo.InvariantCulture);
+                        *((int*)&cbufferDataPtr[offset + compIndex * sizeof(int)]) = int.Parse(comp, NumberStyles.Integer, CultureInfo.InvariantCulture);
                     compIndex++;
                 }
                 break;
             case { Type: EffectParameterType.Int }:
-                *((int*)&cbufferDataPtr[offset]) = int.Parse(value);
+                *((int*)&cbufferDataPtr[offset]) = int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
                 break;
             case { Type: EffectParameterType.Float }:
-                *((float*)&cbufferDataPtr[offset]) = float.Parse(value);
+                *((float*)&cbufferDataPtr[offset]) = float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
                 break;
             default:
                 throw new NotImplementedException();

--- a/sources/shaders/Stride.Shaders.Tests/FrameRenderer.cs
+++ b/sources/shaders/Stride.Shaders.Tests/FrameRenderer.cs
@@ -33,10 +33,10 @@ public abstract class FrameRenderer(uint width = 800, uint height = 600, byte[]?
                 }
                 break;
             case { Type: EffectParameterType.Int }:
-                *((int*)&cbufferDataPtr[offset]) = int.Parse(value);
+                *((int*)&cbufferDataPtr[offset]) = int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
                 break;
             case { Type: EffectParameterType.Float }:
-                *((float*)&cbufferDataPtr[offset]) = float.Parse(value);
+                *((float*)&cbufferDataPtr[offset]) = float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
                 break;
             default:
                 throw new NotImplementedException();


### PR DESCRIPTION
# PR Details

**Summary**

The shader tooling read and wrote numbers with the culture of the machine. Every render test that carries
a float parameter failed on a comma-decimal locale. The SDSL front end also parsed generic arguments with
the current culture, although every producer writes them invariantly.

**Test harness**

A test header is authored in the shader source, so it always uses a period as the decimal separator:

```
// PSMain(ExpectedResult=#7F7F7F7F, stream.EXTRA_COLOR=(0.498 0.498 0.498 0.498))
```

`FrameRenderer` read those values with `float.Parse(value)`, which uses the current culture. On an en-ZA
machine the decimal separator is a comma, so that call throws `FormatException: The input string '0.498'
was not in a correct format`. This failed 9 render tests that pass on CI.

- `FrameRenderer.cs` and `FrameRenderer.D3D11.cs`: parse with `CultureInfo.InvariantCulture`, as the
  neighboring vector case already did. Also pass `NumberStyles.Float` or `NumberStyles.Integer`.

The styles matter. The default set allows a group separator, so `float.Parse("0,498", invariant)` returns
**498** instead of a `FormatException`. A group separator has no meaning here. Rejecting it turns a silent
wrong value into a clear error.

**Compiler**

@Ethereal77 asked for this in review. Parsing a programming language must not depend on the culture of
the machine.

- `Builder.Class.cs:272` and `:275`: `GenericResolverFromValues.TryResolveGenericValue` read generic
  arguments with the current culture. Every producer writes them invariantly. See
  `ShaderClassSource.ConvertGenericArgToString`, which documents the string as the SDSL-parseable
  representation. A float generic argument therefore failed to parse on a comma-decimal locale. The float
  also takes `NumberStyles.Float`, for the reason above.
- `Builder.Class.cs:584`: the resolved generic value becomes macro text that the compiler substitutes into
  shader source. It now goes through `ConvertGenericArgToString` instead of `ToString`, so the text stays
  SDSL-parseable.
- `NumberParsers.cs:37` and `:43`, `SemanticAnalyzer.cs:19`, `BuiltinProcessor.cs:30`: the integer literal
  parser, the semantic index parser and the location decoration parser. A sweep for the same mistake found
  these. They read digits only, so they could not misbehave in practice. They are aligned so the front end
  is consistent.
- `Context.Constants.cs`: name float constants with the invariant culture. `$"{lit.Type}_{lit.Value}"`
  wrote `float_0,5` into `OpName` instead of `float_0.5`, so one shader source compiled to different
  SPIR-V bytes on different machines.

  This last change makes the output deterministic. It does not fix a defect. Nothing reads the name of a
  constant. SPIRV-Cross inlines constant values into the generated HLSL and formats them itself, so the
  name never becomes an identifier. I checked this on an en-ZA machine. I compiled a shader with float
  literals and read the generated HLSL. It contains `float a = 0.5f;` and no `float_` name. The only
  effect is that compiled effects are not byte-identical between machines, so their caches do not transfer.

**Motivation and context** — I found the test failures while I ran `Stride.Shaders.Tests` locally on an
en-ZA machine.

## Related Issue

None. I found this in a local test run.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

**Validation status**

- *Tests*: `Stride.Shaders.Tests` on an en-ZA machine gives **10 failures before and 1 after**, with 524
  passed. The 9 fixed tests are `RenderTest1` for `StreamVSToPS`, `StreamPassthroughPS`, `StreamParameter`,
  `GenericsSemantic`, `GenericsExternal`, `CompositionExternalCBuffer` and
  `CompositionInheritanceStageIndirectAndDirect`, plus `StreamOutTest1` for `StreamGS` and
  `StreamTessellation`. The compiler changes leave that result unchanged at 524 passed and 1 failed.
- *Not covered*: `RenderTest1(GenericsEffect)` still fails with a `NullReferenceException` in
  `GenericIdentifier.ResolveExternalShader` (`Literals.cs:640`). It fails the same way on a clean `master`
  checkout, so it is a separate bug that already exists and has nothing to do with the culture. I can file
  it separately.
- *No new tests*: the existing render tests prove the harness fix, because they pass on a comma-decimal
  locale only with this change. The compiler paths are either unreachable today or read digits only, so a
  test cannot assert anything that the suite does not already cover. A regression test for the harness
  would need to set the thread culture. Tell me if you want one.
- *Editor*: not exercised. This changes the shader test harness, the SDSL front end and the name of a
  constant.
