### PR TITLE
fix: load the assets a run-time material references

### DIFF
--- a/sources/buildengine/Stride.Core.BuildEngine.Common/BuildTransaction.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/BuildTransaction.cs
@@ -31,6 +31,41 @@ internal class BuildTransaction
         }
     }
 
+    public IEnumerable<KeyValuePair<string, ObjectId>> GetMergedIdMap()
+    {
+        var result = new Dictionary<string, ObjectId>();
+
+        lock (transactionOutputObjects)
+        {
+            foreach (var outputObject in transactionOutputObjects)
+            {
+                if (outputObject.Key.Type == UrlType.Content)
+                    result[outputObject.Key.Path] = outputObject.Value;
+            }
+
+            foreach (var outputObjects in outputObjectsGroups)
+            {
+                // Lock underlying EnumerableBuildStep.OutputObjects
+                lock (outputObjects)
+                {
+                    foreach (var outputObject in outputObjects)
+                    {
+                        if (outputObject.Key.Type == UrlType.Content)
+                            result.TryAdd(outputObject.Key.Path, outputObject.Value.ObjectId);
+                    }
+                }
+            }
+
+            if (contentIndexMap != null)
+            {
+                foreach (var entry in contentIndexMap.GetMergedIdMap())
+                    result.TryAdd(entry.Key, entry.Value);
+            }
+        }
+
+        return result;
+    }
+
     public bool TryGetValue(string url, out ObjectId objectId)
     {
         var objUrl = new ObjectUrl(UrlType.Content, url);
@@ -114,8 +149,7 @@ internal class BuildTransaction
 
         public IEnumerable<KeyValuePair<string, ObjectId>> GetMergedIdMap()
         {
-            // Shouldn't be used
-            throw new NotImplementedException();
+            return buildTransaction.GetMergedIdMap();
         }
 
         public void Dispose()

--- a/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
+++ b/sources/core/Stride.Core.Serialization/Serialization/Contents/ContentManager.cs
@@ -670,46 +670,53 @@ public sealed partial class ContentManager : IContentManager
     {
         var errorMessage = $"The asset '{url}' could not be found. Asset path should be 'MyFolder/MyAssetName', or '/PackageName/MyFolder/MyAssetName' for an asset from a namespaced package. Check that the path is correct and that the asset has been included into the build.";
 
-        var contentIndexMap = FileProvider?.ContentIndexMap;
-        if (contentIndexMap != null)
+        try
         {
-            var indexMap = contentIndexMap.GetMergedIdMap();
+            var contentIndexMap = FileProvider?.ContentIndexMap;
+            if (contentIndexMap != null)
+            {
+                var indexMap = contentIndexMap.GetMergedIdMap();
 
-            // First suggest assets differing from the requested URL only by the '/PackageName' root
-            var isRooted = url.StartsWith('/');
-            var candidates = new List<string>();
-            foreach (var entry in indexMap)
-            {
-                if (isRooted ? DiffersByRoot(url, entry.Key) : DiffersByRoot(entry.Key, url))
-                    candidates.Add(entry.Key);
-            }
-            if (candidates.Count > 0)
-            {
-                candidates.Sort();
-                errorMessage = $"The asset '{url}' could not be found. Did you mean:"
-                    + string.Concat(candidates.Select(c => $"{Environment.NewLine}  '{c}'"))
-                    + $"{Environment.NewLine}An asset from a namespaced package is addressed by a rooted URL: '/PackageName/MyFolder/MyAssetName'.";
-            }
-            else
-            {
-                // Otherwise fall back to assets with the same name in other folders
-                var assetName = url.Substring(url.LastIndexOf('/') + 1);
-                var sameNameCandidates = new List<string>();
+                // First suggest assets differing from the requested URL only by the '/PackageName' root
+                var isRooted = url.StartsWith('/');
+                var candidates = new List<string>();
                 foreach (var entry in indexMap)
                 {
-                    if (entry.Key.EndsWith(assetName, StringComparison.OrdinalIgnoreCase)
-                        && (entry.Key.Length == assetName.Length || entry.Key[entry.Key.Length - assetName.Length - 1] == '/'))
-                        sameNameCandidates.Add(entry.Key);
+                    if (isRooted ? DiffersByRoot(url, entry.Key) : DiffersByRoot(entry.Key, url))
+                        candidates.Add(entry.Key);
                 }
-                if (sameNameCandidates.Count > 0)
+                if (candidates.Count > 0)
                 {
-                    sameNameCandidates.Sort();
-                    var more = sameNameCandidates.Count > MaxSameNameCandidates ? $"{Environment.NewLine}  (and {sameNameCandidates.Count - MaxSameNameCandidates} more)" : string.Empty;
-                    errorMessage = $"The asset '{url}' could not be found. Assets with the same name exist at:"
-                        + string.Concat(sameNameCandidates.Take(MaxSameNameCandidates).Select(c => $"{Environment.NewLine}  '{c}'"))
-                        + more;
+                    candidates.Sort();
+                    errorMessage = $"The asset '{url}' could not be found. Did you mean:"
+                        + string.Concat(candidates.Select(c => $"{Environment.NewLine}  '{c}'"))
+                        + $"{Environment.NewLine}An asset from a namespaced package is addressed by a rooted URL: '/PackageName/MyFolder/MyAssetName'.";
+                }
+                else
+                {
+                    // Otherwise fall back to assets with the same name in other folders
+                    var assetName = url.Substring(url.LastIndexOf('/') + 1);
+                    var sameNameCandidates = new List<string>();
+                    foreach (var entry in indexMap)
+                    {
+                        if (entry.Key.EndsWith(assetName, StringComparison.OrdinalIgnoreCase)
+                            && (entry.Key.Length == assetName.Length || entry.Key[entry.Key.Length - assetName.Length - 1] == '/'))
+                            sameNameCandidates.Add(entry.Key);
+                    }
+                    if (sameNameCandidates.Count > 0)
+                    {
+                        sameNameCandidates.Sort();
+                        var more = sameNameCandidates.Count > MaxSameNameCandidates ? $"{Environment.NewLine}  (and {sameNameCandidates.Count - MaxSameNameCandidates} more)" : string.Empty;
+                        errorMessage = $"The asset '{url}' could not be found. Assets with the same name exist at:"
+                            + string.Concat(sameNameCandidates.Take(MaxSameNameCandidates).Select(c => $"{Environment.NewLine}  '{c}'"))
+                            + more;
+                    }
                 }
             }
+        }
+        catch (Exception)
+        {
+            // Suggestions are best effort; an index map that cannot enumerate must not replace the real error
         }
 
         // True when <rooted> is exactly '/PackageName' (a single segment) followed by '/<bare>'.

--- a/sources/editor/Stride.Assets.Presentation/Preview/SkyboxPreview.cs
+++ b/sources/editor/Stride.Assets.Presentation/Preview/SkyboxPreview.cs
@@ -123,7 +123,7 @@ namespace Stride.Assets.Presentation.Preview
                     },
                     SpecularModel = new MaterialSpecularMicrofacetModelFeature()
                 }
-            });
+            }, Game.Content);
         }
     }
 }

