### PR TITLE
perf: transition bound descriptors on Direct3D12 without per-frame allocation

### DIFF
--- a/sources/engine/Stride.Graphics.Tests/GCMeasurement.cs
+++ b/sources/engine/Stride.Graphics.Tests/GCMeasurement.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+namespace Stride.Graphics.Tests;
+
+/// <summary>
+///   The allocation and collection cost of a measured workload.
+/// </summary>
+/// <param name="AllocatedBytes">Bytes allocated across all measured iterations.</param>
+/// <param name="Gen0Collections">Generation 0 collections that ran during the measurement.</param>
+/// <param name="Gen1Collections">Generation 1 collections that ran during the measurement.</param>
+/// <param name="Gen2Collections">Generation 2 collections that ran during the measurement.</param>
+/// <param name="Iterations">The number of measured iterations.</param>
+internal readonly record struct GCMeasurement(
+    long AllocatedBytes,
+    int Gen0Collections,
+    int Gen1Collections,
+    int Gen2Collections,
+    int Iterations)
+{
+    /// <summary>
+    ///   Gets the mean bytes allocated per iteration.
+    /// </summary>
+    public double BytesPerIteration => Iterations == 0 ? 0d : (double) AllocatedBytes / Iterations;
+
+    public override string ToString() =>
+        $"{AllocatedBytes:N0} bytes over {Iterations:N0} iterations ({BytesPerIteration:N1} per iteration), " +
+        $"GC gen0={Gen0Collections} gen1={Gen1Collections} gen2={Gen2Collections}";
+}
+
+/// <summary>
+///   Measures the allocation and collection cost of a workload.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Allocation rate and collection cost are separate axes. Allocated bytes decide how often
+///     generation 0 runs. Collection counts decide what the workload actually costs, and a
+///     workload that allocates nothing can still make collections more expensive by writing
+///     references the collector has to trace. Measure both.
+///   </para>
+///   <para>
+///     Every measurement runs a warm-up first. Pools, and the capacity of any list or dictionary
+///     the workload touches, grow on first use. Without a warm-up those first-touch allocations
+///     are indistinguishable from a steady-state leak.
+///   </para>
+/// </remarks>
+internal static class GCMeasure
+{
+    /// <summary>
+    ///   Measures a workload that runs entirely on the calling thread.
+    /// </summary>
+    /// <param name="iteration">The workload. Invoked once per iteration.</param>
+    /// <param name="warmupIterations">Iterations to run and discard before measuring.</param>
+    /// <param name="measuredIterations">Iterations to measure.</param>
+    /// <remarks>
+    ///   Reads <see cref="GC.GetAllocatedBytesForCurrentThread"/>, which ignores allocations made
+    ///   on any other thread. Use <see cref="RunAcrossThreads"/> when the workload dispatches work
+    ///   to workers, as the render path does.
+    /// </remarks>
+    public static GCMeasurement Run(Action iteration, int warmupIterations = 64, int measuredIterations = 256)
+        => Measure(iteration, warmupIterations, measuredIterations, GC.GetAllocatedBytesForCurrentThread);
+
+    /// <summary>
+    ///   Measures a workload that may allocate on threads other than the caller.
+    /// </summary>
+    /// <param name="iteration">The workload. Invoked once per iteration.</param>
+    /// <param name="warmupIterations">Iterations to run and discard before measuring.</param>
+    /// <param name="measuredIterations">Iterations to measure.</param>
+    /// <remarks>
+    ///   Reads <see cref="GC.GetTotalAllocatedBytes(bool)"/> precisely, which counts the whole
+    ///   process. Anything else allocating at the same time lands in the result, so this is only
+    ///   meaningful on an otherwise quiet process.
+    /// </remarks>
+    public static GCMeasurement RunAcrossThreads(Action iteration, int warmupIterations = 64, int measuredIterations = 256)
+        => Measure(iteration, warmupIterations, measuredIterations, static () => GC.GetTotalAllocatedBytes(precise: true));
+
+    private static GCMeasurement Measure(Action iteration, int warmupIterations, int measuredIterations, Func<long> readAllocatedBytes)
+    {
+        ArgumentNullException.ThrowIfNull(iteration);
+        ArgumentOutOfRangeException.ThrowIfNegative(warmupIterations);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(measuredIterations);
+
+        for (int i = 0; i < warmupIterations; i++)
+            iteration();
+
+        // Settle anything the warm-up left behind, so collections counted below belong to the
+        // measured iterations rather than to the warm-up.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var bytesBefore = readAllocatedBytes();
+        int gen0Before = GC.CollectionCount(0);
+        int gen1Before = GC.CollectionCount(1);
+        int gen2Before = GC.CollectionCount(2);
+
+        for (int i = 0; i < measuredIterations; i++)
+            iteration();
+
+        return new GCMeasurement(
+            readAllocatedBytes() - bytesBefore,
+            GC.CollectionCount(0) - gen0Before,
+            GC.CollectionCount(1) - gen1Before,
+            GC.CollectionCount(2) - gen2Before,
+            measuredIterations);
+    }
+}

