### PR TITLE
feat: GameStudio: show where a dragged entity will land in the entity tree

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityFolderViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityFolderViewModel.cs
@@ -60,6 +60,14 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
         /// <inheritdoc/>
         public override IEnumerable<EntityViewModel> InnerSubEntities => Children.SelectMany(x => x.InnerSubEntities);
 
+        /// <inheritdoc/>
+        /// <remarks>
+        /// A folder has no index in the asset, because <see cref="EntityDesign.Folder"/> holds a path only. Folders are
+        /// also sorted by name, and they always come before the entities. Therefore an item cannot be put before or
+        /// after a folder.
+        /// </remarks>
+        protected override bool SupportsInsertion => false;
+
         [NotNull]
         public ICommandBase RenameCommand { get; }
 

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyItemViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyItemViewModel.cs
@@ -434,7 +434,16 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
                     }
                     if (checkSameParent && Children.Contains(entity))
                     {
-                        noOpMessage = $"Already a child of {parentName}";
+                        // The entity keeps its parent and its folder, but the move still changes its order. It changes
+                        // nothing only if it is already at the target index. MoveChildren corrects the index for an
+                        // entity that it removes from this item, therefore the entity goes to the index before it.
+                        if (Owner.IndexOfEntity(entity) == index - 1)
+                        {
+                            noOpMessage = $"Already the last child of {parentName}";
+                            continue;
+                        }
+                        message = $"Move to the end of {parentName}";
+                        accepted = true;
                         continue;
                     }
                     var currentParent = Parent;

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyItemViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/EntityHierarchyEditor/ViewModels/EntityHierarchyItemViewModel.cs
@@ -108,6 +108,15 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
 
         public virtual bool IsEditing { get => isEditing; set => SetValue(ref isEditing, value); }
 
+        /// <summary>
+        /// Gets whether items can be inserted before or after this item.
+        /// </summary>
+        /// <remarks>
+        /// An item that has no position in the asset cannot accept an insertion. The drop then applies to the item
+        /// itself. Therefore the caller adds the items as children of this item.
+        /// </remarks>
+        protected virtual bool SupportsInsertion => true;
+
         public bool IsExpanded { get => isExpanded; set => SetValue(ref isExpanded, value); }
 
         /// <summary>
@@ -369,17 +378,32 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             }
         }
 
-        protected virtual bool CanAddOrInsertChildren([NotNull] IReadOnlyCollection<object> children, bool checkSameParent, AddChildModifiers modifiers, int index, [NotNull] out string message)
+        /// <summary>
+        /// Gets how this item accepts the given children.
+        /// </summary>
+        /// <param name="children">The children to add or to insert.</param>
+        /// <param name="checkSameParent">True to give a no-op when a child is already a child of this item.</param>
+        /// <param name="modifiers">The modifier keys currently active.</param>
+        /// <param name="index">The index at which the children go.</param>
+        /// <param name="message">The feedback message that can be used in the user interface.</param>
+        /// <remarks>
+        /// A rejected child stops the check immediately. If no child is rejected and no child is accepted, but a child
+        /// changes nothing, the result is <see cref="DropAcceptance.NoOp"/>. Therefore a selection that mixes items
+        /// which are already here with items which are not stays accepted, and it moves only the second group.
+        /// </remarks>
+        protected virtual DropAcceptance CanAddOrInsertChildren([NotNull] IReadOnlyCollection<object> children, bool checkSameParent, AddChildModifiers modifiers, int index, [NotNull] out string message)
         {
             var root = Owner as EntityHierarchyRootViewModel ?? EntityHierarchyEditorViewModel.GetRoot((EntityViewModel)Owner);
             if (root.IsLoading)
             {
                 message = "Loading. Please wait";
-                return false;
+                return DropAcceptance.Rejected;
             }
 
             message = "Empty selection";
             var parentName = this is EntityHierarchyRootViewModel ? "root level" : (!string.IsNullOrWhiteSpace(Name) ? Name : "this location");
+            string noOpMessage = null;
+            var accepted = false;
 
             foreach (var child in children)
             {
@@ -389,28 +413,29 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
                     if (policy != null)
                     {
                         if (!policy.CanAddOrInsert(this, asset, modifiers, index, out message, parentName))
-                            return false;
+                            return DropAcceptance.Rejected;
+                        accepted = true;
                         continue;
                     }
                     message = $"Can't add {asset.AssetType.Name}s here";
-                    return false;
+                    return DropAcceptance.Rejected;
                 }
                 if (index > Owner.EntityCount)
                 {
                     message = "Index out of range";
-                    return false;
+                    return DropAcceptance.Rejected;
                 }
                 if (child is EntityViewModel entity)
                 {
                     if (entity == this)
                     {
-                        message = "Can't drop an entity on itself or its children";
-                        return false;
+                        noOpMessage = "Nothing to move";
+                        continue;
                     }
                     if (checkSameParent && Children.Contains(entity))
                     {
-                        message = "Entity already has this parent";
-                        return false;
+                        noOpMessage = $"Already a child of {parentName}";
+                        continue;
                     }
                     var currentParent = Parent;
                     while (currentParent != null)
@@ -418,7 +443,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
                         if (currentParent == entity)
                         {
                             message = "Can't drop an entity on itself or its children";
-                            return false;
+                            return DropAcceptance.Rejected;
                         }
                         currentParent = currentParent.Parent;
                     }
@@ -426,31 +451,33 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
                     if (Editor.GatherAllBasePartAssets(entity, true).Contains(Asset.Id))
                     {
                         message = "Entity depends on this asset";
-                        return false;
+                        return DropAcceptance.Rejected;
                     }
 
                     // Accepting entities
                     message = (modifiers & AddChildModifiers.Alt) != AddChildModifiers.Alt
                         ? $"Add as a child to {parentName}\r\n(Hold Alt to maintain world position)"
                         : $"Add as a child to {parentName}\r\n(Release Alt to maintain local position)";
+                    accepted = true;
                     continue;
                 }
                 if (child is EntityFolderViewModel folder)
                 {
-                    if (Folders.Any(x => string.Equals(x.Name, folder.Name, EntityFolderViewModel.FolderCase)))
-                    {
-                        message = "A folder with the same name already exists";
-                        return false;
-                    }
+                    // A folder that is already here matches its own name. Therefore the no-op cases come first.
                     if (folder == this)
                     {
-                        message = "Can't drop a folder on itself or its children";
-                        return false;
+                        noOpMessage = "Nothing to move";
+                        continue;
                     }
                     if (Children.Contains(folder))
                     {
-                        message = "Folder already has this parent";
-                        return false;
+                        noOpMessage = $"Already a child of {parentName}";
+                        continue;
+                    }
+                    if (Folders.Any(x => string.Equals(x.Name, folder.Name, EntityFolderViewModel.FolderCase)))
+                    {
+                        message = "A folder with the same name already exists";
+                        return DropAcceptance.Rejected;
                     }
                     var currentParent = Parent;
                     while (currentParent != null)
@@ -458,7 +485,7 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
                         if (currentParent == folder)
                         {
                             message = "Can't drop a folder on itself or its children";
-                            return false;
+                            return DropAcceptance.Rejected;
                         }
                         currentParent = currentParent.Parent;
                     }
@@ -466,17 +493,24 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
                     if (folder.TransformChildren.SelectMany(e => Editor.GatherAllBasePartAssets(e, true)).Contains(Asset.Id))
                     {
                         message = "Folder depends on this asset";
-                        return false;
+                        return DropAcceptance.Rejected;
                     }
 
                     // Accepting folders
                     message = $"Move the selection to {parentName}";
+                    accepted = true;
                     continue;
                 }
                 message = DragDropBehavior.InvalidDropAreaMessage;
-                return false;
+                return DropAcceptance.Rejected;
             }
-            return true;
+
+            if (!accepted && noOpMessage != null)
+            {
+                message = noOpMessage;
+                return DropAcceptance.NoOp;
+            }
+            return DropAcceptance.Accepted;
         }
 
         private static Vector3 CalculateSceneOffset([NotNull] EntityHierarchyElementViewModel element)
@@ -734,16 +768,28 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             return 0;
         }
 
-        /// <inheritdoc/>
-        bool IAddChildViewModel.CanAddChildren(IReadOnlyCollection<object> children, AddChildModifiers modifiers, out string message)
+        private DropAcceptance CheckAddChildren([NotNull] IReadOnlyCollection<object> children, AddChildModifiers modifiers, [NotNull] out string message)
         {
             var addIndex = GetAddIndex(children);
             if (addIndex < -1)
             {
                 message = DragDropBehavior.InvalidDropAreaMessage;
-                return false;
+                return DropAcceptance.Rejected;
             }
             return CanAddOrInsertChildren(children, true, modifiers, addIndex, out message);
+        }
+
+        /// <inheritdoc/>
+        bool IAddChildViewModel.CanAddChildren(IReadOnlyCollection<object> children, AddChildModifiers modifiers, out string message)
+        {
+            // A no-op gives false here, because the caller of this method then does the operation.
+            return CheckAddChildren(children, modifiers, out message) == DropAcceptance.Accepted;
+        }
+
+        /// <inheritdoc/>
+        DropAcceptance IAddChildViewModel.GetAddChildrenAcceptance(IReadOnlyCollection<object> children, AddChildModifiers modifiers, out string message)
+        {
+            return CheckAddChildren(children, modifiers, out message);
         }
 
         /// <inheritdoc/>
@@ -752,33 +798,55 @@ namespace Stride.Assets.Presentation.AssetEditors.EntityHierarchyEditor.ViewMode
             MoveChildren(children, modifiers, GetAddIndex(children));
         }
 