--- a/sources/editor/Stride.Assets.Presentation/Preview/SkyboxPreview.cs
+++ b/sources/editor/Stride.Assets.Presentation/Preview/SkyboxPreview.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System.Threading.Tasks;
+using Stride.Core.Assets.Compiler;
 using Stride.Core.Mathematics;
 using Stride.Assets.Skyboxes;
 using Stride.Editor.Annotations;
 using Stride.Editor.Preview;
 using Stride.Engine;
+using Stride.Graphics;
 using Stride.Rendering.Skyboxes;
 using Stride.Rendering;
 using Stride.Rendering.Lights;
@@ -51,6 +53,23 @@ namespace Stride.Assets.Presentation.Preview
         protected override void SetupLighting(Entity camera)
         {
             // No default lighting
+        }
+
+        protected override AssetCompilerResult Compile()
+        {
+            var result = base.Compile();
+
+            // The preview material is generated at run time, so the specular lookup table it references
+            // is not a dependency of the skybox asset; compile it too so the preview database can serve it
+            foreach (var profile in new[] { GraphicsProfile.Level_9_1, GraphicsProfile.Level_10_0 })
+            {
+                var lutReference = MaterialSpecularMicrofacetEnvironmentGGXLUT.CreateLookupTableReference(profile);
+                var lutItem = AssetItem.Package.Session.FindAssetFromProxyObject(lutReference);
+                if (lutItem != null)
+                    result.BuildSteps.Add(Builder.Compile(lutItem).BuildSteps);
+            }
+
+            return result;
         }
 
         protected override PreviewEntity CreatePreviewEntity()

--- a/sources/editor/Stride.Assets.Presentation/Themes/Generic.xaml
+++ b/sources/editor/Stride.Assets.Presentation/Themes/Generic.xaml
@@ -145,7 +145,7 @@
                   <Slider Grid.Column="1" Value="{Binding Metalness}" Height="16" Minimum="0" Maximum="1" HorizontalAlignment="Stretch"
                           TickFrequency="0.0333" TickPlacement="BottomRight" IsMoveToPointEnabled="True"/>
                 </Grid>
-                <Grid HorizontalAlignment="Stretch">
+                <Grid HorizontalAlignment="Stretch" Margin="0,3,0,0">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="70" />
                     <ColumnDefinition Width="*" />

--- a/sources/engine/Stride.Assets.Tests/TestMaterialGenerator.cs
+++ b/sources/engine/Stride.Assets.Tests/TestMaterialGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using Stride.Core.Mathematics;
+using Stride.Core.Serialization;
 using Stride.Core.Yaml;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
@@ -913,6 +914,49 @@ Compositions:
             AssertShaderSourceEqual(expected, pixelShaders);
         }
 
