### PR TITLE
fix: read by direction when resampling the prefiltered radiance highest level

### DIFF
--- a/sources/engine/Stride.Assets/Skyboxes/SkyboxGenerator.cs
+++ b/sources/engine/Stride.Assets/Skyboxes/SkyboxGenerator.cs
@@ -12,6 +12,7 @@ using Stride.Core.Serialization.Contents;
 using Stride.Rendering;
 using Stride.Rendering.ComputeEffect.GGXPrefiltering;
 using Stride.Rendering.ComputeEffect.LambertianPrefiltering;
+using Stride.Rendering.Images;
 using Stride.Rendering.Skyboxes;
 using Stride.Games;
 using Stride.Graphics;
@@ -100,7 +101,8 @@ namespace Stride.Assets.Skyboxes
 
             // load the skybox texture from the asset.
             var reference = AttachedReferenceManager.GetAttachedReference(cubemap);
-            var skyboxTexture = context.Content.Load<Texture>(BuildTextureForSkyboxGenerationLocation(reference.Url), ContentManagerLoaderSettings.StreamingDisabled);
+            var loadedTexture = context.Content.Load<Texture>(BuildTextureForSkyboxGenerationLocation(reference.Url), ContentManagerLoaderSettings.StreamingDisabled);
+            var skyboxTexture = loadedTexture;
             if (skyboxTexture.ViewDimension == TextureDimension.Texture2D)
             {
                 var cubemapSize = (int)Math.Pow(2, Math.Ceiling(Math.Log(skyboxTexture.Width / 4) / Math.Log(2))); // maximum resolution is around horizontal middle line which composes 4 images.
@@ -110,6 +112,17 @@ namespace Stride.Assets.Skyboxes
             {
                 result.Error($"SkyboxGenerator: The texture type ({skyboxTexture.ViewDimension}) used as skybox is not supported. Should be a Cubemap or a 2D texture.");
                 return result;
+            }
+
+            // The prefilters read the radiance through its mipmaps, both to fill the highest level and to
+            // pick a sampling level per roughness, so build the chain when the source comes without one
+            // (e.g. a cubemap generated from a 2D texture above).
+            if (skyboxTexture.MipLevelCount == 1)
+            {
+                var mipless = skyboxTexture;
+                skyboxTexture = GenerateMipmaps(context, mipless);
+                if (mipless != loadedTexture)
+                    mipless.Dispose();
             }
 
             // If we are using the skybox asset for lighting, we can compute it
@@ -165,7 +178,37 @@ namespace Stride.Assets.Skyboxes
             }
             // TODO: cubeTexture is not deallocated
 
+            // Release the intermediate radiance when one was created above; the loaded texture belongs to the content manager.
+            if (skyboxTexture != loadedTexture)
+                skyboxTexture.Dispose();
+
             return result;
