### PR TITLE
Update templates and sample code to better support pausing

### DIFF
--- a/samples/Games/JumpyJet/JumpyJet.Game/CharacterScript.cs
+++ b/samples/Games/JumpyJet/JumpyJet.Game/CharacterScript.cs
@@ -124,7 +124,7 @@ namespace JumpyJet
                 if (!isRunning)
                     continue;
 
-                var elapsedTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                var elapsedTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
                 // apply impulse on the touch/space
                 if (Input.IsKeyPressed(Keys.Space) || UserTappedScreen())

--- a/samples/Games/JumpyJet/JumpyJet.Game/PipesScript.cs
+++ b/samples/Games/JumpyJet/JumpyJet.Game/PipesScript.cs
@@ -66,7 +66,7 @@ namespace JumpyJet
             if (!isScrolling)
                 return;
 
-            var elapsedTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var elapsedTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
             for (int i = 0; i < pipeSets.Count; i++)
             {

--- a/samples/Games/SpaceEscape/SpaceEscape.Game/Background/BackgroundScript.cs
+++ b/samples/Games/SpaceEscape/SpaceEscape.Game/Background/BackgroundScript.cs
@@ -78,7 +78,7 @@ namespace SpaceEscape.Background
             if (!isScrolling)
                 return;
 
-            var elapsedTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var elapsedTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
             // Check if needed to remove the first block
             var firstBlock = levelBlocks[0];

--- a/samples/Graphics/AnimatedModel/AnimatedModel.Game/RotateEntity.cs
+++ b/samples/Graphics/AnimatedModel/AnimatedModel.Game/RotateEntity.cs
@@ -24,7 +24,7 @@ namespace AnimatedModel
                     rotationSpeed = 200f * Input.PointerEvents.Sum(x => x.DeltaPosition.X);
 
                 rotationSpeed *= 0.93f;
-                var elapsedTime = (float) Game.UpdateTime.Elapsed.TotalSeconds;
+                var elapsedTime = (float) Game.UpdateTime.WarpElapsed.TotalSeconds;
                 Entity.Transform.Rotation *= Quaternion.RotationY(rotationSpeed * elapsedTime);
             }
         }