+
+        /// <summary>
+        /// The generator on its own leaves texture references as proxies.
+        /// </summary>
+        /// <remarks>
+        /// This is what the asset compiler serializes: the proxy carries the reference, and a content
+        /// load turns it back into the texture. A caller that generates a material at run time is outside
+        /// that path and has to resolve the references itself, which is what <c>Material.New</c> does.
+        /// Pinning it here keeps a change made for the run-time path from breaking the build-time one.
+        /// </remarks>
+        [Fact]
+        public void TestGeneratorLeavesTextureReferencesAsProxies()
+        {
+            var context = new MaterialGeneratorContextExtended();
+            var materialDesc = new MaterialDescriptor
+            {
+                Attributes =
+                {
+                    Diffuse = new MaterialDiffuseMapFeature(new ComputeColor(Color.White)),
+                    DiffuseModel = new MaterialDiffuseLambertModelFeature(),
+                    Specular = new MaterialMetalnessMapFeature(new ComputeFloat(1.0f)),
+                    MicroSurface = new MaterialGlossinessMapFeature(new ComputeFloat(0.9f)),
+
+                    // Defaults its environment function to MaterialSpecularMicrofacetEnvironmentGGXLUT,
+                    // which attaches a reference to a lookup table texture.
+                    SpecularModel = new MaterialSpecularMicrofacetModelFeature(),
+                },
+            };
+
+            var result = MaterialGenerator.Generate(materialDesc, context, "test_material");
+            Assert.False(result.HasErrors, result.ToText());
+
+            var lookupTable = result.Material.Passes[0].Parameters
+                .Get(MaterialSpecularMicrofacetEnvironmentGGXLUTKeys.EnvironmentLightingDFG_LUT);
+
+            Assert.NotNull(lookupTable);
+
+            var reference = AttachedReferenceManager.GetAttachedReference(lookupTable);
+
+            Assert.NotNull(reference);
+            Assert.True(reference.IsProxy, "The generator resolved the reference, which the asset compiler relies on staying a proxy.");
+            Assert.Equal("/Stride.Engine/StrideEnvironmentLightingDFGLUT16", reference.Url);
+        }
 
         private class MaterialGeneratorContextExtended : MaterialGeneratorContext
         {

--- a/sources/engine/Stride.Assets.Tests/TestMaterialGenerator.cs
+++ b/sources/engine/Stride.Assets.Tests/TestMaterialGenerator.cs
@@ -8,6 +8,7 @@ using Xunit;
 using Stride.Core.Mathematics;
 using Stride.Core.Serialization;
 using Stride.Core.Yaml;
+using Stride.Graphics;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
 using Stride.Rendering.Materials.ComputeColors;
@@ -927,7 +928,9 @@ Compositions:
         [Fact]
         public void TestGeneratorLeavesTextureReferencesAsProxies()
         {
-            var context = new MaterialGeneratorContextExtended();
+            // The graphics profile decides between the LUT16 and LUT8 lookup tables; pin it
+            // so the URL asserted below does not depend on the context's default.
+            var context = new MaterialGeneratorContextExtended { GraphicsProfile = GraphicsProfile.Level_10_0 };
             var materialDesc = new MaterialDescriptor
             {
                 Attributes =

--- a/sources/engine/Stride.Engine.Tests/ParameterCollectionAttachedReferenceTest.cs
+++ b/sources/engine/Stride.Engine.Tests/ParameterCollectionAttachedReferenceTest.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Xunit;
+
+using Stride.Core.Assets;
+using Stride.Core.Diagnostics;
+using Stride.Core.Serialization;
+using Stride.Rendering;
+
+namespace Stride.Engine.Tests
+{
+    /// <summary>
+    /// Tests how a <see cref="ParameterCollection"/> handles object values that are unresolved
+    /// attached references (proxies made by <see cref="AttachedReferenceManager.CreateProxyObject{T}(AssetId, string)"/>).
+    /// </summary>
+    public class ParameterCollectionAttachedReferenceTest
+    {
+        public static readonly ObjectParameterKey<object> ObjectKey = ParameterKeys.NewObject<object>();
+
+        [Fact]
+        public void TestResolveWithoutContentManagerWarnsAndKeepsProxy()
+        {
+            var parameters = new ParameterCollection();
+            var url = $"test/unresolved/{Guid.NewGuid()}";
+            var proxy = AttachedReferenceManager.CreateProxyObject<TestReferencedContent>(AssetId.New(), url);
+            parameters.Set(ObjectKey, proxy);
+
+            var log = new LoggerResult();
+            parameters.ResolveAttachedReferences(null, log);
+
+            Assert.Contains(log.Messages, message => message.Type == LogMessageType.Warning && message.Text.Contains(url));
+            Assert.Same(proxy, parameters.Get(ObjectKey));
+        }
+
+        [Fact]
+        public void TestUpdateLayoutReportsUnresolvedReference()
+        {
+            var parameters = new ParameterCollection();
+            // The report deduplicates per URL for the process lifetime, so make the URL unique
+            var url = $"test/unresolved/{Guid.NewGuid()}";
+            parameters.Set(ObjectKey, AttachedReferenceManager.CreateProxyObject<TestReferencedContent>(AssetId.New(), url));
+
+            var warnings = CollectGlobalWarningsDuring(() => parameters.UpdateLayout(LayoutWith(ObjectKey)));
+
+            Assert.Contains(warnings, text => text.Contains(url));
+        }
+
+        [Fact]
+        public void TestUpdateLayoutIgnoresResolvedObjects()
+        {
+            var parameters = new ParameterCollection();
+            parameters.Set(ObjectKey, new TestReferencedContent());
+
+            var warnings = CollectGlobalWarningsDuring(() => parameters.UpdateLayout(LayoutWith(ObjectKey)));
+
+            Assert.DoesNotContain(warnings, text => text.Contains("unloaded content"));
+        }
+
+        private static ParameterCollectionLayout LayoutWith(ParameterKey key)
+        {
+            var layout = new ParameterCollectionLayout { ResourceCount = 1 };
+            layout.LayoutParameterKeyInfos.Add(new ParameterKeyInfo(key, 0));
+            return layout;
+        }
+
+        private static List<string> CollectGlobalWarningsDuring(Action action)
+        {
+            var warnings = new List<string>();
+
+            void Collect(ILogMessage message)
+            {
+                if (message.Type >= LogMessageType.Warning)
+                {
+                    lock (warnings) warnings.Add(message.Text);
+                }
+            }
+
+            GlobalLogger.GlobalMessageLogged += Collect;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                GlobalLogger.GlobalMessageLogged -= Collect;
+            }
+
+            return warnings;
+        }
+
+        private class TestReferencedContent
+        {
+        }
+    }
+}

--- a/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.csproj
+++ b/sources/engine/Stride.Engine.Tests/Stride.Engine.Tests.csproj
@@ -23,6 +23,7 @@
     <Compile Include="Build\TestBuilder.cs" />
     <Compile Include="EngineTestBase.cs" />
     <Compile Include="ForwardRendererTransparentTargetsTest.cs" />
+    <Compile Include="ParameterCollectionAttachedReferenceTest.cs" />
     <Compile Include="ParameterCollectionUpdateEngineTest.cs" />
     <Compile Include="EntityUpdateEngineTest.cs" />
     <Compile Include="AnimatedModelTests.cs" />

--- a/sources/engine/Stride.Engine/Stride.Engine.sdpkg
+++ b/sources/engine/Stride.Engine/Stride.Engine.sdpkg
@@ -9,3 +9,5 @@ RootAssets:
     - c90f3988-0544-4cbe-993f-13af7d9c23c6:/Stride.Engine/StrideDefaultFont
     - d26edb11-10bd-403c-b3c2-9c7fcccf25e5:/Stride.Engine/StrideDefaultSplashScreen
     - FF02239B-3697-4EBB-9F37-FE880659E64B:/Stride.Engine/StrideDebugSpriteFont
+    - a49995f8-2380-4baa-a03e-f8d1da35b79a:/Stride.Engine/StrideEnvironmentLightingDFGLUT16
+    - 87540190-ab97-4b4e-b3c2-d57d2fbb1ff3:/Stride.Engine/StrideEnvironmentLightingDFGLUT8

--- a/sources/engine/Stride.Foundation/Effects/ParameterCollectionExtensions.cs
+++ b/sources/engine/Stride.Foundation/Effects/ParameterCollectionExtensions.cs
@@ -5,6 +5,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
+using Stride.Core;
+using Stride.Core.Diagnostics;
+using Stride.Core.Serialization;
+using Stride.Core.Serialization.Contents;
+
 namespace Stride.Rendering
 {
     /// <summary>
@@ -55,6 +60,62 @@ namespace Stride.Rendering
             }
 
             return builder.ToString();
+        }
+
+        /// <summary>
+        /// Loads the content that object parameters of this collection only hold references to.
+        /// </summary>
+        /// <param name="parameters">The parameter collection to resolve.</param>
+        /// <param name="content">The content manager to load through, or <c>null</c> to only report.</param>
+        /// <param name="log">The logger that reports references left unresolved, or <c>null</c> for the default one.</param>
+        /// <remarks>
+        /// Code that builds objects outside of a content load can attach a reference with
+        /// <see cref="AttachedReferenceManager.CreateProxyObject{T}(AssetId, string)"/>, which makes an
+        /// empty object and marks it as a proxy. A proxy becomes the real content in one place only,
+        /// <c>ReferenceSerializer</c>, and only during a content load, so such collections keep empty
+        /// objects until they are loaded here.
+        /// </remarks>
+        public static void ResolveAttachedReferences(this ParameterCollection parameters, ContentManager content, Logger log = null)
+        {
+            var objectValues = parameters.ObjectValues;
+
+            if (objectValues is null)
+                return;
+
+            foreach (var keyInfo in parameters.ParameterKeyInfos)
+            {
+                // Permutation keys share ObjectValues with resource parameters; replacing one here
+                // would not bump the permutation counter, so only object (resource) keys are handled.
+                if (keyInfo.Key.Type != ParameterKeyType.Object || !keyInfo.IsResourceParameter || keyInfo.BindingSlot >= objectValues.Length)
+                    continue;
+
+                var reference = AttachedReferenceManager.GetAttachedReference(objectValues[keyInfo.BindingSlot]);
+                if (reference is not { IsProxy: true })
+                    continue;
+
+                log ??= GlobalLogger.GetLogger(nameof(ParameterCollection));
+
+                if (content is null)
+                {
+                    log.Warning($"Parameter '{keyInfo.Key}' keeps an empty object, because no content " +
+                                $"manager was available to load '{reference.Url}'.");
+                    continue;
+                }
+
+                try
+                {
+                    objectValues[keyInfo.BindingSlot] = content.Load(keyInfo.Key.PropertyType, reference.Url);
+                }
+                catch (ContentManagerException exception)
+                {
+                    // An asset reaches a build only when something in the content references it.
+                    // Nothing references what gets attached here, because that happens at run time,
+                    // so the referenced asset can be missing from the build. Keep the empty object
+                    // rather than stop the game, and say what is wrong.
+                    log.Warning($"Parameter '{keyInfo.Key}' keeps an empty object, because the asset " +
+                                $"it references is not in the build: '{reference.Url}'. {exception.Message}");
+                }
+            }
         }
     }
 }

