### PR TITLE
chore: update vulnerable packages in Directory.Packages.props

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -56,7 +56,7 @@
   </ItemGroup>
   <!-- Other dependencies -->
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.4.0" />
+    <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" />
     <PackageVersion Include="JetBrains.Rider.PathLocator" Version="1.0.12" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
@@ -91,7 +91,7 @@
     <PackageVersion Include="Stride.GNU.Getopt" Version="3.0.0" />
     <PackageVersion Include="Stride.GNU.Gettext" Version="3.0.0" />
     <PackageVersion Include="Stride.Mono.TextTemplating" Version="2.1.0-preview-0009-g0d0b6db3ca" />
-    <PackageVersion Include="SSH.NET" Version="2023.0.1" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.Management" Version="10.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Reactive.Linq" Version="6.1.0" />


### PR DESCRIPTION
# PR Details

This PR updates vulnerable packages in `Directory.Packages.props`

- AngleSharp: 1.4.0 → 1.7.1
- SSH.NET: 2023.0.1 → 2026.0.0

@xen2, SSH.NET appears to be used for remote deployment credentials/launch (Linux/macOS path). I don't expect breaking changes, but remote deployment should be tested.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue
n/a
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->

