### PR TITLE
ContentManager.Load: better message when asset is not found (and throw exception in all cases)

### DIFF
--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Stride.Core.Diagnostics;
@@ -117,6 +116,7 @@ public sealed partial class ContentManager : IContentManager
     /// <param name="settings">The settings. If null, fallback to <see cref="ContentManagerLoaderSettings.Default" />.</param>
     /// <remarks>If the asset is already loaded, it just increases the reference count of the asset and return the same instance.</remarks>
     /// <returns>The loaded content.</returns>
+    /// <exception cref="ContentManagerException">The asset or one of its referenced assets could not be found. Use <see cref="Exists"/> to check for optional content.</exception>
     public T Load<T>(string url, ContentManagerLoaderSettings? settings = null) where T : class
     {
         return (T)Load(typeof(T), url, settings);
@@ -131,6 +131,7 @@ public sealed partial class ContentManager : IContentManager
     /// <returns>The loaded content.</returns>
     /// <remarks>If the asset is already loaded, it just increases the reference count of the asset and return the same instance.</remarks>
     /// <exception cref="ArgumentNullException">url</exception>
+    /// <exception cref="ContentManagerException">The asset or one of its referenced assets could not be found. Use <see cref="Exists"/> to check for optional content.</exception>
     public object Load(Type type, string url, ContentManagerLoaderSettings? settings = null)
     {
         settings ??= ContentManagerLoaderSettings.Default;
@@ -393,10 +394,7 @@ public sealed partial class ContentManager : IContentManager
     internal ChunkHeader? ReadChunkHeader(string url)
     {
         if (!FileProvider.FileExists(url))
-        {
-            HandleAssetNotFound(url);
-            return null;
-        }
+            ThrowAssetNotFound(url);
 
         using var stream = FileProvider.OpenStream(url, VirtualFileMode.Open, VirtualFileAccess.Read);
         // File does not exist
@@ -433,10 +431,7 @@ public sealed partial class ContentManager : IContentManager
         }
 
         if (!FileProvider.FileExists(url))
-        {
-            HandleAssetNotFound(url);
-            return null;
-        }
+            ThrowAssetNotFound(url);
 
         ContentSerializerContext contentSerializerContext;
         object result;
@@ -666,12 +661,12 @@ public sealed partial class ContentManager : IContentManager
     }
 
     /// <summary>
-    /// Notify debugger and logging when an asset could not be found.
+    /// Logs and throws when an asset could not be found, suggesting close URL matches when any exist.
     /// </summary>
     /// <param name="url">The URL.</param>
-    /// <exception cref="ContentManagerException">Asset could not be found.</exception>
-    // TODO: Replug this when an asset is not found?
-    private void HandleAssetNotFound(string url)
+    /// <exception cref="ContentManagerException">Always thrown: the asset could not be found.</exception>
+    [DoesNotReturn]
+    private void ThrowAssetNotFound(string url)
     {
         var errorMessage = $"The asset '{url}' could not be found. Asset path should be 'MyFolder/MyAssetName', or '/PackageName/MyFolder/MyAssetName' for an asset from a namespaced package. Check that the path is correct and that the asset has been included into the build.";
 
@@ -727,19 +722,7 @@ public sealed partial class ContentManager : IContentManager
                 && rooted[0] == '/';
         }
 
-        // If a debugger is attached, throw an exception (we do that instead of Debugger.Break so that user can easily ignore this specific type of exception)
-        if (Debugger.IsAttached)
-        {
-            try
-            {
-                throw new ContentManagerException(errorMessage);
-            }
-            catch (ContentManagerException)
-            {
-            }
-        }
-
-        // Log error
         Log.Error(errorMessage);
+        throw new ContentManagerException(errorMessage);
     }
 }

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -18,6 +18,9 @@ public sealed partial class ContentManager : IContentManager
 {
     private static readonly Logger Log = GlobalLogger.GetLogger(nameof(ContentManager));
 
+    /// <summary>Maximum number of same-name assets listed in the "asset not found" message.</summary>
+    private const int MaxSameNameCandidates = 5;
+
     public DatabaseFileProvider FileProvider => databaseFileProviderService.FileProvider;
 
     private readonly IDatabaseFileProviderService databaseFileProviderService;
@@ -668,9 +671,61 @@ public sealed partial class ContentManager : IContentManager
     /// <param name="url">The URL.</param>
     /// <exception cref="ContentManagerException">Asset could not be found.</exception>
     // TODO: Replug this when an asset is not found?
-    private static void HandleAssetNotFound(string url)
+    private void HandleAssetNotFound(string url)
     {
-        var errorMessage = $"The asset '{url}' could not be found. Asset path should be 'MyFolder/MyAssetName'. Check that the path is correct and that the asset has been included into the build.";
+        var errorMessage = $"The asset '{url}' could not be found. Asset path should be 'MyFolder/MyAssetName', or '/PackageName/MyFolder/MyAssetName' for an asset from a namespaced package. Check that the path is correct and that the asset has been included into the build.";
+
+        var contentIndexMap = FileProvider?.ContentIndexMap;
+        if (contentIndexMap != null)
+        {
+            var indexMap = contentIndexMap.GetMergedIdMap();
+
+            // First suggest assets differing from the requested URL only by the '/PackageName' root
+            var isRooted = url.StartsWith('/');
+            var candidates = new List<string>();
+            foreach (var entry in indexMap)
+            {
+                if (isRooted ? DiffersByRoot(url, entry.Key) : DiffersByRoot(entry.Key, url))
+                    candidates.Add(entry.Key);
+            }
+            if (candidates.Count > 0)
+            {
+                candidates.Sort();
+                errorMessage = $"The asset '{url}' could not be found. Did you mean:"
+                    + string.Concat(candidates.Select(c => $"{Environment.NewLine}  '{c}'"))
+                    + $"{Environment.NewLine}An asset from a namespaced package is addressed by a rooted URL: '/PackageName/MyFolder/MyAssetName'.";
+            }
+            else
+            {
+                // Otherwise fall back to assets with the same name in other folders
+                var assetName = url.Substring(url.LastIndexOf('/') + 1);
+                var sameNameCandidates = new List<string>();
+                foreach (var entry in indexMap)
+                {
+                    if (entry.Key.EndsWith(assetName, StringComparison.OrdinalIgnoreCase)
+                        && (entry.Key.Length == assetName.Length || entry.Key[entry.Key.Length - assetName.Length - 1] == '/'))
+                        sameNameCandidates.Add(entry.Key);
+                }
+                if (sameNameCandidates.Count > 0)
+                {
+                    sameNameCandidates.Sort();
+                    var more = sameNameCandidates.Count > MaxSameNameCandidates ? $"{Environment.NewLine}  (and {sameNameCandidates.Count - MaxSameNameCandidates} more)" : string.Empty;
+                    errorMessage = $"The asset '{url}' could not be found. Assets with the same name exist at:"
+                        + string.Concat(sameNameCandidates.Take(MaxSameNameCandidates).Select(c => $"{Environment.NewLine}  '{c}'"))
+                        + more;
+                }
+            }
+        }
+
+        // True when <rooted> is exactly '/PackageName' (a single segment) followed by '/<bare>'.
+        static bool DiffersByRoot(string rooted, string bare)
+        {
+            return rooted.Length > bare.Length + 2
+                && rooted.EndsWith(bare, StringComparison.OrdinalIgnoreCase)
+                && rooted[rooted.Length - bare.Length - 1] == '/'
+                && rooted.IndexOf('/', 1) == rooted.Length - bare.Length - 1
+                && rooted[0] == '/';
+        }
 
         // If a debugger is attached, throw an exception (we do that instead of Debugger.Break so that user can easily ignore this specific type of exception)
         if (Debugger.IsAttached)

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManagerException.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManagerException.cs
@@ -6,7 +6,7 @@ namespace Stride.Core.Serialization.Contents;
 /// <summary>
 /// A subtype of <see cref="Exception"/> thrown by the <see cref="ContentManager"/>.
 /// </summary>
-internal class ContentManagerException : Exception
+public class ContentManagerException : Exception
 {
     public ContentManagerException(string message) : base(message)
     {

--- a/sources/editor/Stride.Assets.Presentation/Preview/AnimationPreview.cs
+++ b/sources/editor/Stride.Assets.Presentation/Preview/AnimationPreview.cs
@@ -90,7 +90,10 @@ namespace Stride.Assets.Presentation.Preview
             // load the created material and the model from the data base
             var model = LoadAsset<Model>(compiledModelUrl);
             var anim = LoadAsset<AnimationClip>(AssetItem.Location);
-            var animSrc = LoadAsset<AnimationClip>(AssetItem.Location + AnimationAssetCompiler.SrcClipSuffix);
+            // The source clip is only compiled for difference animations
+            var animSrc = ((AnimationAsset)AssetItem.Asset).Type.GetType() == typeof(DifferenceAnimationAssetType)
+                ? LoadAsset<AnimationClip>(AssetItem.Location + AnimationAssetCompiler.SrcClipSuffix)
+                : null;
 
             // create the entity, create and set the model component
             var entity = new Entity { Name = "Preview Entity of animation: " + AssetItem.Location };

--- a/sources/engine/Stride.Assets.Models/PrefabModelAssetCompiler.cs
+++ b/sources/engine/Stride.Assets.Models/PrefabModelAssetCompiler.cs
@@ -345,7 +345,7 @@ namespace Stride.Assets.Models
                     if (modelAsset == null)
                         continue;
 
-                    var model = contentManager.Load<Model>(modelAsset.Location, loadSettings);
+                    var model = contentManager.Exists(modelAsset.Location) ? contentManager.Load<Model>(modelAsset.Location, loadSettings) : null;
                     loadedModel.Add(model);
 
                     if (model == null ||

--- a/sources/engine/Stride.Graphics.Tests/TestFixedSizeUI.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestFixedSizeUI.cs
@@ -15,10 +15,6 @@ namespace Stride.Graphics.Tests
 {
     public class TestFixedSizeUI : GraphicTestGameBase
     {
-
-        private SpriteFont arial16;
-
-
         public TestFixedSizeUI()
         {
         }
@@ -104,21 +100,20 @@ namespace Stride.Graphics.Tests
 
             Window.AllowUserResizing = true;
 
-            arial16 = Content.Load<SpriteFont>("DynamicFonts/Arial16");
-
             // Instantiate a scene with a single entity and model component
             var scene = new Scene();
 
+            // No font: the baseline images are captured with label text not rendered
             // Fixed size
-            scene.Entities.Add(GetUIEntity(arial16, true, new Vector3(0, 0, 4)));
-            scene.Entities.Add(GetUIEntity(arial16, true, new Vector3(-2, 1, 0)));
-            scene.Entities.Add(GetUIEntity(arial16, true, new Vector3(2, 2, -2)));
-            scene.Entities.Add(GetUIEntity(arial16, true, new Vector3(0, 1, 0)));
-            scene.Entities.Add(GetUIEntity(arial16, true, new Vector3(0, 2, -2)));
+            scene.Entities.Add(GetUIEntity(null, true, new Vector3(0, 0, 4)));
+            scene.Entities.Add(GetUIEntity(null, true, new Vector3(-2, 1, 0)));
+            scene.Entities.Add(GetUIEntity(null, true, new Vector3(2, 2, -2)));
+            scene.Entities.Add(GetUIEntity(null, true, new Vector3(0, 1, 0)));
+            scene.Entities.Add(GetUIEntity(null, true, new Vector3(0, 2, -2)));
 
-            scene.Entities.Add(GetUIEntity(arial16, false, new Vector3(0, -0.3f, 4)));
-            scene.Entities.Add(GetUIEntity(arial16, false, new Vector3(-2, 0, 0)));
-            scene.Entities.Add(GetUIEntity(arial16, false, new Vector3(2, 1, -2)));
+            scene.Entities.Add(GetUIEntity(null, false, new Vector3(0, -0.3f, 4)));
+            scene.Entities.Add(GetUIEntity(null, false, new Vector3(-2, 0, 0)));
+            scene.Entities.Add(GetUIEntity(null, false, new Vector3(2, 1, -2)));
 
             // Use this graphics compositor
             SceneSystem.GraphicsCompositor = GraphicsCompositorHelper.CreateDefault(false, graphicsProfile: GraphicsProfile.Level_9_1);


### PR DESCRIPTION
# PR Details

As discussed on Discord, I tried to make a better error message when an asset is not found.

Case 1: root-differing candidates ("did you mean"):
```
The asset 'StrideDefaultFont' could not be found. Did you mean:
  '/MyLib/StrideDefaultFont'
  '/Stride.Engine/StrideDefaultFont'
```

Case 2: same name in other folders (capped at 5):
```
The asset 'WrongFolder/Ground' could not be found. Assets with the same name exist at:
  '/A/Ground'
  '/B/Ground'
  '/C/Ground'
  '/D/Sub/Ground'
  '/E/Ground'
  (and 2 more)
```

I also made it a proper exception (previous code was a bit weird: log error and caught exception if debugger attached)
It didn't feel right that `ContentManager.Load` could return null with a simple log error (it was highly unlikely user was checking for null).
We could later add a `ContentManager.TryLoad` if really necessary, but `ContentManager.Exists` should be enough for now.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation (done in XML doc, need a comment in release notes)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->