### PR TITLE
fix: rotate the -Z face 180 degrees in the cubemap cross display

### DIFF
--- a/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgx.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgx.cs
@@ -133,7 +133,7 @@ namespace Stride.Graphics.Tests
             spriteBatch.Draw(displayedViews[2], new RectangleF(size.X, 0f, size.X, size.Y), Color.White);
             spriteBatch.Draw(displayedViews[4], new RectangleF(size.X, size.Y, size.X, size.Y), Color.White);
             spriteBatch.Draw(displayedViews[3], new RectangleF(size.X, 2f * size.Y, size.X, size.Y), Color.White);
-            spriteBatch.Draw(displayedViews[5], new RectangleF(size.X, 3f * size.Y, size.X, size.Y), null, Color.White, 0f, Vector2.Zero, SpriteEffects.FlipVertically);
+            spriteBatch.Draw(displayedViews[5], new RectangleF(size.X, 3f * size.Y, size.X, size.Y), null, Color.White, 0f, Vector2.Zero, SpriteEffects.FlipBoth);
             spriteBatch.Draw(displayedViews[0], new RectangleF(2f * size.X, size.Y, size.X, size.Y), Color.White);
             spriteBatch.End();
         }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/NVIDIA GeForce RTX 5080/TestRadiancePrefilteringGgx.f1.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/NVIDIA GeForce RTX 5080/TestRadiancePrefilteringGgx.f1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a832bc5be887059b3cda34383c62e97bfa4c56a68a7443c9cce5e745154ba07a