--- a/samples/Graphics/SpriteStudioDemo/SpriteStudioDemo.Game/PlayerScript.cs
+++ b/samples/Graphics/SpriteStudioDemo/SpriteStudioDemo.Game/PlayerScript.cs
@@ -103,7 +103,7 @@ namespace SpriteStudioDemo
                 if (inputState == InputState.RunLeft || inputState == InputState.RunRight)
                 {
                     // Update Agent's position
-                    var dt = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                    var dt = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
                     Entity.Transform.Position.X += ((inputState == InputState.RunRight) ? AgentMoveDistance : -AgentMoveDistance) * dt;
 

--- a/samples/Input/TouchInputs/TouchInputs.Game/TouchInputsScript.cs
+++ b/samples/Input/TouchInputs/TouchInputs.Game/TouchInputsScript.cs
@@ -81,7 +81,7 @@ namespace TouchInputs
 
         public override void Update()
         {
-            var currentTime = Game.DrawTime.Total;
+            var currentTime = Game.UpdateTime.Total;
 
             keyDown = "";
             keyEvents = "";

--- a/samples/Particles/ParticlesSample/ParticlesSample.Game/CameraOrbitScript.cs
+++ b/samples/Particles/ParticlesSample/ParticlesSample.Game/CameraOrbitScript.cs
@@ -33,7 +33,7 @@ namespace ParticlesSample
         {
             while (Game.IsRunning)
             {
-                var elapsedTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                var elapsedTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 timeToProcess = Math.Max(timeToProcess + elapsedTime, 1.0f);
 
                 // determine if the user is currently touching the screen.

--- a/samples/Particles/ParticlesSample/ParticlesSample.Game/PrefabInstance.cs
+++ b/samples/Particles/ParticlesSample/ParticlesSample.Game/PrefabInstance.cs
@@ -115,7 +115,7 @@ namespace ParticlesSample
                 while (secondsCountdown > 0f)
                 {
                     await Script.NextFrame();
-                    secondsCountdown -= (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                    secondsCountdown -= (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 }
 
                 // Remove

--- a/samples/Particles/ParticlesSample/ParticlesSample.Game/RotateEntity.cs
+++ b/samples/Particles/ParticlesSample/ParticlesSample.Game/RotateEntity.cs
@@ -24,7 +24,7 @@ namespace ParticlesSample
                     rotationSpeed = 200f * Input.PointerEvents.Sum(x => x.DeltaPosition.X);
 
                 rotationSpeed *= 0.93f;
-                var elapsedTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                var elapsedTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 Entity.Transform.Rotation *= Quaternion.RotationY(rotationSpeed * elapsedTime);
             }
         }

--- a/samples/Physics/BepuSample/BepuSample.Game/Components/Camera/BasicCameraControllerComponent.cs
+++ b/samples/Physics/BepuSample/BepuSample.Game/Components/Camera/BasicCameraControllerComponent.cs
@@ -72,7 +72,7 @@ namespace BepuSample.Game.Components.Camera
 
         private void ProcessInput()
         {
-            float deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            float deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
             translation = Vector3.Zero;
             yaw = 0f;
             pitch = 0f;

--- a/samples/Physics/BepuSample/BepuSample.Game/Components/Camera/FindAndAttachCameraComponent.cs
+++ b/samples/Physics/BepuSample/BepuSample.Game/Components/Camera/FindAndAttachCameraComponent.cs
@@ -16,7 +16,7 @@ public class FindAndAttachCameraComponent : SyncScript
 
     public override void Update()
     {
-        var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+        var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
         var currentPosition = CameraComponent.Entity.Transform.Position;
         var currentRotation = CameraComponent.Entity.Transform.Rotation;
 

--- a/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/AnimationController.cs
+++ b/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/AnimationController.cs
@@ -123,7 +123,7 @@ namespace FirstPersonShooter.Player
 
             // Update current animation
             var currentTicks = TimeSpan.FromTicks((long)(currentTime * currentClip.Duration.Ticks));
-            var updatedTicks = currentTicks.Ticks + (long)(Game.DrawTime.Elapsed.Ticks * TimeFactor);
+            var updatedTicks = currentTicks.Ticks + (long)(Game.UpdateTime.WarpElapsed.Ticks * TimeFactor);
 
             var currentClipFinished = (updatedTicks >= currentClip.Duration.Ticks);
 

--- a/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/WeaponScript.cs
+++ b/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Player/WeaponScript.cs
@@ -56,7 +56,7 @@ namespace FirstPersonShooter.Player
                 while (secondsCountdown > 0f)
                 {
                     await Script.NextFrame();
-                    secondsCountdown -= (float) Game.UpdateTime.Elapsed.TotalSeconds;
+                    secondsCountdown -= (float) Game.UpdateTime.WarpElapsed.TotalSeconds;
                 }
 
                 remainingBullets = 9;
@@ -77,7 +77,7 @@ namespace FirstPersonShooter.Player
             bool didReload;
             reloadEvent.TryReceive(out didReload);
 
-            cooldownRemaining = (cooldownRemaining > 0) ? (cooldownRemaining - (float)this.Game.UpdateTime.Elapsed.TotalSeconds) : 0f;
+            cooldownRemaining = (cooldownRemaining > 0) ? (cooldownRemaining - (float)this.Game.UpdateTime.WarpElapsed.TotalSeconds) : 0f;
             if (cooldownRemaining > 0)
                 return; // Can't shoot yet
 

--- a/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Trigger/TriggerScript.cs
+++ b/samples/Templates/FirstPersonShooter/FirstPersonShooter/FirstPersonShooter.Game/Trigger/TriggerScript.cs
@@ -59,7 +59,7 @@ namespace FirstPersonShooter
                 while (secondsCountdown > 0f)
                 {
                     await Script.NextFrame();
-                    secondsCountdown -= (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                    secondsCountdown -= (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 }
 
                 // Remove

--- a/samples/Templates/Platformer2D/Platformer2D/Platformer2D.Game/Gameplay/CoinRotation.cs
+++ b/samples/Templates/Platformer2D/Platformer2D/Platformer2D.Game/Gameplay/CoinRotation.cs
@@ -19,7 +19,7 @@ public class CoinRotation : SyncScript
 
     public override void Update()
     {
-        animationTimer += (float) Game.UpdateTime.Elapsed.TotalSeconds;
+        animationTimer += (float) Game.UpdateTime.WarpElapsed.TotalSeconds;
         
         if (animationTimer >= animationInterval)
         {

--- a/samples/Templates/Platformer2D/Platformer2D/Platformer2D.Game/PlayerController.cs
+++ b/samples/Templates/Platformer2D/Platformer2D/Platformer2D.Game/PlayerController.cs
@@ -93,7 +93,7 @@ public class PlayerController : SyncScript
     
     private void HandleAnimation(bool isMoving)
     {
-        animationTimer += (float) Game.UpdateTime.Elapsed.TotalSeconds;
+        animationTimer += (float) Game.UpdateTime.WarpElapsed.TotalSeconds;
         
         if (CharacterComponent.IsGrounded && !isMoving)
         {

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/BasicCameraController.cs
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/BasicCameraController.cs
@@ -157,7 +157,7 @@ namespace ThirdPersonPlatformer
 
         private void UpdateTransform()
         {
-            var elapsedTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var elapsedTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
             translation *= elapsedTime;
             yaw *= elapsedTime;

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Player/AnimationController.cs
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Player/AnimationController.cs
@@ -139,8 +139,7 @@ namespace ThirdPersonPlatformer.Player
                 animationClipWalkLerp2 = AnimationRun;
             }
 
-            // Use DrawTime rather than UpdateTime
-            var time = Game.DrawTime;
+            var time = Game.UpdateTime;
             // This update function will account for animation with different durations, keeping a current time relative to the blended maximum duration
             long blendedMaxDuration = 0;
             blendedMaxDuration =
@@ -150,7 +149,7 @@ namespace ThirdPersonPlatformer.Player
 
             currentTicks = blendedMaxDuration == 0
                 ? TimeSpan.Zero
-                : TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.Elapsed.Ticks * TimeFactor)) %
+                : TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.WarpElapsed.Ticks * TimeFactor)) %
                                      blendedMaxDuration);
 
             currentTime = ((double)currentTicks.Ticks / (double)blendedMaxDuration);
@@ -160,7 +159,7 @@ namespace ThirdPersonPlatformer.Player
         {
             var speedFactor = 1;
             var currentTicks = TimeSpan.FromTicks((long)(currentTime * AnimationJumpStart.Duration.Ticks));
-            var updatedTicks = currentTicks.Ticks + (long)(Game.DrawTime.Elapsed.Ticks * TimeFactor * speedFactor);
+            var updatedTicks = currentTicks.Ticks + (long)(Game.UpdateTime.WarpElapsed.Ticks * TimeFactor * speedFactor);
 
             if (updatedTicks < AnimationJumpStart.Duration.Ticks)
             {
@@ -177,10 +176,9 @@ namespace ThirdPersonPlatformer.Player
 
         private void UpdateAirborne()
         {
-            // Use DrawTime rather than UpdateTime
-            var time = Game.DrawTime;
+            var time = Game.UpdateTime;
             var currentTicks = TimeSpan.FromTicks((long)(currentTime * AnimationJumpMid.Duration.Ticks));
-            currentTicks = TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.Elapsed.Ticks * TimeFactor)) %
+            currentTicks = TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.WarpElapsed.Ticks * TimeFactor)) %
                                      AnimationJumpMid.Duration.Ticks);
             currentTime = ((double)currentTicks.Ticks / (double)AnimationJumpMid.Duration.Ticks);
         }
@@ -189,7 +187,7 @@ namespace ThirdPersonPlatformer.Player
         {
             var speedFactor = 1;
             var currentTicks = TimeSpan.FromTicks((long)(currentTime * AnimationJumpEnd.Duration.Ticks));
-            var updatedTicks = currentTicks.Ticks + (long) (Game.DrawTime.Elapsed.Ticks * TimeFactor * speedFactor);
+            var updatedTicks = currentTicks.Ticks + (long) (Game.UpdateTime.WarpElapsed.Ticks * TimeFactor * speedFactor);
 
             if (updatedTicks < AnimationJumpEnd.Duration.Ticks)
             {

--- a/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Player/PlayerController.cs
+++ b/samples/Templates/ThirdPersonPlatformer/ThirdPersonPlatformer/ThirdPersonPlatformer.Game/Player/PlayerController.cs
@@ -61,7 +61,6 @@ namespace ThirdPersonPlatformer.Player
         /// </summary>
         public override void Update()
         {
-            // var dt = Game.UpdateTime.Elapsed.Milliseconds * 0.001;
             Move(MaxRunSpeed);
 
             Jump();

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Core/Utils.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Core/Utils.cs
@@ -77,7 +77,7 @@ namespace TopDownRPG.Core
                 while (secondsCountdown > 0f)
                 {
                     await script.Script.NextFrame();
-                    secondsCountdown -= (float)script.Game.UpdateTime.Elapsed.TotalSeconds;
+                    secondsCountdown -= (float)script.Game.UpdateTime.WarpElapsed.TotalSeconds;
                 }
 
                 // Remove

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Gameplay/CoinScript.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Gameplay/CoinScript.cs
@@ -43,7 +43,7 @@ namespace TopDownRPG.Gameplay
 
         public void UpdateAnimation()
         {
-            var dt = (float) Game.UpdateTime.Elapsed.TotalSeconds;
+            var dt = (float) Game.UpdateTime.WarpElapsed.TotalSeconds;
             Entity.Transform.Rotation *= Quaternion.RotationMatrix(Matrix.RotationY(spinSpeed * (float)(dt * Math.PI)));
 
             if (!activated)

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Gameplay/CrateScript.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Gameplay/CrateScript.cs
@@ -46,7 +46,7 @@ namespace TopDownRPG.Gameplay
             if (!activated)
                 return;
 
-            var dt = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var dt = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
             animationTime += dt * 8;
             var coinHeight = Math.Max(0, Math.Sin(animationTime));

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Gameplay/LootCoinScript.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Gameplay/LootCoinScript.cs
@@ -44,7 +44,7 @@ namespace TopDownRPG.Gameplay
 
         public void UpdateAnimation()
         {
-            var dt = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var dt = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
             if (!activated)
                 return;

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Player/AnimationController.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Player/AnimationController.cs
@@ -121,8 +121,7 @@ namespace TopDownRPG.Player
                 animationClipWalkLerp2 = AnimationRun;
             }
 
-            // Use DrawTime rather than UpdateTime
-            var time = Game.DrawTime;
+            var time = Game.UpdateTime;
             // This update function will account for animation with different durations, keeping a current time relative to the blended maximum duration
             long blendedMaxDuration = 0;
             blendedMaxDuration =
@@ -132,7 +131,7 @@ namespace TopDownRPG.Player
 
             currentTicks = blendedMaxDuration == 0
                 ? TimeSpan.Zero
-                : TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.Elapsed.Ticks * TimeFactor)) %
+                : TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.WarpElapsed.Ticks * TimeFactor)) %
                                      blendedMaxDuration);
 
             currentTime = ((double)currentTicks.Ticks / (double)blendedMaxDuration);
@@ -142,7 +141,7 @@ namespace TopDownRPG.Player
         {
             var speedFactor = 1;
             var currentTicks = TimeSpan.FromTicks((long)(currentTime * AnimationPunch.Duration.Ticks));
-            var updatedTicks = currentTicks.Ticks + (long)(Game.DrawTime.Elapsed.Ticks * TimeFactor * speedFactor);
+            var updatedTicks = currentTicks.Ticks + (long)(Game.UpdateTime.WarpElapsed.Ticks * TimeFactor * speedFactor);
 
             if (updatedTicks < AnimationPunch.Duration.Ticks)
             {

--- a/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Player/PlayerController.cs
+++ b/samples/Templates/TopDownRPG/TopDownRPG/TopDownRPG.Game/Player/PlayerController.cs
@@ -123,7 +123,7 @@ namespace TopDownRPG.Player
 
         private void Attack()
         {
-            var dt = (float) Game.UpdateTime.Elapsed.TotalSeconds;
+            var dt = (float) Game.UpdateTime.WarpElapsed.TotalSeconds;
             attackCooldown = (attackCooldown > 0) ? attackCooldown - dt : 0f;
 
             PunchCollision.Enabled = (attackCooldown > 0);

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/DeltaTimeDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/DeltaTimeDemo.cs
@@ -30,7 +30,7 @@ namespace CSharpBeginner.Code
         public override void Update()
         {
             /// We can access Delta time through the static 'Game' object.
-            var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
             // We update the total time
             totalTime += deltaTime;

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/KeyboardInputDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/KeyboardInputDemo.cs
@@ -27,7 +27,7 @@ namespace CSharpBeginner.Code
                 DebugText.Print("Hold the 1 key down to rotate the blue teapot", new Int2(340, 500));
                 if (Input.IsKeyDown(Keys.D1))
                 {
-                    var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                    var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                     BlueTeapot.Transform.Rotation *= Quaternion.RotationY(0.3f * deltaTime);
                 }
 

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/LerpDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/LerpDemo.cs
@@ -30,7 +30,7 @@ namespace CSharpBeginner.Code
         public override void Update()
         {
             // Keep track of elapsed time
-            var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
             elapsedTime += deltaTime;
 
             // In order to make use of the lerp method, we need to calculate the 'interpolation value': a value going from 0 to 1.

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/MouseInputDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/MouseInputDemo.cs
@@ -30,7 +30,7 @@ namespace CSharpBeginner.Code
                 DebugText.Print("Hold the left mouse button down to rotate the blue teapot", new Int2(400, 600));
                 if (Input.IsMouseButtonDown(MouseButton.Left))
                 {
-                    var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                    var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                     BlueTeapot.Transform.Rotation *= Quaternion.RotationY(0.4f * deltaTime);
                 }
 

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/RemoveEntitiesDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/RemoveEntitiesDemo.cs
@@ -49,7 +49,7 @@ namespace CSharpBeginner.Code
         public override void Update()
         {
             // We use a simple timer
-            timer += (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            timer += (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
             if (timer > currentTimer)
             {
                 // If the entities exist, we remove them from the scene

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/TutorialUI.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/TutorialUI.cs
@@ -124,7 +124,7 @@ namespace CSharpBeginner.Code
         {
             if (startTransform != null && cameraLerpTimer < cameraLerpTime)
             {
-                var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 cameraLerpTimer += deltaTime;
                 var lerpTime = cameraLerpTimer / cameraLerpTime;
                 Camera.Transform.Position = Vector3.Lerp(startTransform.Position, targetTransform.Position, lerpTime);

--- a/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/VirtualButtonsDemo.cs
+++ b/samples/Tutorials/CSharpBeginner/CSharpBeginner/CSharpBeginner.Game/Code/VirtualButtonsDemo.cs
@@ -49,7 +49,7 @@ namespace CSharpBeginner.Code
             // Note: Gamepad sticks can be a negative value. For this example we only check if the value is higher than 0
             if (forward > 0)
             {
-                var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 BlueTeapot.Transform.Rotation *= Quaternion.RotationY(0.6f * forward * deltaTime);
             }
             

--- a/samples/Tutorials/CSharpIntermediate/CSharpIntermediate/CSharpIntermediate.Game/11_Navigation/NavigateCharacter.cs
+++ b/samples/Tutorials/CSharpIntermediate/CSharpIntermediate/CSharpIntermediate.Game/11_Navigation/NavigateCharacter.cs
@@ -48,7 +48,7 @@ namespace CSharpIntermediate.Code
                 return;
             }
 
-            var deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
             var curPosition = RegularCharacter.Transform.WorldMatrix.TranslationVector;
             var nextWaypointPosition = waypoints[waypointIndex];
             var distanceToWaypoint = Vector3.Distance(curPosition, nextWaypointPosition);

--- a/samples/Tutorials/CSharpIntermediate/CSharpIntermediate/CSharpIntermediate.Game/Utils/OmniDirectionMovement.cs
+++ b/samples/Tutorials/CSharpIntermediate/CSharpIntermediate/CSharpIntermediate.Game/Utils/OmniDirectionMovement.cs
@@ -55,7 +55,7 @@ namespace CSharpIntermediate.Code
                 movement.X -= 1;
             }
 
-            var delta = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+            var delta = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
             Entity.Transform.Position += movement * delta * MoveSpeed;
         }
     }

--- a/samples/UI/GameMenu/GameMenu.Game/MainScript.cs
+++ b/samples/UI/GameMenu/GameMenu.Game/MainScript.cs
@@ -198,7 +198,7 @@ namespace GameMenu
             {
                 await Script.NextFrame();
 
-                gaugePercentage = Math.Min(1f, gaugePercentage + (float)Game.UpdateTime.Elapsed.TotalSeconds * 0.02f);
+                gaugePercentage = Math.Min(1f, gaugePercentage + (float)Game.UpdateTime.WarpElapsed.TotalSeconds * 0.02f);
 
                 var gaugeCurrentRegion = lifebarGaugeImage.Region;
                 gaugeCurrentRegion.Width = gaugePercentage * gaugeBarRegion.Width;

--- a/samples/UI/UIParticles/UIParticles.Game/SplashScript.cs
+++ b/samples/UI/UIParticles/UIParticles.Game/SplashScript.cs
@@ -211,7 +211,7 @@ namespace UIParticles
                 while (secondsCountdown > 0f)
                 {
                     await Script.NextFrame();
-                    secondsCountdown -= (float)Game.UpdateTime.Elapsed.TotalSeconds;
+                    secondsCountdown -= (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
                 }
 
                 // Remove
@@ -283,7 +283,7 @@ namespace UIParticles
 
         private void DrawFuse()
         {
-            fusePercentage = Math.Min(1f, fusePercentage - (float)Game.UpdateTime.Elapsed.TotalSeconds * 0.04f);
+            fusePercentage = Math.Min(1f, fusePercentage - (float)Game.UpdateTime.WarpElapsed.TotalSeconds * 0.04f);
 
             var gaugeCurrentRegion = lifeBarGaugeImage.Region;
             gaugeCurrentRegion.Width = Math.Max(1, fusePercentage * gaugeBarRegion.Width);
@@ -323,7 +323,7 @@ namespace UIParticles
 
         private void NewGameState()
         {
-            fusePercentage = Math.Min(1f, fusePercentage - (float)Game.UpdateTime.Elapsed.TotalSeconds * 0.03f);
+            fusePercentage = Math.Min(1f, fusePercentage - (float)Game.UpdateTime.WarpElapsed.TotalSeconds * 0.03f);
             DrawFuse();
 
             if (desiredState == GameState.EndGame || fusePercentage <= 0f)

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Animation/AnimationBlend.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Animation/AnimationBlend.cs
@@ -58,8 +58,7 @@ public class ##Scriptname## : SyncScript, IBlendTreeBuilder
 
     public override void Update()
     {
-        // Use DrawTime rather than UpdateTime
-        var time = Game.DrawTime;
+        var time = Game.UpdateTime;
 
         // This update function will account for animation with different durations, keeping a current time relative to the blended maximum duration
         long blendedMaxDuration = 0;
@@ -67,7 +66,7 @@ public class ##Scriptname## : SyncScript, IBlendTreeBuilder
 
         var currentTicks = TimeSpan.FromTicks((long)(currentTime * blendedMaxDuration));
 
-        currentTicks = blendedMaxDuration == 0 ? TimeSpan.Zero : TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.Elapsed.Ticks * TimeFactor)) % blendedMaxDuration);
+        currentTicks = blendedMaxDuration == 0 ? TimeSpan.Zero : TimeSpan.FromTicks((currentTicks.Ticks + (long)(time.WarpElapsed.Ticks * TimeFactor)) % blendedMaxDuration);
 
         currentTime = (currentTicks.Ticks/(double) blendedMaxDuration);
     }

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/BasicCameraController.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/BasicCameraController.cs
@@ -59,7 +59,7 @@ public class ##Scriptname## : SyncScript
 
     private void ProcessInput()
     {
-        float deltaTime = (float)Game.UpdateTime.Elapsed.TotalSeconds;
+        float deltaTime = (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
         translation = Vector3.Zero;
         yaw = 0f;
         pitch = 0f;

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/FpsCamera.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/FpsCamera.cs
@@ -156,7 +156,7 @@ public class ##Scriptname## : AsyncScript
         }
 
         // Compute translation speed according to framerate and modifiers
-        var translationSpeed = MoveSpeed * (float)Game.UpdateTime.Elapsed.TotalSeconds;
+        var translationSpeed = MoveSpeed * (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
         var oldPitch = Pitch;
 
@@ -170,7 +170,7 @@ public class ##Scriptname## : AsyncScript
         desiredYaw = Yaw + deltaYaw;
 
         // Perform orientation transition
-        var rotationAdaptation = (float)Game.UpdateTime.Elapsed.TotalSeconds * RotationAdaptationSpeed;
+        var rotationAdaptation = (float)Game.UpdateTime.WarpElapsed.TotalSeconds * RotationAdaptationSpeed;
         Yaw = Math.Abs(deltaYaw) < rotationAdaptation ? desiredYaw : Yaw + rotationAdaptation * Math.Sign(deltaYaw);
         Pitch = Math.Abs(deltaPitch) < rotationAdaptation ? desiredPitch : Pitch + rotationAdaptation * Math.Sign(deltaPitch);
 

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/FreeCamera.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Camera/FreeCamera.cs
@@ -173,7 +173,7 @@ public class FreeCamera : AsyncScript
         }
 
         // Compute translation speed according to framerate and modifiers
-        float translationSpeed = MoveSpeed * (float)Game.UpdateTime.Elapsed.TotalSeconds;
+        float translationSpeed = MoveSpeed * (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
         if (Input.IsKeyDown(Keys.LeftShift) || Input.IsKeyDown(Keys.RightShift))
             translationSpeed *= 10;
 
@@ -193,7 +193,7 @@ public class FreeCamera : AsyncScript
         var isAdaptingOrientation = !MathUtil.NearEqual(deltaPitch, 0) || !MathUtil.NearEqual(deltaYaw, 0);
 
         // Perform orientation transition
-        var rotationAdaptation = (float)Game.UpdateTime.Elapsed.TotalSeconds * RotationAdaptationSpeed;
+        var rotationAdaptation = (float)Game.UpdateTime.WarpElapsed.TotalSeconds * RotationAdaptationSpeed;
         Yaw = Math.Abs(deltaYaw) < rotationAdaptation ? desiredYaw : Yaw + rotationAdaptation * Math.Sign(deltaYaw);
         Pitch = Math.Abs(deltaPitch) < rotationAdaptation ? desiredPitch : Pitch + rotationAdaptation * Math.Sign(deltaPitch);
 

--- a/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Physics/PlayerController.cs
+++ b/sources/editor/Stride.Assets.Presentation/Templates/Assets/Scripts/Physics/PlayerController.cs
@@ -97,7 +97,7 @@ public class ##Scriptname## : SyncScript
         var rotationDelta = Input.MouseDelta;
 
         // Compute translation speed according to framerate and modifiers
-        var translationSpeed = Speed * (float)Game.UpdateTime.Elapsed.TotalSeconds;
+        var translationSpeed = Speed * (float)Game.UpdateTime.WarpElapsed.TotalSeconds;
 
         // Take shortest path
         var deltaPitch = desiredPitch - pitch;
@@ -109,7 +109,7 @@ public class ##Scriptname## : SyncScript
         desiredYaw = yaw + deltaYaw;
 
         // Perform orientation transition
-        var rotationAdaptation = (float)Game.UpdateTime.Elapsed.TotalSeconds * RotationAdaptationSpeed;
+        var rotationAdaptation = (float)Game.UpdateTime.WarpElapsed.TotalSeconds * RotationAdaptationSpeed;
         yaw = Math.Abs(deltaYaw) < rotationAdaptation ? desiredYaw : yaw + rotationAdaptation * Math.Sign(deltaYaw);
         pitch = Math.Abs(deltaPitch) < rotationAdaptation ? desiredPitch : pitch + rotationAdaptation * Math.Sign(deltaPitch);
 


### PR DESCRIPTION
# PR Details

A couple places incorrectly used `Game.DrawTime` in an `Update` method. I replaced them with with `Game.UpdateTime`.

https://github.com/stride3d/stride/discussions/2999 says that the proper way to do game pausing for animations, particles, and physics is to set `Game.UpdateTime.Factor` to zero. However, most of the sample code used `Game.UpdateTime.Elapsed` instead of `Game.UpdateTime.WarpElapsed`. `Game.UpdateTime.WarpElapsed` is equal to `Game.UpdateTime.Factor * Game.UpdateTime.Elapsed`. Both are automatically calculated every frame, so there is no performance difference for using one over the other.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**