+        }
+
+        private static Texture GenerateMipmaps(SkyboxGeneratorContext context, Texture texture)
+        {
+            var format = texture.Format.IsCompressed
+                ? texture.Format.IsHDR ? PixelFormat.R16G16B16A16_Float : texture.Format.IsSRgb ? PixelFormat.R8G8B8A8_UNorm_SRgb : PixelFormat.R8G8B8A8_UNorm
+                : texture.Format;
+            var mipped = Texture.NewCube(context.GraphicsDevice, texture.Width, true, format, TextureFlags.ShaderResource | TextureFlags.RenderTarget);
+
+            using var scaler = new ImageScaler(SamplingPattern.Linear);
+            for (var face = 0; face < 6; face++)
+            {
+                for (var mip = 0; mip < mipped.MipLevelCount; mip++)
+                {
+                    // A single bilinear tap at an exact 2x downscale averages the 2x2 source texels
+                    using var source = mip == 0
+                        ? texture.ToTextureView(ViewType.Single, face, 0)
+                        : mipped.ToTextureView(ViewType.Single, face, mip - 1);
+                    using var target = mipped.ToTextureView(ViewType.Single, face, mip);
+                    scaler.SetInput(0, source);
+                    scaler.SetOutput(target);
+                    scaler.Draw(context.RenderDrawContext);
+                }
+            }
+
+            return mipped;
         }
 
         public static string BuildTextureForSkyboxGenerationLocation(string textureLocation)

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgxFaceContinuity.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgxFaceContinuity.cs
@@ -1,0 +1,137 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+using Xunit;
+
+using Stride.Core.Mathematics;
+using Stride.Rendering;
+using Stride.Rendering.ComputeEffect.GGXPrefiltering;
+
+namespace Stride.Graphics.Tests;
+
+public class TestRadiancePrefilteringGgxFaceContinuity : GraphicTestGameBase
+{
+    // The 12 edges cube faces share, in Direct3D face order, with the orientation each pair meets at.
+    private static readonly (int FaceA, Edge EdgeA, int FaceB, Edge EdgeB, bool Reversed)[] SharedEdges =
+    {
+        (0, Edge.Bottom, 3, Edge.Right,  false), (0, Edge.Left,  4, Edge.Right,  false),
+        (0, Edge.Right,  5, Edge.Left,   false), (0, Edge.Top,   2, Edge.Right,  true),
+        (1, Edge.Bottom, 3, Edge.Left,   true),  (1, Edge.Left,  5, Edge.Right,  false),
+        (1, Edge.Right,  4, Edge.Left,   false), (1, Edge.Top,   2, Edge.Left,   false),
+        (2, Edge.Bottom, 4, Edge.Top,    false), (2, Edge.Top,   5, Edge.Top,    true),
+        (3, Edge.Bottom, 5, Edge.Bottom, true),  (3, Edge.Top,   4, Edge.Bottom, false),
+    };
+
+    private enum Edge { Top, Bottom, Left, Right }
+
+    private const int OutputSize = 64;
+
+    private double seamRatio;
+
+    protected override void RegisterTests()
+    {
+        base.RegisterTests();
+
+        FrameGameSystem.Draw(MeasureFaceContinuity);
+    }
+
+    /// <summary>
+    /// A cubemap discretizes a function over a sphere, so neighboring texels on either side of a shared
+    /// face edge must stay as close as neighboring texels within a face. The output format differs from
+    /// the source here, which is what a low dynamic range skybox produces in <c>SkyboxGenerator</c>.
+    /// </summary>
+    private void MeasureFaceContinuity()
+    {
+        var commandList = GraphicsContext.CommandList;
+        var input = Content.Load<Texture>("CubeMap");
+
+        using var output = Texture.New2D(GraphicsDevice, OutputSize, OutputSize, MathUtil.Log2(OutputSize),
+            PixelFormat.R8G8B8A8_UNorm, TextureFlags.ShaderResource | TextureFlags.RenderTarget, 6);
+
+        var filter = new RadiancePrefilteringGGXNoCompute(RenderContext.GetShared(Services))
+        {
+            RadianceMap = input,
+            PrefilteredRadiance = output,
+            MipmapGenerationCount = MathUtil.Log2(OutputSize),
+        };
+        filter.Draw(new RenderDrawContext(Services, RenderContext.GetShared(Services), GraphicsContext));
+
+        var faces = new double[6][,];
+        for (var face = 0; face < faces.Length; face++)
+            faces[face] = ReadLuminance(output, commandList, face);
+
+        var seam = 0.0;
+        foreach (var (faceA, edgeA, faceB, edgeB, reversed) in SharedEdges)
+        {
+            var a = ReadEdge(faces[faceA], edgeA);
+            var b = ReadEdge(faces[faceB], edgeB);
+            if (reversed)
+                Array.Reverse(b);
+
+            var total = 0.0;
+            for (var i = 0; i < OutputSize; i++)
+                total += Math.Abs(a[i] - b[i]);
+            seam += total / OutputSize;
+        }
+        seam /= SharedEdges.Length;
+
+        var within = 0.0;
+        foreach (var face in faces)
+        {
+            var total = 0.0;
+            for (var y = 1; y < OutputSize; y++)
+                for (var x = 0; x < OutputSize; x++)
+                    total += Math.Abs(face[y, x] - face[y - 1, x]);
+            within += total / ((OutputSize - 1) * OutputSize);
+        }
+        within /= faces.Length;
+
+        seamRatio = seam / Math.Max(double.Epsilon, within);
+    }
+
+    private static double[,] ReadLuminance(Texture texture, CommandList commandList, int face)
+    {
+        var data = texture.GetData<byte>(commandList, face, 0);
+        var result = new double[OutputSize, OutputSize];
+        for (var y = 0; y < OutputSize; y++)
+        {
+            for (var x = 0; x < OutputSize; x++)
+            {
+                var i = (y * OutputSize + x) * 4;
+                result[y, x] = 0.2126 * data[i] + 0.7152 * data[i + 1] + 0.0722 * data[i + 2];
+            }
+        }
+        return result;
+    }
+
+    private static double[] ReadEdge(double[,] face, Edge edge)
+    {
+        var result = new double[OutputSize];
+        for (var i = 0; i < OutputSize; i++)
+        {
+            result[i] = edge switch
+            {
+                Edge.Top => face[0, i],
+                Edge.Bottom => face[OutputSize - 1, i],
+                Edge.Left => face[i, 0],
+                _ => face[i, OutputSize - 1],
+            };
+        }
+        return result;
+    }
+
+    [SkippableFact]
+    public void HighestLevelIsContinuousAcrossFaces()
+    {
+        SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan);
+
+        var game = new TestRadiancePrefilteringGgxFaceContinuity();
+        RunGameTest(game);
+
+        Assert.True(game.seamRatio < 0.5,
+            $"Mip 0 steps across cube face edges by {game.seamRatio:F2} times the variation inside a face. " +
+            "The levels the filter produces stay near 0.3, so this level does not match its neighbors.");
+    }
+}

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgxFaceContinuity.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgxFaceContinuity.cs
@@ -29,6 +29,7 @@ public class TestRadiancePrefilteringGgxFaceContinuity : GraphicTestGameBase
     private const int OutputSize = 64;
 
     private double seamRatio;
