### PR TITLE
fix: Adjust platform detection logic in Stride.Core.targets file

### DIFF
--- a/sources/core/Stride.Core/build/Stride.Core.targets
+++ b/sources/core/Stride.Core/build/Stride.Core.targets
@@ -35,17 +35,19 @@
   -->
   <PropertyGroup>
     <!-- Default mappings -->
-    <StridePlatform></StridePlatform>
-    <StridePlatform Condition="'$(RuntimeIdentifier.StartsWith(win))'">Windows</StridePlatform>
-    <StridePlatform Condition="'$(RuntimeIdentifier.StartsWith(osx))'">macOS</StridePlatform>
-    <StridePlatform Condition="'$(RuntimeIdentifier.StartsWith(linux))'">Linux</StridePlatform>
-    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'Windows'">Windows</StridePlatform>
-    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'macOS'">macOS</StridePlatform>
-    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'UAP'">UWP</StridePlatform>
-    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'Android'">Android</StridePlatform>
-    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'iOS'">iOS</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Linux))' ">Linux</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('win'))">Windows</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('osx'))">macOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('linux'))">Linux</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('android'))">Android</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('ios'))">iOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'Windows'">Windows</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'macOS'">macOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'UAP'">UWP</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'Android'">Android</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'iOS'">iOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Windows))' ">Windows</StridePlatform>
     <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(OSX))' ">macOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Linux))' ">Linux</StridePlatform>
     <StridePlatform Condition="'$(StridePlatform)' == ''">Windows</StridePlatform>
   </PropertyGroup>
 

--- a/sources/core/Stride.Core/build/Stride.Core.targets
+++ b/sources/core/Stride.Core/build/Stride.Core.targets
@@ -35,13 +35,17 @@
   -->
   <PropertyGroup>
     <!-- Default mappings -->
-    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'Windows'">Windows</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'macOS'">macOS</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'UAP'">UWP</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'Android'">Android</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'iOS'">iOS</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('osx'))">macOS</StridePlatform>
-    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('linux'))">Linux</StridePlatform>
+    <StridePlatform></StridePlatform>
+    <StridePlatform Condition="'$(RuntimeIdentifier.StartsWith(win))'">Windows</StridePlatform>
+    <StridePlatform Condition="'$(RuntimeIdentifier.StartsWith(osx))'">macOS</StridePlatform>
+    <StridePlatform Condition="'$(RuntimeIdentifier.StartsWith(linux))'">Linux</StridePlatform>
+    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'Windows'">Windows</StridePlatform>
+    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'macOS'">macOS</StridePlatform>
+    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'UAP'">UWP</StridePlatform>
+    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'Android'">Android</StridePlatform>
+    <StridePlatform Condition="'$(TargetPlatformIdentifier)' == 'iOS'">iOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Linux))' ">Linux</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(OSX))' ">macOS</StridePlatform>
     <StridePlatform Condition="'$(StridePlatform)' == ''">Windows</StridePlatform>
   </PropertyGroup>
 

--- a/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Platform.props
+++ b/sources/sdk/Stride.Build.Sdk/Sdk/Stride.Platform.props
@@ -22,18 +22,20 @@
     <StridePlatformOriginal>$(StridePlatform)</StridePlatformOriginal>
 
     <!-- Detect platform from RuntimeIdentifier first, then TargetFramework, then OS -->
-    <StridePlatform></StridePlatform>
-    <StridePlatform Condition=" '$(RuntimeIdentifier.StartsWith(win))' ">Windows</StridePlatform>
-    <StridePlatform Condition=" '$(RuntimeIdentifier.StartsWith(osx))' ">macOS</StridePlatform>
-    <StridePlatform Condition=" '$(RuntimeIdentifier.StartsWith(linux))' ">Linux</StridePlatform>
-    <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkWindows)' ">Windows</StridePlatform>
-    <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkmacOS)' ">macOS</StridePlatform>
-    <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkUWP)' ">UWP</StridePlatform>
-    <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkAndroid)' ">Android</StridePlatform>
-    <StridePlatform Condition=" '$(StrideTargetFramework)' == '$(StrideFrameworkiOS)' ">iOS</StridePlatform>
-    <StridePlatform Condition=" '$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Linux))' ">Linux</StridePlatform>
-    <StridePlatform Condition=" '$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(OSX))' ">macOS</StridePlatform>
-    <StridePlatform Condition=" '$(StridePlatform)' == '' ">Windows</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('win'))">Windows</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('osx'))">macOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('linux'))">Linux</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('android'))">Android</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And $(RuntimeIdentifier.StartsWith('ios'))">iOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'Windows'">Windows</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'macOS'">macOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'UAP'">UWP</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'Android'">Android</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$(TargetPlatformIdentifier)' == 'iOS'">iOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Windows))' ">Windows</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(OSX))' ">macOS</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == '' And '$([MSBuild]::IsOSPlatform(Linux))' ">Linux</StridePlatform>
+    <StridePlatform Condition="'$(StridePlatform)' == ''">Windows</StridePlatform>
 
     <!-- Platform full name (may be extended with build dir suffix) -->
     <StridePlatformFullName Condition="'$(StridePlatformFullName)' == ''">$(StridePlatform)</StridePlatformFullName>


### PR DESCRIPTION
# PR Details

Temporary fix for Linux. It brings platform detection logic from Stride.Platform.props, so It makes setting `StridePlatform` msbuild variable fully optional.   

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->