--- a/sources/engine/Stride.Foundation/Rendering/ParameterCollection.cs
+++ b/sources/engine/Stride.Foundation/Rendering/ParameterCollection.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
 using Stride.Core.Serialization;
 
@@ -704,7 +705,54 @@ namespace Stride.Rendering
 
             DataValues = newDataValues;
             ObjectValues = newResourceValues;
+
+            // An unresolved reference exists from the moment its object was created, so the first
+            // binding sees it too; later layout updates (effect permutation changes, per-draw layout
+            // switches) skip the scan.
+            if (oldLayout == null)
+                ReportUnresolvedReferences();
         }
+
+        /// <summary>
+        /// Reports object values that still reference unloaded content, because such a value binds as
+        /// an empty resource and renders silently wrong.
+        /// </summary>
+        /// <remarks>
+        /// A layout update is how a collection gets prepared for an effect, so this is the last moment
+        /// where every render path still passes by; running only on the first one keeps the cost at one
+        /// scan per collection.
+        /// Unresolved references only ever come from code that attaches them outside of a content load
+        /// (see <see cref="ParameterCollectionExtensions.ResolveAttachedReferences"/>); a reference
+        /// deliberately skipped during a content load becomes null instead, so it is not reported here.
+        /// </remarks>
+        private void ReportUnresolvedReferences()
+        {
+            foreach (var keyInfo in parameterKeyInfos)
+            {
+                if (!keyInfo.IsResourceParameter || keyInfo.BindingSlot >= ObjectValues.Length)
+                    continue;
+
+                var reference = AttachedReferenceManager.GetAttachedReference(ObjectValues[keyInfo.BindingSlot]);
+                if (reference is not { IsProxy: true })
+                    continue;
+
+                bool firstTime;
+                lock (reportedUnresolvedUrls)
+                {
+                    firstTime = reportedUnresolvedUrls.Add(reference.Url);
+                }
+
+                if (firstTime)
+                {
+                    GlobalLogger.GetLogger(nameof(ParameterCollection)).Warning(
+                        $"Parameter '{keyInfo.Key}' still references unloaded content '{reference.Url}' while its " +
+                        $"collection is prepared for rendering; an empty object will be bound. Resolve attached " +
+                        $"references first, for example by passing a content manager to Material.New.");
+                }
+            }
+        }
+
+        private static readonly HashSet<string> reportedUnresolvedUrls = [];
 
         protected ParameterAccessor GetObjectParameterHelper(ParameterKey parameterKey, bool createIfNew = true)
         {

--- a/sources/engine/Stride.Graphics.Tests.10_0/TestMaterialProxyResolution.cs
+++ b/sources/engine/Stride.Graphics.Tests.10_0/TestMaterialProxyResolution.cs
@@ -1,0 +1,121 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Stride.Core.Diagnostics;
+using Stride.Core.Mathematics;
+using Stride.Core.Serialization;
+using Stride.Graphics.Regression;
+using Stride.Rendering;
+using Stride.Rendering.Materials;
+using Stride.Rendering.Materials.ComputeColors;
+
+using Xunit;
+
+namespace Stride.Graphics.Tests
+{
+    /// <summary>
+    /// Tests that a material built at run time binds real textures.
+    /// </summary>
+    /// <remarks>
+    /// A material feature attaches its texture references with
+    /// <c>AttachedReferenceManager.CreateProxyObject</c>, which makes an empty object and marks it as a
+    /// proxy. Only a content load turns such a proxy into a loaded object, and <see cref="Material.New"/>
+    /// runs the generator outside that path, so it must resolve the references itself.
+    /// <para>
+    /// This lives here rather than in Stride.Graphics.Tests because the lookup table reaches a build only
+    /// when an asset references it. This project has material assets that do; that one has none.
+    /// </para>
+    /// </remarks>
+    public class TestMaterialProxyResolution : GameTestBase
+    {
+        [Fact]
+        public static void EnvironmentLookupTableIsARealTexture()
+        {
+            var game = new TestMaterialProxyResolution();
+            Texture lookupTable = null;
+
+            game.Script.AddTask(async () =>
+            {
+                game.ScreenShotAutomationEnabled = false;
+                await game.Script.NextFrame();
+
+                var material = Material.New(game.GraphicsDevice, DefaultSpecularModelDescriptor(), game.Content);
+
+                lookupTable = material.Passes[0].Parameters
+                    .Get(MaterialSpecularMicrofacetEnvironmentGGXLUTKeys.EnvironmentLightingDFG_LUT);
+
+                game.Exit();
+            });
+
+            RunGameTest(game);
+
+            Assert.NotNull(lookupTable);
+
+            var reference = AttachedReferenceManager.GetAttachedReference(lookupTable);
+
+            Assert.False(reference is { IsProxy: true },
+                         $"The lookup table is still an unresolved proxy: {reference?.Url}");
+            Assert.True(lookupTable.Width > 0 && lookupTable.Height > 0,
+                        $"The lookup table has no pixels: {lookupTable.Width}x{lookupTable.Height}");
+        }
+
+        /// <summary>
+        /// Without a content manager there is nothing to load through, so the reference stays a proxy.
+        /// The material says so rather than leaving an empty texture to find later.
+        /// </summary>
+        [Fact]
+        public static void WithoutAContentManagerItSaysSo()
+        {
+            var game = new TestMaterialProxyResolution();
+            var warnings = new List<string>();
+
+            void Collect(ILogMessage message)
+            {
+                if (message.Type >= LogMessageType.Warning)
+                {
+                    lock (warnings) warnings.Add(message.Text);
+                }
+            }
+
+            GlobalLogger.GlobalMessageLogged += Collect;
+            try
+            {
+                game.Script.AddTask(async () =>
+                {
+                    game.ScreenShotAutomationEnabled = false;
+                    await game.Script.NextFrame();
+
+                    Material.New(game.GraphicsDevice, DefaultSpecularModelDescriptor());
+
+                    game.Exit();
+                });
+
+                RunGameTest(game);
+            }
+            finally
+            {
+                GlobalLogger.GlobalMessageLogged -= Collect;
+            }
+
+            Assert.Contains(warnings, text => text.Contains("StrideEnvironmentLightingDFGLUT"));
+        }
+
+        /// <summary>
+        /// A metal material with the default specular model, whose default environment function is
+        /// <c>MaterialSpecularMicrofacetEnvironmentGGXLUT</c>.
+        /// </summary>
+        private static MaterialDescriptor DefaultSpecularModelDescriptor() => new()
+        {
+            Attributes =
+            {
+                Diffuse = new MaterialDiffuseMapFeature(new ComputeColor(Color.White)),
+                DiffuseModel = new MaterialDiffuseLambertModelFeature(),
+                Specular = new MaterialMetalnessMapFeature(new ComputeFloat(1.0f)),
+                MicroSurface = new MaterialGlossinessMapFeature(new ComputeFloat(0.9f)),
+                SpecularModel = new MaterialSpecularMicrofacetModelFeature(),
+            },
+        };
+    }
+}

--- a/sources/engine/Stride.Graphics.Tests/TestMaterialProxyResolution.cs
+++ b/sources/engine/Stride.Graphics.Tests/TestMaterialProxyResolution.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Core.Serialization;
-using Stride.Graphics.Regression;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
 using Stride.Rendering.Materials.ComputeColors;
@@ -24,11 +23,12 @@ namespace Stride.Graphics.Tests
     /// proxy. Only a content load turns such a proxy into a loaded object, and <see cref="Material.New"/>
     /// runs the generator outside that path, so it must resolve the references itself.
     /// <para>
-    /// This lives here rather than in Stride.Graphics.Tests because the lookup table reaches a build only
-    /// when an asset references it. This project has material assets that do; that one has none.
+    /// This project holds no material asset that references the lookup table, so the table reaches the
+    /// build only because <c>Stride.Engine</c> declares it as a root asset. That makes this the place
+    /// where both halves have to hold: the table is packaged, and the material resolves it.
     /// </para>
     /// </remarks>
-    public class TestMaterialProxyResolution : GameTestBase
+    public class TestMaterialProxyResolution : GraphicTestGameBase
     {
         [Fact]
         public static void EnvironmentLookupTableIsARealTexture()

--- a/sources/engine/Stride.Rendering/Rendering/Material.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Material.cs
@@ -102,7 +102,9 @@ namespace Stride.Rendering
 
                 foreach (var keyInfo in parameters.ParameterKeyInfos)
                 {
-                    if (!keyInfo.IsResourceParameter || keyInfo.BindingSlot >= objectValues.Length)
+                    // Permutation keys share ObjectValues with resource parameters; replacing one here
+                    // would not bump the permutation counter, so only object (resource) keys are handled.
+                    if (keyInfo.Key.Type != ParameterKeyType.Object || !keyInfo.IsResourceParameter || keyInfo.BindingSlot >= objectValues.Length)
                         continue;
 
                     var reference = AttachedReferenceManager.GetAttachedReference(objectValues[keyInfo.BindingSlot]);

--- a/sources/engine/Stride.Rendering/Rendering/Material.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Material.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Serialization;
 using Stride.Core.Serialization.Contents;
 using Stride.Graphics;
@@ -18,6 +19,8 @@ namespace Stride.Rendering
     [DataContract]
     public class Material
     {
+        private static readonly Logger Log = GlobalLogger.GetLogger(nameof(Material));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Material"/> class.
         /// </summary>
@@ -43,10 +46,15 @@ namespace Stride.Rendering
         /// </summary>
         /// <param name="device"></param>
         /// <param name="descriptor">The material descriptor.</param>
+        /// <param name="content">
+        /// The content manager that loads the assets the material's features reference, such as
+        /// <c>Game.Content</c>. Without one, those references stay empty objects and the material reports
+        /// each one it could not load.
+        /// </param>
         /// <returns>An instance of a <see cref="Material"/>.</returns>
         /// <exception cref="System.ArgumentNullException">descriptor</exception>
         /// <exception cref="System.InvalidOperationException">If an error occurs with the material description</exception>
-        public static Material New(GraphicsDevice device, MaterialDescriptor descriptor)
+        public static Material New(GraphicsDevice device, MaterialDescriptor descriptor, ContentManager content = null)
         {
             if (descriptor == null) throw new ArgumentNullException("descriptor");
 
@@ -64,7 +72,66 @@ namespace Stride.Rendering
                 throw new InvalidOperationException(string.Format("Error when creating the material [{0}]", result.ToText()));
             }
 
-            return result.Material;
+            var material = result.Material;
+
+            ResolveAttachedReferences(material, content);
+
+            return material;
+        }
+
+        /// <summary>
+        /// Loads the assets that the generated material only holds references to.
+        /// </summary>
+        /// <param name="material">The generated material.</param>
+        /// <param name="content">The content manager to load through, or <c>null</c> to only report.</param>
+        /// <remarks>
+        /// A material feature attaches a reference with <see cref="AttachedReferenceManager.CreateProxyObject{T}(AssetId, string)"/>,
+        /// which makes an empty object and marks it as a proxy. A proxy becomes the real asset in one
+        /// place only, <c>ReferenceSerializer</c>, and only during a content load. The generator does not
+        /// run there, so the material keeps empty objects until they are loaded here.
+        /// </remarks>
+        private static void ResolveAttachedReferences(Material material, ContentManager content)
+        {
+            foreach (var pass in material.Passes)
+            {
+                var parameters = pass.Parameters;
+                var objectValues = parameters.ObjectValues;
+
+                if (objectValues is null)
+                    continue;
+
+                foreach (var keyInfo in parameters.ParameterKeyInfos)
+                {
+                    if (!keyInfo.IsResourceParameter || keyInfo.BindingSlot >= objectValues.Length)
+                        continue;
+
+                    var reference = AttachedReferenceManager.GetAttachedReference(objectValues[keyInfo.BindingSlot]);
+                    if (reference is not { IsProxy: true })
+                        continue;
+
+                    if (content is null)
+                    {
+                        Log.Warning($"Material parameter '{keyInfo.Key}' keeps an empty object, because no " +
+                                    $"content manager was given to load '{reference.Url}'. Pass one to " +
+                                    $"{nameof(Material)}.{nameof(New)}, such as Game.Content.");
+                        continue;
+                    }
+
+                    try
+                    {
+                        objectValues[keyInfo.BindingSlot] = content.Load(keyInfo.Key.PropertyType, reference.Url);
+                    }
+                    catch (ContentManagerException exception)
+                    {
+                        // An asset reaches a build only when something in the content references it.
+                        // Nothing references what a material feature attaches here, because that happens
+                        // at run time, so a game that builds all of its materials in code can lack the
+                        // asset. Keep the empty object rather than stop the game, and say what is wrong.
+                        Log.Warning($"Material parameter '{keyInfo.Key}' keeps an empty object, because the " +
+                                    $"asset it references is not in the build: '{reference.Url}'. {exception.Message}");
+                    }
+                }
+            }
         }
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/Material.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Material.cs
@@ -74,66 +74,15 @@ namespace Stride.Rendering
 
             var material = result.Material;
 
-            ResolveAttachedReferences(material, content);
-
-            return material;
-        }
-
-        /// <summary>
-        /// Loads the assets that the generated material only holds references to.
-        /// </summary>
-        /// <param name="material">The generated material.</param>
-        /// <param name="content">The content manager to load through, or <c>null</c> to only report.</param>
-        /// <remarks>
-        /// A material feature attaches a reference with <see cref="AttachedReferenceManager.CreateProxyObject{T}(AssetId, string)"/>,
-        /// which makes an empty object and marks it as a proxy. A proxy becomes the real asset in one
-        /// place only, <c>ReferenceSerializer</c>, and only during a content load. The generator does not
-        /// run there, so the material keeps empty objects until they are loaded here.
-        /// </remarks>
-        private static void ResolveAttachedReferences(Material material, ContentManager content)
-        {
+            // A material feature can attach references to content instead of loaded objects (such as the
+            // lookup table of the default specular model), and only a content load resolves those.
+            // The generator runs outside of one, so the references are loaded here.
             foreach (var pass in material.Passes)
             {
-                var parameters = pass.Parameters;
-                var objectValues = parameters.ObjectValues;
-
-                if (objectValues is null)
-                    continue;
-
-                foreach (var keyInfo in parameters.ParameterKeyInfos)
-                {
-                    // Permutation keys share ObjectValues with resource parameters; replacing one here
-                    // would not bump the permutation counter, so only object (resource) keys are handled.
-                    if (keyInfo.Key.Type != ParameterKeyType.Object || !keyInfo.IsResourceParameter || keyInfo.BindingSlot >= objectValues.Length)
-                        continue;
-
-                    var reference = AttachedReferenceManager.GetAttachedReference(objectValues[keyInfo.BindingSlot]);
-                    if (reference is not { IsProxy: true })
-                        continue;
-
-                    if (content is null)
-                    {
-                        Log.Warning($"Material parameter '{keyInfo.Key}' keeps an empty object, because no " +
-                                    $"content manager was given to load '{reference.Url}'. Pass one to " +
-                                    $"{nameof(Material)}.{nameof(New)}, such as Game.Content.");
-                        continue;
-                    }
-
-                    try
-                    {
-                        objectValues[keyInfo.BindingSlot] = content.Load(keyInfo.Key.PropertyType, reference.Url);
-                    }
-                    catch (ContentManagerException exception)
-                    {
-                        // An asset reaches a build only when something in the content references it.
-                        // Nothing references what a material feature attaches here, because that happens
-                        // at run time, so a game that builds all of its materials in code can lack the
-                        // asset. Keep the empty object rather than stop the game, and say what is wrong.
-                        Log.Warning($"Material parameter '{keyInfo.Key}' keeps an empty object, because the " +
-                                    $"asset it references is not in the build: '{reference.Url}'. {exception.Message}");
-                    }
-                }
+                pass.Parameters.ResolveAttachedReferences(content, Log);
             }
+
+            return material;
         }
     }
 }

