### PR TITLE
Vulkan: switch to Vulkan 1.3 and use dynamic rendering

### DIFF
--- a/sources/engine/Stride.Graphics.Tests/TestFramebufferAttachmentGuard.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestFramebufferAttachmentGuard.cs
@@ -19,12 +19,12 @@ public class TestFramebufferAttachmentGuard : GraphicTestGameBase
     }
 
     /// <summary>
-    /// The Vulkan backend's debug guard turns a framebuffer/render-pass attachment-count mismatch into a clear
-    /// exception instead of a device loss. Verify it fires when more render targets are bound than the active
-    /// pipeline's render pass declares.
+    /// The Vulkan backend's debug guard turns an attachment mismatch with the pipeline's declared output
+    /// into a clear exception instead of a device loss. Verify it fires when more render targets are bound
+    /// than the active pipeline's output declares.
     /// </summary>
     [SkippableFact]
-    public void ThrowsWhenBoundTargetsExceedPipelineRenderPass()
+    public void ThrowsWhenBoundTargetsExceedPipelineOutput()
     {
         PerformTest(game =>
         {
@@ -54,19 +54,19 @@ public class TestFramebufferAttachmentGuard : GraphicTestGameBase
             pipelineState.State.InputElements = declaration.CreateInputElements();
             pipelineState.State.PrimitiveType = PrimitiveType.TriangleList;
 
-            // Capture the pipeline Output with a single color + depth bound: its render pass declares 2 attachments.
+            // Capture the pipeline Output with a single color + depth bound: it declares 2 attachments.
             commandList.SetRenderTargetAndViewport(depth, backBuffer);
             pipelineState.State.Output.CaptureState(commandList);
             pipelineState.Update();
 
-            // Now bind two color targets + depth: the framebuffer would have 3 attachments, mismatching the pass.
+            // Now bind two color targets + depth: 3 attachments, mismatching the pipeline output.
             commandList.SetRenderTargets(depth, backBuffer, extraTarget);
             commandList.SetPipelineState(pipelineState.CurrentState);
             commandList.SetVertexBuffer(0, vertexBuffer, 0, declaration.VertexStride);
             effect.Apply(game.GraphicsContext);
 
             var exception = Assert.Throws<InvalidOperationException>(() => commandList.Draw(3));
-            Assert.Contains("render pass", exception.Message);
+            Assert.Contains("do not match the active pipeline", exception.Message);
 
             sampledTexture.Dispose();
             extraTarget.Dispose();

--- a/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/CommandList.Vulkan.cs
@@ -23,8 +23,6 @@ namespace Stride.Graphics
 
         internal CommandBufferPool CommandBufferPool;
 
-        private VkRenderPass activeRenderPass;
-        private VkRenderPass previousRenderPass;
         private PipelineState activePipeline;
         private bool pipelineDirty = true;
 
@@ -36,11 +34,11 @@ namespace Stride.Graphics
         // that's a known limitation to be addressed by adding a "last-submitted layout" tracker.
         private readonly Dictionary<Texture, BarrierLayout> currentCbLayouts = new();
 
-        private readonly Dictionary<FramebufferKey, VkFramebuffer> framebuffers = new();
-        private readonly VkImageView[] framebufferAttachments = new VkImageView[9];
-        private int framebufferAttachmentCount;
-        private bool framebufferDirty = true;
-        private VkFramebuffer activeFramebuffer;
+        // Dynamic rendering state: whether a render pass instance (vkCmdBeginRendering) is active,
+        // whether the bound attachments changed since it began, and which depth layout it declared.
+        private bool activeRendering;
+        private bool renderingDirty = true;
+        private bool activeDepthReadOnly;
 
         private VkDescriptorPool descriptorPool;
         private VkDescriptorSet descriptorSet;
@@ -88,8 +86,7 @@ namespace Stride.Graphics
             boundDescriptorSets.Clear();
             currentCbLayouts.Clear();
 
-            framebuffers.Clear();
-            framebufferDirty = true;
+            renderingDirty = true;
 
             currentCommandList.Builder = this;
             currentCommandList.NativeCommandBuffer = CommandBufferPool.GetObject(GraphicsDevice.CommandListFence.GetCompletedValue());
@@ -178,28 +175,9 @@ namespace Stride.Graphics
         /// <exception cref="ArgumentNullException">renderTargetViews</exception>
         private partial void SetRenderTargetsImpl(Texture depthStencilBuffer, ReadOnlySpan<Texture> renderTargets)
         {
-            var oldFramebufferAttachmentCount = framebufferAttachmentCount;
-            framebufferAttachmentCount = renderTargets.Length;
-
-            for (int i = 0; i < renderTargets.Length; i++)
-            {
-                if (renderTargets[i].NativeColorAttachmentView != framebufferAttachments[i])
-                    framebufferDirty = true;
-
-                framebufferAttachments[i] = renderTargets[i].NativeColorAttachmentView;
-            }
-
-            if (depthStencilBuffer != null)
-            {
-                if (depthStencilBuffer.NativeDepthStencilView != framebufferAttachments[renderTargets.Length])
-                    framebufferDirty = true;
-
-                framebufferAttachments[renderTargets.Length] = depthStencilBuffer.NativeDepthStencilView;
-                framebufferAttachmentCount++;
-            }
-
-            if (framebufferAttachmentCount != oldFramebufferAttachmentCount)
-                framebufferDirty = true;
+            // The base class updated the bound targets; the next draw restarts the render pass
+            // instance with them if they changed
+            renderingDirty = true;
         }
 
         /// <summary>
@@ -328,8 +306,8 @@ namespace Stride.Graphics
             }
 
             // If the pipeline disables depth+stencil writes the depth attachment can ride in
-            // DepthStencilReadOnlyOptimal — matching the render-pass layout picked in
-            // PipelineState.CreateRenderPass and leaving the image sampleable (soft-edge particles).
+            // DepthStencilReadOnlyOptimal — matching the attachment layout EnsureRenderPass declares
+            // and leaving the image sampleable (soft-edge particles).
             var dss = activePipeline.Description.DepthStencilState;
             bool depthReadOnly = !dss.DepthBufferWriteEnable
                 && (!dss.StencilEnable || dss.StencilWriteMask == 0);
@@ -1752,171 +1730,107 @@ namespace Stride.Graphics
 
         private unsafe void EnsureRenderPass()
         {
-            if (activePipeline == null)
+            if (activePipeline == null || activePipeline.NativePipeline == VkPipeline.Null)
                 return;
 
-            var pipelineRenderPass = activePipeline.NativeRenderPass;
+            // The depth attachment layout must match what the auto-transition pass moves the depth
+            // buffer to for this pipeline (read-only when the pipeline writes neither depth nor stencil)
+            var dss = activePipeline.Description.DepthStencilState;
+            bool depthReadOnly = depthStencilBuffer != null
+                && !dss.DepthBufferWriteEnable
+                && (!dss.StencilEnable || dss.StencilWriteMask == 0);
 
-            // Reuse the Framebuffer if the VkRenderPass didn't change
-            if (previousRenderPass != pipelineRenderPass)
-                framebufferDirty = true;
-
-            // Nothing to do. VkRenderPass and Framebuffer are still valid
-            if (!framebufferDirty && activeRenderPass == pipelineRenderPass)
+            // The render pass instance stays active across pipeline changes as long as the
+            // attachments and the depth layout stay the same
+            if (activeRendering && !renderingDirty && activeDepthReadOnly == depthReadOnly)
                 return;
 
-            // End old render pass
+            // End old render pass instance
             CleanupRenderPass();
 
-            if (pipelineRenderPass != VkRenderPass.Null)
+            var renderTarget = RenderTargetCount > 0 ? renderTargets[0] : depthStencilBuffer;
+            if (renderTarget == null)
+                return;
+
+            // An attachment mismatch with the pipeline's declared formats is undefined behavior that
+            // loses the device on strict drivers; fail loud in debug (only, to not break drivers that
+            // tolerate it) instead.
+            if (GraphicsDevice.IsDebugMode)
             {
-                var renderTarget = RenderTargetCount > 0 ? renderTargets[0] : depthStencilBuffer;
-
-                if (framebufferDirty)
-                {
-                    // A framebuffer/render-pass attachment mismatch is undefined behavior that loses the device on
-                    // strict drivers; fail loud in debug (only, to not break drivers that tolerate it) instead.
-                    if (GraphicsDevice.IsDebugMode)
-                    {
-                        var output = activePipeline.Description.Output;
-                        var expectedAttachmentCount = output.RenderTargetCount + (output.DepthStencilFormat != PixelFormat.None ? 1 : 0);
-                        if (framebufferAttachmentCount != expectedAttachmentCount)
-                            throw new InvalidOperationException(
-                                $"Bound render targets ({framebufferAttachmentCount}) do not match the active pipeline's render pass " +
-                                $"({expectedAttachmentCount} attachments). The render targets bound on the command list must match the pipeline's Output description.");
-                    }
-
-                    // Create new frame buffer
-                    fixed (VkImageView* attachmentsPointer = &framebufferAttachments[0])
-                    {
-                        var framebufferKey = new FramebufferKey(pipelineRenderPass, framebufferAttachmentCount, attachmentsPointer);
-
-                        if (!framebuffers.TryGetValue(framebufferKey, out activeFramebuffer))
-                        {
-                            var framebufferCreateInfo = new VkFramebufferCreateInfo
-                            {
-                                sType = VkStructureType.FramebufferCreateInfo,
-                                renderPass = pipelineRenderPass,
-                                attachmentCount = (uint) framebufferAttachmentCount,
-                                pAttachments = attachmentsPointer,
-                                width = (uint) renderTarget.ViewWidth,
-                                height = (uint) renderTarget.ViewHeight,
-                                layers = 1 // TODO VULKAN: Use correct view depth/array size
-                            };
-                            GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkCreateFramebuffer(GraphicsDevice.NativeDevice, &framebufferCreateInfo, null, out activeFramebuffer));
-                            GraphicsDevice.Collect(activeFramebuffer);
-                            framebuffers.Add(framebufferKey, activeFramebuffer);
-                        }
-                    }
-                    framebufferDirty = false;
-                }
-
-                // Clear attachments if needed
-                // TODO VULKAN: Can we use a custom render pass for this?
-                for (int index = 0; index < RenderTargetCount; index++)
-                {
-                    if (!renderTarget.IsInitialized)
-                    {
-                        Clear(renderTargets[index], Color.Transparent);
-                    }
-                }
-
-                if (depthStencilBuffer != null && !depthStencilBuffer.IsInitialized)
-                {
-                    Clear(depthStencilBuffer, DepthStencilClearOptions.DepthBuffer | DepthStencilClearOptions.Stencil);
-                }
-
-                // Start new render pass
-                var renderPassBegin = new VkRenderPassBeginInfo
-                {
-                    sType = VkStructureType.RenderPassBeginInfo,
-                    renderPass = pipelineRenderPass,
-                    framebuffer = activeFramebuffer,
-                    renderArea = new VkRect2D(0, 0, (uint)renderTarget.ViewWidth, (uint)renderTarget.ViewHeight)
-                };
-                GraphicsDevice.NativeDeviceApi.vkCmdBeginRenderPass(currentCommandList.NativeCommandBuffer, &renderPassBegin, VkSubpassContents.Inline);
-
-                previousRenderPass = activeRenderPass = pipelineRenderPass;
+                var output = activePipeline.Description.Output;
+                if (RenderTargetCount != output.RenderTargetCount || (depthStencilBuffer != null) != (output.DepthStencilFormat != PixelFormat.None))
+                    throw new InvalidOperationException(
+                        $"Bound render targets ({RenderTargetCount} color, depth: {depthStencilBuffer != null}) do not match the active pipeline's output " +
+                        $"({output.RenderTargetCount} color, depth: {output.DepthStencilFormat != PixelFormat.None}). The render targets bound on the command list must match the pipeline's Output description.");
             }
+
+            // Clear attachments if needed
+            for (int index = 0; index < RenderTargetCount; index++)
+            {
+                if (!renderTarget.IsInitialized)
+                {
+                    Clear(renderTargets[index], Color.Transparent);
+                }
+            }
+
+            if (depthStencilBuffer != null && !depthStencilBuffer.IsInitialized)
+            {
+                Clear(depthStencilBuffer, DepthStencilClearOptions.DepthBuffer | DepthStencilClearOptions.Stencil);
+            }
+
+            // Start new render pass instance
+            var colorAttachments = stackalloc VkRenderingAttachmentInfo[RenderTargetCount > 0 ? RenderTargetCount : 1];
+            for (int i = 0; i < RenderTargetCount; i++)
+            {
+                colorAttachments[i] = new VkRenderingAttachmentInfo
+                {
+                    sType = VkStructureType.RenderingAttachmentInfo,
+                    imageView = renderTargets[i].NativeColorAttachmentView,
+                    imageLayout = VkImageLayout.ColorAttachmentOptimal,
+                    loadOp = VkAttachmentLoadOp.Load,
+                    storeOp = VkAttachmentStoreOp.Store,
+                };
+            }
+
+            var depthAttachment = new VkRenderingAttachmentInfo
+            {
+                sType = VkStructureType.RenderingAttachmentInfo,
+                imageView = depthStencilBuffer?.NativeDepthStencilView ?? VkImageView.Null,
+                imageLayout = depthReadOnly ? VkImageLayout.DepthStencilReadOnlyOptimal : VkImageLayout.DepthStencilAttachmentOptimal,
+                loadOp = VkAttachmentLoadOp.Load,
+                storeOp = VkAttachmentStoreOp.Store,
+            };
+
+            bool hasStencil = depthStencilBuffer != null && (depthStencilBuffer.NativeImageAspect & VkImageAspectFlags.Stencil) != 0;
+
+            var renderingInfo = new VkRenderingInfo
+            {
+                sType = VkStructureType.RenderingInfo,
+                renderArea = new VkRect2D(0, 0, (uint)renderTarget.ViewWidth, (uint)renderTarget.ViewHeight),
+                layerCount = 1, // TODO VULKAN: Use correct view depth/array size
+                colorAttachmentCount = (uint)RenderTargetCount,
+                pColorAttachments = colorAttachments,
+                pDepthAttachment = depthStencilBuffer != null ? &depthAttachment : null,
+                pStencilAttachment = hasStencil ? &depthAttachment : null,
+            };
+
+            GraphicsDevice.NativeDeviceApi.vkCmdBeginRendering(currentCommandList.NativeCommandBuffer, &renderingInfo);
+
+            activeRendering = true;
+            activeDepthReadOnly = depthReadOnly;
+            renderingDirty = false;
         }
 
         private unsafe void CleanupRenderPass()
         {
-            if (activeRenderPass != VkRenderPass.Null)
+            if (activeRendering)
             {
-                GraphicsDevice.NativeDeviceApi.vkCmdEndRenderPass(currentCommandList.NativeCommandBuffer);
-                activeRenderPass = VkRenderPass.Null;
+                GraphicsDevice.NativeDeviceApi.vkCmdEndRendering(currentCommandList.NativeCommandBuffer);
+                activeRendering = false;
 
                 viewportDirty = true;
                 scissorsDirty = true;
                 pipelineDirty = true;
-            }
-        }
-
-        private readonly struct FramebufferKey : IEquatable<FramebufferKey>
-        {
-            private readonly VkRenderPass renderPass;
-            private readonly int attachmentCount;
-            private readonly VkImageView attachment0;
-            private readonly VkImageView attachment1;
-            private readonly VkImageView attachment2;
-            private readonly VkImageView attachment3;
-            private readonly VkImageView attachment4;
-            private readonly VkImageView attachment5;
-            private readonly VkImageView attachment6;
-            private readonly VkImageView attachment7;
-            private readonly VkImageView attachment8;
-            private readonly VkImageView attachment9;
-
-            public unsafe FramebufferKey(VkRenderPass renderPass, int attachmentCount, VkImageView* attachments)
-            {
-                this.renderPass = renderPass;
-                this.attachmentCount = attachmentCount;
-
-                attachment0 = attachments[0];
-                attachment1 = attachments[1];
-                attachment2 = attachments[2];
-                attachment3 = attachments[3];
-                attachment4 = attachments[4];
-                attachment5 = attachments[5];
-                attachment6 = attachments[6];
-                attachment7 = attachments[7];
-                attachment8 = attachments[8];
-                attachment9 = attachments[9];
-            }
-
-            public override unsafe int GetHashCode()
-            {
-                var hashcode = renderPass.GetHashCode();
-
-                fixed (VkImageView* attachmentsPointer = &attachment0)
-                {
-                    for (int i = 0; i < attachmentCount; i++)
-                    {
-                        hashcode = attachmentsPointer[i].GetHashCode() ^ (hashcode * 397);
-                    }
-                }
-
-                return hashcode;
-            }
-
-            public unsafe bool Equals(FramebufferKey other)
-            {
-                if (other.renderPass != renderPass || attachmentCount != other.attachmentCount)
-                    return false;
-
-                fixed (VkImageView* attachmentsPointer = &attachment0)
-                {
-                    var otherAttachmentsPointer = &other.attachment0;
-
-                    for (int i = 0; i < attachmentCount; i++)
-                    {
-                        if (attachmentsPointer[i] != otherAttachmentsPointer[i])
-                            return false;
-                    }
-                }
-
-                return true;
             }
         }
 

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsAdapter.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsAdapter.Vulkan.cs
@@ -26,6 +26,11 @@ namespace Stride.Graphics
         private readonly int adapterOrdinal;
         private readonly VkPhysicalDeviceProperties properties;
 
+        /// <summary>
+        ///   The raw Vulkan API version supported by the physical device.
+        /// </summary>
+        internal VkVersion NativeApiVersion => properties.apiVersion;
+
         private static readonly Dictionary<int, string> VendorNames = new Dictionary<int, string>
         {
             [0x1002] = "AMD",

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
@@ -183,6 +183,26 @@ namespace Stride.Graphics
 #endif
 
         /// <summary>
+        ///   Builds a <see cref="VkSemaphoreSubmitInfo"/> for a <see cref="vkQueueSubmit2"/> wait or signal.
+        /// </summary>
+        internal static VkSemaphoreSubmitInfo SemaphoreSubmit(VkSemaphore semaphore, ulong value = 0) => new()
+        {
+            sType = VkStructureType.SemaphoreSubmitInfo,
+            semaphore = semaphore,
+            value = value,
+            stageMask = VkPipelineStageFlags2.AllCommands,
+        };
+
+        /// <summary>
+        ///   Builds a <see cref="VkCommandBufferSubmitInfo"/> for a <see cref="vkQueueSubmit2"/>.
+        /// </summary>
+        internal static VkCommandBufferSubmitInfo CommandBufferSubmit(VkCommandBuffer commandBuffer) => new()
+        {
+            sType = VkStructureType.CommandBufferSubmitInfo,
+            commandBuffer = commandBuffer,
+        };
+
+        /// <summary>
         ///     Marks context as active on the current thread.
         /// </summary>
         public void Begin()
@@ -207,33 +227,18 @@ namespace Stride.Graphics
             lock (QueueLock)
             {
                 // Add a dependency between command list fence and frame fence
-                var commandListFenceValue = CommandListFence.NextFenceValue;
-                var frameFenceValue = FrameFence.NextFenceValue++;
-
-                var timelineInfo = new VkTimelineSemaphoreSubmitInfo
+                var waitInfo = SemaphoreSubmit(CommandListFence.Semaphore, CommandListFence.NextFenceValue);
+                var signalInfo = SemaphoreSubmit(FrameFence.Semaphore, FrameFence.NextFenceValue++);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.TimelineSemaphoreSubmitInfo,
-                    waitSemaphoreValueCount = 1,
-                    pWaitSemaphoreValues = &commandListFenceValue,
-                    signalSemaphoreValueCount = 1,
-                    pSignalSemaphoreValues = &frameFenceValue,
+                    sType = VkStructureType.SubmitInfo2,
+                    waitSemaphoreInfoCount = 1,
+                    pWaitSemaphoreInfos = &waitInfo,
+                    signalSemaphoreInfoCount = 1,
+                    pSignalSemaphoreInfos = &signalInfo,
                 };
 
-                var commandListSemaphore = CommandListFence.Semaphore;
-                var frameSemaphore = FrameFence.Semaphore;
-                var pipelineStageFlags = VkPipelineStageFlags.BottomOfPipe;
-                var submitInfo = new VkSubmitInfo
-                {
-                    sType = VkStructureType.SubmitInfo,
-                    pNext = &timelineInfo,
-                    waitSemaphoreCount = 1,
-                    pWaitSemaphores = &commandListSemaphore,
-                    pWaitDstStageMask = &pipelineStageFlags,
-                    signalSemaphoreCount = 1,
-                    pSignalSemaphores = &frameSemaphore,
-                };
-
-                CheckResult(NativeDeviceApi.vkQueueSubmit(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
+                CheckResult(NativeDeviceApi.vkQueueSubmit2(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
             }
 
             // Throttle CPU ahead of GPU so the deferred-release queue stays bounded.
@@ -263,9 +268,9 @@ namespace Stride.Graphics
             if (commandLists == null) throw new ArgumentNullException(nameof(commandLists));
             if (count > commandLists.Length) throw new ArgumentOutOfRangeException(nameof(count));
 
-            var commandBuffers = stackalloc VkCommandBuffer[count];
+            var commandBufferInfos = stackalloc VkCommandBufferSubmitInfo[count];
             for (int i = 0; i < count; i++)
-                commandBuffers[i] = commandLists[i].NativeCommandBuffer;
+                commandBufferInfos[i] = CommandBufferSubmit(commandLists[i].NativeCommandBuffer);
 
             ulong nextCommandListFenceValue;
             lock (QueueLock)
@@ -274,39 +279,32 @@ namespace Stride.Graphics
                 nextCommandListFenceValue = commandListFenceValue + 1;
                 // Make sure all copies are done as well
                 var copyFenceValue = CopyFence.NextFenceValue;
-                var waitFenceValues = stackalloc ulong[] { commandListFenceValue, copyFenceValue };
+
+                var waitInfos = stackalloc VkSemaphoreSubmitInfo[]
+                {
+                    SemaphoreSubmit(CommandListFence.Semaphore, commandListFenceValue),
+                    SemaphoreSubmit(CopyFence.Semaphore, copyFenceValue),
+                };
 
                 // Do we need to wait for CopyFence?
-                var semaphoreCount = copyFenceValue > LastGPUSyncCopyFenceToCommandFence ? 2 : 1;
-                // Remember that we waited 
+                var waitSemaphoreCount = copyFenceValue > LastGPUSyncCopyFenceToCommandFence ? 2 : 1;
+                // Remember that we waited
                 LastGPUSyncCopyFenceToCommandFence = copyFenceValue;
 
                 // Submit commands
-                var timelineInfo = new VkTimelineSemaphoreSubmitInfo
+                var signalInfo = SemaphoreSubmit(CommandListFence.Semaphore, nextCommandListFenceValue);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.TimelineSemaphoreSubmitInfo,
-                    waitSemaphoreValueCount = 2,
-                    pWaitSemaphoreValues = &waitFenceValues[0],
-                    signalSemaphoreValueCount = 1,
-                    pSignalSemaphoreValues = &nextCommandListFenceValue,
+                    sType = VkStructureType.SubmitInfo2,
+                    commandBufferInfoCount = (uint)count,
+                    pCommandBufferInfos = commandBufferInfos,
+                    waitSemaphoreInfoCount = (uint)waitSemaphoreCount,
+                    pWaitSemaphoreInfos = &waitInfos[0],
+                    signalSemaphoreInfoCount = 1,
+                    pSignalSemaphoreInfos = &signalInfo,
                 };
 
-                var semaphores = stackalloc VkSemaphore[] { CommandListFence.Semaphore, CopyFence.Semaphore };
-                var pipelineStageFlags = stackalloc VkPipelineStageFlags[] { VkPipelineStageFlags.BottomOfPipe, VkPipelineStageFlags.BottomOfPipe };
-                var submitInfo = new VkSubmitInfo
-                {
-                    sType = VkStructureType.SubmitInfo,
-                    pNext = &timelineInfo,
-                    commandBufferCount = (uint)count,
-                    pCommandBuffers = commandBuffers,
-                    waitSemaphoreCount = 2,
-                    pWaitSemaphores = &semaphores[0],
-                    pWaitDstStageMask = &pipelineStageFlags[0],
-                    signalSemaphoreCount = 1,
-                    pSignalSemaphores = &semaphores[0],
-                };
-
-                CheckResult(NativeDeviceApi.vkQueueSubmit(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
+                CheckResult(NativeDeviceApi.vkQueueSubmit2(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
 
                 if (IsDebugMode)
                 {
@@ -536,14 +534,15 @@ namespace Stride.Graphics
                 throw new InvalidOperationException("Vulkan: Timeline semaphores are not supported by this device, but are required by Stride.");
 
             // Dynamic rendering is required: the backend renders with vkCmdBeginRendering and
-            // creates no render pass objects
-            if (!supportedVulkan13Features.dynamicRendering)
-                throw new NotSupportedException("Vulkan: Dynamic rendering is not supported by this device, but is required by Stride.");
+            // creates no render pass objects. Synchronization2 is required for vkQueueSubmit2.
+            if (!supportedVulkan13Features.dynamicRendering || !supportedVulkan13Features.synchronization2)
+                throw new NotSupportedException("Vulkan: Dynamic rendering and synchronization2 are not supported by this device, but are required by Stride.");
 
             var enabledVulkan13Features = new VkPhysicalDeviceVulkan13Features
             {
                 sType = VkStructureType.PhysicalDeviceVulkan13Features,
                 dynamicRendering = VkBool32.True,
+                synchronization2 = VkBool32.True,
             };
             var enabledVulkan12Features = new VkPhysicalDeviceVulkan12Features
             {
@@ -686,24 +685,18 @@ namespace Stride.Graphics
                 var copyFenceValue = CopyFence.NextFenceValue++;
                 var nextCopyFenceValue = copyFenceValue + 1;
 
-                var timelineInfo = new VkTimelineSemaphoreSubmitInfo
+                var commandBufferInfo = CommandBufferSubmit(commandBuffer);
+                var signalInfo = SemaphoreSubmit(CopyFence.Semaphore, nextCopyFenceValue);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.TimelineSemaphoreSubmitInfo,
-                    signalSemaphoreValueCount = 1,
-                    pSignalSemaphoreValues = &nextCopyFenceValue,
+                    sType = VkStructureType.SubmitInfo2,
+                    commandBufferInfoCount = 1,
+                    pCommandBufferInfos = &commandBufferInfo,
+                    signalSemaphoreInfoCount = 1,
+                    pSignalSemaphoreInfos = &signalInfo,
                 };
-                var copySemaphore = CopyFence.Semaphore;
-                var submitInfo = new VkSubmitInfo
-                {
-                    sType = VkStructureType.SubmitInfo,
-                    pNext = &timelineInfo,
-                    commandBufferCount = 1,
-                    pCommandBuffers = &commandBuffer,
-                    signalSemaphoreCount = 1,
-                    pSignalSemaphores = &copySemaphore,
-                };
-                
-                CheckResult(NativeDeviceApi.vkQueueSubmit(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
+
+                CheckResult(NativeDeviceApi.vkQueueSubmit2(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
 
                 return nextCopyFenceValue;
             }
@@ -825,40 +818,33 @@ namespace Stride.Graphics
                 nextCommandListFenceValue = commandListFenceValue + 1;
                 // Make sure all copies are done as well
                 var copyFenceValue = CopyFence.NextFenceValue;
-                var waitFenceValues = stackalloc ulong[] { commandListFenceValue, copyFenceValue };
+
+                var waitInfos = stackalloc VkSemaphoreSubmitInfo[]
+                {
+                    SemaphoreSubmit(CommandListFence.Semaphore, commandListFenceValue),
+                    SemaphoreSubmit(CopyFence.Semaphore, copyFenceValue),
+                };
 
                 // Do we need to wait for CopyFence?
-                var semaphoreCount = copyFenceValue > LastGPUSyncCopyFenceToCommandFence ? 2 : 1;
-                // Remember that we waited 
+                var waitSemaphoreCount = copyFenceValue > LastGPUSyncCopyFenceToCommandFence ? 2 : 1;
+                // Remember that we waited
                 LastGPUSyncCopyFenceToCommandFence = copyFenceValue;
 
                 // Submit commands
-                var timelineInfo = new VkTimelineSemaphoreSubmitInfo
+                var commandBufferInfo = CommandBufferSubmit(commandList.NativeCommandBuffer);
+                var signalInfo = SemaphoreSubmit(CommandListFence.Semaphore, nextCommandListFenceValue);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.TimelineSemaphoreSubmitInfo,
-                    waitSemaphoreValueCount = 2,
-                    pWaitSemaphoreValues = &waitFenceValues[0],
-                    signalSemaphoreValueCount = 1,
-                    pSignalSemaphoreValues = &nextCommandListFenceValue,
+                    sType = VkStructureType.SubmitInfo2,
+                    commandBufferInfoCount = 1,
+                    pCommandBufferInfos = &commandBufferInfo,
+                    waitSemaphoreInfoCount = (uint)waitSemaphoreCount,
+                    pWaitSemaphoreInfos = &waitInfos[0],
+                    signalSemaphoreInfoCount = 1,
+                    pSignalSemaphoreInfos = &signalInfo,
                 };
 
-                var semaphores = stackalloc VkSemaphore[] { CommandListFence.Semaphore, CopyFence.Semaphore };
-                var pipelineStageFlags = stackalloc VkPipelineStageFlags[] { VkPipelineStageFlags.BottomOfPipe, VkPipelineStageFlags.BottomOfPipe };
-                var nativeCommandBufferCopy = commandList.NativeCommandBuffer;
-                var submitInfo = new VkSubmitInfo
-                {
-                    sType = VkStructureType.SubmitInfo,
-                    pNext = &timelineInfo,
-                    commandBufferCount = 1,
-                    pCommandBuffers = &nativeCommandBufferCopy,
-                    waitSemaphoreCount = 2,
-                    pWaitSemaphores = &semaphores[0],
-                    pWaitDstStageMask = &pipelineStageFlags[0],
-                    signalSemaphoreCount = 1,
-                    pSignalSemaphores = &semaphores[0],
-                };
-                
-                CheckResult(NativeDeviceApi.vkQueueSubmit(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
+                CheckResult(NativeDeviceApi.vkQueueSubmit2(NativeCommandQueue, 1, &submitInfo, VkFence.Null));
 
                 if (IsDebugMode)
                     DebugAggregateLocalCounters(commandList.Builder.DebugScopeExtractLocalCounters());

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
@@ -506,10 +506,18 @@ namespace Stride.Graphics
             uniformBufferStandardLayoutFeature.sType = VkStructureType.PhysicalDeviceUniformBufferStandardLayoutFeatures;
             uniformBufferStandardLayoutFeature.uniformBufferStandardLayout = VkBool32.True;
 
+            // Dynamic rendering (core in Vulkan 1.3) is required:
+            // the backend renders with vkCmdBeginRendering and creates no render pass objects.
+            var dynamicRenderingFeatures = new VkPhysicalDeviceDynamicRenderingFeatures
+            {
+                sType = VkStructureType.PhysicalDeviceDynamicRenderingFeatures,
+            };
+
             // FP16 in shaders (SPIR-V Float16 capability) — required by some HLSL→SPIR-V output.
             var shaderFloat16Int8Features = new VkPhysicalDeviceShaderFloat16Int8Features
             {
                 sType = VkStructureType.PhysicalDeviceShaderFloat16Int8Features,
+                pNext = &dynamicRenderingFeatures,
             };
 
             // Timeline semaphores (core in Vulkan 1.2+, extension in 1.1)
@@ -549,10 +557,17 @@ namespace Stride.Graphics
             if (!timelineSemaphoreFeatures.timelineSemaphore)
                 throw new InvalidOperationException("Vulkan: Timeline semaphores are not supported by this device, but are required by Stride.");
             timelineSemaphoreFeatures.timelineSemaphore = VkBool32.True;
+
+            if (!dynamicRenderingFeatures.dynamicRendering)
+                throw new NotSupportedException("Vulkan: Dynamic rendering is not supported by this device, but is required by Stride.");
+            dynamicRenderingFeatures.dynamicRendering = VkBool32.True;
+
             // Keep shaderInt8 disabled regardless; only enable shaderFloat16 if supported.
             shaderFloat16Int8Features.shaderInt8 = VkBool32.False;
             timelineSemaphoreFeatures.pNext = &shaderFloat16Int8Features;
             shaderFloat16Int8Features.pNext = &uniformBufferStandardLayoutFeature;
+            uniformBufferStandardLayoutFeature.pNext = &dynamicRenderingFeatures;
+            dynamicRenderingFeatures.pNext = null;
 
             // Only keep multiview in the chain when the device supports it; drop the geom/tess sub-features regardless.
             void* pNextChainHead = &timelineSemaphoreFeatures;
@@ -1214,11 +1229,6 @@ namespace Stride.Graphics
             return new NativeResource(VkDebugReportObjectTypeEXT.Sampler, *(ulong*)&handle);
         }
 
-        public static unsafe implicit operator NativeResource(VkFramebuffer handle)
-        {
-            return new NativeResource(VkDebugReportObjectTypeEXT.Framebuffer, *(ulong*)&handle);
-        }
-
         public static unsafe implicit operator NativeResource(VkSemaphore handle)
         {
             return new NativeResource(VkDebugReportObjectTypeEXT.Semaphore, *(ulong*)&handle);
@@ -1242,11 +1252,6 @@ namespace Stride.Graphics
         public static unsafe implicit operator NativeResource(VkPipelineLayout handle)
         {
             return new NativeResource(VkDebugReportObjectTypeEXT.PipelineLayout, *(ulong*)&handle);
-        }
-
-        public static unsafe implicit operator NativeResource(VkRenderPass handle)
-        {
-            return new NativeResource(VkDebugReportObjectTypeEXT.RenderPass, *(ulong*)&handle);
         }
 
         public static unsafe implicit operator NativeResource(VkDescriptorSetLayout handle)
@@ -1283,9 +1288,6 @@ namespace Stride.Graphics
                 case VkDebugReportObjectTypeEXT.Sampler:
                     device.NativeDeviceApi.vkDestroySampler(device.NativeDevice, *(VkSampler*)&handleCopy, null);
                     break;
-                case VkDebugReportObjectTypeEXT.Framebuffer:
-                    device.NativeDeviceApi.vkDestroyFramebuffer(device.NativeDevice, *(VkFramebuffer*)&handleCopy, null);
-                    break;
                 case VkDebugReportObjectTypeEXT.Semaphore:
                     device.NativeDeviceApi.vkDestroySemaphore(device.NativeDevice, *(VkSemaphore*)&handleCopy, null);
                     break;
@@ -1300,9 +1302,6 @@ namespace Stride.Graphics
                     break;
                 case VkDebugReportObjectTypeEXT.PipelineLayout:
                     device.NativeDeviceApi.vkDestroyPipelineLayout(device.NativeDevice, *(VkPipelineLayout*)&handleCopy, null);
-                    break;
-                case VkDebugReportObjectTypeEXT.RenderPass:
-                    device.NativeDeviceApi.vkDestroyRenderPass(device.NativeDevice, *(VkRenderPass*)&handleCopy, null);
                     break;
                 case VkDebugReportObjectTypeEXT.DescriptorSetLayout:
                     device.NativeDeviceApi.vkDestroyDescriptorSetLayout(device.NativeDevice, *(VkDescriptorSetLayout*)&handleCopy, null);

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
@@ -456,6 +456,10 @@ namespace Stride.Graphics
             if (availableExtensionProperties.Contains(VK_KHR_SWAPCHAIN_EXTENSION_NAME))
                 desiredExtensionProperties.Add(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
+            // Stride uses Vulkan 1.3 core features and entry points
+            if (Adapter.NativeApiVersion < VkVersion.Version_1_3)
+                throw new NotSupportedException($"Vulkan: Device supports only Vulkan {Adapter.DriverInfo.ApiVersion}, but Stride requires Vulkan 1.3.");
+
             // Vulkan portability spec: if VK_KHR_portability_subset is advertised, the app MUST enable it.
             // MoltenVK is the only ICD that advertises it; conformant drivers do not.
             bool isPortabilitySubsetDevice = availableExtensionProperties.Contains(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
@@ -502,81 +502,67 @@ namespace Stride.Graphics
             IsProfilingSupported = IsDebugMode && GraphicsAdapterFactory.GetInstance(IsDebugMode).HasDebugUtilsSupport;
 
             // Activate VK_KHR_uniform_buffer_standard_layout (promoted Vulkan 1.2)
-            var uniformBufferStandardLayoutFeature = new VkPhysicalDeviceUniformBufferStandardLayoutFeatures();
-            uniformBufferStandardLayoutFeature.sType = VkStructureType.PhysicalDeviceUniformBufferStandardLayoutFeatures;
-            uniformBufferStandardLayoutFeature.uniformBufferStandardLayout = VkBool32.True;
-
-            // Dynamic rendering (core in Vulkan 1.3) is required:
-            // the backend renders with vkCmdBeginRendering and creates no render pass objects.
-            var dynamicRenderingFeatures = new VkPhysicalDeviceDynamicRenderingFeatures
+            // Query supported features through the aggregate per-version structs, then enable
+            // below only the features Stride uses
+            var supportedVulkan13Features = new VkPhysicalDeviceVulkan13Features
             {
-                sType = VkStructureType.PhysicalDeviceDynamicRenderingFeatures,
+                sType = VkStructureType.PhysicalDeviceVulkan13Features,
             };
-
-            // FP16 in shaders (SPIR-V Float16 capability) — required by some HLSL→SPIR-V output.
-            var shaderFloat16Int8Features = new VkPhysicalDeviceShaderFloat16Int8Features
+            var supportedVulkan12Features = new VkPhysicalDeviceVulkan12Features
             {
-                sType = VkStructureType.PhysicalDeviceShaderFloat16Int8Features,
-                pNext = &dynamicRenderingFeatures,
+                sType = VkStructureType.PhysicalDeviceVulkan12Features,
+                pNext = &supportedVulkan13Features,
             };
-
-            // Timeline semaphores (core in Vulkan 1.2+, extension in 1.1)
-            // Check if the feature is supported before requesting it
-            var timelineSemaphoreFeatures = new VkPhysicalDeviceTimelineSemaphoreFeatures
+            var supportedVulkan11Features = new VkPhysicalDeviceVulkan11Features
             {
-                sType = VkStructureType.PhysicalDeviceTimelineSemaphoreFeatures,
-                pNext = &shaderFloat16Int8Features,
-            };
-            // Needed to keep RenderDoc happy until https://github.com/baldurk/renderdoc/pull/3831 is merged.
-            var multiviewFeatures = new VkPhysicalDeviceMultiviewFeatures
-            {
-                sType = VkStructureType.PhysicalDeviceMultiviewFeatures,
-                pNext = &timelineSemaphoreFeatures,
-            };
-            // Queried unconditionally — the feature struct is just metadata; only the AHardwareBuffer
-            // import path on Android actually requires the feature to be enabled.
-            var samplerYcbcrConversionFeatures = new VkPhysicalDeviceSamplerYcbcrConversionFeatures
-            {
-                sType = VkStructureType.PhysicalDeviceSamplerYcbcrConversionFeatures,
-                pNext = &multiviewFeatures,
+                sType = VkStructureType.PhysicalDeviceVulkan11Features,
+                pNext = &supportedVulkan12Features,
             };
             // Portability subset features (MoltenVK only) — queried so we can forward the device-reported
             // capabilities verbatim to vkCreateDevice, which is what the portability spec requires.
             var portabilitySubsetFeatures = new VkPhysicalDevicePortabilitySubsetFeaturesKHR
             {
                 sType = VkStructureType.PhysicalDevicePortabilitySubsetFeaturesKHR,
-                pNext = &samplerYcbcrConversionFeatures,
+                pNext = &supportedVulkan11Features,
             };
             var physicalDeviceFeatures2 = new VkPhysicalDeviceFeatures2
             {
                 sType = VkStructureType.PhysicalDeviceFeatures2,
-                pNext = isPortabilitySubsetDevice ? (void*)&portabilitySubsetFeatures : &samplerYcbcrConversionFeatures,
+                pNext = isPortabilitySubsetDevice ? (void*)&portabilitySubsetFeatures : &supportedVulkan11Features,
             };
             NativeInstanceApi.vkGetPhysicalDeviceFeatures2(NativePhysicalDevice, &physicalDeviceFeatures2);
 
-            if (!timelineSemaphoreFeatures.timelineSemaphore)
+            if (!supportedVulkan12Features.timelineSemaphore)
                 throw new InvalidOperationException("Vulkan: Timeline semaphores are not supported by this device, but are required by Stride.");
-            timelineSemaphoreFeatures.timelineSemaphore = VkBool32.True;
 
-            if (!dynamicRenderingFeatures.dynamicRendering)
+            // Dynamic rendering is required: the backend renders with vkCmdBeginRendering and
+            // creates no render pass objects
+            if (!supportedVulkan13Features.dynamicRendering)
                 throw new NotSupportedException("Vulkan: Dynamic rendering is not supported by this device, but is required by Stride.");
-            dynamicRenderingFeatures.dynamicRendering = VkBool32.True;
 
-            // Keep shaderInt8 disabled regardless; only enable shaderFloat16 if supported.
-            shaderFloat16Int8Features.shaderInt8 = VkBool32.False;
-            timelineSemaphoreFeatures.pNext = &shaderFloat16Int8Features;
-            shaderFloat16Int8Features.pNext = &uniformBufferStandardLayoutFeature;
-            uniformBufferStandardLayoutFeature.pNext = &dynamicRenderingFeatures;
-            dynamicRenderingFeatures.pNext = null;
-
-            // Only keep multiview in the chain when the device supports it; drop the geom/tess sub-features regardless.
-            void* pNextChainHead = &timelineSemaphoreFeatures;
-            if (multiviewFeatures.multiview)
+            var enabledVulkan13Features = new VkPhysicalDeviceVulkan13Features
             {
-                multiviewFeatures.multiviewGeometryShader = VkBool32.False;
-                multiviewFeatures.multiviewTessellationShader = VkBool32.False;
-                pNextChainHead = &multiviewFeatures;
-            }
+                sType = VkStructureType.PhysicalDeviceVulkan13Features,
+                dynamicRendering = VkBool32.True,
+            };
+            var enabledVulkan12Features = new VkPhysicalDeviceVulkan12Features
+            {
+                sType = VkStructureType.PhysicalDeviceVulkan12Features,
+                pNext = &enabledVulkan13Features,
+                timelineSemaphore = VkBool32.True,
+                uniformBufferStandardLayout = VkBool32.True,
+                // FP16 in shaders (SPIR-V Float16 capability) — required by some HLSL→SPIR-V output.
+                shaderFloat16 = supportedVulkan12Features.shaderFloat16,
+            };
+            var enabledVulkan11Features = new VkPhysicalDeviceVulkan11Features
+            {
+                sType = VkStructureType.PhysicalDeviceVulkan11Features,
+                pNext = &enabledVulkan12Features,
+                // Needed to keep RenderDoc happy until https://github.com/baldurk/renderdoc/pull/3831 is merged.
+                multiview = supportedVulkan11Features.multiview,
+            };
+
+            void* pNextChainHead = &enabledVulkan11Features;
             // Re-attach portability subset at the head of the create-info chain so MoltenVK sees the
             // feature flags it reported. The values were populated by the query above; pass them back as-is.
             if (isPortabilitySubsetDevice)

--- a/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
@@ -20,7 +20,6 @@ namespace Stride.Graphics
 
         internal VkPipelineLayout NativeLayout;
         internal VkPipeline NativePipeline;
-        internal VkRenderPass NativeRenderPass;
         internal int[] ResourceGroupMapping;
         internal int ResourceGroupCount;
         internal PipelineStateDescription Description;
@@ -63,8 +62,6 @@ namespace Stride.Graphics
         {
             if (Description.RootSignature == null)
                 return;
-
-            CreateRenderPass(Description);
 
             CreatePipelineLayout(Description);
 
@@ -215,9 +212,30 @@ namespace Stride.Graphics
                         pDynamicStates = dynamicStatesPointer
                     };
 
+                    // Dynamic rendering: the pipeline declares only the attachment formats
+                    var output = Description.Output;
+                    var colorAttachmentFormats = stackalloc VkFormat[renderTargetCount > 0 ? renderTargetCount : 1];
+                    var renderTargetFormat = &output.RenderTargetFormat0;
+                    for (int i = 0; i < renderTargetCount; i++)
+                        colorAttachmentFormats[i] = VulkanConvertExtensions.ConvertPixelFormat(*(renderTargetFormat + i));
+
+                    var depthAttachmentFormat = output.DepthStencilFormat != PixelFormat.None
+                        ? Texture.GetFallbackDepthStencilFormat(GraphicsDevice, VulkanConvertExtensions.ConvertPixelFormat(output.DepthStencilFormat))
+                        : VkFormat.Undefined;
+
+                    var renderingCreateInfo = new VkPipelineRenderingCreateInfo
+                    {
+                        sType = VkStructureType.PipelineRenderingCreateInfo,
+                        colorAttachmentCount = (uint)renderTargetCount,
+                        pColorAttachmentFormats = colorAttachmentFormats,
+                        depthAttachmentFormat = depthAttachmentFormat,
+                        stencilAttachmentFormat = HasStencilAspect(depthAttachmentFormat) ? depthAttachmentFormat : VkFormat.Undefined,
+                    };
+
                     var createInfo = new VkGraphicsPipelineCreateInfo
                     {
                         sType = VkStructureType.GraphicsPipelineCreateInfo,
+                        pNext = &renderingCreateInfo,
                         layout = NativeLayout,
                         stageCount = (uint)stages.Length,
                         pStages = stages.Length > 0 ? fStages : null,
@@ -230,8 +248,6 @@ namespace Stride.Graphics
                         pDynamicState = &dynamicState,
                         pViewportState = &viewportState,
                         pTessellationState = &tessellationState,
-                        renderPass = NativeRenderPass,
-                        subpass = 0,
                     };
                     fixed (VkPipeline* nativePipelinePtr = &NativePipeline)
                         GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkCreateGraphicsPipelines(GraphicsDevice.NativeDevice, VkPipelineCache.Null, createInfoCount: 1, &createInfo, allocator: null, nativePipelinePtr));
@@ -249,116 +265,21 @@ namespace Stride.Graphics
             return true;
         }
 
-        private unsafe void CreateRenderPass(PipelineStateDescription pipelineStateDescription)
-        {
-            bool hasDepthStencilAttachment = pipelineStateDescription.Output.DepthStencilFormat != PixelFormat.None;
-
-            var renderTargetCount = pipelineStateDescription.Output.RenderTargetCount;
-
-            var attachmentCount = renderTargetCount;
-            if (hasDepthStencilAttachment)
-                attachmentCount++;
-
-            var attachments = new VkAttachmentDescription[attachmentCount];
-            var colorAttachmentReferences = new VkAttachmentReference[renderTargetCount];
-
-            fixed (PixelFormat* renderTargetFormat = &pipelineStateDescription.Output.RenderTargetFormat0)
-            fixed (BlendStateRenderTargetDescription* blendDescription = &pipelineStateDescription.BlendState.RenderTargets[0])
-            {
-                for (int i = 0; i < renderTargetCount; i++)
-                {
-                    var currentBlendDesc = pipelineStateDescription.BlendState.IndependentBlendEnable ? (blendDescription + i) : blendDescription;
-
-                    // loadOp=Load: per-pipeline render passes restart mid-frame; DontCare drops contents of tiles a non-fullscreen draw touches (visible as block garbage on Lavapipe/MoltenVK).
-                    attachments[i] = new VkAttachmentDescription
-                    {
-                        format = VulkanConvertExtensions.ConvertPixelFormat(*(renderTargetFormat + i)),
-                        samples = VkSampleCountFlags.Count1,
-                        loadOp = VkAttachmentLoadOp.Load,
-                        storeOp = VkAttachmentStoreOp.Store,
-                        stencilLoadOp = VkAttachmentLoadOp.DontCare,
-                        stencilStoreOp = VkAttachmentStoreOp.DontCare,
-                        initialLayout = VkImageLayout.ColorAttachmentOptimal,
-                        finalLayout = VkImageLayout.ColorAttachmentOptimal
-                    };
-
-                    colorAttachmentReferences[i] = new VkAttachmentReference
-                    {
-                        attachment = (uint)i,
-                        layout = VkImageLayout.ColorAttachmentOptimal
-                    };
-                }
-            }
-
-            // A pipeline that disables depth writes AND doesn't write stencil is compatible with
-            // DepthStencilReadOnlyOptimal, which is also a valid layout for shader sampling. Using
-            // that layout here lets a depth buffer be bound simultaneously as read-only attachment
-            // and as a SampledImage (e.g. soft-edge particles sampling the scene depth) without
-            // triggering VUID-vkCmdBeginRenderPass-initialLayout-00900.
-            var dss = pipelineStateDescription.DepthStencilState;
-            bool depthReadOnly = hasDepthStencilAttachment
-                && !dss.DepthBufferWriteEnable
-                && (!dss.StencilEnable || dss.StencilWriteMask == 0);
-            var depthLayout = depthReadOnly
-                ? VkImageLayout.DepthStencilReadOnlyOptimal
-                : VkImageLayout.DepthStencilAttachmentOptimal;
-
-            if (hasDepthStencilAttachment)
-            {
-                attachments[attachmentCount - 1] = new VkAttachmentDescription
-                {
-                    format = Texture.GetFallbackDepthStencilFormat(GraphicsDevice, VulkanConvertExtensions.ConvertPixelFormat(pipelineStateDescription.Output.DepthStencilFormat)),
-                    samples = VkSampleCountFlags.Count1,
-                    loadOp = VkAttachmentLoadOp.Load, // TODO VULKAN: Only if depth read enabled?
-                    storeOp = VkAttachmentStoreOp.Store, // TODO VULKAN: Only if depth write enabled?
-                    stencilLoadOp = VkAttachmentLoadOp.Load,
-                    stencilStoreOp = VkAttachmentStoreOp.Store,
-                    initialLayout = depthLayout,
-                    finalLayout = depthLayout
-                };
-            }
-
-            // fixed yields null if array is empty or null
-            fixed (VkAttachmentReference* fColorAttachmentReferences = colorAttachmentReferences)
-            fixed (VkAttachmentDescription* fAttachments = attachments)
-            {
-                var depthAttachmentReference = new VkAttachmentReference
-                {
-                    attachment = (uint)attachments.Length - 1,
-                    layout = depthLayout
-                };
-
-                var subpass = new VkSubpassDescription
-                {
-                    pipelineBindPoint = VkPipelineBindPoint.Graphics,
-                    colorAttachmentCount = (uint)renderTargetCount,
-                    pColorAttachments = fColorAttachmentReferences,
-                    pDepthStencilAttachment = hasDepthStencilAttachment ? &depthAttachmentReference : null
-                };
-
-                var renderPassCreateInfo = new VkRenderPassCreateInfo
-                {
-                    sType = VkStructureType.RenderPassCreateInfo,
-                    attachmentCount = (uint)attachmentCount,
-                    pAttachments = fAttachments,
-                    subpassCount = 1,
-                    pSubpasses = &subpass
-                };
-                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkCreateRenderPass(GraphicsDevice.NativeDevice, &renderPassCreateInfo, allocator: null, out NativeRenderPass));
-            }
-        }
+        /// <summary>
+        ///   Indicates if the given depth-stencil format contains a stencil aspect.
+        /// </summary>
+        internal static bool HasStencilAspect(VkFormat format) =>
+            format is VkFormat.D24UnormS8Uint or VkFormat.D32SfloatS8Uint or VkFormat.D16UnormS8Uint or VkFormat.S8Uint;
 
         /// <inheritdoc/>
         protected internal override unsafe void OnDestroyed(bool immediately = false)
         {
             if (NativePipeline != VkPipeline.Null)
             {
-                GraphicsDevice.Collect(NativeRenderPass);
                 GraphicsDevice.Collect(NativePipeline);
                 GraphicsDevice.Collect(NativeLayout);
                 GraphicsDevice.Collect(NativeDescriptorSetLayout);
 
-                NativeRenderPass = VkRenderPass.Null;
                 NativePipeline = VkPipeline.Null;
                 NativeLayout = VkPipelineLayout.Null;
                 NativeDescriptorSetLayout = VkDescriptorSetLayout.Null;

--- a/sources/engine/Stride.Graphics/Vulkan/SwapChainGraphicsPresenter.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/SwapChainGraphicsPresenter.Vulkan.cs
@@ -149,27 +149,18 @@ namespace Stride.Graphics
             {
                 // Signal semaphore (that we will wait on during present for GPU=>GPU sync, to make sure all previous command buffers have been executed)
                 var submitSemaphore = submitSemaphores[currentBufferIndex];
-                var frameFence = GraphicsDevice.FrameFence.Semaphore;
-                var frameFenceValue = GraphicsDevice.FrameFence.NextFenceValue - 1;
-                var pipelineStageFlags = VkPipelineStageFlags.BottomOfPipe;
-                var timelineInfo = new VkTimelineSemaphoreSubmitInfo
+                var waitInfo = GraphicsDevice.SemaphoreSubmit(GraphicsDevice.FrameFence.Semaphore, GraphicsDevice.FrameFence.NextFenceValue - 1);
+                var signalInfo = GraphicsDevice.SemaphoreSubmit(submitSemaphore);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.TimelineSemaphoreSubmitInfo,
-                    waitSemaphoreValueCount = 1,
-                    pWaitSemaphoreValues = &frameFenceValue,
-                };
-                var submitInfo = new VkSubmitInfo
-                {
-                    sType = VkStructureType.SubmitInfo,
-                    pNext = &timelineInfo,
-                    waitSemaphoreCount = 1,
-                    pWaitSemaphores = &frameFence,
-                    pWaitDstStageMask = &pipelineStageFlags,
-                    signalSemaphoreCount = 1,
-                    pSignalSemaphores = &submitSemaphore,
+                    sType = VkStructureType.SubmitInfo2,
+                    waitSemaphoreInfoCount = 1,
+                    pWaitSemaphoreInfos = &waitInfo,
+                    signalSemaphoreInfoCount = 1,
+                    pSignalSemaphoreInfos = &signalInfo,
                 };
 
-                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueSubmit(GraphicsDevice.NativeCommandQueue, 1, &submitInfo, frameFences[currentFrameIndex]));
+                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueSubmit2(GraphicsDevice.NativeCommandQueue, 1, &submitInfo, frameFences[currentFrameIndex]));
 
                 var currentBufferIndexCopy = currentBufferIndex;
                 var swapChainCopy = swapChain;
@@ -235,33 +226,24 @@ namespace Stride.Graphics
             lock (GraphicsDevice.QueueLock)
             {
                 // Signal vkAcquireNextImageKHR Fence => GraphicsDevice.CommandList (so that next command list will wait for this to complete)
-                var acquireSemaphore = acquireSemaphores[currentFrameIndex];
-                var commandListFence = GraphicsDevice.CommandListFence.Semaphore;
                 var commandListFenceValue = GraphicsDevice.CommandListFence.NextFenceValue++;
                 var nextCommandListFenceValue = commandListFenceValue + 1;
-                var waitFenceValues = stackalloc ulong[] { commandListFenceValue, 0 }; // second value is ignored (binary semaphore)
-                var timelineInfo = new VkTimelineSemaphoreSubmitInfo
+                var waitInfos = stackalloc VkSemaphoreSubmitInfo[]
                 {
-                    sType = VkStructureType.TimelineSemaphoreSubmitInfo,
-                    waitSemaphoreValueCount = 2,
-                    pWaitSemaphoreValues = &waitFenceValues[0],
-                    signalSemaphoreValueCount = 1,
-                    pSignalSemaphoreValues = &nextCommandListFenceValue,
+                    GraphicsDevice.SemaphoreSubmit(GraphicsDevice.CommandListFence.Semaphore, commandListFenceValue),
+                    GraphicsDevice.SemaphoreSubmit(acquireSemaphores[currentFrameIndex]),
                 };
-                var semaphores = stackalloc VkSemaphore[] { commandListFence, acquireSemaphore };
-                var pipelineStageFlags = stackalloc VkPipelineStageFlags[] { VkPipelineStageFlags.BottomOfPipe, VkPipelineStageFlags.BottomOfPipe };
-                var submitInfo = new VkSubmitInfo
+                var signalInfo = GraphicsDevice.SemaphoreSubmit(GraphicsDevice.CommandListFence.Semaphore, nextCommandListFenceValue);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.SubmitInfo,
-                    pNext = &timelineInfo,
-                    waitSemaphoreCount = 2,
-                    pWaitSemaphores = &semaphores[0],
-                    pWaitDstStageMask = &pipelineStageFlags[0],
-                    signalSemaphoreCount = 1,
-                    pSignalSemaphores = &commandListFence,
+                    sType = VkStructureType.SubmitInfo2,
+                    waitSemaphoreInfoCount = 2,
+                    pWaitSemaphoreInfos = &waitInfos[0],
+                    signalSemaphoreInfoCount = 1,
+                    pSignalSemaphoreInfos = &signalInfo,
                 };
 
-                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueSubmit(GraphicsDevice.NativeCommandQueue, 1, &submitInfo, VkFence.Null));
+                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueSubmit2(GraphicsDevice.NativeCommandQueue, 1, &submitInfo, VkFence.Null));
             }
         }
 
@@ -677,13 +659,14 @@ namespace Stride.Graphics
 
             lock (GraphicsDevice.QueueLock)
             {
-                var submitInfo = new VkSubmitInfo
+                var commandBufferInfo = GraphicsDevice.CommandBufferSubmit(commandBuffer);
+                var submitInfo = new VkSubmitInfo2
                 {
-                    sType = VkStructureType.SubmitInfo,
-                    commandBufferCount = 1,
-                    pCommandBuffers = &commandBuffer,
+                    sType = VkStructureType.SubmitInfo2,
+                    commandBufferInfoCount = 1,
+                    pCommandBufferInfos = &commandBufferInfo,
                 };
-                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueSubmit(GraphicsDevice.NativeCommandQueue, 1, &submitInfo, VkFence.Null));
+                GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueSubmit2(GraphicsDevice.NativeCommandQueue, 1, &submitInfo, VkFence.Null));
                 GraphicsDevice.CheckResult(GraphicsDevice.NativeDeviceApi.vkQueueWaitIdle(GraphicsDevice.NativeCommandQueue));
             }
 


### PR DESCRIPTION
## PR Details

Moves the Vulkan backend to Vulkan 1.3 core:

- **Require Vulkan 1.3**: clear error at device creation otherwise. Excludes almost nothing in practice: timeline semaphores already made 1.2 the effective floor, and Android drivers jumped from 1.1 straight to 1.3.
  Note that we could have emulated timeline semaphore on 1.1 using https://github.com/KhronosGroup/Vulkan-ExtensionLayer but we're talking about pre-2022 devices. Let's drop support and if some game/user really need such old devices for a large scale game, we could reconsider.
- **Dynamic rendering**: `vkCmdBeginRendering` replaces render pass objects, deleting the VkRenderPass/VkFramebuffer machinery. Pipelines only declare attachment formats, and the render pass instance now stays open across pipeline changes. Also unblocks the upcoming explicit resource transition work.
- **Aggregate feature structs** (`VkPhysicalDeviceVulkan11/12/13Features`) instead of many individual structs.
- **`vkQueueSubmit2`**: simpler submits, and fixes wait stage masks that were too weak.

Net ~200 lines removed.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->