### PR TITLE
chore: Stride.Assets.csproj - remove Microsoft.Build.Tasks.Core reference

### DIFF
--- a/sources/engine/Stride.Assets/Stride.Assets.csproj
+++ b/sources/engine/Stride.Assets/Stride.Assets.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
-    <!-- Override the 17.7.2 transitive from Microsoft.CodeAnalysis.Workspaces.MSBuild 4.12.
-         No PrivateAssets — version constraint must propagate to consumers' nuspec. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="SixLabors.ImageSharp" />

--- a/sources/engine/Stride.Assets/Stride.Assets.csproj
+++ b/sources/engine/Stride.Assets/Stride.Assets.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
     <!-- Override the 17.7.2 transitive from Microsoft.CodeAnalysis.Workspaces.MSBuild 4.12.
          No PrivateAssets — version constraint must propagate to consumers' nuspec. -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="SixLabors.ImageSharp" />


### PR DESCRIPTION
# PR Details

This package isn't needed most likely, also it was causing frequently many vulnerabilities warnings.

I don't think we need this.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->

chore: Stride.Assets.csproj - remove Microsoft.Build.Tasks.Core reference

- Removed unnecessary PackageReference for Microsoft.Build.Tasks.Core

#### PR Classification
This pull request performs code cleanup by removing an unused package dependency.

#### PR Summary
The Microsoft.Build.Tasks.Core package reference was removed from the Stride.Assets.csproj project file as it is no longer required.
- Stride.Assets.csproj: removed Microsoft.Build.Tasks.Core package reference