-        /// <inheritdoc/>
-        bool IInsertChildViewModel.CanInsertChildren(IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, out string message)
+        private DropAcceptance CheckInsertChildren([NotNull] IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, [NotNull] out string message)
         {
+            if (!SupportsInsertion)
+            {
+                // The caller then adds the items as children of this item instead, and it replaces this message.
+                message = DragDropBehavior.InvalidDropAreaMessage;
+                return DropAcceptance.Rejected;
+            }
+
             var parentName = Parent is SceneRootViewModel ? "root level" : (!string.IsNullOrWhiteSpace(Parent?.Name) ? Parent.Name : "this location");
 
             message = "This entity has no parent.";
-            var canAdd = Parent != null && Parent.CanAddOrInsertChildren(children, false, modifiers, GetInsertionIndex(position), out message);
-            // TODO: try to move all evaluation into CheckAddOrInsertChildren so everything is at the same place
-            if (canAdd)
-            {
-                if (children.Any(x => x == this))
-                {
-                    message = "Can't insert before or after selected entity";
-                    return false;
-                }
-                message = children.All(x => x is EntityFolderViewModel)
-                    ? $"Move the selection to {parentName}"
-                    : $"Insert {(position == InsertPosition.Before ? "before" : "after")} {Name}";
+            if (Parent == null)
+                return DropAcceptance.Rejected;
 
-                if (children.OfType<EntityHierarchyItemViewModel>().Any())
-                {
-                    message = (modifiers & AddChildModifiers.Alt) != AddChildModifiers.Alt
-                        ? $"{message}\r\n(Hold Alt to maintain world position)"
-                        : $"{message}\r\n(Release Alt to maintain local position)";
-                }
+            // TODO: try to move all evaluation into CheckAddOrInsertChildren so everything is at the same place
+            var acceptance = Parent.CanAddOrInsertChildren(children, false, modifiers, GetInsertionIndex(position), out message);
+            if (acceptance != DropAcceptance.Accepted)
+                return acceptance;
+
+            if (children.Any(x => x == this))
+            {
+                message = "Nothing to move";
+                return DropAcceptance.NoOp;
             }
-            return canAdd;
+            message = children.All(x => x is EntityFolderViewModel)
+                ? $"Move the selection to {parentName}"
+                : $"Insert {(position == InsertPosition.Before ? "before" : "after")} {Name}";
+
+            if (children.OfType<EntityHierarchyItemViewModel>().Any())
+            {
+                message = (modifiers & AddChildModifiers.Alt) != AddChildModifiers.Alt
+                    ? $"{message}\r\n(Hold Alt to maintain world position)"
+                    : $"{message}\r\n(Release Alt to maintain local position)";
+            }
+            return DropAcceptance.Accepted;
+        }
+
+        /// <inheritdoc/>
+        bool IInsertChildViewModel.CanInsertChildren(IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, out string message)
+        {
+            // A no-op gives false here, because the caller of this method then does the operation.
+            return CheckInsertChildren(children, position, modifiers, out message) == DropAcceptance.Accepted;
+        }
+
+        /// <inheritdoc/>
+        DropAcceptance IInsertChildViewModel.GetInsertChildrenAcceptance(IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, out string message)
+        {
+            return CheckInsertChildren(children, position, modifiers, out message);
         }
 
         /// <inheritdoc/>

--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/SceneEditor/ViewModels/SceneRootViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/SceneEditor/ViewModels/SceneRootViewModel.cs
@@ -262,7 +262,7 @@ namespace Stride.Assets.Presentation.AssetEditors.SceneEditor.ViewModels
         }
 
         /// <inheritdoc />