+    private double withinFaceVariation;
 
     protected override void RegisterTests()
     {
@@ -88,6 +89,7 @@ public class TestRadiancePrefilteringGgxFaceContinuity : GraphicTestGameBase
         }
         within /= faces.Length;
 
+        withinFaceVariation = within;
         seamRatio = seam / Math.Max(double.Epsilon, within);
     }
 
@@ -129,6 +131,11 @@ public class TestRadiancePrefilteringGgxFaceContinuity : GraphicTestGameBase
 
         var game = new TestRadiancePrefilteringGgxFaceContinuity();
         RunGameTest(game);
+
+        // A flat level has no seam to measure, so it would satisfy the ratio below for the wrong reason.
+        Assert.True(game.withinFaceVariation > 1.0,
+            $"Mip 0 varies by {game.withinFaceVariation:F2} between neighboring texels, so it carries no image. " +
+            "The filter returns a single averaged color when it runs at roughness 0.");
 
         Assert.True(game.seamRatio < 0.5,
             $"Mip 0 steps across cube face edges by {game.seamRatio:F2} times the variation inside a face. " +

--- a/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgxFaceContinuity.cs
+++ b/sources/engine/Stride.Graphics.Tests.11_0/TestRadiancePrefilteringGgxFaceContinuity.cs
@@ -124,11 +124,9 @@ public class TestRadiancePrefilteringGgxFaceContinuity : GraphicTestGameBase
         return result;
     }
 
-    [SkippableFact]
+    [Fact]
     public void HighestLevelIsContinuousAcrossFaces()
     {
-        SkipTestForGraphicPlatform(GraphicsPlatform.Vulkan);
-
         var game = new TestRadiancePrefilteringGgxFaceContinuity();
         RunGameTest(game);
 

--- a/sources/engine/Stride.Rendering/Rendering/ComputeEffect/GGXPrefiltering/CubemapFaceResampleShader.sdsl
+++ b/sources/engine/Stride.Rendering/Rendering/ComputeEffect/GGXPrefiltering/CubemapFaceResampleShader.sdsl
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Rendering.Images
+{
+    /// <summary>
+    /// Shader writing one face of a cubemap from a given mipmap level of another cubemap.
+    /// It reads by direction, so a texel on a face border takes the neighboring face into account instead
+    /// of clamping inside its own face.
+    /// </summary>
+    shader CubemapFaceResampleShader : Math, ImageEffectShader
+    {
+        TextureCube RadianceMap;
+
+        // The mipmap level to read
+        stage float MipLevel;
+
+        // The face being written
+        stage int Face;
+
+        override stage float4 Shading()
+        {
+            float3 direction = normalize(CubemapUtils.ConvertTexcoordsNoFlip(streams.TexCoord, Face));
+
+            return RadianceMap.SampleLevel(Texturing.LinearSampler, direction, MipLevel);
+        }
+    };
+}

--- a/sources/engine/Stride.Rendering/Rendering/ComputeEffect/GGXPrefiltering/RadiancePrefilteringGGXNoCompute.cs
+++ b/sources/engine/Stride.Rendering/Rendering/ComputeEffect/GGXPrefiltering/RadiancePrefilteringGGXNoCompute.cs
@@ -38,7 +38,7 @@ namespace Stride.Rendering.ComputeEffect.GGXPrefiltering
         /// </summary>
         public int MipmapGenerationCount { get; set; }
 
-        private ImageScaler scaler;
+        private readonly ImageEffectShader resampleShader;
 
         /// <summary>
         /// Create a new instance of the class.
@@ -48,11 +48,9 @@ namespace Stride.Rendering.ComputeEffect.GGXPrefiltering
             : base(context, "RadiancePrefilteringGGX")
         {
             shader = new ImageEffectShader("RadiancePrefilteringGGXNoComputeEffect");
+            resampleShader = new ImageEffectShader("CubemapFaceResampleShader");
             DoNotFilterHighestLevel = true;
             samplingsCount = 1024;
-
-            scaler = new ImageScaler(SamplingPattern.Expanded);
-            scaler.Initialize(context);
         }
 
         /// <summary>
@@ -107,13 +105,17 @@ namespace Stride.Rendering.ComputeEffect.GGXPrefiltering
                             var outputSubresource = 0 + faceIndex * output.MipLevelCount;
                             context.CommandList.CopyRegion(input, inputSubresource, null, output, outputSubresource);
                         }