--- a/sources/engine/Stride.Graphics.Tests/TestResourceGroupAllocation.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestResourceGroupAllocation.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Xunit;
+
+using Stride.Rendering;
+using Stride.Shaders;
+
+namespace Stride.Graphics.Tests;
+
+/// <summary>
+///   Measures what preparing resource groups costs the garbage collector.
+/// </summary>
+/// <remarks>
+///   <para>
+///     <see cref="ResourceGroupAllocator.PrepareResourceGroup"/> runs once per resource group per
+///     frame, which is a few thousand times in a normal scene. Anything it allocates is allocated
+///     again every frame, so this is the one place on the descriptor path where a small allocation
+///     becomes a large allocation rate.
+///   </para>
+///   <para>
+///     The pools this path uses grow on first touch, so the measurement discards a warm-up before
+///     it counts anything.
+///   </para>
+/// </remarks>
+public class TestResourceGroupAllocation : GraphicTestGameBase
+{
+    private const int ResourceGroupsPerFrame = 256;
+    private const int ShaderResourceBindings = 4;
+
+    /// <summary>
+    ///   Preparing resource groups must not allocate once the pools have settled.
+    /// </summary>
+    [Fact]
+    public void PreparingResourceGroupsDoesNotAllocate()
+    {
+        PerformTest(game =>
+        {
+            var device = game.GraphicsDevice;
+            var commandList = game.GraphicsContext.CommandList;
+
+            using var resourceAllocator = new GraphicsResourceAllocator(device);
+            using var groupAllocator = new ResourceGroupAllocator(resourceAllocator, commandList);
+
+            var layout = CreateResourceGroupLayout(device);
+
+            var measurement = GCMeasure.Run(
+                () => PrepareOneFrameOfResourceGroups(groupAllocator, commandList, layout),
+                warmupIterations: 16,
+                measuredIterations: 64);
+
+            Assert.True(
+                measurement.AllocatedBytes == 0,
+                $"Preparing {ResourceGroupsPerFrame} resource groups per frame allocated. Measured {measurement}.");
+        });
+    }
+
+    /// <summary>
+    ///   Models one frame: reset the pools, then prepare every resource group the frame needs.
+    /// </summary>
+    /// <remarks>
+    ///   The reset is what makes the pools reusable. Without it the tracking pool grows for as long
+    ///   as the loop runs, because it only rewinds when a frame starts.
+    /// </remarks>
+    private static void PrepareOneFrameOfResourceGroups(ResourceGroupAllocator groupAllocator, CommandList commandList, ResourceGroupLayout layout)
+    {
+        groupAllocator.Reset(commandList);
+
+        for (int i = 0; i < ResourceGroupsPerFrame; i++)
+        {
+            var resourceGroup = groupAllocator.AllocateResourceGroup();
+            groupAllocator.PrepareResourceGroup(layout, BufferPoolAllocationType.UsedMultipleTime, resourceGroup);
+        }
+    }
+
+    /// <summary>
+    ///   Builds a layout holding only shader resource views, so the measurement covers the
+    ///   descriptor set and not the constant buffer pool.
+    /// </summary>
+    private static ResourceGroupLayout CreateResourceGroupLayout(GraphicsDevice device)
+    {
+        var builder = new DescriptorSetLayoutBuilder();
+
+        for (int i = 0; i < ShaderResourceBindings; i++)
+        {
+            builder.AddBinding(
+                ParameterKeys.NewObject<Texture>(name: $"TestResourceGroupAllocation.Texture{i}"),
+                logicalGroup: null,
+                EffectParameterClass.ShaderResourceView,
+                EffectParameterType.Texture2D,
+                EffectParameterType.Float);
+        }
+
+        return new ResourceGroupLayout
+        {
+            DescriptorSetLayoutBuilder = builder,
+            DescriptorSetLayout = DescriptorSetLayout.New(device, builder),
+        };
+    }
+}

