### PR TITLE
chore(deps): update MarkView.Avalonia to 12.1.0

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -127,7 +127,7 @@
   <PropertyGroup>
     <AvaloniaVersion>12.1.1</AvaloniaVersion>
     <AvaloniaBehaviorVersion>12.0.0</AvaloniaBehaviorVersion>
-    <AvaloniaMarkViewVersion>12.0.3</AvaloniaMarkViewVersion>
+    <AvaloniaMarkViewVersion>12.1.0</AvaloniaMarkViewVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />


### PR DESCRIPTION
# PR Details

Following #3276, update MarkView.Avalonia to [12.1.0](https://github.com/Kryptos-FR/MarkView.Avalonia/releases/tag/v12.1.0).

This makes images in markdown viewers scale nicely, for example in the release notes panel.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the launcher to try this change out.**