### PR TITLE
SDSL: preserve Buffer<T> element type, align buffer loads with textures

### DIFF
--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
@@ -327,7 +327,7 @@ public partial class ShaderMixer
                             var resolved = effectResourceBinding with
                             {
                                 Type = bufferType.WriteAllowed ? EffectParameterType.RWBuffer : EffectParameterType.Buffer,
-                                ElementType = new EffectTypeDescription { Type = ScalarToEffectParameterType(bufferType.BaseType) },
+                                ElementType = new EffectTypeDescription { Type = ScalarToEffectParameterType(bufferType.BaseType.GetElementType()) },
                             };
                             globalContext.Reflection.ResourceBindings.Add(resolved);
                             EmitResourceEntry(globalContext, resolved);

--- a/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
@@ -71,22 +71,21 @@ public abstract record SymbolType()
         static SymbolType ResolveReturnType(TypeName? templateTypeName)
             => templateTypeName == null ? new VectorType(ScalarType.Float, 4) : templateTypeName.Type!;
 
-        // Returns only the scalar element type — required for OpTypeImage sampled type and intrinsic base-type matching.
-        static ScalarType ResolveScalarType(TypeName? templateTypeName)
+        // Typed buffers only allow scalar/vector element types.
+        static SymbolType ResolveBufferReturnType(TypeName? templateTypeName)
         {
-            var templateType = templateTypeName?.Type ?? ScalarType.Float;
+            var templateType = templateTypeName?.Type ?? new VectorType(ScalarType.Float, 4);
             return templateType switch
             {
-                VectorType v => v.BaseType,
-                ScalarType s => s,
-                _ => throw new NotSupportedException($"Unsupported template type {templateType} for scalar resolution"),
+                VectorType or ScalarType => templateType,
+                _ => throw new NotSupportedException($"Unsupported template type {templateType} for Buffer"),
             };
         }
 
         SymbolType? foundType = name switch
         {
-            "Buffer" => new BufferType(ResolveScalarType(templateTypeName)),
-            "RWBuffer" => new BufferType(ResolveScalarType(templateTypeName), true),
+            "Buffer" => new BufferType(ResolveBufferReturnType(templateTypeName)),
+            "RWBuffer" => new BufferType(ResolveBufferReturnType(templateTypeName), true),
 
             "ByteAddressBuffer" => new ByteAddressBufferType(false),
             "RWByteAddressBuffer" => new ByteAddressBufferType(true),
@@ -314,7 +313,7 @@ public sealed partial record ConsumeStructuredBufferType(SymbolType BaseType) : 
     public override string ToString() => $"ConsumeStructuredBuffer<{BaseType}>";
 }
 