--- a/sources/engine/Stride.Graphics/Direct3D12/CommandList.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/CommandList.Direct3D12.cs
@@ -397,10 +397,77 @@ namespace Stride.Graphics
         /// </remarks>
         private void PrepareDraw(bool isDispatch = false)
         {
+            TransitionBoundResources();
+
             FlushResourceBarriers();
             SetViewportImpl();
 
             RecordDebugCounter(isDispatch ? DebugCounterKind.Dispatch : DebugCounterKind.Draw);
+        }
+
+        /// <summary>
+        ///   Transitions every Texture bound in a Descriptor Set to the state its use needs.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     The pass is idempotent. <see cref="ResourceBarrierTransition"/> returns early when the
+        ///     tracked layout already matches, so a resource an explicit transition already moved
+        ///     costs nothing here.
+        ///   </para>
+        ///   <para>
+        ///     Buffers are out of scope, which matches the Vulkan pass. A buffer barrier replaces the
+        ///     whole access mask, and nothing restores the vertex, index or constant buffer access a
+        ///     buffer may still need, because binding those emits no barrier. Covering buffers means
+        ///     combining every access a buffer is currently bound for, on both backends together.
+        ///   </para>
+        /// </remarks>
+        private void TransitionBoundResources()
+        {
+            if (boundDescriptorSets is null)
+                return;
+
+            for (int setIndex = 0; setIndex < boundDescriptorSets.Length; setIndex++)
+            {
+                var descriptorSet = boundDescriptorSets[setIndex];
+                var tracking = descriptorSet.Tracking;
+                if (tracking is null || descriptorSet.Description is null)
+                    continue;
+
+                int slotCount = descriptorSet.Description.SrvCount;
+                for (int slot = 0; slot < slotCount; slot++)
+                {
+                    if (tracking.Resources[slot] is not Texture texture)
+                        continue;
+
+                    // A render target or depth buffer the pipeline is about to write keeps the state
+                    // its producer set. Moving it here would invalidate the draw.
+                    if (IsBoundAsRenderTargetOrDepth(texture))
+                        continue;
+
+                    ResourceBarrierTransition(
+                        texture,
+                        tracking.IsUAV[slot] ? BarrierLayout.UnorderedAccess : BarrierLayout.ShaderResource);
+                }
+            }
+        }
+
+        private bool IsBoundAsRenderTargetOrDepth(Texture texture)
+        {
+            var parent = texture.ParentTexture ?? texture;
+
+            var depth = DepthStencilBuffer;
+            if (depth is not null && ReferenceEquals(depth.ParentTexture ?? depth, parent))
+                return true;
+
+            var boundTargets = RenderTargets;
+            for (int i = 0; i < boundTargets.Length; i++)
+            {
+                var target = boundTargets[i];
+                if (target is not null && ReferenceEquals(target.ParentTexture ?? target, parent))
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/sources/engine/Stride.Graphics/Direct3D12/DescriptorPool.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/DescriptorPool.Direct3D12.cs
@@ -35,6 +35,9 @@ namespace Stride.Graphics
         /// </remarks>
         protected internal ComPtr<ID3D12DescriptorHeap> SamplerHeap => ToComPtr(nativeSamplerHeap);
 
+        private readonly System.Collections.Generic.List<ResourceTracking> trackingPool = [];
+        private int trackingOffset;
+
         internal CpuDescriptorHandle SrvStart;  // CPU handle to the start of the Shader Resource View heap
         internal int SrvOffset;                 // Offset in the SRV heap from SrvStart
         internal int SrvCount;                  // Number of SRVs allocated in the pool
@@ -102,12 +105,40 @@ namespace Stride.Graphics
         }
 
         /// <summary>
+        ///   Lends a <see cref="ResourceTracking"/> to a Descriptor Set being allocated from this pool.
+        /// </summary>
+        /// <param name="srvCount">The number of Shader Resource View slots the Descriptor Set needs to track.</param>
+        /// <param name="handleIncrementSize">The size of one Shader Resource View Descriptor, in bytes.</param>
+        /// <remarks>
+        ///   A Descriptor Set lives for one frame, so its tracking can live in the pool that the
+        ///   frame already resets. Steady state reuses the same instances and allocates nothing.
+        /// </remarks>
+        internal ResourceTracking RentTracking(int srvCount, int handleIncrementSize)
+        {
+            if (trackingOffset >= trackingPool.Count)
+                trackingPool.Add(new ResourceTracking(srvCount, handleIncrementSize));
+
+            var tracking = trackingPool[trackingOffset];
+            if (!tracking.CanTrack(srvCount))
+                trackingPool[trackingOffset] = tracking = new ResourceTracking(srvCount, handleIncrementSize);
+
+            trackingOffset++;
+
+            // A slot the Descriptor Set never writes must read as empty, because a constant buffer
+            // occupies a slot without a resource the transition pass can act on.
+            tracking.Clear();
+
+            return tracking;
+        }
+
+        /// <summary>
         ///   Clears the Descriptor Pool, resetting all allocated Descriptors.
         /// </summary>
         public void Reset()
         {
             SrvOffset = 0;
             SamplerOffset = 0;
+            trackingOffset = 0;
         }
     }
 }

