### PR TITLE
fix: preserve model materials across source reimport

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/ViewModel/ModelViewModel.cs
+++ b/sources/editor/Stride.Assets.Presentation/ViewModel/ModelViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
+using Stride.Assets.Materials;
 using Stride.Assets.Models;
 using Stride.Assets.Presentation.Templates;
 using Stride.Core.Assets;
@@ -70,13 +71,31 @@ namespace Stride.Assets.Presentation.ViewModel
             // Repopulate the list of materials
             for (var i = 0; i < assetToMerge.Materials.Count; ++i)
             {
+                var materialName = assetToMerge.Materials[i].Name;
+                var modelMaterial = dictionary[materialName];
+
                 // Retrieve or create an id for the material
-                ItemId id;
-                if (!ids.TryGetValue(assetToMerge.Materials[i].Name, out id))
+                if (!ids.TryGetValue(materialName, out var id))
+                {
                     id = ItemId.New();
 
+                    // Update-from-source imports only the ModelAsset. A source material that
+                    // disappeared in the previous revision and now reappears therefore has a
+                    // null material reference in assetToMerge. Reconnect the MaterialAsset that
+                    // was created by the original import, when it still exists beside the model.
+                    if (modelMaterial.MaterialInstance?.Material == null)
+                    {
+                        var materialAsset = Directory.Assets.FirstOrDefault(x =>
+                            x.Asset is MaterialAsset &&
+                            string.Equals(x.Name, materialName, StringComparison.OrdinalIgnoreCase));
+
+                        if (materialAsset != null)
+                            modelMaterial.MaterialInstance.Material = ContentReferenceHelper.CreateReference<Material>(materialAsset);
+                    }
+                }
+
                 // Use Restore to allow to set manually the id.
-                materialsNode.Restore(dictionary[assetToMerge.Materials[i].Name], new NodeIndex(i), id);
+                materialsNode.Restore(modelMaterial, new NodeIndex(i), id);
             }
         }
 

--- a/sources/engine/Stride.Assets.Models/ImportThreeDCommand.cs
+++ b/sources/engine/Stride.Assets.Models/ImportThreeDCommand.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Stride.Core.BuildEngine;
+using Stride.Core.Serialization;
 using Stride.Core.Serialization.Contents;
 using Stride.Animations;
 using Stride.Importer.Common;
@@ -40,12 +41,59 @@ namespace Stride.Assets.Models
         protected override Model LoadModel(ICommandContext commandContext, ContentManager contentManager)
         {
             var converter = CreateMeshConverter(commandContext);
+            var sceneData = converter.Convert(SourcePath, Location, DeduplicateMaterials, out var sourceMaterialNames);
 
-            // Note: FBX exporter uses Materials for the mapping, but Assimp already uses indices so we can reuse them
-            // We should still unify the behavior to be more consistent at some point (i.e. if model was changed on the HDD but not in the asset).
-            // This should probably be better done during a large-scale FBX/Assimp refactoring.
-            var sceneData = converter.Convert(SourcePath, Location, DeduplicateMaterials);
+            // Assimp mesh material indices refer to the material order in the freshly imported source.
+            // ModelAsset.Materials can still reflect the previous source revision while an asset is being
+            // updated, so build a local material list in source order instead of reusing stale positions.
+            AlignMaterialsWithSource(sourceMaterialNames);
+
             return sceneData;
+        }
+
+        private void AlignMaterialsWithSource(IReadOnlyList<string> sourceMaterialNames)
+        {
+            // Keep the existing fallback behavior for formats/scenes where Assimp exposes no materials.
+            if (sourceMaterialNames.Count == 0)
+                return;
+
+            var materialsByName = new Dictionary<string, ModelMaterial>(StringComparer.Ordinal);
+            if (Materials != null)
+            {
+                foreach (var material in Materials)
+                {
+                    if (material?.Name != null && !materialsByName.ContainsKey(material.Name))
+                        materialsByName.Add(material.Name, material);
+                }
+            }
+
+            var alignedMaterials = new List<ModelMaterial>(sourceMaterialNames.Count);
+            foreach (var materialName in sourceMaterialNames)
+            {
+                if (materialsByName.TryGetValue(materialName, out var material))
+                {
+                    alignedMaterials.Add(material);
+                }
+                else
+                {
+                    // The source contains a new/reintroduced material that is not present in the
+                    // currently saved ModelAsset yet. Keep its source slot so later material indices
+                    // do not shift; UpdateAssetFromSource will reconnect its asset reference.
+                    alignedMaterials.Add(new ModelMaterial
+                    {
+                        Name = materialName,
+                        MaterialInstance = new MaterialInstance(),
+                    });
+                }
+            }
+
+            Materials = alignedMaterials;
+        }
+
+        protected override void ComputeParameterHash(BinarySerializationWriter writer)
+        {
+            base.ComputeParameterHash(writer);
+            writer.Write(1); // Increment when Assimp model compilation behavior changes.
         }
 
         protected override Dictionary<string, AnimationClip> LoadAnimation(ICommandContext commandContext, ContentManager contentManager, out TimeSpan duration)

--- a/sources/tools/Stride.Importer.3D/MeshConverter.cs
+++ b/sources/tools/Stride.Importer.3D/MeshConverter.cs
@@ -136,6 +136,11 @@ namespace Stride.Importer.ThreeD
 
         public unsafe Model Convert(string inputFilename, string outputFilename, bool deduplicateMaterials)
         {
+            return Convert(inputFilename, outputFilename, deduplicateMaterials, out _);
+        }
+
+        public unsafe Model Convert(string inputFilename, string outputFilename, bool deduplicateMaterials, out List<string> materialNames)
+        {
             uint importFlags = 0;
 
             aiPostProcessSteps postProcessFlags = 0;
@@ -145,7 +150,24 @@ namespace Stride.Importer.ThreeD
             }
 
             var scene = Initialize(inputFilename, outputFilename, importFlags, postProcessFlags);
+            materialNames = GetMaterialNames(scene);
             return ConvertAssimpScene(scene);
+        }
+
+        private unsafe List<string> GetMaterialNames(Scene* scene)
+        {
+            var namesByMaterial = new Dictionary<IntPtr, string>();
+            GenerateMaterialNames(scene, namesByMaterial);
+
+            var materialNames = new List<string>((int)scene->MNumMaterials);
+            for (uint i = 0; i < scene->MNumMaterials; ++i)
+            {
+                var material = scene->MMaterials[i];
+                // Keep this normalization in sync with ExtractMaterials().
+                materialNames.Add(namesByMaterial[(IntPtr)material].Replace('/', '_'));
+            }
+
+            return materialNames;
         }
 
         public unsafe AnimationInfo ConvertAnimation(string inputFilename, string outputFilename, int animationIndex)


### PR DESCRIPTION
# PR Details

Fixes model material assignments becoming misaligned or losing references when updating a model from source after materials are removed and later restored.

The importer now aligns saved materials to the current source material order by name, while the editor reconnects genuinely reintroduced material slots to an existing same-named material asset.

Tested with the reproduction from #3363, including repeated v1 ? v2 ? v1 updates, multiple material removals, manual overrides, save/reopen, and running the editor.

Developed with assistance from ChatGPT using GPT-5.6 Sol. The final changes were reviewed and tested before submission.

## Related Issue

Fixes #3363

## Types of changes

* [ ] Docs change / refactoring / dependency upgrade
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

* [ ] My change requires a change to the documentation.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] **I have built and run the editor to try this change out.**