--- a/sources/engine/Stride.Rendering/Rendering/Materials/MaterialSpecularMicrofacetEnvironmentGGXLUT.cs
+++ b/sources/engine/Stride.Rendering/Rendering/Materials/MaterialSpecularMicrofacetEnvironmentGGXLUT.cs
@@ -23,12 +23,23 @@ namespace Stride.Rendering.Materials
     {
         public ShaderSource Generate(MaterialGeneratorContext context)
         {
-            var texture = context.GraphicsProfile >= GraphicsProfile.Level_10_0
-                ? AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("a49995f8-2380-4baa-a03e-f8d1da35b79a"), "/Stride.Engine/StrideEnvironmentLightingDFGLUT16")
-                : AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("87540190-ab97-4b4e-b3c2-d57d2fbb1ff3"), "/Stride.Engine/StrideEnvironmentLightingDFGLUT8");
-            context.Parameters.Set(MaterialSpecularMicrofacetEnvironmentGGXLUTKeys.EnvironmentLightingDFG_LUT, texture);
+            context.Parameters.Set(MaterialSpecularMicrofacetEnvironmentGGXLUTKeys.EnvironmentLightingDFG_LUT, CreateLookupTableReference(context.GraphicsProfile));
 
             return new ShaderClassSource("MaterialSpecularMicrofacetEnvironmentGGXLUT");