-public sealed partial record BufferType(ScalarType BaseType, bool WriteAllowed = false) : SymbolType()
+public sealed partial record BufferType(SymbolType BaseType, bool WriteAllowed = false) : SymbolType()
 {
     public override string ToString() => $"{(WriteAllowed ? "RW" : "")}Buffer<{BaseType}>";
 }

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/BufferMethodsImplementations.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/BufferMethodsImplementations.cs
@@ -12,17 +12,19 @@ public class BufferMethodsImplementations : BufferMethodsDeclarations
     public override SpirvValue CompileLoad(SymbolTable table, SpirvContext context, SpirvBuilder builder, FunctionType functionType, SpirvValue buffer, SpirvValue x, SpirvValue? status = null, TextLocation location = default)
     {
         var bufferType = (BufferType)context.ReverseTypes[buffer.TypeId];
-        var resultTypeId = context.GetOrRegister(functionType.ReturnType);
+
+        // SPIR-V requires OpImageRead/OpImageFetch result types to be a 4-component vector
+        var (vec4TypeId, needsExtract) = TextureMethodsImplementations.GetImageSampleResultType(context, functionType);
+
+        int loadResultId;
         if (bufferType.WriteAllowed)
-        {
-            var loadResult = builder.Insert(new OpImageRead(resultTypeId, context.Bound++, buffer.Id, x.Id, null, []));
-            return new(loadResult.ResultId, loadResult.ResultType);
-        }
+            loadResultId = builder.Insert(new OpImageRead(vec4TypeId, context.Bound++, buffer.Id, x.Id, null, [])).ResultId;
         else
-        {
-            var loadResult = builder.Insert(new OpImageFetch(resultTypeId, context.Bound++, buffer.Id, x.Id, null, []));
-            return new(loadResult.ResultId, loadResult.ResultType);
-        }
+            loadResultId = builder.Insert(new OpImageFetch(vec4TypeId, context.Bound++, buffer.Id, x.Id, null, [])).ResultId;
+
+        if (needsExtract)
+            return TextureMethodsImplementations.ExtractFromVec4(context, builder, functionType, loadResultId);
+        return new(loadResultId, vec4TypeId);
     }
 
     public override SpirvValue CompileGetDimensions(SymbolTable table, SpirvContext context, SpirvBuilder builder, FunctionType functionType, SpirvValue buffer, SpirvValue width, TextLocation location = default)

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -704,7 +704,7 @@ public partial class AccessorChainExpression(Expression source, TextLocation inf
             {
                 case (PointerType { BaseType: BufferType bufferType }, IndexerExpression indexer):
                     {
-                        var resultType = new VectorType(bufferType.BaseType, 4);
+                        var resultType = new VectorType(bufferType.BaseType.GetElementType(), 4);
                         var buffer = builder.AsValue(context, lvalueBase);
 
                         var location = indexer.Index.CompileAsValue(table, compiler);

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/IntrinsicTemplateExpander.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/IntrinsicTemplateExpander.cs
@@ -224,7 +224,7 @@ public class IntrinsicTemplateExpander(SymbolType? thisType, string @namespace, 
                                 parameterTypeHelper[index].BaseType = thisType switch
                                 {
                                     TextureType t => t.ReturnType.GetElementType(),
-                                    BufferType b => b.BaseType,
+                                    BufferType b => b.BaseType.GetElementType(),
                                     AppendStructuredBufferType b => b.BaseType,
                                     ConsumeStructuredBufferType b => b.BaseType,
                                     StructuredBufferType b => b.BaseType,
@@ -284,7 +284,7 @@ public class IntrinsicTemplateExpander(SymbolType? thisType, string @namespace, 
                                 {
                                     null => throw new ArgumentNullException(nameof(thisType)),
                                     TextureType t => new(t.ReturnType.GetElementType(), new(t.ReturnType.GetElementCount(), null), default),
-                                    BufferType b => new(b.BaseType, new(4, null), default),
+                                    BufferType b => new(b.BaseType.GetElementType(), new(b.BaseType.GetElementCount(), null), default),
                                     AppendStructuredBufferType b => new(b.BaseType, new(1, null), default),
                                     ConsumeStructuredBufferType b => new(b.BaseType, new(1, null), default),
                                     StructuredBufferType b => new(b.BaseType, new(1, null), default),

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/TextureMethodsImplementations.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/TextureMethodsImplementations.cs
@@ -12,11 +12,11 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
     public static TextureMethodsImplementations Instance { get; } = new();
 
     /// <summary>
-    /// SPIR-V requires OpImageSample*/OpImageFetch result types to be a 4-component vector.
+    /// SPIR-V requires OpImageSample*/OpImageFetch/OpImageRead result types to be a 4-component vector.
     /// This method returns the vec4 type for sampling, and if the actual return type is smaller,
     /// extracts the needed components from the vec4 result.
     /// </summary>
-    private static (int Vec4TypeId, bool NeedsExtract) GetImageSampleResultType(SpirvContext context, FunctionType functionType, TextureType textureType)
+    internal static (int Vec4TypeId, bool NeedsExtract) GetImageSampleResultType(SpirvContext context, FunctionType functionType)
     {
         var returnType = functionType.ReturnType;
         var scalarType = returnType.GetElementType();
@@ -26,7 +26,7 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
         return (vec4TypeId, needsExtract);
     }
 
-    private static SpirvValue ExtractFromVec4(SpirvContext context, SpirvBuilder builder, FunctionType functionType, int vec4ResultId)
+    internal static SpirvValue ExtractFromVec4(SpirvContext context, SpirvBuilder builder, FunctionType functionType, int vec4ResultId)
     {
         var returnType = functionType.ReturnType;
         var elementCount = returnType.GetElementCount();
@@ -60,7 +60,7 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
 
         var textureDim = textureType.CoordinateDimension;
 
-        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType, textureType);
+        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType);
 
         // Extract LOD from coords if present (sampled images only, not storage)
         SpirvValue? lod = null;
@@ -94,7 +94,7 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
             throw new NotImplementedException();
 
         var textureType = (TextureType)context.ReverseTypes[texture.TypeId];
-        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType, textureType);
+        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType);
 
         var typeSampledImage = context.GetOrRegister(new SampledImage(textureType));
         var sampledImage = builder.Insert(new OpSampledImage(typeSampledImage, context.Bound++, texture.Id, s.Id));
@@ -112,7 +112,7 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
             throw new NotImplementedException();
 
         var textureType = (TextureType)context.ReverseTypes[texture.TypeId];
-        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType, textureType);
+        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType);
 
         var typeSampledImage = context.GetOrRegister(new SampledImage(textureType));
         var sampledImage = builder.Insert(new OpSampledImage(typeSampledImage, context.Bound++, texture.Id, s.Id));
@@ -130,7 +130,7 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
             throw new NotImplementedException();
 
         var textureType = (TextureType)context.ReverseTypes[texture.TypeId];
-        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType, textureType);
+        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType);
 
         var typeSampledImage = context.GetOrRegister(new SampledImage(textureType));
         var sampledImage = builder.Insert(new OpSampledImage(typeSampledImage, context.Bound++, texture.Id, s.Id));