-size 224683

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/NVIDIA GeForce RTX 5080/TestRadiancePrefilteringGgx.f2.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/NVIDIA GeForce RTX 5080/TestRadiancePrefilteringGgx.f2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28333dcbc69d0b63c548424cfd0642e0e64555ed5076b2020b6a5bdb3f955c97
-size 173153

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f1.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f1.metadata.json
@@ -1,13 +1,13 @@
 {
   "os": "Microsoft Windows 10.0.26100",
-  "cpu": "AMD EPYC 9V74 80-Core Processor",
+  "cpu": "AMD EPYC 7763 64-Core Processor",
   "gpu": "Microsoft Basic Render Driver",
   "gpuVendorId": "0x1414",
   "gpuDeviceId": "0x008C",
   "vendorName": "Microsoft",
   "driverId": "Microsoft",
   "driverName": "Microsoft",
-  "driverVersion": "1.0.18.0",
+  "driverVersion": "1.0.20.0",
   "apiName": "Direct3D11",
   "apiVersion": ""
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f1.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fbe928448cccc79a70649baacea1dd4b40aacd763c373d1d03530862ab5ddd2
-size 255329
+oid sha256:96c56d87ee0a13e534410151be91029a16041c8daefc43019229510a50496154
+size 256172

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f2.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f2.metadata.json
@@ -1,13 +1,13 @@
 {
   "os": "Microsoft Windows 10.0.26100",
-  "cpu": "AMD EPYC 9V74 80-Core Processor",
+  "cpu": "AMD EPYC 7763 64-Core Processor",
   "gpu": "Microsoft Basic Render Driver",
   "gpuVendorId": "0x1414",
   "gpuDeviceId": "0x008C",
   "vendorName": "Microsoft",
   "driverId": "Microsoft",
   "driverName": "Microsoft",
-  "driverVersion": "1.0.18.0",
+  "driverVersion": "1.0.20.0",
   "apiName": "Direct3D11",
   "apiVersion": ""
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f2.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.f2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7d815c1fbef27bfb9151729c68b4a8891d6af23674f05d79a641192c7b30d9b
-size 194166
+oid sha256:a790dc2702fb0294ae01d4f1849ee42bfd45729d9e34cced0075f262f1119d44
+size 195067

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.metadata.json
@@ -1,13 +1,13 @@
 {
   "os": "Microsoft Windows 10.0.26100",
-  "cpu": "AMD EPYC 9V74 80-Core Processor",
+  "cpu": "AMD EPYC 7763 64-Core Processor",
   "gpu": "Microsoft Basic Render Driver",
   "gpuVendorId": "0x1414",
   "gpuDeviceId": "0x008C",
   "vendorName": "Microsoft",
   "driverId": "Microsoft",
   "driverName": "Microsoft",
-  "driverVersion": "1.0.18.0",
+  "driverVersion": "1.0.20.0",
   "apiName": "Direct3D11",
   "apiVersion": ""
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D11/WARP/TestRadiancePrefilteringGgx.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:438bff7f44f2950cf17099c64ba513a40cfa2fbc67d1add49035701e1535048e
-size 667996
+oid sha256:e3b2ee041ff1e25d0f094436c9b44565ddd955625e64f54fb77d664a1ee24c0a
+size 667651

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f1.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f1.metadata.json
@@ -1,13 +1,13 @@
 {
   "os": "Microsoft Windows 10.0.26100",
-  "cpu": "AMD EPYC 7763 64-Core Processor",
+  "cpu": "AMD EPYC 9V74 80-Core Processor",
   "gpu": "Microsoft Basic Render Driver",
   "gpuVendorId": "0x1414",
   "gpuDeviceId": "0x008C",
   "vendorName": "Microsoft",
   "driverId": "Microsoft",
   "driverName": "Microsoft",
-  "driverVersion": "1.0.18.0",
+  "driverVersion": "1.0.20.0",
   "apiName": "Direct3D12",
   "apiVersion": ""
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f1.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53bcc8f4177bcc5da5dce101f1109aea72fb32bd84a43de507bb4719fef55d1c
-size 255284
+oid sha256:75173cfffd34672ee621409277806acf128514352b9d331dc3a3d10d0d16d1be
+size 256169

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f2.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f2.metadata.json
@@ -1,13 +1,13 @@
 {
   "os": "Microsoft Windows 10.0.26100",
-  "cpu": "AMD EPYC 7763 64-Core Processor",
+  "cpu": "AMD EPYC 9V74 80-Core Processor",
   "gpu": "Microsoft Basic Render Driver",
   "gpuVendorId": "0x1414",
   "gpuDeviceId": "0x008C",
   "vendorName": "Microsoft",
   "driverId": "Microsoft",
   "driverName": "Microsoft",
-  "driverVersion": "1.0.18.0",
+  "driverVersion": "1.0.20.0",
   "apiName": "Direct3D12",
   "apiVersion": ""
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f2.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.f2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f19a056deec8e6e389adda291d8103d8840f86a8f96621ea1ed8748ad5a04bce
-size 194195
+oid sha256:bcdb11e03e277fe331f9ebee1a3a04de9be301ff7b73e5e3e48ac3c2a7d95b4f
+size 195087

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.metadata.json
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.metadata.json
@@ -1,13 +1,13 @@
 {
   "os": "Microsoft Windows 10.0.26100",
-  "cpu": "AMD EPYC 7763 64-Core Processor",
+  "cpu": "AMD EPYC 9V74 80-Core Processor",
   "gpu": "Microsoft Basic Render Driver",
   "gpuVendorId": "0x1414",
   "gpuDeviceId": "0x008C",
   "vendorName": "Microsoft",
   "driverId": "Microsoft",
   "driverName": "Microsoft",
-  "driverVersion": "1.0.18.0",
+  "driverVersion": "1.0.20.0",
   "apiName": "Direct3D12",
   "apiVersion": ""
 }

--- a/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.png
+++ b/tests/Stride.Graphics.Tests.11_0/Windows.Direct3D12/WARP/TestRadiancePrefilteringGgx.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:438bff7f44f2950cf17099c64ba513a40cfa2fbc67d1add49035701e1535048e
-size 667996
+oid sha256:e3b2ee041ff1e25d0f094436c9b44565ddd955625e64f54fb77d664a1ee24c0a
+size 667651


### PR DESCRIPTION
## PR Details

**Summary**

`TestRadiancePrefilteringGgx` lays the six cube faces out as a vertical cross. The bottom tile of that
layout is the `-Z` face turned 180 degrees. The test applied a vertical flip instead, so that face
appeared mirrored against its neighbor and the cross showed a seam between the bottom and back faces.

**Description**

`SpriteBatch` reads `SpriteEffects` as a corner index XOR mask rather than a bit field
(`SpriteBatch.cs:623`, with `CornerOffsets` at `:17`):

| value | swaps | result |
|---|---|---|
| `FlipHorizontally = 1` | 0 and 1, 2 and 3 | mirror in X |
| `FlipBoth = 2` | 0 and 2, 1 and 3 | 180 degree rotation |
| `FlipVertically = 3` | 0 and 3, 1 and 2 | mirror in Y |

So the fix is one token at `TestRadiancePrefilteringGgx.cs:136`, `FlipVertically` to `FlipBoth`.

I measured the mean absolute luminance step across the `-Y` and `-Z` boundary of the rendered cross,
against the variation between neighboring rows inside a face:

| image | before | after | within-face variation |
|---|---|---|---|
| base | 8.78 | 0.53 | 6.34 |
| f1 | 4.62 | 0.75 | 0.95 |
| f2 | 4.04 | 1.50 | 0.33 |

On NVIDIA hardware the same measurement gives 4.46 to 0.72 for `f1` and 3.60 to 1.49 for `f2`, which
matches the values predicted in #3328.

**Gold images**

The `-Z` tile changes in all three screenshots, so the gold for this test moves.

- The Direct3D11 and Direct3D12 WARP buckets are regenerated by `test-gold-gen.yml`, 6 images and 6
  metadata files.
- The two RTX 5080 images are **deleted**. They were rendered before this fix, so they now assert the
  wrong picture. A render on NVIDIA hardware differs from them by a maximum of 171 at a PSNR of 28.2 dB.
  Falling back to the regenerated WARP gold puts that same render within a maximum difference of 10 at a
  PSNR of 61.6 dB, with no pixel off by 16 or more. Neither CI nor my machine can regenerate that bucket,
  because the CI runner has no GPU and my card is an RTX 3080 Ti. Somebody with RTX 5080 hardware should
  regenerate it if the remaining device difference matters.

**What this does not fix**

#3328 also reports a smaller discontinuity that grows with roughness. This PR does not address it, and it
survives here as `+Y` and `+Z` measuring 2.89 at `f2` against a within-face variation of 0.53. I posted
measurements on the issue that rule out two suspected causes.

## Related Issue

Fixes the display transform reported in #3328. The residual discontinuity in that issue stays open.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

**Validation status**

- `TestRadiancePrefilteringGgx` passes against the regenerated gold on Direct3D11 WARP.
- The regenerated gold carries the corrected values on both APIs, 0.53, 0.75 and 1.50.
- No new test. The defect is in the display code of this test, and the gold images already guard what it
  renders.
- Editor not exercised. This changes one test.
