### PR TITLE
chore: Removed unreferenced NuGet packages

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -20,7 +20,6 @@
     <PackageVersion Include="Microsoft.Direct3D.D3D12" Version="1.619.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0-preview.4" />
-    <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.TemplateEngine.IDE" Version="10.0.100" />
     <PackageVersion Include="Microsoft.TemplateEngine.Edge" Version="10.0.100" />
@@ -49,7 +48,6 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="10.0.0" />
-    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="Vortice.Vulkan" Version="3.0.3" />
     <PackageVersion Include="WinPixEventRuntime" Version="1.0.240308001" />
   </ItemGroup>

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -48,7 +48,6 @@
     <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="$(SilkVersion)" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
-    <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="10.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="Vortice.Vulkan" Version="3.0.3" />
@@ -59,11 +58,8 @@
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" />
     <PackageVersion Include="JetBrains.Rider.PathLocator" Version="1.0.12" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <!-- 18.3.3 matches what .NET 10 SDK 10.0.202 ships. -->
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.3.3" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="18.3.3" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.3.3" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.12" />

--- a/sources/core/Stride.Core/Stride.Core.csproj
+++ b/sources/core/Stride.Core/Stride.Core.csproj
@@ -17,11 +17,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <Compile Include="..\..\shared\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>

--- a/sources/engine/Stride.Engine/Stride.Engine.csproj
+++ b/sources/engine/Stride.Engine/Stride.Engine.csproj
@@ -29,7 +29,6 @@
     <None Include="..\Stride.Assets.Generators\bin\$(Configuration)\netstandard2.0\Stride.Assets.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" />
     <ProjectReference Include="..\Stride.Audio\Stride.Audio.csproj" />
     <ProjectReference Include="..\Stride.Rendering\Stride.Rendering.csproj" />
     <ProjectReference Include="..\Stride.VirtualReality\Stride.VirtualReality.csproj" />


### PR DESCRIPTION
# PR Details

This PR removes unused NuGet package references to clean up dependency management.

- Microsoft.NETCore.Platforms
- System.Memory
- System.ValueTuple
- Microsoft.AspNet.WebApi.Client
- Microsoft.Bcl.AsyncInterfaces
- Microsoft.Bcl.HashCode

Direct PackageReference entries were removed where present; remaining usages (if any) are only transitive.

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->