-        protected override bool CanAddOrInsertChildren(IReadOnlyCollection<object> children, bool checkSameParent, AddChildModifiers modifiers, int index, out string message)
+        protected override DropAcceptance CanAddOrInsertChildren(IReadOnlyCollection<object> children, bool checkSameParent, AddChildModifiers modifiers, int index, out string message)
         {
             message = "Selection is empty";
             var roots = children.OfType<SceneRootViewModel>().ToList();
@@ -273,19 +273,19 @@ namespace Stride.Assets.Presentation.AssetEditors.SceneEditor.ViewModels
             if (index < EntityCount)
             {
                 message = "Can only add a scene to another scene";
-                return false;
+                return DropAcceptance.Rejected;
             }
             var parentName = !string.IsNullOrWhiteSpace(Name) ? Name : "this location";
             foreach (var root in roots)
             {
                 if (!SceneAsset.CanBeParentOf(root.SceneAsset, out message, checkSameParent))
                 {
-                    return false;
+                    return DropAcceptance.Rejected;
                 }
                 // Accepting child scenes
                 message = $"Add as a child to {parentName}";
             }
-            return true;
+            return DropAcceptance.Accepted;
         }
 
         /// <inheritdoc />

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDragContainer.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDragContainer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Collections.Generic;
+using System.ComponentModel;
+using Xunit;
+using Stride.Core.Assets.Editor.View.Behaviors;
+using Stride.Core.Assets.Editor.ViewModel;
+
+namespace Stride.Core.Assets.Editor.Tests
+{
+    public class TestDragContainer
+    {
+        [Fact]
+        public void TestAcceptedShowsAcceptedOnly()
+        {
+            var container = new DragContainer(new object[] { new object() }) { Acceptance = DropAcceptance.Accepted };
+            Assert.True(container.IsAccepted);
+            Assert.False(container.IsRejected);
+        }
+
+        [Fact]
+        public void TestRejectedShowsRejectedOnly()
+        {
+            var container = new DragContainer(new object[] { new object() }) { Acceptance = DropAcceptance.Rejected };
+            Assert.False(container.IsAccepted);
+            Assert.True(container.IsRejected);
+        }
+
+        [Fact]
+        public void TestNoOpShowsNeither()
+        {
+            // The drag visual binds one image to each of these. A no-op must show no image at all.
+            var container = new DragContainer(new object[] { new object() }) { Acceptance = DropAcceptance.NoOp };
+            Assert.False(container.IsAccepted);
+            Assert.False(container.IsRejected);
+        }
+
+        [Fact]
+        public void TestDefaultIsRejected()
+        {
+            var container = new DragContainer(new object[] { new object() });
+            Assert.Equal(DropAcceptance.Rejected, container.Acceptance);
+        }
+
+        [Fact]
+        public void TestAcceptanceNotifiesTheDerivedProperties()
+        {
+            var container = new DragContainer(new object[] { new object() });
+            var changed = new List<string>();
+            ((INotifyPropertyChanged)container).PropertyChanged += (s, e) => changed.Add(e.PropertyName);
+
+            container.Acceptance = DropAcceptance.Accepted;
+
+            Assert.Contains(nameof(DragContainer.Acceptance), changed);
+            Assert.Contains(nameof(DragContainer.IsAccepted), changed);
+            Assert.Contains(nameof(DragContainer.IsRejected), changed);
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDragContainer.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDragContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropAcceptanceDefaults.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropAcceptanceDefaults.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Collections.Generic;
+using Xunit;
+using Stride.Core.Assets.Editor.View.Behaviors;
+using Stride.Core.Assets.Editor.ViewModel;
+
+namespace Stride.Core.Assets.Editor.Tests
+{
+    /// <summary>
+    /// Verifies that a view model which implements only the boolean members keeps its behaviour.
+    /// </summary>
+    public class TestDropAcceptanceDefaults
+    {
+        private const string ExpectedMessage = "message from the view model";
+
+        private class LegacyAddChild : IAddChildViewModel
+        {
+            private readonly bool canAdd;
+
+            public LegacyAddChild(bool canAdd) { this.canAdd = canAdd; }
+
+            public bool CanAddChildren(IReadOnlyCollection<object> children, AddChildModifiers modifiers, out string message)
+            {
+                message = ExpectedMessage;
+                return canAdd;
+            }
+
+            public void AddChildren(IReadOnlyCollection<object> children, AddChildModifiers modifiers) { }
+        }
+
+        private class LegacyInsertChild : IInsertChildViewModel
+        {
+            private readonly bool canInsert;
+
+            public LegacyInsertChild(bool canInsert) { this.canInsert = canInsert; }
+
+            public bool CanInsertChildren(IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, out string message)
+            {
+                message = ExpectedMessage;
+                return canInsert;
+            }
+
+            public void InsertChildren(IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers) { }
+        }
+
+        [Theory]
+        [InlineData(true, DropAcceptance.Accepted)]
+        [InlineData(false, DropAcceptance.Rejected)]
+        public void TestAddChildrenDefaultFollowsTheBoolean(bool canAdd, DropAcceptance expected)
+        {
+            IAddChildViewModel viewModel = new LegacyAddChild(canAdd);
+
+            var acceptance = viewModel.GetAddChildrenAcceptance(new object[0], AddChildModifiers.None, out var message);
+
+            Assert.Equal(expected, acceptance);
+            Assert.Equal(ExpectedMessage, message);
+        }
+
+        [Theory]
+        [InlineData(true, DropAcceptance.Accepted)]
+        [InlineData(false, DropAcceptance.Rejected)]
+        public void TestInsertChildrenDefaultFollowsTheBoolean(bool canInsert, DropAcceptance expected)
+        {
+            IInsertChildViewModel viewModel = new LegacyInsertChild(canInsert);
+
+            var acceptance = viewModel.GetInsertChildrenAcceptance(new object[0], InsertPosition.Before, AddChildModifiers.None, out var message);
+
+            Assert.Equal(expected, acceptance);
+            Assert.Equal(ExpectedMessage, message);
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropAcceptanceDefaults.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropAcceptanceDefaults.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Collections.Generic;
 using Xunit;

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropFeedbackResources.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropFeedbackResources.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Media;
+using Xunit;
+using Stride.Core.Assets.Editor.View.Behaviors;
+
+namespace Stride.Core.Assets.Editor.Tests
+{
+    public class TestDropFeedbackResources
+    {
+        private const string Key = "TestDropFeedbackKey";
+
+        [Fact]
+        public void TestMissingResourceGivesTheDefault()
+        {
+            Assert.Equal(7.0, DropFeedbackResources.Find(null, "NoSuchResourceKey", 7.0));
+        }
+
+        [Fact]
+        public void TestResourceOfTheElementWins()
+        {
+            RunSta(() =>
+            {
+                var brush = Brushes.Fuchsia;
+                var element = new FrameworkElement();
+                element.Resources[Key] = brush;
+
+                Assert.Same(brush, DropFeedbackResources.Find<Brush>(element, Key, null));
+            });
+        }
+
+        [Fact]
+        public void TestResourceOfAnotherTypeGivesTheDefault()
+        {
+            RunSta(() =>
+            {
+                // An adorner must not throw while it draws, therefore a wrong type counts as a missing resource.
+                var element = new FrameworkElement();
+                element.Resources[Key] = "not a number";
+
+                Assert.Equal(7.0, DropFeedbackResources.Find(element, Key, 7.0));
+            });
+        }
+
+        /// <summary>
+        /// Runs the given action on a thread in the single-threaded apartment.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        /// <remarks>
+        /// A <see cref="FrameworkElement"/> can only be made on such a thread, but the test runner does not use one.
+        /// </remarks>
+        private static void RunSta(Action action)
+        {
+            ExceptionDispatchInfo failure = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception exception)
+                {
+                    failure = ExceptionDispatchInfo.Capture(exception);
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            failure?.Throw();
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropZoneCalculator.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropZoneCalculator.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using Xunit;
+using Stride.Core.Assets.Editor.View.Behaviors;
+
+namespace Stride.Core.Assets.Editor.Tests
+{
+    public class TestDropZoneCalculator
+    {
+        private const double RowHeight = 24.0;
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(3.0)]
+        [InlineData(7.0)]
+        public void TestTopBandInsertsBefore(double positionY)
+        {
+            Assert.Equal(InsertPosition.Before, DropZoneCalculator.GetInsertPosition(positionY, RowHeight, true));
+        }
+
+        [Theory]
+        [InlineData(20.0)]
+        [InlineData(24.0)]
+        public void TestBottomBandInsertsAfter(double positionY)
+        {
+            Assert.Equal(InsertPosition.After, DropZoneCalculator.GetInsertPosition(positionY, RowHeight, true));
+        }
+
+        [Theory]
+        [InlineData(9.0)]
+        [InlineData(12.0)]
+        [InlineData(15.0)]
+        public void TestMiddleIsDropZone(double positionY)
+        {
+            Assert.Null(DropZoneCalculator.GetInsertPosition(positionY, RowHeight, true));
+        }
+
+        [Fact]
+        public void TestBottomBandIsDropZoneWhenAfterIsNotAllowed()
+        {
+            for (var positionY = 0.0; positionY <= RowHeight; positionY += 0.5)
+            {
+                Assert.NotEqual(InsertPosition.After, DropZoneCalculator.GetInsertPosition(positionY, RowHeight, false));
+            }
+        }
+
+        [Fact]
+        public void TestBandsAreHalfOpen()
+        {
+            var band = DropZoneCalculator.GetInsertBandHeight(RowHeight);
+            Assert.Null(DropZoneCalculator.GetInsertPosition(band, RowHeight, true));
+            Assert.Null(DropZoneCalculator.GetInsertPosition(RowHeight - band, RowHeight, true));
+        }
+
+        [Fact]
+        public void TestBandIsProportionalToRowHeight()
+        {
+            Assert.Equal(RowHeight * DropZoneCalculator.InsertBandRatio, DropZoneCalculator.GetInsertBandHeight(RowHeight));
+        }
+
+        [Fact]
+        public void TestBandIsClampedOnTallRow()
+        {
+            Assert.Equal(DropZoneCalculator.MaxInsertBandHeight, DropZoneCalculator.GetInsertBandHeight(100.0));
+        }
+
+        [Fact]
+        public void TestShortRowKeepsADropZone()
+        {
+            const double shortRow = 6.0;
+            var band = DropZoneCalculator.GetInsertBandHeight(shortRow);
+            Assert.True(band * 2 < shortRow);
+            Assert.Null(DropZoneCalculator.GetInsertPosition(shortRow / 2, shortRow, true));
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(-1.0)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        public void TestInvalidRowHeightHasNoBand(double rowHeight)
+        {
+            Assert.Equal(0.0, DropZoneCalculator.GetInsertBandHeight(rowHeight));
+            Assert.Null(DropZoneCalculator.GetInsertPosition(0.0, rowHeight, true));
+        }
+
+        [Theory]
+        [InlineData(-1.0)]
+        [InlineData(RowHeight + 1.0)]
+        [InlineData(double.NaN)]
+        public void TestPositionOutsideRowIsNotAnInsert(double positionY)
+        {
+            Assert.Null(DropZoneCalculator.GetInsertPosition(positionY, RowHeight, true));
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropZoneCalculator.cs
+++ b/sources/editor/Stride.Core.Assets.Editor.Tests/TestDropZoneCalculator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using Xunit;
 using Stride.Core.Assets.Editor.View.Behaviors;

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragContainer.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragContainer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using Stride.Core.Annotations;
+using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Presentation.ViewModels;
 
 namespace Stride.Core.Assets.Editor.View.Behaviors
@@ -13,7 +14,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
     public sealed class DragContainer : ViewModelBase, ISerializable
     {
         private string message;
-        private bool isAccepted;
+        private DropAcceptance acceptance;
 
         public const string Format = "DraggedData";
         public const int PreviewItemCount = 10;
@@ -26,7 +27,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
 
         private DragContainer()
         {
-            DependentProperties.Add(nameof(IsAccepted), new[] { nameof(IsRejected) });
+            DependentProperties.Add(nameof(Acceptance), new[] { nameof(IsAccepted), nameof(IsRejected) });
         }
 
         [NotNull]
@@ -40,9 +41,20 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
 
         public string Message { get { return message; } set { SetValue(ref message, value); } }
 
-        public bool IsAccepted { get { return isAccepted; } set { SetValue(ref isAccepted, value); } }
+        /// <summary>
+        /// Gets or sets how the item currently under the pointer accepts the dragged items.
+        /// </summary>
+        public DropAcceptance Acceptance { get { return acceptance; } set { SetValue(ref acceptance, value); } }
 
-        public bool IsRejected => !isAccepted;
+        /// <summary>
+        /// Gets whether the drop is accepted. A no-op is not accepted, because it changes nothing.
+        /// </summary>
+        public bool IsAccepted => acceptance == DropAcceptance.Accepted;
+
+        /// <summary>
+        /// Gets whether the drop is refused. A no-op is not refused, because the user made no error.
+        /// </summary>
+        public bool IsRejected => acceptance == DropAcceptance.Rejected;
 
         /// <summary>
         /// The special constructor is used to deserialize values.

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DragDropAdornerManager.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DragDropAdornerManager.cs
@@ -26,9 +26,6 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         /// <summary>
         /// The resource key of the brush that highlights an item which the dragged items do not change.
         /// </summary>
-        internal const string NeutralBrushKey = "NormalBorderBrush";
-
-        private static readonly Brush FallbackNeutralBrush = CreateFallbackNeutralBrush();
 
         private static readonly Dictionary<Visual, Tuple<AdornerLayer, HighlightBorderAdorner>> DropAdorners = new Dictionary<Visual, Tuple<AdornerLayer, HighlightBorderAdorner>>();
         private static readonly TimeoutDispatcherTimer DragLeaveTimer = new TimeoutDispatcherTimer(100);
@@ -113,12 +110,37 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
             dropTargetLayer = null;
         }
 
-        [NotNull]
-        private static Brush CreateFallbackNeutralBrush()
+        /// <summary>
+        /// Applies the colours of the theme to an adorner that highlights the header of an item.
+        /// </summary>
+        /// <param name="adorner">The adorner to change.</param>
+        /// <param name="adornedElement">The element that the adorner covers.</param>
+        /// <remarks>
+        /// The default colours of <see cref="HighlightBorderAdorner"/> are made for a light background, but these rows
+        /// follow the theme. A colour that the theme does not give keeps the default of the adorner.
+        /// </remarks>
+        private static void ApplyTheme([NotNull] HighlightBorderAdorner adorner, [NotNull] FrameworkElement adornedElement)
         {
-            var brush = new SolidColorBrush(Color.FromArgb(255, 148, 148, 148));
-            brush.Freeze();
-            return brush;
+            var neutral = DropFeedbackResources.GetTargetNeutralBrush(adornedElement);
+            if (neutral != null)
+            {
+                adorner.BorderBrush = neutral;
+                adorner.BackgroundBrush = neutral;
+            }
+
+            var accept = DropFeedbackResources.GetTargetAcceptBrush(adornedElement);
+            if (accept != null)
+            {
+                adorner.AcceptBorderBrush = accept;
+                adorner.AcceptBackgroundBrush = accept;
+            }
+
+            var refuse = DropFeedbackResources.GetTargetRefuseBrush(adornedElement);
+            if (refuse != null)
+            {
+                adorner.RefuseBorderBrush = refuse;
+                adorner.RefuseBackgroundBrush = refuse;
+            }
         }
 
         /// <summary>
@@ -171,11 +193,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
 
             adornerLayer.IsHitTestVisible = false;
             dropTargetAdorner = new HighlightBorderAdorner(adornedElement) { State = state };
-            // The neutral colours of the adorner are made for a light background, but the rows here are dark. A muted
-            // grey also keeps the accent colour for the insert line only.
-            var neutralBrush = adornedElement.TryFindResource(NeutralBrushKey) as Brush ?? FallbackNeutralBrush;
-            dropTargetAdorner.BorderBrush = neutralBrush;
-            dropTargetAdorner.BackgroundBrush = neutralBrush;
+            ApplyTheme(dropTargetAdorner, adornedElement);
             adornerLayer.Add(dropTargetAdorner);
             dropTargetLayer = adornerLayer;
         }

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DragDropAdornerManager.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DragDropAdornerManager.cs
@@ -9,6 +9,7 @@ using System.Windows.Documents;
 using Microsoft.Xaml.Behaviors;
 using System.Windows.Media;
 using Stride.Core.Annotations;
+using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Extensions;
 using Stride.Core.Presentation.Adorners;
 using Stride.Core.Presentation.Core;
@@ -22,12 +23,21 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
     /// </summary>
     internal static class DragDropAdornerManager
     {
+        /// <summary>
+        /// The resource key of the brush that highlights an item which the dragged items do not change.
+        /// </summary>
+        internal const string NeutralBrushKey = "NormalBorderBrush";
+
+        private static readonly Brush FallbackNeutralBrush = CreateFallbackNeutralBrush();
+
         private static readonly Dictionary<Visual, Tuple<AdornerLayer, HighlightBorderAdorner>> DropAdorners = new Dictionary<Visual, Tuple<AdornerLayer, HighlightBorderAdorner>>();
         private static readonly TimeoutDispatcherTimer DragLeaveTimer = new TimeoutDispatcherTimer(100);
         private static readonly DependencyProperty BehaviorsProperty;
         private static bool dropAdornersCreated;
         private static InsertAdorner insertAdorner;
         private static AdornerLayer currentLayer;
+        private static HighlightBorderAdorner dropTargetAdorner;
+        private static AdornerLayer dropTargetLayer;
         private static DisplayDropAdorner dataType;
 
         private static readonly Dictionary<FrameworkElement, Window> ElementToWindowLookup = new Dictionary<FrameworkElement, Window>();
@@ -86,9 +96,100 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         {
             if (currentLayer != null && insertAdorner != null)
                 currentLayer.Remove(insertAdorner);
+
+            insertAdorner = null;
+            currentLayer = null;
         }
 
-        internal static void UpdateInsertAdorner([NotNull] UIElement container, InsertPosition position)
+        /// <summary>
+        /// Removes the adorner highlighting the item into which the dragged items would be dropped.
+        /// </summary>
+        internal static void ClearDropTargetAdorner()
+        {
+            if (dropTargetLayer != null && dropTargetAdorner != null)
+                dropTargetLayer.Remove(dropTargetAdorner);
+
+            dropTargetAdorner = null;
+            dropTargetLayer = null;
+        }
+
+        [NotNull]
+        private static Brush CreateFallbackNeutralBrush()
+        {
+            var brush = new SolidColorBrush(Color.FromArgb(255, 148, 148, 148));
+            brush.Freeze();
+            return brush;
+        }
+
+        /// <summary>
+        /// Gets the adorner state that shows the given acceptance.
+        /// </summary>
+        /// <param name="acceptance">The acceptance to show.</param>
+        /// <returns>The matching adorner state.</returns>
+        internal static HighlightAdornerState ToAdornerState(DropAcceptance acceptance)
+        {
+            switch (acceptance)
+            {
+                case DropAcceptance.Accepted:
+                    return HighlightAdornerState.HighlightAccept;
+                case DropAcceptance.NoOp:
+                    return HighlightAdornerState.Visible;
+                default:
+                    return HighlightAdornerState.HighlightRefuse;
+            }
+        }
+
+        /// <summary>
+        /// Highlights the given element to indicate how it accepts the dragged items.
+        /// </summary>
+        /// <param name="adornedElement">The element to highlight, or <c>null</c> to remove the highlight.</param>
+        /// <param name="acceptance">How the element accepts the dragged items.</param>
+        /// <remarks>
+        /// While the same element stays adorned, the adorner is kept and only its state changes, because drag over
+        /// occurs approximately one time per frame.
+        /// </remarks>
+        internal static void UpdateDropTargetAdorner([CanBeNull] FrameworkElement adornedElement, DropAcceptance acceptance)
+        {
+            if (adornedElement == null)
+            {
+                ClearDropTargetAdorner();
+                return;
+            }
+
+            var state = ToAdornerState(acceptance);
+            if (dropTargetAdorner != null && Equals(dropTargetAdorner.AdornedElement, adornedElement))
+            {
+                dropTargetAdorner.State = state;
+                return;
+            }
+
+            ClearDropTargetAdorner();
+
+            var adornerLayer = AdornerLayer.GetAdornerLayer(adornedElement);
+            if (adornerLayer == null)
+                return;
+
+            adornerLayer.IsHitTestVisible = false;
+            dropTargetAdorner = new HighlightBorderAdorner(adornedElement) { State = state };
+            // The neutral colours of the adorner are made for a light background, but the rows here are dark. A muted
+            // grey also keeps the accent colour for the insert line only.
+            var neutralBrush = adornedElement.TryFindResource(NeutralBrushKey) as Brush ?? FallbackNeutralBrush;
+            dropTargetAdorner.BorderBrush = neutralBrush;
+            dropTargetAdorner.BackgroundBrush = neutralBrush;
+            adornerLayer.Add(dropTargetAdorner);
+            dropTargetLayer = adornerLayer;
+        }
+
+        /// <summary>
+        /// Shows the line at which the dragged items would be inserted.
+        /// </summary>
+        /// <param name="container">The container that the pointer is over.</param>
+        /// <param name="position">The position of the line, before or after the container.</param>
+        /// <param name="indent">
+        /// The horizontal position at which the line starts, or <see cref="double.NaN"/> to use the indentation of the
+        /// container.
+        /// </param>
+        internal static void UpdateInsertAdorner([NotNull] UIElement container, InsertPosition position, double indent = double.NaN)
         {
             var adornerLayer = AdornerLayer.GetAdornerLayer(container);
             if (adornerLayer != null)
@@ -97,6 +198,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
                 if (insertAdorner == null || !Equals(insertAdorner.AdornedElement, container))
                     insertAdorner = new InsertAdorner(container);
                 insertAdorner.Position = position;
+                insertAdorner.Indent = indent;
                 adornerLayer.Add(insertAdorner);
                 currentLayer = adornerLayer;
             }

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DragDropBehavior.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DragDropBehavior.cs
@@ -130,6 +130,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         protected override void OnDetaching()
         {
             base.OnDetaching();
+            ClearDropTargetVisual();
             DragDropAdornerManager.UnregisterElement(AssociatedObject);
             UnsubscribeFromDragEvents();
             UnsubscribeFromDropEvents();
@@ -278,6 +279,8 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
             finally
             {
                 IsDragging = false;
+                DragDropAdornerManager.ClearInsertAdorner();
+                ClearDropTargetVisual();
                 if (DragWindow != null)
                 {
                     DragWindow.Close();
@@ -311,6 +314,33 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
             return null;
         }
 
+        /// <summary>
+        /// Updates the visual indicating where the dragged items would be inserted.
+        /// </summary>
+        /// <param name="container">The container that the pointer is over.</param>
+        /// <param name="position">The pointer position, relative to the container.</param>
+        /// <param name="insertPosition">The insert position, before or after.</param>
+        protected virtual void UpdateInsertVisual([NotNull] TContainer container, Point position, InsertPosition insertPosition)
+        {
+            DragDropAdornerManager.UpdateInsertAdorner(container, insertPosition);
+        }
+
+        /// <summary>
+        /// Updates the visual indicating the container into which the dragged items would be dropped.
+        /// </summary>
+        /// <param name="container">The container currently hovered.</param>
+        /// <param name="acceptance">How the container accepts the dragged items.</param>
+        protected virtual void UpdateDropTargetVisual([NotNull] TContainer container, DropAcceptance acceptance)
+        {
+        }
+
+        /// <summary>
+        /// Clears the visual set by <see cref="UpdateDropTargetVisual"/>.
+        /// </summary>
+        protected virtual void ClearDropTargetVisual()
+        {
+        }
+
         [NotNull]
         protected abstract IEnumerable<object> GetItemsToDrag(TContainer container);
 
@@ -340,11 +370,14 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
 
         protected bool OnDragLeave(IDataObject data)
         {
+            DragDropAdornerManager.ClearInsertAdorner();
+            ClearDropTargetVisual();
+
             // Invalidate current drag status
             var dragContainer = DragDropHelper.GetDragContainer(data);
             if (dragContainer != null)
             {
-                dragContainer.IsAccepted = false;
+                dragContainer.Acceptance = DropAcceptance.Rejected;
                 dragContainer.Message = DragDropBehavior.InvalidDropAreaMessage;
             }
 
@@ -369,11 +402,12 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         {
             var dragContainer = DragDropHelper.GetDragContainer(data);
             DragDropAdornerManager.ClearInsertAdorner();
+            ClearDropTargetVisual();
 
             // Invalidate current drag status
             if (dragContainer != null)
             {
-                dragContainer.IsAccepted = false;
+                dragContainer.Acceptance = DropAcceptance.Rejected;
                 dragContainer.Message = DragDropBehavior.InvalidDropAreaMessage;
             }
 
@@ -393,16 +427,25 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
             {
                 InsertPosition insertPosition;
                 var target = GetInsertTargetItem(container, position, out insertPosition);
-                if (target != null && target.CanInsertChildren(itemsToDrop, insertPosition, ComputeModifiers(), out message))
+                // A rejected insertion falls through to the add path, so that the item itself becomes the target.
+                // A no-op stops here, otherwise the row below would answer a gesture that points at this one.
+                var acceptance = DropAcceptance.Rejected;
+                message = DragDropBehavior.InvalidDropAreaMessage;
+                if (target != null)
+                    acceptance = target.GetInsertChildrenAcceptance(itemsToDrop, insertPosition, ComputeModifiers(), out message);
+                if (acceptance != DropAcceptance.Rejected)
                 {
                     if (dragContainer != null)
                     {
-                        dragContainer.IsAccepted = true;
+                        dragContainer.Acceptance = acceptance;
                         dragContainer.Message = message;
                     }
                     // The event must be handled otherwise OnDrop won't be invoked
                     e.Handled = true;
-                    DragDropAdornerManager.UpdateInsertAdorner(container, insertPosition);
+                    if (acceptance == DropAcceptance.Accepted)
+                        UpdateInsertVisual(container, position, insertPosition);
+                    else
+                        UpdateDropTargetVisual(container, acceptance);
                     return true;
                 }
             }
@@ -413,23 +456,24 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
                 if (target == null)
                     return false;
 
-                var isAccepted = target.CanAddChildren(itemsToDrop, ComputeModifiers(), out message);
+                var acceptance = target.GetAddChildrenAcceptance(itemsToDrop, ComputeModifiers(), out message);
                 if (dragContainer != null)
                 {
-                    dragContainer.IsAccepted = isAccepted;
+                    dragContainer.Acceptance = acceptance;
                     dragContainer.Message = message;
                 }
 
                 // The event must be handled otherwise OnDrop won't be invoked
-                if (isAccepted)
+                if (acceptance != DropAcceptance.Rejected)
                     e.Handled = true;
+
+                UpdateDropTargetVisual(container, acceptance);
 
                 if (DragDropHelper.ShouldDisplayDropAdorner(DisplayDropAdorner, itemsToDrop))
                 {
-                    var adornerState = isAccepted ? HighlightAdornerState.HighlightAccept : HighlightAdornerState.HighlightRefuse;
-                    DragDropAdornerManager.SetAdornerState(AssociatedObject, adornerState);
+                    DragDropAdornerManager.SetAdornerState(AssociatedObject, DragDropAdornerManager.ToAdornerState(acceptance));
                 }
-                return isAccepted;
+                return acceptance != DropAcceptance.Rejected;
             }
 
             return false;
@@ -438,6 +482,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         protected bool OnDrop(TContainer container, Point position, IDataObject data, RoutedEventArgs e)
         {
             DragDropAdornerManager.ClearInsertAdorner();
+            ClearDropTargetVisual();
 
             if (DragWindow != null)
             {
@@ -457,11 +502,19 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
                 {
                     var dragContainer = DragDropHelper.GetDragContainer(data);
                     var itemsToDrop = DragDropHelper.GetItemsToDrop(dragContainer, data as DataObject);
-                    string message;
 
-                    if (itemsToDrop != null && target.CanInsertChildren(itemsToDrop, insertPosition, ComputeModifiers(), out message))
+                    var acceptance = itemsToDrop != null
+                        ? target.GetInsertChildrenAcceptance(itemsToDrop, insertPosition, ComputeModifiers(), out _)
+                        : DropAcceptance.Rejected;
+                    if (acceptance == DropAcceptance.Accepted)
                     {
                         target.InsertChildren(itemsToDrop, insertPosition, ComputeModifiers());
+                        if (e != null) e.Handled = true;
+                        return true;
+                    }
+                    if (acceptance == DropAcceptance.NoOp)
+                    {
+                        // The gesture points at the dragged items themselves. Do nothing, and do not add them as children.
                         if (e != null) e.Handled = true;
                         return true;
                     }
@@ -477,9 +530,9 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
 
                 var dragContainer = DragDropHelper.GetDragContainer(data);
                 var itemsToDrop = DragDropHelper.GetItemsToDrop(dragContainer, data as DataObject);
-                string message;
 
-                if (itemsToDrop != null && target.CanAddChildren(itemsToDrop, ComputeModifiers(), out message))
+                // Only an accepted drop changes the asset. A no-op leaves it untouched and creates no undo entry.
+                if (itemsToDrop != null && target.GetAddChildrenAcceptance(itemsToDrop, ComputeModifiers(), out _) == DropAcceptance.Accepted)
                 {
                     target.AddChildren(itemsToDrop, ComputeModifiers());
                     if (e != null) e.Handled = true;
@@ -534,7 +587,11 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
             // Check if we can drop and if we have a valid target.
             var container = GetContainer(e.OriginalSource);
             if (container == null)
+            {
+                DragDropAdornerManager.ClearInsertAdorner();
+                ClearDropTargetVisual();
                 return;
+            }
 
             if (OnDragOver(container, e.GetPosition(container), e.Data, e))
             {

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DropFeedbackResources.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DropFeedbackResources.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Windows;
+using System.Windows.Media;
+
+namespace Stride.Core.Assets.Editor.View.Behaviors
+{
+    /// <summary>
+    /// Gives the theme resources that the drag and drop feedback draws with.
+    /// </summary>
+    /// <remarks>
+    /// Every theme gives a value for each of these keys. A brush that the theme does not give is <c>null</c>, and the
+    /// caller then keeps the default of the adorner. The two sizes have a default value, because an adorner must draw
+    /// something when no theme is loaded, for example in a test or in a designer.
+    /// </remarks>
+    internal static class DropFeedbackResources
+    {
+        internal const string InsertLineBrushKey = "DropInsertLineBrush";
+        internal const string InsertLineThicknessKey = "DropInsertLineThickness";
+        internal const string InsertMarkerRadiusKey = "DropInsertMarkerRadius";
+        internal const string TargetNeutralBrushKey = "DropTargetNeutralBrush";
+        internal const string TargetAcceptBrushKey = "DropTargetAcceptBrush";
+        internal const string TargetRefuseBrushKey = "DropTargetRefuseBrush";
+
+        // These apply only when no theme is loaded. The themes give the values that the editor shows.
+        private const double DefaultInsertLineThickness = 2.0;
+        private const double DefaultInsertMarkerRadius = 3.0;
+
+        internal static Brush GetInsertLineBrush(DependencyObject target)
+        {
+            return Find<Brush>(target, InsertLineBrushKey, SystemColors.HighlightBrush);
+        }
+
+        internal static double GetInsertLineThickness(DependencyObject target)
+        {
+            return Find(target, InsertLineThicknessKey, DefaultInsertLineThickness);
+        }
+
+        internal static double GetInsertMarkerRadius(DependencyObject target)
+        {
+            return Find(target, InsertMarkerRadiusKey, DefaultInsertMarkerRadius);
+        }
+
+        internal static Brush GetTargetNeutralBrush(DependencyObject target)
+        {
+            return Find<Brush>(target, TargetNeutralBrushKey, null);
+        }
+
+        internal static Brush GetTargetAcceptBrush(DependencyObject target)
+        {
+            return Find<Brush>(target, TargetAcceptBrushKey, null);
+        }
+
+        internal static Brush GetTargetRefuseBrush(DependencyObject target)
+        {
+            return Find<Brush>(target, TargetRefuseBrushKey, null);
+        }
+
+        /// <summary>
+        /// Finds a resource of the given type for the given element.
+        /// </summary>
+        /// <typeparam name="T">The type of the resource.</typeparam>
+        /// <param name="target">The element to search from, or <c>null</c> to search the application only.</param>
+        /// <param name="key">The key of the resource.</param>
+        /// <param name="defaultValue">The value to give when the resource is missing or of another type.</param>
+        /// <returns>The resource, or <paramref name="defaultValue"/>.</returns>
+        /// <remarks>
+        /// The element is searched first, therefore a window or a control can override a value. A resource of another
+        /// type is treated as a missing resource, because an adorner must not throw while it draws.
+        /// </remarks>
+        internal static T Find<T>(DependencyObject target, string key, T defaultValue)
+        {
+            var value = (target as FrameworkElement)?.TryFindResource(key) ?? Application.Current?.TryFindResource(key);
+            return value is T result ? result : defaultValue;
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DropZoneCalculator.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DropZoneCalculator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 namespace Stride.Core.Assets.Editor.View.Behaviors
 {

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DropZoneCalculator.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/DropZoneCalculator.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+namespace Stride.Core.Assets.Editor.View.Behaviors
+{
+    /// <summary>
+    /// Splits a row into the drop zones of a drag and drop operation: an insert band along its top edge,
+    /// an insert band along its bottom edge, and a drop zone in between.
+    /// </summary>
+    public static class DropZoneCalculator
+    {
+        /// <summary>
+        /// The fraction of the height of a row covered by each insert band.
+        /// </summary>
+        public const double InsertBandRatio = 0.3;
+
+        /// <summary>
+        /// The minimum height of an insert band, in device-independent pixels.
+        /// </summary>
+        public const double MinInsertBandHeight = 3.0;
+
+        /// <summary>
+        /// The maximum height of an insert band, in device-independent pixels.
+        /// </summary>
+        public const double MaxInsertBandHeight = 10.0;
+
+        /// <summary>
+        /// The largest fraction of the height of a row that an insert band can cover.
+        /// </summary>
+        public const double MaxInsertBandRatio = 0.4;
+
+        /// <summary>
+        /// Computes the height of an insert band for a row of the given height.
+        /// </summary>
+        /// <param name="rowHeight">The height of the row.</param>
+        /// <returns>The height of an insert band, or zero if the row height is not a usable value.</returns>
+        /// <remarks>
+        /// A band is never more than <see cref="MaxInsertBandRatio"/> of the row height. Therefore a drop zone always
+        /// stays between the two bands, even if <see cref="MinInsertBandHeight"/> applies.
+        /// </remarks>
+        public static double GetInsertBandHeight(double rowHeight)
+        {
+            if (double.IsNaN(rowHeight) || double.IsInfinity(rowHeight) || rowHeight <= 0)
+                return 0;
+
+            var band = Math.Min(Math.Max(rowHeight * InsertBandRatio, MinInsertBandHeight), MaxInsertBandHeight);
+            return Math.Min(band, rowHeight * MaxInsertBandRatio);
+        }
+
+        /// <summary>
+        /// Determines the insert position matching a pointer position inside a row.
+        /// </summary>
+        /// <param name="positionY">The vertical position of the pointer, relative to the top of the row.</param>
+        /// <param name="rowHeight">The height of the row.</param>
+        /// <param name="allowAfter">True if the bottom band inserts after the row, false if it drops into the row.</param>
+        /// <returns>The insert position, or <c>null</c> if the pointer is in the drop zone between the two bands.</returns>
+        public static InsertPosition? GetInsertPosition(double positionY, double rowHeight, bool allowAfter)
+        {
+            var band = GetInsertBandHeight(rowHeight);
+            if (band <= 0 || double.IsNaN(positionY) || positionY < 0 || positionY > rowHeight)
+                return null;
+
+            if (positionY < band)
+                return InsertPosition.Before;
+
+            if (allowAfter && positionY > rowHeight - band)
+                return InsertPosition.After;
+
+            return null;
+        }
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/InsertAdorner.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/InsertAdorner.cs
@@ -1,42 +1,87 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
-using System;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
 using Stride.Core.Annotations;
+using TreeViewItem = Stride.Core.Presentation.Controls.TreeViewItem;
 
 namespace Stride.Core.Assets.Editor.View.Behaviors
 {
+    /// <summary>
+    /// An adorner that draws the line at which dragged items would be inserted.
+    /// </summary>
+    /// <remarks>
+    /// If the adorned element is a <see cref="TreeViewItem"/>, the line starts at the indentation of that item and a
+    /// marker precedes it. This shows the nesting level at which the items land. The line follows the header of the
+    /// item, because the height of an expanded item includes its child items.
+    /// </remarks>
     public class InsertAdorner : Adorner
     {
-        private readonly Pen renderPen;
+        private const string LineBrushKey = "SelectedBackgroundBrush";
+        private const double LineThickness = 2.0;
+        private const double MarkerRadius = 3.0;
+
+        private static readonly Brush FallbackBrush = CreateFallbackBrush();
 
         public InsertAdorner([NotNull] UIElement adornedElement)
             : base(adornedElement)
         {
-            renderPen = new Pen(new SolidColorBrush(Color.FromArgb(255, 173, 173, 173)), 3);
         }
 
         public InsertPosition Position { get; set; }
 
+        /// <summary>
+        /// Gets or sets the horizontal position at which the line starts, or <see cref="double.NaN"/> to use the
+        /// indentation of the adorned item.
+        /// </summary>
+        /// <remarks>
+        /// The gap below a subtree is also the gap below each of its ancestors. Therefore the line can point at an
+        /// ancestor of the adorned item, and it then starts at the indentation of that ancestor.
+        /// </remarks>
+        public double Indent { get; set; } = double.NaN;
+
         protected override void OnRender(DrawingContext drawingContext)
         {
-            var adornedElementRect = new Rect(AdornedElement.RenderSize);
+            var item = AdornedElement as TreeViewItem;
+            var width = AdornedElement.RenderSize.Width;
+            var height = item?.HeaderHeight ?? AdornedElement.RenderSize.Height;
 
+            double y;
             switch (Position)
             {
                 case InsertPosition.Before:
-                    drawingContext.DrawLine(renderPen, adornedElementRect.TopLeft, adornedElementRect.TopRight);
+                    y = 0;
                     break;
                 case InsertPosition.After:
-                    drawingContext.DrawLine(renderPen, adornedElementRect.BottomLeft, adornedElementRect.BottomRight);
+                    y = height;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
 
+            var brush = (AdornedElement as FrameworkElement)?.TryFindResource(LineBrushKey) as Brush ?? FallbackBrush;
+            var lineStart = 0.0;
+
+            if (item != null)
+            {
+                lineStart = double.IsNaN(Indent) ? item.Offset : Indent;
+                drawingContext.DrawEllipse(brush, null, new Point(lineStart + MarkerRadius, y), MarkerRadius, MarkerRadius);
+                lineStart += MarkerRadius * 2;
+            }
+
+            if (lineStart < width)
+                drawingContext.DrawLine(new Pen(brush, LineThickness), new Point(lineStart, y), new Point(width, y));
+
             base.OnRender(drawingContext);
+        }
+
+        [NotNull]
+        private static Brush CreateFallbackBrush()
+        {
+            var brush = new SolidColorBrush(Color.FromArgb(255, 173, 173, 173));
+            brush.Freeze();
+            return brush;
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/InsertAdorner.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/InsertAdorner.cs
@@ -18,12 +18,6 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
     /// </remarks>
     public class InsertAdorner : Adorner
     {
-        private const string LineBrushKey = "SelectedBackgroundBrush";
-        private const double LineThickness = 2.0;
-        private const double MarkerRadius = 3.0;
-
-        private static readonly Brush FallbackBrush = CreateFallbackBrush();
-
         public InsertAdorner([NotNull] UIElement adornedElement)
             : base(adornedElement)
         {
@@ -60,28 +54,24 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
                     throw new ArgumentOutOfRangeException();
             }
 
-            var brush = (AdornedElement as FrameworkElement)?.TryFindResource(LineBrushKey) as Brush ?? FallbackBrush;
+            var brush = DropFeedbackResources.GetInsertLineBrush(AdornedElement);
+            var markerRadius = DropFeedbackResources.GetInsertMarkerRadius(AdornedElement);
             var lineStart = 0.0;
 
             if (item != null)
             {
                 lineStart = double.IsNaN(Indent) ? item.Offset : Indent;
-                drawingContext.DrawEllipse(brush, null, new Point(lineStart + MarkerRadius, y), MarkerRadius, MarkerRadius);
-                lineStart += MarkerRadius * 2;
+                drawingContext.DrawEllipse(brush, null, new Point(lineStart + markerRadius, y), markerRadius, markerRadius);
+                lineStart += markerRadius * 2;
             }
 
             if (lineStart < width)
-                drawingContext.DrawLine(new Pen(brush, LineThickness), new Point(lineStart, y), new Point(width, y));
+            {
+                var pen = new Pen(brush, DropFeedbackResources.GetInsertLineThickness(AdornedElement));
+                drawingContext.DrawLine(pen, new Point(lineStart, y), new Point(width, y));
+            }
 
             base.OnRender(drawingContext);
-        }
-
-        [NotNull]
-        private static Brush CreateFallbackBrush()
-        {
-            var brush = new SolidColorBrush(Color.FromArgb(255, 173, 173, 173));
-            brush.Freeze();
-            return brush;
         }
     }
 }

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/TreeViewDragDropBehavior.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/TreeViewDragDropBehavior.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using Stride.Core.Annotations;
 using Stride.Core.Assets.Editor.ViewModel;
 using Stride.Core.Extensions;
 using Stride.Core.Presentation.Controls;
@@ -53,21 +54,99 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// An expanded item has no band to insert after it. The lower part of its row adds the items as its last
+        /// children instead. A line there would show above the first child of the item, but it would mean "sibling of
+        /// the item". To go after an expanded item, use the gap below its last descendant and move the pointer to the
+        /// left. See <see cref="ResolveInsertAfterTarget"/>.
+        /// The empty area below the last item has no row to measure. Therefore it keeps bands of a fixed size.
+        /// </remarks>
         protected override IInsertChildViewModel GetInsertTargetItem(FrameworkElement container, Point mousePosition, out InsertPosition insertPosition)
         {
             insertPosition = InsertPosition.Before;
 
-            if (mousePosition.Y >= 0 && mousePosition.Y <= InsertThreshold)
+            if (!(container is TreeViewItem item))
             {
-                insertPosition = InsertPosition.Before;
-                return container.DataContext as IInsertChildViewModel;
+                if (mousePosition.Y >= 0 && mousePosition.Y <= InsertThreshold)
+                {
+                    return container.DataContext as IInsertChildViewModel;
+                }
+                if (mousePosition.Y >= container.ActualHeight - InsertThreshold && mousePosition.Y <= container.ActualHeight)
+                {
+                    insertPosition = InsertPosition.After;
+                    return container.DataContext as IInsertChildViewModel;
+                }
+                return null;
             }
-            if (mousePosition.Y >= container.ActualHeight - InsertThreshold && mousePosition.Y <= container.ActualHeight)
+
+            var allowAfter = !(item.IsExpanded && item.HasItems);
+            var position = DropZoneCalculator.GetInsertPosition(mousePosition.Y, item.HeaderHeight, allowAfter);
+            if (position == null)
+                return null;
+
+            insertPosition = position.Value;
+            var target = insertPosition == InsertPosition.After ? ResolveInsertAfterTarget(item, mousePosition.X) : item;
+            return target.DataContext as IInsertChildViewModel;
+        }
+
+        /// <summary>
+        /// Finds the item after which the dragged items go, from the horizontal position of the pointer.
+        /// </summary>
+        /// <param name="item">The item that the pointer is over.</param>
+        /// <param name="mouseX">The horizontal position of the pointer, relative to the item.</param>
+        /// <returns>The item after which the dragged items go.</returns>
+        /// <remarks>
+        /// The gap below the last item of a subtree is also the gap below each ancestor that ends there. The pointer
+        /// then selects one of these items by its indentation. Therefore an item can go after an expanded ancestor,
+        /// which has no gap of its own.
+        /// </remarks>
+        [NotNull]
+        private static TreeViewItem ResolveInsertAfterTarget([NotNull] TreeViewItem item, double mouseX)
+        {
+            var target = item;
+            var child = item;
+            var parent = child.ParentTreeViewItem;
+            while (parent != null && IsLastChild(child, parent))
             {
-                insertPosition = InsertPosition.After;
-                return container.DataContext as IInsertChildViewModel;
+                // The deepest item whose indentation the pointer has passed wins. Moving left selects an ancestor.
+                if (mouseX < target.Offset)
+                    target = parent;
+                child = parent;
+                parent = child.ParentTreeViewItem;
             }
-            return null;
+            return target;
+        }
+
+        private static bool IsLastChild([NotNull] TreeViewItem child, [NotNull] TreeViewItem parent)
+        {
+            var count = parent.Items.Count;
+            return count > 0 && Equals(parent.Items[count - 1], child.DataContext);
+        }
+
+        /// <inheritdoc />
+        protected override void UpdateInsertVisual(FrameworkElement container, Point position, InsertPosition insertPosition)
+        {
+            var indent = double.NaN;
+            if (insertPosition == InsertPosition.After && container is TreeViewItem item)
+                indent = ResolveInsertAfterTarget(item, position.X).Offset;
+
+            DragDropAdornerManager.UpdateInsertAdorner(container, insertPosition, indent);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The header of the item is highlighted, not the item, because the height of an expanded item includes its
+        /// child items. The empty area below the last item has no header. Therefore it gets no highlight.
+        /// </remarks>
+        protected override void UpdateDropTargetVisual(FrameworkElement container, DropAcceptance acceptance)
+        {
+            DragDropAdornerManager.UpdateDropTargetAdorner((container as TreeViewItem)?.HeaderElement, acceptance);
+        }
+
+        /// <inheritdoc />
+        protected override void ClearDropTargetVisual()
+        {
+            DragDropAdornerManager.ClearDropTargetAdorner();
         }
 
         /// <inheritdoc />

--- a/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/TreeViewDragDropBehavior.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/View/Behaviors/DragDrop/TreeViewDragDropBehavior.cs
@@ -65,7 +65,7 @@ namespace Stride.Core.Assets.Editor.View.Behaviors
         {
             insertPosition = InsertPosition.Before;
 
-            if (!(container is TreeViewItem item))
+            if (container is not TreeViewItem item)
             {
                 if (mousePosition.Y >= 0 && mousePosition.Y <= InsertThreshold)
                 {

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/DropAcceptance.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/DropAcceptance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 namespace Stride.Core.Assets.Editor.ViewModel
 {

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/DropAcceptance.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/DropAcceptance.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+namespace Stride.Core.Assets.Editor.ViewModel
+{
+    /// <summary>
+    /// The result of a check that a drag and drop operation is possible.
+    /// </summary>
+    public enum DropAcceptance
+    {
+        /// <summary>
+        /// The operation is not possible.
+        /// </summary>
+        Rejected,
+        /// <summary>
+        /// The operation is possible, but it changes nothing.
+        /// </summary>
+        /// <remarks>
+        /// The user interface shows this result as neutral, because the user made no error. The caller must not do the
+        /// operation.
+        /// </remarks>
+        NoOp,
+        /// <summary>
+        /// The operation is possible.
+        /// </summary>
+        Accepted,
+    }
+}

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/IAddChildViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/IAddChildViewModel.cs
@@ -20,6 +20,26 @@ namespace Stride.Core.Assets.Editor.ViewModel
         bool CanAddChildren([NotNull] IReadOnlyCollection<object> children, AddChildModifiers modifiers, [NotNull] out string message);
 
         /// <summary>
+        /// Gets how this instance accepts the given children.
+        /// </summary>
+        /// <param name="children">The children to add.</param>
+        /// <param name="modifiers">The modifier keys currently active.</param>
+        /// <param name="message">The feedback message that can be used in the user interface.</param>
+        /// <returns>
+        /// <see cref="DropAcceptance.Accepted"/> if this instance can add the given children,
+        /// <see cref="DropAcceptance.NoOp"/> if the children are already there,
+        /// <see cref="DropAcceptance.Rejected"/> if this instance cannot add the given children.
+        /// </returns>
+        /// <remarks>
+        /// The default implementation uses <see cref="CanAddChildren"/>. Therefore it never gives
+        /// <see cref="DropAcceptance.NoOp"/>. Override this method to tell a no-op from an error.
+        /// </remarks>
+        DropAcceptance GetAddChildrenAcceptance([NotNull] IReadOnlyCollection<object> children, AddChildModifiers modifiers, [NotNull] out string message)
+        {
+            return CanAddChildren(children, modifiers, out message) ? DropAcceptance.Accepted : DropAcceptance.Rejected;
+        }
+
+        /// <summary>
         /// Adds the given children to this instance. Should be invoked only if <see cref="CanAddChildren"/> returned <c>true</c>.
         /// </summary>
         /// <param name="children">The children to add.</param>

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/IInsertChildViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/IInsertChildViewModel.cs
@@ -22,6 +22,27 @@ namespace Stride.Core.Assets.Editor.ViewModel
         bool CanInsertChildren([NotNull] IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, [NotNull] out string message);
 
         /// <summary>
+        /// Gets how this instance accepts the given children before or after itself.
+        /// </summary>
+        /// <param name="children">The children to insert.</param>
+        /// <param name="position">The position to insert, before or after.</param>
+        /// <param name="modifiers">The modifier keys currently active.</param>
+        /// <param name="message">The feedback message that can be used in the user interface.</param>
+        /// <returns>
+        /// <see cref="DropAcceptance.Accepted"/> if this instance can insert the given children,
+        /// <see cref="DropAcceptance.NoOp"/> if the children are already there,
+        /// <see cref="DropAcceptance.Rejected"/> if this instance cannot insert the given children.
+        /// </returns>
+        /// <remarks>
+        /// The default implementation uses <see cref="CanInsertChildren"/>. Therefore it never gives
+        /// <see cref="DropAcceptance.NoOp"/>. Override this method to tell a no-op from an error.
+        /// </remarks>
+        DropAcceptance GetInsertChildrenAcceptance([NotNull] IReadOnlyCollection<object> children, InsertPosition position, AddChildModifiers modifiers, [NotNull] out string message)
+        {
+            return CanInsertChildren(children, position, modifiers, out message) ? DropAcceptance.Accepted : DropAcceptance.Rejected;
+        }
+
+        /// <summary>
         /// Inserts the given children before or after itself in the collection it is contained in. Should be invoked only if <see cref="CanInsertChildren"/> returned <c>true</c>.
         /// </summary>
         /// <param name="children">The children to add.</param>

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Controls/TreeViewItem.cs
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Controls/TreeViewItem.cs
@@ -18,10 +18,18 @@ namespace Stride.Core.Presentation.Controls
     /// <summary>
     /// An item of the TreeView.
     /// </summary>
+    [TemplatePart(Name = HeaderPartName, Type = typeof(FrameworkElement))]
     public class TreeViewItem : ExpandableItemsControl
     {
+        /// <summary>
+        /// The name of the element that displays the header of this <see cref="TreeViewItem"/>, excluding its child items.
+        /// </summary>
+        public const string HeaderPartName = "border";
+
         internal double ItemTopInTreeSystem; // for virtualization purposes
         internal int HierachyLevel;// for virtualization purposes
+
+        private FrameworkElement headerElement;
 
         /// <summary>
         /// Identifies the <see cref="IsEditable"/> dependency property.
@@ -83,7 +91,22 @@ namespace Stride.Core.Presentation.Controls
 
         [DependsOn("Indentation")]
         public double Offset => ParentTreeViewItem?.Offset + Indentation ?? 0;
-        
+
+        /// <summary>
+        /// Gets the element that displays the header of this item, or <c>null</c> if the template has not been applied yet.
+        /// </summary>
+        [CanBeNull]
+        public FrameworkElement HeaderElement => headerElement;
+
+        /// <summary>
+        /// Gets the height of the header of this item, excluding the height of its child items.
+        /// </summary>
+        /// <remarks>
+        /// This is not <see cref="FrameworkElement.ActualHeight"/>. The control template puts the header and the items
+        /// presenter in one stack panel. Therefore the actual height of an expanded item includes its child items.
+        /// </remarks>
+        public double HeaderHeight => headerElement?.ActualHeight ?? ActualHeight;
+
         public TreeViewItem ParentTreeViewItem => ItemsControlFromItemContainer(this) as TreeViewItem;
 
         public TreeView ParentTreeView { get; internal set; }
@@ -197,6 +220,8 @@ namespace Stride.Core.Presentation.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
+
+            headerElement = DependencyObjectExtensions.CheckTemplatePart<FrameworkElement>(GetTemplateChild(HeaderPartName));
 
             if (ParentTreeView?.SelectedItems != null && ParentTreeView.SelectedItems.Contains(DataContext))
             {

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/DarkSteelTheme.xaml
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/DarkSteelTheme.xaml
@@ -52,6 +52,12 @@
   <SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#3399FF"/>
   <SolidColorBrush x:Key="SelectedTextBrush" Color="#EBEBEB"/>
 
+  <!-- Drag and drop feedback. These live in the theme so that a theme can restyle them. -->
+  <SolidColorBrush x:Key="DropInsertLineBrush" Color="#3399FF"/>
+  <SolidColorBrush x:Key="DropTargetNeutralBrush" Color="#FF5E5E60"/>
+  <SolidColorBrush x:Key="DropTargetAcceptBrush" Color="#FF65C36A"/>
+  <SolidColorBrush x:Key="DropTargetRefuseBrush" Color="#FFDC4E4E"/>
+
   <Color x:Key="EmphasisGreenColor">#FF8ABB2E</Color>
   <SolidColorBrush x:Key="EmphasisGreenBrush" Color="{StaticResource EmphasisGreenColor}"/>
 

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/DividedTheme.xaml
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/DividedTheme.xaml
@@ -52,6 +52,12 @@
   <SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#FF46607C"/>
   <SolidColorBrush x:Key="SelectedTextBrush" Color="#FFEBEBEB"/>
 
+  <!-- Drag and drop feedback. These live in the theme so that a theme can restyle them. -->
+  <SolidColorBrush x:Key="DropInsertLineBrush" Color="#FF46607C"/>
+  <SolidColorBrush x:Key="DropTargetNeutralBrush" Color="#FF212121"/>
+  <SolidColorBrush x:Key="DropTargetAcceptBrush" Color="#FF65C36A"/>
+  <SolidColorBrush x:Key="DropTargetRefuseBrush" Color="#FFDC4E4E"/>
+
   <SolidColorBrush x:Key="EmphasisColorBrush" Color="#FF3E5F96" />
 
   <Color x:Key="EmphasisGreenColor">#FF8ABB2E</Color>

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/ExpressionDarkTheme.xaml
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/ExpressionDarkTheme.xaml
@@ -58,6 +58,12 @@
   <SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#007ACC"/>
   <SolidColorBrush x:Key="SelectedTextBrush" Color="#E6E6E6"/>
 
+  <!-- Drag and drop feedback. These live in the theme so that a theme can restyle them. -->
+  <SolidColorBrush x:Key="DropInsertLineBrush" Color="#007ACC"/>
+  <SolidColorBrush x:Key="DropTargetNeutralBrush" Color="#FF333333"/>
+  <SolidColorBrush x:Key="DropTargetAcceptBrush" Color="#FF65C36A"/>
+  <SolidColorBrush x:Key="DropTargetRefuseBrush" Color="#FFDC4E4E"/>
+
   <Color x:Key="EmphasisGreenColor">#FF8ABB2E</Color>
   <SolidColorBrush x:Key="EmphasisGreenBrush" Color="{StaticResource EmphasisGreenColor}"/>
 

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/LightSteelBlueTheme.xaml
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Themes/Overrides/LightSteelBlueTheme.xaml
@@ -52,6 +52,12 @@
   <SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#FF007ACC"/>
   <SolidColorBrush x:Key="SelectedTextBrush" Color="White"/>
 
+  <!-- Drag and drop feedback. These live in the theme so that a theme can restyle them. -->
+  <SolidColorBrush x:Key="DropInsertLineBrush" Color="#FF007ACC"/>
+  <SolidColorBrush x:Key="DropTargetNeutralBrush" Color="#FF9B9999"/>
+  <SolidColorBrush x:Key="DropTargetAcceptBrush" Color="#FF65C36A"/>
+  <SolidColorBrush x:Key="DropTargetRefuseBrush" Color="#FFDC4E4E"/>
+
   <Color x:Key="EmphasisGreenColor">#FF8ABB2E</Color>
   <SolidColorBrush x:Key="EmphasisGreenBrush" Color="{StaticResource EmphasisGreenColor}"/>
 

--- a/sources/presentation/Stride.Core.Presentation.Wpf/Themes/generic.xaml
+++ b/sources/presentation/Stride.Core.Presentation.Wpf/Themes/generic.xaml
@@ -9,6 +9,7 @@
                     xmlns:behaviors="clr-namespace:Stride.Core.Presentation.Behaviors"
                     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
                     xmlns:sd="http://schemas.stride3d.net/xaml/presentation"
+                    xmlns:s="clr-namespace:System;assembly=mscorlib"
                     mc:Ignorable="d">
 
   <!--<Style TargetType="{x:Type ctrl:PropertyGrid}">
@@ -29,6 +30,10 @@
   <SolidColorBrush x:Key="GreenBrush" Color="#FF65C36A" />
   <SolidColorBrush x:Key="BlueBrush" Color="#FF3F74D1" />
   <SolidColorBrush x:Key="AlphaBrush" Color="#FFBCBCBC" />
+
+    <!-- Drag and drop feedback. The colours live in the theme files. -->
+    <s:Double x:Key="DropInsertLineThickness">2</s:Double>
+    <s:Double x:Key="DropInsertMarkerRadius">3</s:Double>
 
   <!-- ### EditableListBox ################################################################################################################################################# -->
   <SolidColorBrush x:Key="GlyphBrush" Color="Black" />


### PR DESCRIPTION
# PR Details

The entity tree gave no reliable indication of where a dragged entity would land. The insert line was a flat grey line drawn across the whole row at the same place for every nesting level, so two drops that mean different parents looked identical, and some gestures were offered that the drop could not honour.

This makes the indicator state the outcome before you commit to it.

## What changed

**The insert line carries depth.** It starts at the indentation of its target, is preceded by a marker, and uses the accent colour of the theme instead of a fixed grey.

<img width="1232" height="936" alt="A1_before_after" src="https://github.com/user-attachments/assets/6be5c276-f9c3-47fb-81be-cf604ff49a41" />

**The drop target is highlighted**, in three states: green to accept, grey when nothing would change, red to refuse.

<img width="1318" height="740" alt="B4_three_states" src="https://github.com/user-attachments/assets/c45f91d8-f8c8-46ff-8e7e-3a3b4d1e645d" />

**The insert bands scale with the row** — 30% of the row height, clamped to [3, 10] px and then to 40% of the row so a drop-into zone always survives — instead of a fixed 4 px. `DropZoneCalculator` holds this geometry and is unit tested.

<img width="1400" height="830" alt="A3_hit_zones" src="https://github.com/user-attachments/assets/7a21ef44-ef05-4e9e-846a-73fcac0ace85" />

**A position that could not be reached is now reachable.** An item could not be placed after an expanded item that is the last child at its level. In the gap below a subtree, the horizontal position of the pointer now selects the ancestor level, and the indentation of the line shows which one.

<img width="1200" height="584" alt="C2_ancestor_picking" src="https://github.com/user-attachments/assets/4c5ca95e-4245-4063-8ffb-66c5876a6aee" />

**An item can be moved to the end of its parent**, by dropping it in the empty area below the tree or on the row of its parent. `MoveChildren` already corrected the insertion index for an item it removes from the same parent, so the move itself was supported; only the check stopped it.

<img width="752" height="516" alt="C3_empty_area_states" src="https://github.com/user-attachments/assets/622840a5-62e0-449a-8908-a5cc8312c5db" />

## Behaviour changes worth reviewing

Three things change for existing users. None of them is silent — each is stated in the drag message before the drop happens.

**1. Folder rows no longer offer insert bands.** The gesture existed, but it could not honour the position it promised. `EntityDesign.Folder` is a path string with no index, and folders are sorted by name and always come before the entities, so a folder has no position to insert around. `EntityFolderViewModel` did not override `GetInsertionIndex`, so it inherited the base implementation that returns `0` and ignores `InsertPosition`. The whole folder row now adds the items as its children, which works.

<img width="1232" height="1396" alt="C1_folder_before_after" src="https://github.com/user-attachments/assets/2094147b-4909-4187-8fc9-aef7cdaad779" />

**2. Dropping an item on the parent it already has now moves it to the end** of that parent, instead of being refused. It stays a no-op only when the item is already the last child.

**3. A drop that changes nothing is neutral, not an error.** Dropping an item on itself used to show a red cross. `DropAcceptance` adds a third result between accepted and refused. The interfaces give it a default implementation, therefore the other view models keep their behaviour.

## Implementation notes

- `TreeViewItem` gains `HeaderHeight` and `HeaderElement`. The control template puts the header and the items presenter in one stack panel, so `ActualHeight` includes all children of an expanded item and cannot be used for row geometry. Adorning the header rather than the item is also what keeps the highlight on the row instead of the whole subtree.
- `DropAcceptance` reaches the behaviour through default interface members on `IAddChildViewModel` and `IInsertChildViewModel`, so none of the existing implementers changed. Only `EntityHierarchyItemViewModel` overrides them.
- The boolean members map `== Accepted`, so `NoOp` is a subset of the previous `false` and every existing caller behaves exactly as before.
- One pre-existing leak is fixed along the way: the `finally` in `DoDragDrop` never cleared the insert adorner, so an aborted drag left the line on screen.

## Testing

29 unit tests covering the new pure pieces: the band geometry in `DropZoneCalculator`, the tri-state on `DragContainer`, and proof that the default interface members keep the old boolean behaviour for view models that implement only the old members.

**These tests do not run in CI on this PR.** The `runtime` filter in `changes.yml` does not list `sources/editor/**` or `sources/presentation/**`, so only `Windows-Full` (which builds with `-p:StrideSkipUnitTests=true`) and `VS-Package` are triggered. `Windows-Tests-Simple`, the only lane that runs `Stride.Core.Assets.Editor.Tests`, is gated on `runtime` and stays skipped, and `Gate` still passes. To run them:

```
dotnet test build\Stride.Tests.Simple.slnf --filter "FullyQualifiedName~Stride.Core.Assets.Editor.Tests"
```

I did not want to add an unrelated file just to trip the path filter, but I am happy to if you would prefer the lane to run. The change is visible in GameStudio, so the `ci-editor` label may also be worth applying.

Verified by hand in a Debug GameStudio on `samples/Templates/FirstPersonShooter`, checking the resulting order of the tree after each drop rather than only the indicator: folder rows, the three drop states, ancestor selection in the gap below a subtree, move to the end from the empty area and from the row of the parent, and that a no-op writes nothing (a single undo after a no-op reverts the move that preceded it).

## Known limitations

- The ancestor zones are narrow. The level changes at the indentation of the target, which is about 10 px per level at the left edge of the tree.
- In the bottom band of an item whose parent is a folder, moving the pointer left does not step up a level. The walk reaches the folder, folders refuse insertion, and it falls through to "add as a child" on the hovered row. It is safe and the message states it, but it changes the operation instead of the level. There is no valid shallower target to offer in that case.
- The classification in the view model has no automated coverage, because there is no test project for `Stride.Assets.Presentation`. The geometry and the tri-state plumbing are covered by tests; the acceptance decisions are covered by hand.
- Themes other than the default, and virtualized scrolling, were not exercised.

## Related Issue

Fixes #3364

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
