### PR TITLE
Enable Vulkan validation layers on Windows CI

### DIFF
--- a/.github/workflows/test-enduser.yml
+++ b/.github/workflows/test-enduser.yml
@@ -168,6 +168,26 @@ jobs:
       # so the samples' Vulkan path resolves a software driver on the CI runner (no GPU).
       # On Windows the loader reads HKLM\SOFTWARE\Khronos\Vulkan\Drivers — VK_DRIVER_FILES
       # env var alone isn't reliable across runner Vulkan SDK versions.
+      # Install the Vulkan SDK for its validation layers so debug-mode samples run validated.
+      - name: Install Vulkan SDK (Windows / Vulkan)
+        if: runner.os == 'Windows' && matrix.graphics-api == 'Vulkan'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: 1.4.341.1
+          install_runtime: true
+          cache: true
+          stripdown: true
+      - name: Enable Vulkan validation layers (Windows / Vulkan)
+        if: runner.os == 'Windows' && matrix.graphics-api == 'Vulkan'
+        shell: pwsh
+        run: |
+          # Register via the registry: the loader ignores VK_LAYER_PATH for elevated processes,
+          # same as VK_DRIVER_FILES for drivers (see the Lavapipe step below)
+          $manifest = Join-Path $env:VULKAN_SDK 'Bin\VkLayer_khronos_validation.json'
+          if (-not (Test-Path $manifest)) { throw "Validation layer manifest not found: $manifest" }
+          New-Item -Path "HKLM:\SOFTWARE\Khronos\Vulkan\ExplicitLayers" -Force | Out-Null
+          New-ItemProperty -Path "HKLM:\SOFTWARE\Khronos\Vulkan\ExplicitLayers" -Name $manifest -Value 0 -PropertyType DWord -Force | Out-Null
+
       - name: Install Lavapipe and register its Vulkan ICD (Windows / Vulkan)
         if: runner.os == 'Windows' && matrix.graphics-api == 'Vulkan'
         shell: pwsh

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -126,10 +126,20 @@ jobs:
         if: matrix.graphics-api == 'Vulkan'
         uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          vulkan_version: 1.4.304.1
+          vulkan_version: 1.4.341.1
           install_runtime: true
           cache: true
           stripdown: true
+      - name: Enable Vulkan validation layers
+        if: matrix.graphics-api == 'Vulkan'
+        shell: pwsh
+        run: |
+          # Register via the registry: the loader ignores VK_LAYER_PATH for elevated processes,
+          # same as VK_DRIVER_FILES for drivers (see the Lavapipe step below)
+          $manifest = Join-Path $env:VULKAN_SDK 'Bin\VkLayer_khronos_validation.json'
+          if (-not (Test-Path $manifest)) { throw "Validation layer manifest not found: $manifest" }
+          New-Item -Path "HKLM:\SOFTWARE\Khronos\Vulkan\ExplicitLayers" -Force | Out-Null
+          New-ItemProperty -Path "HKLM:\SOFTWARE\Khronos\Vulkan\ExplicitLayers" -Name $manifest -Value 0 -PropertyType DWord -Force | Out-Null
       - name: Register Lavapipe ICD
         if: matrix.graphics-api == 'Vulkan'
         shell: pwsh

--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -234,6 +234,7 @@ namespace Stride.Engine
 #if DEBUG
             // If DEBUG, default to initializing the graphics device in debug mode
             GraphicsDeviceManager.DeviceCreationFlags |= DeviceCreationFlags.Debug;
+            GlobalLogger.GetLogger("Game").Info("Debug-built engine: requesting graphics debug device");
 #endif
 
             AutoLoadDefaultSettings = true;

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsAdapterFactory.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsAdapterFactory.Vulkan.cs
@@ -195,6 +195,7 @@ namespace Stride.Graphics
 
                 // Reset when the layer isn't actually installed; otherwise vkCreateInstance returns ErrorLayerNotPresent.
                 enableValidation = enabledLayerNames.Count > 0;
+                Log.Info($"Vulkan validation layer {(enableValidation ? "enabled" : "not found")} for debug instance");
             }
 
             var supportedExtensionNames = stackalloc VkUtf8String[]


### PR DESCRIPTION
# PR Details

Windows test and sample lanes ran without Vulkan validation; only Linux and macOS caught violations.

- Register the SDK validation layer in the registry (the loader ignores `VK_LAYER_PATH` for elevated processes).
- Pin SDK 1.4.341.1 (the 1.4.304 layer breaks pipeline creation on Lavapipe).
- Log debug device and validation status at init so runs can confirm it is active.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->