@@ -148,7 +148,7 @@ internal class TextureMethodsImplementations : TextureMethodsDeclarations
             throw new NotImplementedException();
 
         var textureType = (TextureType)context.ReverseTypes[texture.TypeId];
-        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType, textureType);
+        var (vec4TypeId, needsExtract) = GetImageSampleResultType(context, functionType);
 
         var typeSampledImage = context.GetOrRegister(new SampledImage(textureType));
         var sampledImage = builder.Insert(new OpSampledImage(typeSampledImage, context.Bound++, texture.Id, s.Id));

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Builder.Expressions.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Builder.Expressions.cs
@@ -691,7 +691,7 @@ public partial class SpirvBuilder
 
 
 
-internal static class SymbolExtensions
+public static class SymbolExtensions
 {
     public static SymbolType GetValueType(this SpirvValue value, SpirvContext context)
     {

--- a/sources/shaders/assets/SDSL/ComputeTests/CSBufferLoad.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSBufferLoad.sdsl
@@ -1,0 +1,29 @@
+// CSMain(ExpectedResult=#00000000)
+
+namespace Stride.Shaders.Tests;
+
+// Regression: Buffer/RWBuffer loads with fewer than 4 components must emit
+// OpImageFetch/OpImageRead with a vec4 result and extract from it
+// (VUID-StandaloneSpirv-Result-04780).
+shader CSBufferLoad
+{
+    stage stream uint3 DispatchThreadId : SV_DispatchThreadID;
+
+    rgroup PerDraw.Test
+    {
+        stage Buffer<float>    InScalars;
+        stage Buffer<float3>   InVectors;
+        stage RWBuffer<float>  Values;
+        stage RWBuffer<float4> Results;
+    }
+
+    [numthreads(1, 1, 1)]
+    void CSMain()
+    {
+        uint i = streams.DispatchThreadId.x;
+        float scalar = InScalars[i] + Values[i];
+        float3 vec = InVectors[i];
+        Values[i] = scalar;
+        Results[i] = float4(vec * scalar, 1);
+    }
+};


### PR DESCRIPTION
# PR Details

`Buffer<T>` lost its element type: `Buffer<float3>` was treated as `Buffer<float>`, and loads were widened to return `float4`, unlike HLSL.

Now typed buffers work like textures:
- The declared element type is kept (`Buffer<float3>` stays `float3`).
- Loads return the declared type, like in HLSL. The SPIR-V requirement that image reads return 4 components is handled internally, like for textures.

Added a compute test covering loads/writes of `Buffer<float>`, `Buffer<float3>`, `RWBuffer<float>` and `RWBuffer<float4>`.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->