### PR TITLE
Asset packs for New Game (Stride.Templates.AssetPacks)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -137,10 +137,10 @@ jobs:
           }
 
           $packages = Get-ChildItem -Path bin/packages -Filter "*.nupkg"
-          $contentVersionedIds = @('Stride.Templates.Samples', 'Stride.Templates.Games.Starters')
-          $contentVersioned = $packages | Where-Object { $_.Name -match 'Stride\.Templates\.(Samples|Games\.Starters)\.' }
+          $contentVersionedIds = @('Stride.Templates.Samples', 'Stride.Templates.Games.Starters', 'Stride.Templates.AssetPacks')
+          $contentVersioned = $packages | Where-Object { $_.Name -match 'Stride\.Templates\.(Samples|Games\.Starters|AssetPacks)\.' }
           $gameStudio = $packages | Where-Object { $_.Name -match 'GameStudio' }
-          $main = $packages | Where-Object { $_.Name -notmatch 'GameStudio' -and $_.Name -notmatch 'Stride\.Templates\.(Samples|Games\.Starters)\.' }
+          $main = $packages | Where-Object { $_.Name -notmatch 'GameStudio' -and $_.Name -notmatch 'Stride\.Templates\.(Samples|Games\.Starters|AssetPacks)\.' }
 
           echo "::group::Pushing main packages ($($main.Count))"
           foreach ($pkg in $main) {
@@ -150,7 +150,7 @@ jobs:
           echo "::endgroup::"
 
           if ($contentVersioned) {
-            echo "::group::Pushing content-versioned template packages (Samples, Starters)"
+            echo "::group::Pushing content-versioned template packages (Samples, Starters, AssetPacks)"
             foreach ($pkg in $contentVersioned) {
               $id = $contentVersionedIds | Where-Object { $pkg.Name.StartsWith($_ + '.') } | Select-Object -First 1
               if ($id -and (Test-NuGetPublished $id $pkg.BaseName.Substring($id.Length + 1))) {

--- a/build/Stride.slnx
+++ b/build/Stride.slnx
@@ -190,6 +190,7 @@
   </Folder>
   <Folder Name="/72-StrideSamples.Templates/">
     <Project Path="../sources/engine/Stride.Games.AutoTesting/Stride.Games.AutoTesting.csproj" />
+    <Project Path="../sources/templates/Stride.Templates.AssetPacks/Stride.Templates.AssetPacks.csproj" />
     <Project Path="../sources/templates/Stride.Templates.Games.Starters/Stride.Templates.Games.Starters.csproj" />
     <Project Path="../sources/templates/Stride.Templates.Games/Stride.Templates.Games.csproj" />
     <Project Path="../sources/templates/Stride.Templates.Samples/Stride.Templates.Samples.csproj" />

--- a/docs/build/versioning.md
+++ b/docs/build/versioning.md
@@ -82,6 +82,6 @@ dotnet msbuild build/Stride.Samples.build -t:SamplesToReleaseVersion   # finaliz
 **Template package versions** ([`Stride.Templates.Common.targets`](../../sources/templates/Stride.Templates.Common.targets)):
 
 - `Stride.Templates.Games` (NewGame + Library) → **engine-versioned** (`$(StrideNuGetVersion)`), always rebuilt and pushed (small).
-- `Stride.Templates.Samples` + `Stride.Templates.Games.Starters` → **content-versioned** at the committed `StrideSamplesVersion` ([`StrideSamplesVersion.props`](../../sources/templates/StrideSamplesVersion.props)); they only change (and re-publish) when the samples are actually bumped. The GameStudio bridge resolves the highest published version `<=` the engine version for these.
+- `Stride.Templates.Samples` + `Stride.Templates.Games.Starters` + `Stride.Templates.AssetPacks` → **content-versioned** at the committed `StrideSamplesVersion` ([`StrideSamplesVersion.props`](../../sources/templates/StrideSamplesVersion.props)); they only change (and re-publish) when the samples are actually bumped. The GameStudio bridge resolves the highest published version `<=` the engine version for these.
 
 A user instantiating any template gets their installed engine version stamped in (the package upgrader rewrites `Stride.*` references on instantiation), so a lagging template package still produces a project on the user's current Stride.

--- a/samples/NewGame/NewGame/NewGame.sdtpl
+++ b/samples/NewGame/NewGame/NewGame.sdtpl
@@ -12,3 +12,4 @@ Parameters:
     - HDR
     - graphicsProfile
     - orientation
+    - assetPacks

--- a/samples/Templates/Packs/MaterialPackage/MaterialPackage.sdtpl
+++ b/samples/Templates/Packs/MaterialPackage/MaterialPackage.sdtpl
@@ -1,0 +1,5 @@
+!TemplateAssetPack
+Id: 02eb39ec-2ec1-4bbb-a3fd-d1541f3a8727
+Name: "Materials pack"
+Description: A collection of ready-made materials.
+Group: AssetPacks

--- a/samples/Templates/Packs/PrototypingBlocks/PrototypingBlocks.sdtpl
+++ b/samples/Templates/Packs/PrototypingBlocks/PrototypingBlocks.sdtpl
@@ -1,0 +1,5 @@
+!TemplateAssetPack
+Id: dcaecb85-b5e8-4001-a394-a7039fe95d4d
+Name: "Building blocks"
+Description: Simple block models and prefabs to quickly prototype levels.
+Group: AssetPacks

--- a/samples/Templates/Packs/VFXPackage/VFXPackage.sdtpl
+++ b/samples/Templates/Packs/VFXPackage/VFXPackage.sdtpl
@@ -1,0 +1,5 @@
+!TemplateAssetPack
+Id: 63911545-be4b-40d9-b851-e0861fcee961
+Name: "Particles pack"
+Description: Ready-made particle effects such as fire, smoke and explosions.
+Group: AssetPacks

--- a/samples/Templates/Packs/mannequinModel/mannequinModel.sdtpl
+++ b/samples/Templates/Packs/mannequinModel/mannequinModel.sdtpl
@@ -1,0 +1,5 @@
+!TemplateAssetPack
+Id: faf82c1e-579e-49a3-a6aa-73548d01be04
+Name: "Animated models"
+Description: Mannequin model with a set of ready-to-use animations.
+Group: AssetPacks

--- a/sources/assets/Stride.Core.Assets/PackageStore.cs
+++ b/sources/assets/Stride.Core.Assets/PackageStore.cs
@@ -118,6 +118,17 @@ public class PackageStore
     }
 
     /// <summary>
+    /// Fetches (if needed) and installs <paramref name="packageName"/> at <paramref name="version"/>
+    /// into the local package store, from the configured NuGet sources. Returns the installed
+    /// package, or null when it could not be resolved (e.g. offline and not cached).
+    /// </summary>
+    public Task<NugetLocalPackage?> InstallPackage(string packageName, PackageVersion version, ProgressReport? progress = null)
+    {
+        ArgumentNullException.ThrowIfNull(packageName);
+        return store.InstallPackage(packageName, version, [], progress);
+    }
+
+    /// <summary>
     /// Gets the default package manager.
     /// </summary>
     /// <value>A default instance.</value>

--- a/sources/assets/Stride.Core.Packages/NugetStore.cs
+++ b/sources/assets/Stride.Core.Packages/NugetStore.cs
@@ -482,7 +482,7 @@ public partial class NugetStore : INugetDownloadProgress
     /// <remarks>It is safe to call it concurrently be cause we operations are done using the FileLock.</remarks>
     /// <param name="packageId">Name of package to install.</param>
     /// <param name="version">Version of package to install.</param>
-    public async Task<NugetLocalPackage?> InstallPackage(string packageId, PackageVersion version, IEnumerable<string> targetFrameworks, ProgressReport progress)
+    public async Task<NugetLocalPackage?> InstallPackage(string packageId, PackageVersion version, IEnumerable<string> targetFrameworks, ProgressReport? progress)
     {
         using (GetLocalRepositoryLock())
         {

--- a/sources/editor/Stride.Assets.Presentation/Templates/DotNetNewTemplateParametersWindow.xaml.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/DotNetNewTemplateParametersWindow.xaml.cs
@@ -32,6 +32,9 @@ public partial class DotNetNewTemplateParametersWindow : ModalWindow
     /// <summary>Per-parameter UI binding callback: returns the chosen value as a string (or null for "use default").</summary>
     private readonly List<(ITemplateParameter Param, Func<string?> Read)> bindings = new();
 
+    /// <summary>Asset-pack checkboxes, keyed by the pack template's identity.</summary>
+    private readonly List<(string Identity, CheckBox CheckBox)> assetPackChecks = new();
+
     /// <summary>
     /// Built-in cross-parameter coupling: HDR is meaningful only on graphics feature level 10.0+
     /// (the sample's HDR materials use shader features not available below SM4). Holds the
@@ -53,7 +56,11 @@ public partial class DotNetNewTemplateParametersWindow : ModalWindow
     /// </summary>
     public Dictionary<string, string> Parameters { get; } = new();
 
-    public DotNetNewTemplateParametersWindow(ITemplateInfo template)
+    /// <summary>Identities of the asset-pack templates the user ticked (empty when none offered/selected).</summary>
+    public IReadOnlyList<string> SelectedAssetPacks =>
+        assetPackChecks.Where(t => t.CheckBox.IsChecked == true).Select(t => t.Identity).ToList();
+
+    public DotNetNewTemplateParametersWindow(ITemplateInfo template, IReadOnlyList<ITemplateInfo>? assetPacks = null)
     {
         ArgumentNullException.ThrowIfNull(template);
         TemplateName = template.Name ?? template.Identity;
@@ -66,6 +73,8 @@ public partial class DotNetNewTemplateParametersWindow : ModalWindow
             DescriptionTextBlock.Visibility = Visibility.Collapsed;
 
         BuildControls(template);
+        if (assetPacks is { Count: > 0 })
+            ParametersPanel.Children.Add(BuildAssetPacksRow(assetPacks));
     }
 
     private void BuildControls(ITemplateInfo template)
@@ -229,6 +238,35 @@ public partial class DotNetNewTemplateParametersWindow : ModalWindow
         stack.Children.Add(img);
         stack.Children.Add(new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center });
         return stack;
+    }
+
+    /// <summary>
+    /// Checkbox list for the optional asset packs (Building blocks, Materials, ...), one per
+    /// item template of the AssetPacks package. All unchecked by default; each selected pack is
+    /// instantiated into the generated game library after the main template.
+    /// </summary>
+    private UIElement BuildAssetPacksRow(IReadOnlyList<ITemplateInfo> assetPacks)
+    {
+        var row = new StackPanel { Margin = new Thickness(0, 6, 0, 6) };
+        row.Children.Add(new TextBlock
+        {
+            Text = "Asset packs — Ready-made asset collections added to your project",
+            Margin = new Thickness(0, 0, 0, 3),
+            TextWrapping = TextWrapping.Wrap,
+        });
+        foreach (var pack in assetPacks)
+        {
+            var label = string.IsNullOrEmpty(pack.Description) ? pack.Name : $"{pack.Name} — {pack.Description}";
+            var item = new CheckBox
+            {
+                Content = label,
+                IsChecked = false,
+                Margin = new Thickness(0, 2, 0, 2),
+            };
+            row.Children.Add(item);
+            assetPackChecks.Add((pack.Identity, item));
+        }
+        return row;
     }
 
     private static bool ParseBool(string? s) => bool.TryParse(s, out var b) && b;

--- a/sources/editor/Stride.Assets.Presentation/Templates/WpfDotNetNewParameterPrompt.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/WpfDotNetNewParameterPrompt.cs
@@ -12,10 +12,16 @@ namespace Stride.Assets.Presentation.Templates;
 /// <summary>WPF impl of <see cref="IDotNetNewParameterPrompt"/> — shows <see cref="DotNetNewTemplateParametersWindow"/> modally.</summary>
 internal sealed class WpfDotNetNewParameterPrompt : IDotNetNewParameterPrompt
 {
-    public async Task<IReadOnlyDictionary<string, string>?> PromptAsync(ITemplateInfo template)
+    public async Task<DotNetNewPromptResult?> PromptAsync(ITemplateInfo template, TemplateDotNetNewDescription description)
     {
-        var dialog = new DotNetNewTemplateParametersWindow(template);
+        // Templates that opt into asset packs get the pack checkboxes; the bridge downloads the
+        // AssetPacks package on first use. Empty list (e.g. offline) = no packs section.
+        IReadOnlyList<ITemplateInfo> assetPacks = [];
+        if (description.OffersAssetPacks)
+            assetPacks = await DotNetNewTemplateBridge.GetAssetPackTemplatesAsync().ConfigureAwait(true);
+
+        var dialog = new DotNetNewTemplateParametersWindow(template, assetPacks);
         var result = await dialog.ShowModal();
-        return result == SDDialogResult.Ok ? dialog.Parameters : null;
+        return result == SDDialogResult.Ok ? new DotNetNewPromptResult(dialog.Parameters, dialog.SelectedAssetPacks) : null;
     }
 }

--- a/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
+++ b/sources/editor/Stride.GameStudio/Stride.GameStudio.csproj
@@ -95,6 +95,14 @@
     <ProjectReference Include="..\..\templates\Stride.Templates.Samples\Stride.Templates.Samples.csproj">
       <Private>false</Private>
     </ProjectReference>
+    <!-- Build-ordering only (no nuspec dependency): asset packs are fetched on demand by the New
+         Game dialog, not pulled at install time. The reference just makes a dev GameStudio build
+         produce the .nupkg so the packs show up locally. -->
+    <ProjectReference Include="..\..\templates\Stride.Templates.AssetPacks\Stride.Templates.AssetPacks.csproj">
+      <Private>false</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\BACKERS.md" Link="BACKERS.md">

--- a/sources/engine/Stride.Assets/Templates/DotNetNewTemplateBridge.cs
+++ b/sources/engine/Stride.Assets/Templates/DotNetNewTemplateBridge.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Stride.Core;
@@ -34,9 +35,10 @@ public static class DotNetNewTemplateBridge
     /// <summary>
     /// Package IDs the bridge tries to resolve via <see cref="PackageStore"/> on startup.
     /// Only <c>Stride.Templates.Games</c> (NewGame) ships in the GameStudio installer; the
-    /// other two are dev-only here (present in <c>%LocalAppData%\stride\nugetdev</c> when the
+    /// others are dev-only here (present in <c>%LocalAppData%\stride\nugetdev</c> when the
     /// solution has been built, absent in installer-only setups). End users reach Starters /
-    /// Samples via the editor's template store (future) or CLI <c>dotnet new install</c>; this
+    /// Samples via the editor's template store (future) or CLI <c>dotnet new install</c>, and
+    /// AssetPacks via the on-demand download in <see cref="GetAssetPackTemplatesAsync"/>; this
     /// list just controls which packages the bridge proactively probes on startup. Missing
     /// packages are tolerated (per-package warning, no error).
     /// </summary>
@@ -45,7 +47,16 @@ public static class DotNetNewTemplateBridge
         "Stride.Templates.Games",
         "Stride.Templates.Games.Starters",
         "Stride.Templates.Samples",
+        AssetPacksPackageId,
     };
+
+    /// <summary>
+    /// Package holding the asset-pack item templates offered by the New Game flow. Probed at
+    /// startup like the others; additionally fetched on demand by
+    /// <see cref="GetAssetPackTemplatesAsync"/> when a game template offering packs is
+    /// instantiated on a machine that doesn't have it yet.
+    /// </summary>
+    public const string AssetPacksPackageId = "Stride.Templates.AssetPacks";
 
     private static DotNetNewTemplateRegistry? registry;
     private static readonly object InitLock = new();
@@ -108,6 +119,12 @@ public static class DotNetNewTemplateBridge
             var synthetic = new Package { FullPath = new UFile("Stride.DotNetNewTemplates.synthetic") };
             foreach (var template in templates)
             {
+                // Item templates (asset packs) are not stand-alone projects — they surface as
+                // checkboxes inside the parameter dialog of templates that offer them, not as
+                // entries in the New-Project list.
+                if (IsItemTemplate(template))
+                    continue;
+
                 // Cross-ref by template.json identity → matches the sdtpl Id (we set
                 // `identity = sdtpl.Id` in the preprocessor) so the dict lookup hits.
                 sdtplsByIdentity.TryGetValue(template.Identity, out var source);
@@ -131,6 +148,7 @@ public static class DotNetNewTemplateBridge
                         : TemplateScope.Session,
                     TemplateIdentity = template.Identity,
                     TemplateShortName = shortName ?? string.Empty,
+                    OffersAssetPacks = sdtpl?.HasParameter("assetPacks") == true,
                     // FullPath must be non-null: TemplateDescriptionViewModel calls
                     // Template.FullPath.GetFullDirectory() unconditionally when constructing
                     // image paths. We point it at a synthetic file inside the per-template
@@ -160,13 +178,65 @@ public static class DotNetNewTemplateBridge
     }
 
     /// <summary>
+    /// The asset-pack item templates available for the New Game flow, in registry order. When
+    /// none are installed and <paramref name="allowDownload"/> is true, resolves the
+    /// <see cref="AssetPacksPackageId"/> package via <see cref="PackageStore"/> — downloading it
+    /// from the configured NuGet sources if this machine doesn't have it — and installs it into
+    /// the registry. Returns an empty list when the package can't be obtained (e.g. offline);
+    /// callers degrade by not offering packs.
+    /// </summary>
+    public static async Task<IReadOnlyList<ITemplateInfo>> GetAssetPackTemplatesAsync(bool allowDownload = true)
+    {
+        var logger = GlobalLogger.GetLogger("DotNetNewTemplateBridge");
+        if (registry == null)
+            return [];
+
+        var packs = FilterAssetPacks(await registry.GetTemplatesAsync().ConfigureAwait(false));
+        if (packs.Count > 0 || !allowDownload)
+            return packs;
+
+        var version = new PackageVersion(DesiredVersionFor(AssetPacksPackageId));
+        var versionRange = new PackageVersionRange(version, true, version, true);
+        if (PackageStore.Instance.GetPackageDirectory(AssetPacksPackageId, versionRange) is null)
+        {
+            logger.Info($"{AssetPacksPackageId} {version} not present locally; downloading...");
+            try
+            {
+                await PackageStore.Instance.InstallPackage(AssetPacksPackageId, version).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                logger.Warning($"Could not download {AssetPacksPackageId} {version}: {e.Message}. Asset packs will be unavailable.");
+                return [];
+            }
+        }
+
+        lock (InitLock)
+        {
+            // Same path as startup probing: resolves the package dir and installs it into the
+            // registry (no TemplateManager registration — item templates stay out of the
+            // New-Project list).
+            InstallBundledPackage(AssetPacksPackageId, new Dictionary<string, TemplateMetadataSource>(), logger);
+        }
+        return FilterAssetPacks(await registry.GetTemplatesAsync().ConfigureAwait(false));
+    }
+
+    /// <summary>Asset packs = item templates classified <c>AssetPacks</c> (see the preprocessor's item-template emission).</summary>
+    private static IReadOnlyList<ITemplateInfo> FilterAssetPacks(IReadOnlyList<ITemplateInfo> templates)
+        => templates.Where(t => IsItemTemplate(t) && t.Classifications.Contains("AssetPacks", StringComparer.Ordinal)).ToList();
+
+    /// <summary>True for dotnet new item templates (<c>"tags": { "type": "item" }</c>).</summary>
+    private static bool IsItemTemplate(ITemplateInfo template)
+        => template.TagsCollection.TryGetValue("type", out var type) && string.Equals(type, "item", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// The package version this build expects for <paramref name="packageId"/>: content packages
-    /// (Samples, Starters) use <see cref="StrideVersion.SamplesVersion"/> + the engine NuGet suffix;
+    /// (Samples, Starters, AssetPacks) use <see cref="StrideVersion.SamplesVersion"/> + the engine NuGet suffix;
     /// everything else tracks <see cref="StrideVersion.NuGetVersion"/>.
     /// </summary>
     private static string DesiredVersionFor(string packageId)
     {
-        var contentVersioned = packageId is "Stride.Templates.Samples" or "Stride.Templates.Games.Starters";
+        var contentVersioned = packageId is "Stride.Templates.Samples" or "Stride.Templates.Games.Starters" or AssetPacksPackageId;
         return contentVersioned
             ? StrideVersion.SamplesVersion + StrideVersion.NuGetVersionSuffix
             : StrideVersion.NuGetVersion;

--- a/sources/engine/Stride.Assets/Templates/DotNetNewTemplateGenerator.cs
+++ b/sources/engine/Stride.Assets/Templates/DotNetNewTemplateGenerator.cs
@@ -34,6 +34,10 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
     private static readonly PropertyKey<IReadOnlyDictionary<string, string>> ParameterValuesKey
         = new("ParameterValues", typeof(DotNetNewTemplateGenerator));
 
+    /// <summary>Identities of the asset-pack item templates to instantiate into the generated game library.</summary>
+    private static readonly PropertyKey<IReadOnlyList<string>> AssetPacksKey
+        = new("AssetPacks", typeof(DotNetNewTemplateGenerator));
+
     private readonly IDotNetNewParameterPrompt? prompt;
 
     /// <summary>Headless ctor (no UI). PrepareForRun returns true without collecting parameter values; callers must <see cref="SetParameters"/> on parameters.Unattended runs.</summary>
@@ -61,6 +65,16 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
         parameters.SetTag(ParameterValuesKey, values);
     }
 
+    /// <summary>
+    /// Sets the asset packs (template identities) to add to the generated game for an unattended
+    /// run. Attended runs collect them from the parameter dialog.
+    /// </summary>
+    public static void SetAssetPacks(SessionTemplateGeneratorParameters parameters, IReadOnlyList<string> assetPackIdentities)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        parameters.SetTag(AssetPacksKey, assetPackIdentities);
+    }
+
     public override async Task<bool> PrepareForRun(SessionTemplateGeneratorParameters parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
@@ -79,11 +93,12 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
             return false;
         }
 
-        var values = await prompt.PromptAsync(template).ConfigureAwait(true);
-        if (values == null)
+        var result = await prompt.PromptAsync(template, description).ConfigureAwait(true);
+        if (result == null)
             return false;
 
-        parameters.SetTag(ParameterValuesKey, values);
+        parameters.SetTag(ParameterValuesKey, result.Parameters);
+        parameters.SetTag(AssetPacksKey, result.AssetPackIdentities);
         return true;
     }
 
@@ -92,6 +107,7 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
         var sdpkg = InstantiateFiles(parameters);
         if (sdpkg == null)
             return false;
+        InstantiateAssetPacks(parameters, sdpkg);
         if (!UpgradeGeneratedProjects(parameters))
             return false;
         return IntegrateIntoSession(sdpkg, parameters);
@@ -104,7 +120,57 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
     /// </summary>
     public bool GenerateFilesOnly(SessionTemplateGeneratorParameters parameters)
     {
-        return InstantiateFiles(parameters) != null && UpgradeGeneratedProjects(parameters);
+        var sdpkg = InstantiateFiles(parameters);
+        if (sdpkg == null)
+            return false;
+        InstantiateAssetPacks(parameters, sdpkg);
+        return UpgradeGeneratedProjects(parameters);
+    }
+
+    /// <summary>
+    /// Instantiates each selected asset-pack item template into the generated game library dir
+    /// (next to the .sdpkg), dropping the pack's Assets/ + Resources/ into the project — the
+    /// dotnet new equivalent of the legacy New Game asset-pack copy. A failing pack is logged
+    /// but doesn't fail generation; the game itself is intact without it.
+    /// </summary>
+    protected virtual void InstantiateAssetPacks(SessionTemplateGeneratorParameters parameters, string sdpkgPath)
+    {
+        var identities = parameters.TryGetTag(AssetPacksKey);
+        if (identities == null || identities.Count == 0)
+            return;
+
+        var log = parameters.Logger;
+        if (DotNetNewTemplateBridge.Registry == null)
+        {
+            log.Error("DotNetNewTemplateBridge is not initialized; cannot add asset packs.");
+            return;
+        }
+
+        var outputDir = Path.GetDirectoryName(sdpkgPath)!;
+        var templates = DotNetNewTemplateBridge.Registry.GetTemplatesAsync().GetAwaiter().GetResult();
+        foreach (var identity in identities)
+        {
+            var packTemplate = templates.FirstOrDefault(t => string.Equals(t.Identity, identity, StringComparison.Ordinal));
+            if (packTemplate == null)
+            {
+                log.Error($"Asset pack template '{identity}' could not be resolved; skipping.");
+                continue;
+            }
+            try
+            {
+                var creation = DotNetNewTemplateBridge.Registry
+                    .InstantiateAsync(packTemplate, packTemplate.ShortNameList.FirstOrDefault() ?? "asset-pack", outputDir, new Dictionary<string, string>())
+                    .GetAwaiter().GetResult();
+                if (creation.Status != CreationResultStatus.Success)
+                    log.Error($"Asset pack '{packTemplate.Name}' failed: {creation.Status} — {creation.ErrorMessage}");
+                else
+                    log.Info($"Added asset pack '{packTemplate.Name}'.");
+            }
+            catch (Exception ex)
+            {
+                log.Error($"Asset pack '{packTemplate.Name}' failed: {ex.Message}", ex);
+            }
+        }
     }
 
     /// <summary>

--- a/sources/engine/Stride.Assets/Templates/IDotNetNewParameterPrompt.cs
+++ b/sources/engine/Stride.Assets/Templates/IDotNetNewParameterPrompt.cs
@@ -10,5 +10,14 @@ namespace Stride.Assets.Templates;
 /// <summary>UI hook for collecting dotnet new template parameter values; null result = cancel.</summary>
 public interface IDotNetNewParameterPrompt
 {
-    Task<IReadOnlyDictionary<string, string>?> PromptAsync(ITemplateInfo template);
+    Task<DotNetNewPromptResult?> PromptAsync(ITemplateInfo template, TemplateDotNetNewDescription description);
 }
+
+/// <summary>
+/// What the parameter dialog collected: template parameter values, plus the identities of the
+/// asset-pack item templates the user selected (empty when the template offers none or the user
+/// selected none).
+/// </summary>
+public sealed record DotNetNewPromptResult(
+    IReadOnlyDictionary<string, string> Parameters,
+    IReadOnlyList<string> AssetPackIdentities);

--- a/sources/engine/Stride.Assets/Templates/SdtplMetadata.cs
+++ b/sources/engine/Stride.Assets/Templates/SdtplMetadata.cs
@@ -10,12 +10,20 @@ using Stride.Core.Yaml.Serialization;
 namespace Stride.Assets.Templates;
 
 /// <summary>
-/// Subset of <c>!TemplateSample</c> / <c>!Template</c> fields the preprocessor cares about.
-/// Loaded from each sample's <c>.sdtpl</c> file; informs template.json emission and (later)
-/// the aggregated <c>templates.sdtpls</c> shipped at the package root for GameStudio.
+/// Subset of <c>!TemplateSample</c> / <c>!Template</c> / <c>!TemplateAssetPack</c> fields the
+/// preprocessor cares about. Loaded from each sample's <c>.sdtpl</c> file; informs template.json
+/// emission and (later) the aggregated <c>templates.sdtpls</c> shipped at the package root for
+/// GameStudio.
 /// </summary>
 internal sealed class SdtplMetadata
 {
+    /// <summary>
+    /// True when the .sdtpl root tag is <c>!TemplateAssetPack</c>: the input is an asset pack
+    /// (Assets/ + Resources/ dropped into an existing project) packed as a dotnet new item
+    /// template, not a full project template.
+    /// </summary>
+    public bool IsAssetPack { get; set; }
+
     public Guid? Id { get; set; }
     public string? Name { get; set; }
     public string? Description { get; set; }
@@ -30,8 +38,9 @@ internal sealed class SdtplMetadata
     /// <summary>
     /// Per-template opt-in to optional preprocessor-emitted parameters. Values are case-
     /// insensitive; currently recognized: <c>HDR</c>, <c>graphicsProfile</c>, <c>orientation</c>.
-    /// Unknown entries are kept (forward-compat for future parameter names) but ignored at
-    /// emission time.
+    /// <c>assetPacks</c> is editor-level only (offers the asset-pack checkboxes in GameStudio's
+    /// parameter dialog; no template.json parameter is emitted for it). Unknown entries are kept
+    /// (forward-compat for future parameter names) but ignored at emission time.
     /// </summary>
     public List<string> Parameters { get; } = new();
 
@@ -74,7 +83,10 @@ internal sealed class SdtplMetadata
 
     private static SdtplMetadata FromMapping(YamlMappingNode root)
     {
-        var meta = new SdtplMetadata();
+        var meta = new SdtplMetadata
+        {
+            IsAssetPack = string.Equals(root.Tag?.TrimStart('!'), "TemplateAssetPack", StringComparison.Ordinal),
+        };
         foreach (var entry in root.Children)
         {
             var key = (entry.Key as YamlScalarNode)?.Value;

--- a/sources/engine/Stride.Assets/Templates/TemplateDotNetNewDescription.cs
+++ b/sources/engine/Stride.Assets/Templates/TemplateDotNetNewDescription.cs
@@ -26,4 +26,12 @@ public class TemplateDotNetNewDescription : TemplateDescription
     /// and tools that need to look up a template by a stable human-readable name.
     /// </summary>
     public string TemplateShortName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when the template's <c>.sdtpl</c> opts into the asset-packs step (an
+    /// <c>assetPacks</c> entry in its <c>Parameters</c> list): the parameter dialog then offers
+    /// the <c>Stride.Templates.AssetPacks</c> item templates as checkboxes, and each selected
+    /// pack is instantiated into the generated game library after the main template.
+    /// </summary>
+    public bool OffersAssetPacks { get; set; }
 }

--- a/sources/launcher/Stride.Cli/NewCommand.cs
+++ b/sources/launcher/Stride.Cli/NewCommand.cs
@@ -89,11 +89,16 @@ internal static class NewCommand
                 }
 
                 var name = parseResult.GetValue(nameOption) ?? template.DefaultName ?? templateName;
-                var output = parseResult.GetValue(outputOption) ?? Path.Combine(Environment.CurrentDirectory, name);
+                // Item templates (e.g. the stride-pack-* asset packs) drop content into an existing
+                // project, so they default to the current directory and skip the non-empty check.
+                var isItemTemplate = template.TagsCollection.TryGetValue("type", out var templateType)
+                    && string.Equals(templateType, "item", StringComparison.OrdinalIgnoreCase);
+                var output = parseResult.GetValue(outputOption)
+                    ?? (isItemTemplate ? Environment.CurrentDirectory : Path.Combine(Environment.CurrentDirectory, name));
 
                 // Refuse to write into an existing non-empty directory unless --force (mirrors `dotnet new`),
                 // so a repeated command doesn't silently overwrite a project.
-                if (!parseResult.GetValue(forceOption) && Directory.Exists(output) && Directory.EnumerateFileSystemEntries(output).Any())
+                if (!isItemTemplate && !parseResult.GetValue(forceOption) && Directory.Exists(output) && Directory.EnumerateFileSystemEntries(output).Any())
                 {
                     Console.Error.WriteLine($"The output directory '{output}' already exists and is not empty. Choose another name with --name, a different --output, or pass --force to overwrite.");
                     return 1;

--- a/sources/templates/README.md
+++ b/sources/templates/README.md
@@ -1,12 +1,13 @@
 # Stride `dotnet new` Templates
 
-Three NuGet packages ship Stride project templates for the `dotnet new` engine:
+Four NuGet packages ship Stride templates for the `dotnet new` engine:
 
 | Package | Contents | Distribution |
 |---|---|---|
 | **`Stride.Templates.Games`** | `stride-game` (blank NewGame starter) | Bundled with GameStudio installer |
 | **`Stride.Templates.Games.Starters`** | `stride-fps`, `stride-platformer2d`, `stride-topdownrpg`, `stride-thirdpersonplatformer`, `stride-vrsandbox` | nuget.org (CLI install / future template store) |
 | **`Stride.Templates.Samples`** | 18 feature demos (tutorials, games, graphics, physics, UI, particles, input, audio) | nuget.org (CLI install / future template store) |
+| **`Stride.Templates.AssetPacks`** | 4 asset packs as item templates: `stride-pack-buildingblocks`, `stride-pack-animatedmodels`, `stride-pack-materials`, `stride-pack-particles` | nuget.org (downloaded on demand by GameStudio's New Game dialog / CLI install) |
 
 GameStudio's "New Project" dialog and CLI `dotnet new` consume the same packages — there is one template flow, not two.
 
@@ -34,6 +35,18 @@ dotnet new install Stride.Templates.Samples
 dotnet new stride-jumpyjet -n MyJumpyJet
 cd MyJumpyJet && dotnet run --project MyJumpyJet.Windows
 ```
+
+Asset packs are *item* templates: they drop ready-made assets into an existing game library
+(the same content the New Game dialog offers as checkboxes):
+
+```bash
+dotnet new install Stride.Templates.AssetPacks
+cd MyGame/MyGame.Game
+dotnet new stride-pack-buildingblocks   # merges the pack's Assets/ + Resources/ into the project
+```
+
+The `stride` CLI resolves installed template packages automatically; with the AssetPacks package
+present, `stride new stride-pack-buildingblocks` run inside the game library does the same.
 
 `dotnet new -l` after the installs lists every available stride-* short name.
 
@@ -87,7 +100,7 @@ dotnet pack sources/templates/Stride.Templates.Games -p:StridePackageBuild=true
 
 ## Sample versioning
 
-In-repo samples are committed at a **clean release version**, but locally only the `-devN` dev packages exist — so switch them to the local dev version to build/edit (e.g. in GameStudio), and back before committing. `SamplesToDevVersion` rewrites every `Stride.*` reference in the sample csprojs to this checkout's dev build (real edits); `SamplesToReleaseVersion` rewrites them back to the clean version. `Stride.Templates.Games` is engine-versioned; `Stride.Templates.Samples` + `.Games.Starters` are content-versioned at `StrideSamplesVersion`. Full details (engine version, `-devN`, release flow, the `StrideSamplesVersion` authority) — including why — are in **[docs/build/versioning.md](../../docs/build/versioning.md)**.
+In-repo samples are committed at a **clean release version**, but locally only the `-devN` dev packages exist — so switch them to the local dev version to build/edit (e.g. in GameStudio), and back before committing. `SamplesToDevVersion` rewrites every `Stride.*` reference in the sample csprojs to this checkout's dev build (real edits); `SamplesToReleaseVersion` rewrites them back to the clean version. `Stride.Templates.Games` is engine-versioned; `Stride.Templates.Samples` + `.Games.Starters` + `.AssetPacks` are content-versioned at `StrideSamplesVersion`. Full details (engine version, `-devN`, release flow, the `StrideSamplesVersion` authority) — including why — are in **[docs/build/versioning.md](../../docs/build/versioning.md)**.
 
 ```bash
 dotnet msbuild build/Stride.Samples.build -t:SamplesToDevVersion       # before editing/building (e.g. GameStudio)
@@ -133,6 +146,25 @@ dotnet msbuild build/Stride.Samples.build -t:UpgradeSamplesVersion     # full re
 
 4. **Build the package**. The preprocessor handles GUID rewriting (sample-internal → template.json placeholders, engine archetype Ids preserved), `ProjectReference` dep-collapse (shared packs inlined as `Assets/`/`Resources/`), sourceName rename (`MyCoolSample` → `MyTemplate` → user's `-n` value at instantiation), `.sln` synthesis with platform-conditional project sections, and `template.json` emission. Inspect the output at `obj/template-content/stride-mycoolsample/` before packing if you want to verify the transforms.
 
+## Adding a new asset pack
+
+Asset packs take a reduced pipeline: only `Assets/` + `Resources/` are staged, packed as a dotnet
+new **item** template (no sourceName rename, no GUID placeholdering, no prune). Declare one with a
+`!TemplateAssetPack` .sdtpl at the pack root (see `samples/Templates/Packs/PrototypingBlocks/`):
+
+```yaml
+!TemplateAssetPack
+Id: <new-guid>
+Name: "My pack"
+Description: A short blurb shown next to the checkbox.
+Group: AssetPacks
+```
+
+then add a `<StrideSampleTemplate>` entry to `Stride.Templates.AssetPacks.csproj`. GameStudio's
+New Game dialog lists every item template of the AssetPacks package as a checkbox (templates whose
+`.sdtpl` `Parameters` list includes `assetPacks` opt into the section; today that's `stride-game`),
+and instantiates each selected pack into the generated game library.
+
 ## Architecture pointers
 
 - **[`sources/tools/Stride.TemplateGenerator/TemplatePreprocessor.cs`](../tools/Stride.TemplateGenerator/TemplatePreprocessor.cs)** — the preprocess pipeline (sample → dotnet new template content). Pipeline steps inline-documented at the top of `Run`.
@@ -145,5 +177,6 @@ dotnet msbuild build/Stride.Samples.build -t:UpgradeSamplesVersion     # full re
 ## Future work
 
 - **One-click CLI registration on Windows** — on Linux/macOS the manual `dotnet new install` step in [End-user usage](#end-user-usage-cli) is the canonical path (no editor to integrate with). On Windows, GameStudio bundles `Stride.Templates.Games.<version>.nupkg` and could expose a settings toggle ("Register Stride templates for CLI") that runs the install on the user's behalf. Opt-in to respect user intent and avoid multi-version conflicts when 4.4 + 4.5 GameStudios coexist. GameStudio's own New-Project dialog is unaffected either way — it installs into an isolated TemplateEngine profile, not the global `dotnet new` registry.
+- **Asset packs as referenced packages** — today a pack is a copy the user owns: GameStudio's New Game checkboxes (or, on the CLI, a `stride-pack-*` command run in the game library after creating the game — packs can't be a `stride-game` parameter because a template can't pull content from another package) drop the assets into the project. Later, packs could become real NuGet asset packages added as a `PackageReference` (enabled by asset URL namespacing): assets stay in the package, update with version bumps, third parties can publish their own. The dialog UX stays; only the checkbox action changes from copy to reference, and the item templates phase out with no migration (created games keep their copied assets).
 - **Template store UI** — browse `Stride.Templates.Games.Starters` / `Stride.Templates.Samples` from nuget.org inside the New-Project dialog, install on-demand without manual CLI.
 - **HTTP Range fetch of `templates.sdtpls`** — load just the aggregated metadata (Name/Description/Icon/Screenshots) before downloading a multi-MB nupkg, so the store UI can show rich preview cards without paying full download cost upfront.

--- a/sources/templates/Stride.Templates.AssetPacks/Stride.Templates.AssetPacks.csproj
+++ b/sources/templates/Stride.Templates.AssetPacks/Stride.Templates.AssetPacks.csproj
@@ -1,0 +1,44 @@
+<!-- TreatAsLocalProperty="StrideSkipAutoPack": Pack must always run here (this is a templates
+     package, not a regular library), so an outer build context's StrideSkipAutoPack=true shouldn't
+     suppress it. Removing it from the project's global-property context also keeps MSBuild from
+     deduplicating into two distinct project instances when the property differs across the paths
+     that reach this project. -->
+<Project Sdk="Microsoft.Build.NoTargets" TreatAsLocalProperty="StrideSkipAutoPack">
+  <PropertyGroup>
+    <PackageId>Stride.Templates.AssetPacks</PackageId>
+    <Title>Stride Asset Packs</Title>
+    <Description>Optional asset packs (models, materials, particles) to add to a Stride game.</Description>
+    <PackageTags>dotnet-new;templates;stride;stride-template;assets;gamedev</PackageTags>
+    <!-- Content-versioned (StrideSamplesVersion): pack content only changes when the samples are bumped. -->
+    <StrideTemplateContentVersioned>true</StrideTemplateContentVersioned>
+  </PropertyGroup>
+
+  <Import Project="..\Stride.Templates.Common.targets" />
+
+  <ItemGroup>
+    <!-- One dotnet new item template per asset pack (see the !TemplateAssetPack .sdtpl in each
+         pack dir). Instantiating drops the pack's Assets/ + Resources/ into an existing game
+         library dir; GameStudio's New Game flow and the stride CLI drive these after stride-game. -->
+    <StrideSampleTemplate Include="stride-pack-buildingblocks">
+      <SamplePath>$(StrideRoot)samples/Templates/Packs/PrototypingBlocks</SamplePath>
+    </StrideSampleTemplate>
+    <StrideSampleTemplate Include="stride-pack-animatedmodels">
+      <SamplePath>$(StrideRoot)samples/Templates/Packs/mannequinModel</SamplePath>
+    </StrideSampleTemplate>
+    <StrideSampleTemplate Include="stride-pack-materials">
+      <SamplePath>$(StrideRoot)samples/Templates/Packs/MaterialPackage</SamplePath>
+    </StrideSampleTemplate>
+    <StrideSampleTemplate Include="stride-pack-particles">
+      <SamplePath>$(StrideRoot)samples/Templates/Packs/VFXPackage</SamplePath>
+    </StrideSampleTemplate>
+  </ItemGroup>
+
+  <!-- Static literal-wildcard inputs so a pack edit triggers a repack (CPS needs pre-expanded paths; see
+       Common.targets). One per StrideSampleTemplate above; bin/obj aren't excluded (source packs stay clean). -->
+  <ItemGroup>
+    <UpToDateCheckInput Include="$(StrideRoot)samples/Templates/Packs/PrototypingBlocks/**/*" />
+    <UpToDateCheckInput Include="$(StrideRoot)samples/Templates/Packs/mannequinModel/**/*" />
+    <UpToDateCheckInput Include="$(StrideRoot)samples/Templates/Packs/MaterialPackage/**/*" />
+    <UpToDateCheckInput Include="$(StrideRoot)samples/Templates/Packs/VFXPackage/**/*" />
+  </ItemGroup>
+</Project>

--- a/sources/templates/Stride.Templates.Common.targets
+++ b/sources/templates/Stride.Templates.Common.targets
@@ -1,6 +1,7 @@
 <Project>
   <!--
-    Shared logic for Stride.Templates.Games / Stride.Templates.Games.Starters / Stride.Templates.Samples.
+    Shared logic for Stride.Templates.Games / Stride.Templates.Games.Starters / Stride.Templates.Samples /
+    Stride.Templates.AssetPacks.
     Imported by each per-package csproj; the csproj supplies PackageId / PackageTags /
     StrideSampleTemplate items, this file does everything else (version derivation,
     preprocess+aggregate pipeline, auto-pack-deploy, CI safeguards).

--- a/sources/tools/Stride.TemplateGenerator/TemplatePreprocessor.cs
+++ b/sources/tools/Stride.TemplateGenerator/TemplatePreprocessor.cs
@@ -159,6 +159,11 @@ internal class TemplatePreprocessor
             logger.Info($"Loaded metadata from {Path.GetFileName(sdtplPath)} (Name='{Sdtpl.Name}', Parameters=[{string.Join(", ", Sdtpl.Parameters)}])");
         }
 
+        // Asset packs (!TemplateAssetPack) are content drops, not projects — they take a reduced
+        // pipeline: stage Assets/ + Resources/, emit an item-template template.json, done.
+        if (Sdtpl?.IsAssetPack == true)
+            return RunAssetPack(sdtplPath, logger);
+
         // Stage: recursively mirror input → output. Clean output first to avoid leftover files
         // from prior runs polluting the staged tree.
         if (Directory.Exists(OutputDirectory))
@@ -263,6 +268,91 @@ internal class TemplatePreprocessor
         NormalizeLineEndings(logger);
 
         return true;
+    }
+
+    /// <summary>
+    /// Reduced pipeline for <c>!TemplateAssetPack</c> inputs. An asset pack is a set of assets a
+    /// user can add to an existing game (the "Building blocks" / "Materials" checkboxes of the
+    /// New Game flow): its <c>Assets/</c> and <c>Resources/</c> subdirs are staged verbatim and
+    /// packed as a dotnet new <em>item</em> template, so instantiating into a project dir drops
+    /// the content in place. No sourceName rename (asset files keep their names/URLs), no GUID
+    /// placeholdering (every instantiation gets the same asset Ids, like the pre-dotnet-new
+    /// CopyAssetPacks flow), no prune (pack content is leaf content by design), no platform or
+    /// solution machinery.
+    /// </summary>
+    private bool RunAssetPack(string? sdtplPath, ILogger logger)
+    {
+        if (Directory.Exists(OutputDirectory))
+            Directory.Delete(OutputDirectory, recursive: true);
+        Directory.CreateDirectory(OutputDirectory!);
+
+        var staged = 0;
+        foreach (var subdir in new[] { "Assets", "Resources" })
+        {
+            var source = Path.Combine(InputPath!, subdir);
+            if (!Directory.Exists(source))
+                continue;
+            CopyDirectory(source, Path.Combine(OutputDirectory!, subdir));
+            staged++;
+        }
+        if (staged == 0)
+        {
+            logger.Error($"Asset pack input has no Assets/ or Resources/ dir: {InputPath}");
+            return false;
+        }
+        logger.Info($"Staged asset pack {InputPath} → {OutputDirectory}");
+
+        // Icon/screenshots declared in the .sdtpl (possibly outside the pack dir) land in .sdtpl/.
+        CopyExternalSdtplAssets(sdtplPath, logger);
+
+        EmitAssetPackTemplateJson();
+        logger.Info("Wrote item-template template.json");
+
+        NormalizeLineEndings(logger);
+        return true;
+    }
+
+    /// <summary>
+    /// template.json for an asset pack: a dotnet new item template with no parameters and no
+    /// symbols. Content is copied as-is into the output directory (the game library dir when
+    /// driven by GameStudio / the stride CLI).
+    /// </summary>
+    private void EmitAssetPackTemplateJson()
+    {
+        var configDir = Path.Combine(OutputDirectory!, ".template.config");
+        Directory.CreateDirectory(configDir);
+
+        var shortName = TemplateName ?? "stride-pack";
+        var identity = Sdtpl?.Id?.ToString() ?? $"Stride.Templates.{shortName}";
+        var displayName = JsonEscape(Sdtpl?.Name ?? shortName);
+        var description = JsonEscape(Sdtpl?.Description ?? string.Empty);
+        var classifications = Sdtpl?.Group is { Length: > 0 } g
+            ? string.Join(", ", g.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(p => $"\"{JsonEscape(p.Trim())}\""))
+            : "\"AssetPacks\"";
+
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine("  \"$schema\": \"http://json.schemastore.org/template\",");
+        sb.AppendLine("  \"author\": \"Stride\",");
+        sb.AppendLine($"  \"classifications\": [{classifications}],");
+        sb.AppendLine($"  \"identity\": \"{identity}\",");
+        sb.AppendLine($"  \"name\": \"{displayName}\",");
+        sb.AppendLine($"  \"shortName\": \"{shortName}\",");
+        if (description.Length > 0)
+            sb.AppendLine($"  \"description\": \"{description}\",");
+        sb.AppendLine("  \"tags\": { \"type\": \"item\" },");
+        sb.AppendLine("""
+          "sources": [
+            {
+              "modifiers": [
+                { "exclude": [ ".sdtpl/**" ] }
+              ]
+            }
+          ]
+        """);
+        sb.AppendLine("}");
+
+        File.WriteAllText(Path.Combine(configDir, "template.json"), sb.ToString());
     }
 
     /// <summary>

--- a/sources/tools/Stride.Templates.Tests/Stride.Templates.Tests.csproj
+++ b/sources/tools/Stride.Templates.Tests/Stride.Templates.Tests.csproj
@@ -18,9 +18,14 @@
 
   <!-- ProjectReferences trigger Build on each template project, which in turn auto-packs them
        via Stride.Templates.Common.targets' GeneratePackageOnBuild=true. Result: bin/packages
-       has all three nupkgs by the time the smoke test runs. ReferenceOutputAssembly=false
+       has all the nupkgs by the time the smoke test runs. ReferenceOutputAssembly=false
        keeps these as build-order constraints only — no compile-time assembly link. -->
   <ItemGroup>
+    <ProjectReference Include="..\..\templates\Stride.Templates.AssetPacks\Stride.Templates.AssetPacks.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Private>false</Private>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
     <ProjectReference Include="..\..\templates\Stride.Templates.Games\Stride.Templates.Games.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>false</Private>

--- a/sources/tools/Stride.Templates.Tests/StrideGameTemplateSmokeTests.cs
+++ b/sources/tools/Stride.Templates.Tests/StrideGameTemplateSmokeTests.cs
@@ -9,7 +9,8 @@ namespace Stride.Templates.Tests;
 
 /// <summary>
 /// End-to-end smoke for the Stride template packages: dotnet pack → dotnet new install →
-/// dotnet new <c>&lt;template&gt;</c> for each of stride-game, stride-fps, stride-csharp-beginner.
+/// dotnet new <c>&lt;template&gt;</c> for each of stride-game, stride-fps, stride-csharp-beginner,
+/// plus the stride-pack-buildingblocks asset pack instantiated into the generated blank game.
 /// Validates that the orchestrator output and the packed nupkg shape produce instantiable
 /// projects through the dotnet new template engine. A subsequent <c>dotnet restore</c> isn't
 /// run — it'd need <see cref="Stride"/>.Engine in bin/packages or on nuget.org, neither of
@@ -33,17 +34,21 @@ public class StrideGameTemplateSmokeTests
             $"Expected bin/packages/ to exist at {enginePackagesDir}. Build the engine first " +
             "(any normal test run does this transitively).");
 
-        // Covers all three preprocessor variants:
+        // Covers all preprocessor variants:
         //   - blank game (Stride.Templates.Games → stride-game): NewGame body, no sample-derived steps
         //   - starter (Stride.Templates.Games.Starters → stride-fps): full preprocessor incl. dep
         //     collapse / asset prune / source-name rename
         //   - sample (Stride.Templates.Samples → stride-csharp-beginner): same preprocessor flow as
         //     starters but smaller asset set
+        //   - asset pack (Stride.Templates.AssetPacks → stride-pack-buildingblocks): item-template
+        //     variant, validated separately by instantiating into the blank game (no project of
+        //     its own, so it's excluded from the InstantiateAndValidate loop below)
         var packagesToPack = new[]
         {
             ("Stride.Templates.Games",          "stride-game",            "SmokeBlankGame"),
             ("Stride.Templates.Games.Starters", "stride-fps",             "SmokeFps"),
             ("Stride.Templates.Samples",        "stride-csharp-beginner", "SmokeTutorial"),
+            ("Stride.Templates.AssetPacks",     "",                       ""),
         };
         var nupkgs = new List<string>();
         foreach (var (packageId, _, _) in packagesToPack)
@@ -91,9 +96,14 @@ public class StrideGameTemplateSmokeTests
             try
             {
                 foreach (var (_, shortName, projectName) in packagesToPack)
+                {
+                    if (shortName.Length == 0)
+                        continue;
                     InstantiateAndValidate(workspace, templateShortName: shortName, projectName: projectName);
+                }
 
                 InstantiateUpdateOnlyAndValidate(workspace, projectName: "SmokeUpdateOnly");
+                InstantiateAssetPackAndValidate(workspace, gameProjectName: "SmokeBlankGame");
             }
             finally
             {
@@ -162,6 +172,34 @@ public class StrideGameTemplateSmokeTests
         Assert.False(Directory.Exists(Path.Combine(instantiated, $"{projectName}.Game")),
             $"updateOnly must not regenerate the shared game library {projectName}.Game/ (issue #3262)");
         Assert.Empty(Directory.EnumerateFiles(instantiated, "*.slnx", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
+    /// Instantiates an asset-pack item template (Building blocks) into the game library of the
+    /// blank game generated earlier, the way GameStudio / the stride CLI chain packs after
+    /// stride-game. Validates the pack's Assets/ + Resources/ landed in the project and that no
+    /// template-engine machinery (.template.config) leaked into it.
+    /// </summary>
+    private void InstantiateAssetPackAndValidate(string workspace, string gameProjectName)
+    {
+        var gameDir = Path.Combine(workspace, gameProjectName);
+        var libraryDir = Path.Combine(gameDir, gameProjectName);
+        if (!Directory.Exists(libraryDir))
+            libraryDir = Path.Combine(gameDir, $"{gameProjectName}.Game");
+        Assert.True(Directory.Exists(libraryDir), $"Game library dir missing under {gameDir}");
+
+        var newResult = RunDotnet(libraryDir, "new", "stride-pack-buildingblocks");
+        Assert.True(newResult.exitCode == 0, $"dotnet new stride-pack-buildingblocks failed:\n{newResult.output}");
+
+        Assert.True(File.Exists(Path.Combine(libraryDir, "Assets", "BlocksScene.sdscene")),
+            "Asset pack did not drop its Assets/ content into the game library");
+        Assert.True(File.Exists(Path.Combine(libraryDir, "Resources", "Models", "Box1x1x1.fbx")),
+            "Asset pack did not drop its Resources/ content into the game library");
+        // Pack content must merge with, not replace, the game's own assets.
+        Assert.True(Directory.EnumerateFiles(Path.Combine(libraryDir, "Assets"), "GameSettings.sdgamesettings").Any(),
+            "Game's own assets disappeared after adding the asset pack");
+        Assert.False(Directory.Exists(Path.Combine(libraryDir, ".template.config")),
+            "Template-engine machinery (.template.config) leaked into the game library");
     }
 
     private static string? FindNupkg(string dir, string packageId)


### PR DESCRIPTION
Brings back the New Game asset pack options (Building blocks, Animated models, Materials, Particles) that were lost when adding the new template system.

- New `Stride.Templates.AssetPacks` package: each pack is a `dotnet new` item template that copies its `Assets/` + `Resources/` into an existing game library.
- Game Studio shows the packs as checkboxes when creating a game, and downloads the package on demand (not bundled with the installer).
- CLI: `dotnet new stride-pack-buildingblocks` (or `stride new ...`) inside the game library folder.

Later, packs will likely become referenced NuGet packages instead of copies.
See details in `sources/templates/README.md`.

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->