-                        else // otherwise rescale the closest mipmap
+                        else // otherwise resample the closest mipmap
                         {
+                            // Reading by direction rather than from a single face view keeps the texels on a
+                            // face border continuous with the neighboring face. The filter cannot serve this
+                            // level, because at roughness 0 it collapses to the smallest mipmap.
                             var inputMipmapLevel = Math.Min(inputLevel, input.MipLevelCount - 1);
-                            using var inputView = input.ToTextureView(ViewType.Single, faceIndex, inputMipmapLevel);
-                            scaler.SetInput(inputView);
-                            scaler.SetOutput(outputView);
-                            scaler.Draw(context);
+                            resampleShader.Parameters.Set(CubemapFaceResampleShaderKeys.RadianceMap, input);
+                            resampleShader.Parameters.Set(CubemapFaceResampleShaderKeys.MipLevel, inputMipmapLevel);
+                            resampleShader.Parameters.Set(CubemapFaceResampleShaderKeys.Face, faceIndex);
+                            resampleShader.SetOutput(outputView);
+                            resampleShader.Draw(context);
                         }
                     }
                     else


### PR DESCRIPTION
## PR Details

**Summary**

Mip 0 of the prefiltered cubemap lost continuity around every face edge whenever the copy shortcut did not
apply, because the fallback rescaled each face on its own.

**Description**

`RadiancePrefilteringGGXNoCompute` fills mip 0 from the source when `DoNotFilterHighestLevel` is set. The
copy at `:103` serves that only while the sizes, the mip count and the format agree. Everything else went
through `ImageScaler` over a single face view, which clamps at the face border, so the border texels never
saw the neighboring face.

This replaces that fallback with `CubemapFaceResampleShader`, which reads the source by direction. A
border texel then crosses the face edge the way the hardware samples a cubemap.

Falling through to the existing filter would look like the tidier fix, and it is what the compute path
appears to do, but it does not work. At roughness 0 the GGX distribution returns a zero probability
density, the solid angle goes to infinity, and the sample mip clamps to `MipmapCount`
(`RadiancePrefilteringGGXNoComputeShader.sdsl:41-44`). Every texel reads the smallest mipmap and the level
becomes one flat color. That is why mip 0 carries a special case at all.

Measured over the 12 shared face edges, against the step between neighboring texels inside a face:

| | within-face | seam ratio |
|---|---|---|
| before, `ImageScaler` | 4.03 | 0.86 |
| falling through to the filter | 0.00 | 0.00 |
| after, resample by direction | 5.16 | 0.11 |

The middle row is the trap. A flat level reports no seam, so a continuity check alone would call it fixed.
The test asserts the level still carries an image for that reason.

**Motivation and context** — see #3334.

## Related Issue

Fixes #3334.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

**Validation status**

- *Tests*: `TestRadiancePrefilteringGgxFaceContinuity` drives the filter with an output format that differs
  from the source, which is the case `SkyboxGenerator` creates for a low dynamic range skybox. It measures
  the step across the 12 shared face edges and asserts the level still carries an image. Red at 0.86 before
  the change, green at 0.11 after, verified both ways.
- *No gold image moves.* Every cubemap in the tree takes the copy path, so nothing that is captured today
  reaches the changed branch. `Stride.Graphics.Tests.11_0` passes 5 of 5, including
  `TestRadiancePrefilteringGgx`. The skybox cases in `Stride.Graphics.Tests.10_0` pass 3 of 3.
- *Not covered*: the same roughness 0 problem sits in the compute path if its size check ever fails, and
  that path also skips the format check the no-compute path makes. Both are described in the issue and left
  alone here.
- *Editor*: not exercised.