+        }
+
+        /// <summary>
+        /// Creates the reference to the lookup table texture used for the given profile.
+        /// </summary>
+        /// <remarks>
+        /// The returned texture is an empty proxy holding the asset reference; a content load resolves
+        /// it to the real texture (see <see cref="ParameterCollectionExtensions.ResolveAttachedReferences"/>).
+        /// </remarks>
+        public static Texture CreateLookupTableReference(GraphicsProfile profile)
+        {
+            return profile >= GraphicsProfile.Level_10_0
+                ? AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("a49995f8-2380-4baa-a03e-f8d1da35b79a"), "/Stride.Engine/StrideEnvironmentLightingDFGLUT16")
+                : AttachedReferenceManager.CreateProxyObject<Texture>(new AssetId("87540190-ab97-4b4e-b3c2-d57d2fbb1ff3"), "/Stride.Engine/StrideEnvironmentLightingDFGLUT8");
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
# PR Details

**Summary** — A material built by `Material.New` bound an empty texture for the environment DFG lookup
table. Fixes #3369.

## The two halves

The reported bug is that `Material.New` never resolves the references its features attach:

```
[built by Material.New] url=/Stride.Engine/StrideEnvironmentLightingDFGLUT16 IsProxy=True  size=0x0   format=None
[loaded from an asset]  url=/Stride.Engine/StrideEnvironmentLightingDFGLUT16 IsProxy=False size=32x64 format=R16G16_Float
```

