### PR TITLE
Fix editor test lane instability

### DIFF
--- a/sources/editor/Stride.Core.Assets.Editor/Services/IThumbnailService.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/IThumbnailService.cs
@@ -34,6 +34,11 @@ namespace Stride.Core.Assets.Editor.Services
         bool HasStaticThumbnail(Type assetType);
 
         /// <summary>
+        /// Gets the number of thumbnails currently queued for compilation.
+        /// </summary>
+        int PendingThumbnailCount { get; }
+
+        /// <summary>
         /// Raised when a thumbnail is successfully compiled.
         /// </summary>
         event EventHandler<ThumbnailCompletedArgs> ThumbnailCompleted;

--- a/sources/editor/Stride.Editor/Thumbnails/GameStudioThumbnailService.cs
+++ b/sources/editor/Stride.Editor/Thumbnails/GameStudioThumbnailService.cs
@@ -126,6 +126,9 @@ namespace Stride.Editor.Thumbnails
         public event EventHandler<ThumbnailCompletedArgs> ThumbnailCompleted;
 
         /// <inheritdoc/>
+        public int PendingThumbnailCount { get { lock (hashLock) return thumbnailQueueHash.Count; } }
+
+        /// <inheritdoc/>
         public bool HasStaticThumbnail(Type assetType)
         {
             var compiler = (IThumbnailCompiler)compilerRegistry.GetCompiler(assetType, typeof(ThumbnailCompilationContext));

--- a/sources/editor/Stride.GameStudio.AutoTesting/Program.cs
+++ b/sources/editor/Stride.GameStudio.AutoTesting/Program.cs
@@ -17,6 +17,9 @@ namespace Stride.GameStudio.AutoTesting;
 /// </summary>
 internal static class Program
 {
+    [ThreadStatic]
+    private static bool inFirstChanceDiag;
+
     [STAThread]
     public static int Main(string[] osArgs)
     {
@@ -69,12 +72,33 @@ internal static class Program
         // capture every exception (including the swallowed ones) to a diag log.
         var diagPath = Path.Combine(Path.GetTempPath(), "autotest-diag.log");
         try { File.Delete(diagPath); } catch { }
-        void Diag(string msg) { try { File.AppendAllText(diagPath, $"{DateTime.UtcNow:HH:mm:ss.fff} {msg}\n"); } catch { } }
+        // Serialized and share-tolerant so concurrent writes don't throw inside the first-chance handler
+        var diagLock = new object();
+        void Diag(string msg)
+        {
+            try
+            {
+                lock (diagLock)
+                {
+                    using var stream = new FileStream(diagPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                    using var writer = new StreamWriter(stream);
+                    writer.WriteLine($"{DateTime.UtcNow:HH:mm:ss.fff} {msg}");
+                }
+            }
+            catch { }
+        }
         Diag($"AutoTesting.Main entered. testDll={testDll} testName={testName} gsArgs=[{string.Join(", ", gsArgs)}]");
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
             Diag($"UnhandledException terminating={e.IsTerminating}: {e.ExceptionObject}");
+        // Re-entrancy guard: an exception during Diag would re-enter this handler and overflow the stack
         AppDomain.CurrentDomain.FirstChanceException += (_, e) =>
-            Diag($"FirstChance: {e.Exception.GetType().Name}: {e.Exception.Message}");
+        {
+            if (inFirstChanceDiag)
+                return;
+            inFirstChanceDiag = true;
+            try { Diag($"FirstChance: {e.Exception.GetType().Name}: {e.Exception.Message}"); }
+            finally { inFirstChanceDiag = false; }
+        };
         AppDomain.CurrentDomain.ProcessExit += (_, _) => Diag("ProcessExit");
 
         UITestHost? host = null;

--- a/sources/editor/Stride.GameStudio.AutoTesting/UITestHost.cs
+++ b/sources/editor/Stride.GameStudio.AutoTesting/UITestHost.cs
@@ -248,6 +248,13 @@ internal sealed class UITestHost
             return session?.ServiceProvider.TryGet<GameStudioBuilderService>()?.PendingShaderCompilationCount ?? 0;
         });
 
+        // Thumbnails build on a background queue; panel captures show blank tiles unless it is drained
+        public Task WaitForThumbnails() => WaitForQueueDrained("thumbnails", () =>
+        {
+            var session = TryGetSession();
+            return session?.ServiceProvider.TryGet<Stride.Core.Assets.Editor.Services.IThumbnailService>()?.PendingThumbnailCount ?? 0;
+        });
+
         public Task WaitDispatcherIdle()
         {
             var tcs = new TaskCompletionSource();
@@ -265,6 +272,7 @@ internal sealed class UITestHost
         {
             await WaitForAssetBuild();
             await WaitForShaders();
+            await WaitForThumbnails();
             await WaitDispatcherIdle();
             await WaitFrames(1);
             await WaitForRendering();


### PR DESCRIPTION
# PR Details

Two intermittent editor CI failures:

- **Stack overflow:** an exception thrown while logging re-entered the `FirstChanceException` handler and recursed. Log writes are now serialized and the handler has a re-entrancy guard.
- **Blank thumbnails in captures:** `WaitIdle` did not drain the thumbnail queue, so slow runners captured panels with blank tiles. It now waits on `PendingThumbnailCount` like the other queues.


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->