--- a/sources/engine/Stride.Graphics/Direct3D12/DescriptorSet.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/DescriptorSet.Direct3D12.cs
@@ -85,7 +85,7 @@ namespace Stride.Graphics
 
             nativeDevice = graphicsDevice.NativeDevice;
             Description = layout;
-            Tracking = layout.SrvCount > 0 ? new ResourceTracking(layout.SrvCount, graphicsDevice.SrvHandleIncrementSize) : null;
+            Tracking = layout.SrvCount > 0 ? pool.RentTracking(layout.SrvCount, graphicsDevice.SrvHandleIncrementSize) : null;
 
             // Store starting CpuDescriptorHandle for SRVs, UAVs, etc.
             var startHandle = layout.SrvCount > 0
@@ -246,6 +246,17 @@ namespace Stride.Graphics
             int index = bindingOffset / handleIncrementSize;
             Resources[index] = resource;
             IsUAV[index] = isUav;
+        }
+
+        internal bool CanTrack(int srvCount) => Resources.Length >= srvCount;
+
+        /// <summary>
+        ///   Drops every tracked resource, so a reused instance reports nothing from the frame before.
+        /// </summary>
+        internal void Clear()
+        {
+            Array.Clear(Resources);
+            Array.Clear(IsUAV);
         }
     }
 }


### PR DESCRIPTION
# PR Details

Direct3D12 gains the automatic bound-descriptor transition that Vulkan already has, and the descriptor path stops allocating every frame. Both come from the same piece of abandoned scaffolding.

## The scaffolding

`DescriptorSet.Direct3D12` recorded which resource sits in each shader resource slot, and marked whether that slot is an unordered access view. Nothing ever read it. It was built for a transition pass that nobody wrote.

Meanwhile `ComputeEffectShader` issues no barriers of its own. Every compute consumer in the engine goes through it: `RadiancePrefilteringGGX`, `LambertianPrefilteringSH`, `Stride.Voxels`, and the compute tests.

On Vulkan that works, because `TransitionBoundResources` (`CommandList.Vulkan.cs:318`) walks the bound descriptor sets before each draw and dispatch. Direct3D12 has no such pass. `PrepareDraw` only flushed pending barriers and set the viewport. A texture that a dispatch writes as `UnorderedAccess` therefore never left `ShaderResource` or `Common`. The same engine code was correct on one backend and incorrect on the other.