Fixing that alone is not enough, and writing the test is what showed why. The first red run failed with
`The asset ... could not be found`, because **the table may not be in the build at all**. So there are
two problems, and a game whose materials are all built in code needs both fixed.

**The reference was never resolved.** `MaterialSpecularMicrofacetEnvironmentGGXLUT.Generate` attaches
the table with `AttachedReferenceManager.CreateProxyObject`, which is `new T()` plus reference metadata.
A proxy becomes the real asset in one place only, `ReferenceSerializer`, and only during a content load.
`Material.New` runs the generator outside that path.

`Material.New` now takes an optional `ContentManager` and, after generation, walks each pass's
parameters and loads anything still marked `IsProxy`. It resolves generically rather than special-casing
the lookup table, so `Generate` stays untouched and the asset compiler keeps serializing proxies exactly
as before.

**The asset was never guaranteed to be there.** The asset compiler starts from roots and follows
references. `Package.RootAssets` is the declared escape hatch for assets nothing references — *"needs to
be compiled even if not directly or indirectly referenced (useful for explicit code references)"*.
`Stride.Engine` already declares the default font, the splash screen and the debug sprite font that way;
the splash screen is the identical pattern, named from code in `GameSettingsFactory.cs:23`. The two
lookup tables were never declared, so they reach a build only when some material *asset* happens to use
that environment function and drags them in.

