### PR TITLE
Fix build issue from NuGet.Frameworks conflict

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestMinor"
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
   },
   "msbuild-sdks": {
     // Template packages (Stride.Templates.*) compile no code; NoTargets produces the nupkg

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -81,6 +81,7 @@
     <!-- 7.3.1 matches what .NET 10 SDK 10.0.202 ships. -->
     <PackageVersion Include="NuGet.Commands" Version="7.3.1" />
     <PackageVersion Include="NuGet.Configuration" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Frameworks" Version="7.3.1" />
     <PackageVersion Include="NuGet.PackageManagement" Version="7.3.1" />
     <PackageVersion Include="NuGet.ProjectModel" Version="7.3.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -81,7 +81,6 @@
     <!-- 7.3.1 matches what .NET 10 SDK 10.0.202 ships. -->
     <PackageVersion Include="NuGet.Commands" Version="7.3.1" />
     <PackageVersion Include="NuGet.Configuration" Version="7.3.1" />
-    <PackageVersion Include="NuGet.Frameworks" Version="7.3.1" />
     <PackageVersion Include="NuGet.PackageManagement" Version="7.3.1" />
     <PackageVersion Include="NuGet.ProjectModel" Version="7.3.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -21,11 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- https://github.com/NuGet/Home/issues/13987 -->
-    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="..\..\assets\Stride.AssetCompiler\Tasks\PackAssets.cs" Link="PackAssets.cs" />
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -21,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- https://github.com/stride3d/stride/pull/3350 -->
+    <!-- MSBuild is loaded from the resolved SDK (MSBuildLocator), which brings its own NuGet.Frameworks.
+         Don't copy our (older) version to the output folder or project evaluation fails on newer SDKs. -->
     <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -21,6 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- https://github.com/stride3d/stride/pull/3350 -->
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\..\assets\Stride.AssetCompiler\Tasks\PackAssets.cs" Link="PackAssets.cs" />
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>

--- a/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
+++ b/sources/core/Stride.Core.Tasks/Stride.Core.Tasks.csproj
@@ -21,6 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- https://github.com/NuGet/Home/issues/13987 -->
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\..\assets\Stride.AssetCompiler\Tasks\PackAssets.cs" Link="PackAssets.cs" />
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

This fixes an issue I encountered with building Stride.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

When I try to build Stride, I get 9 errors similar to this:

```
106>  Stride.Core.Tasks.dll: Microsoft.Build.Exceptions.InvalidProjectFileException: The expression "[MSBuild]::GetTargetFrameworkIdentifier(net10.0-windows)" cannot be evaluated. Could not load file or assembly 'NuGet.Frameworks, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)  C:\Program Files\dotnet\sdk\10.0.400-preview.0.26322.102\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets
106>     at Microsoft.Build.Shared.ProjectErrorUtilities.ThrowInvalidProject(String errorSubCategoryResourceName, IElementLocation elementLocation, String resourceName, Object[] args)
106>     at Microsoft.Build.Shared.ProjectErrorUtilities.ThrowInvalidProject[T1,T2](IElementLocation elementLocation, String resourceName, T1 arg0, T2 arg1)
106>     at Microsoft.Build.Evaluation.Expander`2.Function.Execute(Object objectInstance, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation)
106>     at Microsoft.Build.Evaluation.Expander`2.PropertyExpander.ExpandPropertyBody(String propertyBody, Object propertyValue, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, PropertiesUseTracker propertiesUseTracker, IFileSystem fileSystem)
106>     at Microsoft.Build.Evaluation.Expander`2.PropertyExpander.ExpandPropertiesLeaveTypedAndEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, PropertiesUseTracker propertiesUseTracker, IFileSystem fileSystem)
106>     at Microsoft.Build.Evaluation.Expander`2.ExpandIntoStringLeaveEscaped(String expression, ExpanderOptions options, IElementLocation elementLocation)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluatePropertyElement(ProjectPropertyElement propertyElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluatePropertyGroupElement(ProjectPropertyGroupElement propertyGroupElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
106>     at Microsoft.Build.Evaluation.Evaluator`4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement)
106>     at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
106>     at Microsoft.Build.Evaluation.Evaluator`4.Evaluate()
106>     at Microsoft.Build.Evaluation.Evaluator`4.Evaluate(IEvaluatorData`4 data, Project project, ProjectRootElement root, ProjectLoadSettings loadSettings, Int32 maxNodeCount, PropertyDictionary`1 environmentProperties, ICollection`1 propertiesFromCommandLine, ILoggingService loggingService, IItemFactory`2 itemFactory, IToolsetProvider toolsetProvider, IDirectoryCacheFactory directoryCacheFactory, ProjectRootElementCacheBase projectRootElementCache, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, Int32 submissionId, EvaluationContext evaluationContext, Boolean interactive)
106>     at Microsoft.Build.Evaluation.Project.ProjectImpl.Reevaluate(ILoggingService loggingServiceForEvaluation, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
106>     at Microsoft.Build.Evaluation.Project.ProjectImpl.ReevaluateIfNecessary(ILoggingService loggingServiceForEvaluation, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
106>     at Microsoft.Build.Evaluation.Project.ProjectImpl.Initialize(IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, Boolean interactive)
106>     at Microsoft.Build.Evaluation.Project..ctor(String projectFile, IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, Boolean interactive)
106>     at Microsoft.Build.Evaluation.ProjectCollection.LoadProject(String fileName, IDictionary`2 globalProperties, String toolsVersion)
106>     at Stride.Core.Assets.VSProjectHelper.LoadProject(String fullProjectLocation, String configuration, String platform, Dictionary`2 extraProperties) in E:\repos\stride\sources\assets\Stride.Core.Assets\VSProjectHelper.cs:line 224
106>     at Stride.Core.Assets.Package.FindAssetsInProject(String projectFullPath, String& nameSpace) in E:\repos\stride\sources\assets\Stride.Core.Assets\Package.cs:line 1305
106>     at Stride.Core.Assets.Package.FindAssetsInProject(ICollection`1 list, Package package) in E:\repos\stride\sources\assets\Stride.Core.Assets\Package.cs:line 1343
106>     at Stride.Core.Assets.Package.ListAssetFiles(Package package, Boolean listAssetsInMsbuild, Boolean listUnregisteredAssets) in E:\repos\stride\sources\assets\Stride.Core.Assets\Package.cs:line 1296
106>     at Stride.AssetCompiler.Tasks.PackAssetsHelper.Run(Logger logger, String projectFile, String intermediatePackagePath, List`1 generatedItems, IReadOnlyList`1 assetAssemblies, String assetNamespace) in E:\repos\stride\sources\assets\Stride.AssetCompiler\Tasks\PackAssets.cs:line 100
106>     at Stride.Core.Tasks.Program.RealMain(String[] args) in E:\repos\stride\sources\core\Stride.Core.Tasks\Program.cs:line 107
106>E:\repos\stride\sources\sdk\Stride.Build.Sdk\Sdk\Sdk.targets(265,5): error MSB3073: The command "dotnet "E:\repos\stride\sources/core/Stride.Core.Tasks/bin/Debug/net10.0/Stride.Core.Tasks.dll" pack-assets "Stride.Assets.Presentation.csproj" "obj\Debug\net10.0-windows\stride"" exited with code 1.
```

* https://github.com/NuGet/Home/issues/13987
* https://github.com/NuGet/Home/issues/13746

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->