## The transition pass

`PrepareDraw` now runs `TransitionBoundResources` before it flushes barriers. Both `Dispatch` overloads already call `PrepareDraw`, so draws and dispatches both get it from one hook.

The pass skips a resource that is currently bound as a render target or as the depth buffer. Its producer already set that state, and moving it would invalidate the draw.

The pass is additive. `ResourceBarrierTransition` returns early when the tracked layout already matches, so the roughly ten sites that transition explicitly cost nothing extra. Explicit transitions at pass boundaries stay the norm, because only a pass knows enough to batch them. This is the floor beneath that, for generic code that cannot know what it received.

## The allocation

`ResourceTracking` cost three heap objects per descriptor set: the object, a `GraphicsResource[]` and a `bool[]`. `SrvCount` counts every non-Sampler entry, so a set that binds only a constant buffer paid it too.

The tracking now comes from the descriptor pool rather than the managed heap. A descriptor set lives for one frame, so its tracking can live in the pool that the frame already resets. Renting clears the instance. That drops the previous frame's references, and it leaves a slot holding a constant buffer empty rather than reporting the texture that slot held before.

The pool retains one instance per descriptor set at the frame's high-water mark. A frame with 2000 draws holds about 256 KB per pool, one pool per thread context. That is a standing cost where there was none, in exchange for removing a per-frame allocation. It is bounded by real usage rather than by the 85504 descriptor heap capacity.

## Measurement

`GCMeasure` is new, in `Stride.Graphics.Tests`. No helper existed: BenchmarkDotNet is pinned but no project references it, and `GC.GetAllocatedBytesForCurrentThread` appeared nowhere in the tree. It reports allocated bytes and generation 0, 1 and 2 collection counts, because allocation rate and collection cost are separate axes. It discards a warm-up first, since pools and collection capacities grow on first touch.

`TestResourceGroupAllocation` models one frame: reset the pools, then prepare 256 resource groups.

| Backend | Before | After |
|---|---|---|
| Direct3D12 | 32768 bytes per frame, 128 per group | **0** |
| Vulkan | 0 | 0 |
| Direct3D11 | 0 | 0 |

The 128 bytes per group matches the predicted three-object cost, which is what gives confidence that the whole cost is gone rather than merely smaller.

The transition pass itself allocates nothing. A bisection shows this rather than a test. A draw loop reads 420.3 bytes per draw with the pass enabled, and the same 420.3 bytes with it disabled, across three runs. Those 420 bytes belong to `DrawTexture` and predate this change.

## Verification

Debug build, so the validation layers load.

| Suite | Direct3D11 | Direct3D12 | Vulkan |
|---|---|---|---|
| `Stride.Graphics.Tests` | 87 passed, 6 skipped | 87 passed, 6 skipped | 88 passed, 4 skipped |
| `Stride.Graphics.Tests.10_0` | 44 passed, 4 skipped | 44 passed, 4 skipped | 44 passed, 4 skipped |
| `Stride.Graphics.Tests.11_0` | 4 passed, 1 skipped | 4 passed, 1 skipped | 1 passed, 4 skipped |

No failures. The result on Direct3D12 is identical with the pass and without it, which is the idempotence claim holding.

## What this does not prove

The synchronization hole is real but latent, and this change closes it rather than fixing a reported fault:

- Direct3D12 reports nothing for a *missing* barrier. Its debug layer catches an illegal transition, not an absent one. `TestHammersley` runs a compute dispatch that writes an unordered access texture, samples it, and issues no barrier between the two. On Direct3D12 with the debug layer active it passes and the layer reports nothing.
- A missing barrier usually still works. The dispatch normally finishes before its consumer reaches it, and `ExecuteCommandLists` supplies implicit synchronization between command lists.

So the measured claim is the allocation. The correctness claim is that the same engine code now behaves the same way on both backends, which it did not before.

## Related Issue

<!--- No existing issue. -->

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