Both are now declared. They ship in every bundle as a result, including games that never use that
environment function — 32x64 `R16G16_Float` plus the 8-bit variant, the same unconditional treatment the
splash screen already has.

## When it still cannot resolve

Without a `ContentManager`, or when the asset is genuinely absent, the material keeps the empty object
and reports it, naming the parameter and the URL. It does not throw. Turning a subtly wrong render into
a crash would be the worse trade, and the roughly twelve existing callers — editor gizmos, previews,
debug shapes, fallbacks — pass no content manager and none of them uses a specular model.

## Tests

- `TestMaterialProxyResolution` in `Stride.Graphics.Tests`: the table resolves to a real texture, and the
  no-content-manager path reports rather than stays silent. That project holds **no** material asset
  referencing the tables, so it passes only if both halves hold. Reverting just the `.sdpkg` change puts
  it back to red with `ContentManagerException`, so it measures what it claims to.
- `TestGeneratorLeavesTextureReferencesAsProxies` in `Stride.Assets.Tests`: pins that
  `MaterialGenerator.Generate` on its own still yields a proxy, which is what the asset compiler
  serializes. Four tests there already built this feature and asserted only on shader source.

## Related Issue

Fixes #3369.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

**Validation status**

- *Build*: `Stride.Rendering` clean under `StrideGraphicsApi=Direct3D11`, `=Direct3D12` and `=Vulkan`,
  with `-t:Rebuild` rather than an incremental build. Not `=Null`: that backend does not compile on
  `master` today, with partial-method signature drift in `Null/CommandList.Null.cs` and
  `Null/Texture.Null.cs`. Unrelated to this change and worth its own issue.
- *Tests*: 2 passing in `Stride.Graphics.Tests`, 7 in `TestMaterialGenerator` — the new contract test and
  the six that were already there, so the asset compiler's path is unchanged.
- *Gold images*: none should move. The only rendering test that builds this material in code,
  `MaterialLayerABBWithAPI`, is `[Fact(Skip = ...)]` and never runs, so no baseline encodes the broken
  appearance. Left skipped; the stated reason is debugging convenience and I have no evidence it relates
  to this bug.
- *Editor*: outstanding.

## Not fixed here

`Generate` chooses between the 16-bit and 8-bit tables on a graphics profile when the real question is
texture format support. That is a separate concern, already listed under "found, not fixed" in #3368.
