### PR TITLE
fix: make the Null graphics backend compile again

### DIFF
--- a/.github/workflows/build-windows-runtime.yml
+++ b/.github/workflows/build-windows-runtime.yml
@@ -18,6 +18,7 @@ on:
           - Direct3D11
           - Direct3D12
           - Vulkan
+          - Null
   workflow_call:
     inputs:
       build-type:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
     uses: ./.github/workflows/build-windows-runtime.yml
     with:
       build-type: Release
-      graphics-api: Null
+      graphics-api: "Null"
 
   ### Full Windows build (engine + editor + assets + samples) ###
   Windows-Full:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,16 @@ jobs:
       build-type: Release
       graphics-api: Vulkan
 
+  # Null ships no renderer, so nothing else builds it and its stubs drift out of step with the shared
+  # signatures they implement. Compiling it here is what keeps that API honest.
+  Windows-Runtime-Null:
+    needs: changes
+    if: (github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'ci-run-on-draft')) && needs.changes.outputs.runtime == 'true'
+    uses: ./.github/workflows/build-windows-runtime.yml
+    with:
+      build-type: Release
+      graphics-api: Null
+
   ### Full Windows build (engine + editor + assets + samples) ###
   Windows-Full:
     needs: changes

--- a/sources/engine/Stride.Graphics/Null/CommandList.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/CommandList.Null.cs
@@ -81,7 +81,7 @@ namespace Stride.Graphics
         /// <param name="depthStencilBuffer">The depth stencil buffer.</param>
         /// <param name="renderTargets">The render targets.</param>
         /// <exception cref="System.ArgumentNullException">renderTargetViews</exception>
-        private void SetRenderTargetsImpl(Texture depthStencilBuffer, int renderTargetCount, Texture[] renderTargets)
+        private partial void SetRenderTargetsImpl(Texture depthStencilBuffer, ReadOnlySpan<Texture> renderTargets)
         {
             NullHelper.ToImplement();
         }
@@ -90,7 +90,7 @@ namespace Stride.Graphics
         ///   Platform-specific implementation that sets a scissor rectangle to the rasterizer stage.
         /// </summary>
         /// <param name="scissorRectangle">The scissor rectangle to set.</param>
-        private unsafe partial void SetScissorRectangleImpl(ref Rectangle scissorRectangle)
+        private unsafe partial void SetScissorRectangleImpl(ref readonly Rectangle scissorRectangle)
         {
             NullHelper.ToImplement();
         }
@@ -98,9 +98,18 @@ namespace Stride.Graphics
         /// <summary>
         ///   Platform-specific implementation that sets one or more scissor rectangles to the rasterizer stage.
         /// </summary>
-        /// <param name="scissorCount">The number of scissor rectangles to bind.</param>
         /// <param name="scissorRectangles">The set of scissor rectangles to bind.</param>
-        private unsafe partial void SetScissorRectanglesImpl(int scissorCount, Rectangle[] scissorRectangles)
+        private unsafe partial void SetScissorRectanglesImpl(ReadOnlySpan<Rectangle> scissorRectangles)
+        {
+            NullHelper.ToImplement();
+        }
+
+        /// <summary>
+        ///   Writes a GPU timestamp into a query pool.
+        /// </summary>
+        /// <param name="queryPool">The pool that holds the query.</param>
+        /// <param name="index">The index of the query in the pool.</param>
+        public void WriteTimestamp(QueryPool queryPool, int index)
         {
             NullHelper.ToImplement();
         }

--- a/sources/engine/Stride.Graphics/Null/GraphicsDevice.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/GraphicsDevice.Null.cs
@@ -12,6 +12,12 @@ namespace Stride.Graphics
         /// </summary>
         /// <implement>To be implemented.</implement>
         private const GraphicsPlatform GraphicPlatform = GraphicsPlatform.Null;
+
+        /// <summary>
+        ///   The number of GPU timestamp ticks per second, which turns a timestamp query into a duration.
+        /// </summary>
+        public long TimestampFrequency { get; private set; }
+
         private string rendererName = "Null";
 
         /// <summary>

--- a/sources/engine/Stride.Graphics/Null/GraphicsOutput.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/GraphicsOutput.Null.cs
@@ -3,6 +3,8 @@
 
 #if STRIDE_GRAPHICS_API_NULL
 
+using System;
+
 namespace Stride.Graphics
 {
     /// <summary>

--- a/sources/engine/Stride.Graphics/Null/GraphicsResourceBase.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/GraphicsResourceBase.Null.cs
@@ -31,6 +31,15 @@ namespace Stride.Graphics
         }
 
         /// <summary>
+        ///   Swaps the Graphics Resource's internal data with another Graphics Resource.
+        /// </summary>
+        /// <param name="other">The other Graphics Resource.</param>
+        internal virtual void SwapInternal(GraphicsResourceBase other)
+        {
+            NullHelper.ToImplement();
+        }
+
+        /// <summary>
         /// Called when graphics device has been recreated.
         /// </summary>
         /// <returns>True if item transitioned to a <see cref="GraphicsResourceLifetimeState.Active"/> state.</returns>

--- a/sources/engine/Stride.Graphics/Null/QueryPool.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/QueryPool.Null.cs
@@ -8,6 +8,17 @@ namespace Stride.Graphics
     public partial class QueryPool
     {
         /// <summary>
+        ///   Tries to read the results of every query in the pool.
+        /// </summary>
+        /// <param name="dataArray">The array that receives the results.</param>
+        /// <returns><c>true</c> if every result was available; otherwise, <c>false</c>.</returns>
+        public bool TryGetData(long[] dataArray)
+        {
+            NullHelper.ToImplement();
+            return false;
+        }
+
+        /// <summary>
         ///   Platform-specific implementation that recreates the queries in the pool.
         /// </summary>
         private unsafe partial void Recreate()

--- a/sources/engine/Stride.Graphics/Null/Texture.Null.cs
+++ b/sources/engine/Stride.Graphics/Null/Texture.Null.cs
@@ -39,8 +39,10 @@ namespace Stride.Graphics
         ///   Swaps the Texture's internal data with another Texture.
         /// </summary>
         /// <param name="other">The other Texture.</param>
-        internal partial void SwapInternal(Texture other)
+        internal override void SwapInternal(GraphicsResourceBase other)
         {
+            base.SwapInternal(other);
+
             NullHelper.ToImplement();
         }
 


### PR DESCRIPTION
# PR Details

**Summary** — The Null graphics backend does not compile. This makes it compile again, and adds the CI
leg whose absence let it drift.

## What was wrong

`StrideGraphicsApi=Null` fails to build on `master`. Nine problems in three shapes.

**Shared signatures moved and the stubs did not follow.** `CommandList` now declares
`SetScissorRectangleImpl(ref readonly Rectangle)` and `SetScissorRectanglesImpl(ReadOnlySpan<Rectangle>)`,
while Null still had `ref Rectangle` and `(int, Rectangle[])`. `SetRenderTargetsImpl` still took
`(Texture, int, Texture[])` and had lost its `partial` keyword entirely.

**`SwapInternal` was declared as the wrong kind of method.** `Texture.Null.cs` had
`internal partial void SwapInternal(Texture)`, but it is not a partial method: it is
`internal virtual void SwapInternal(GraphicsResourceBase)` on `GraphicsResourceBase`, overridden per
type. Null never declared the base, so the override had nothing to attach to.

**Three members the runtime calls were missing.** `QueryManager` uses `QueryPool.TryGetData`,
`GraphicsDevice.TimestampFrequency` and `CommandList.WriteTimestamp`. None existed in Null, so the
failure only appeared once something compiled against the backend rather than in the backend itself.

Also `GraphicsOutput.Null.cs` uses `ReadOnlySpan<GraphicsProfile>` with no `using System;` — a signature
that was updated at some point and never compiled since.

## Why it went unnoticed

**No CI job builds Null.** `main.yml` has `Windows-Runtime-D3D11`, `-D3D12` and `-Vulkan`, and
`build-windows-runtime.yml` offered only those three. Nothing has compiled this backend in a long time.

This adds a fourth `Windows-Runtime-Null` job beside the others. That is the part that stops it
happening again; without it the same drift returns the next time a shared signature changes.

## What this does not change

Every body stays a `NullHelper.ToImplement()` stub. Null ships no renderer and this does not make it
one. The value is that compiling it keeps the shared API honest across backends — the same reason the
now-disabled `TestGraphicsApiCheck` used Null as its reference.

## Related Issue

Found while verifying #3370. It also means the `GraphicsBackend.Null.cs` partial added in #3368 has
never been compiled; once this lands, that becomes checkable.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

**Validation status**

Every build below used `-t:Rebuild`. An incremental build reports success without compiling, which is
how this was missed in the first place and how I first mis-reported it as working.

- *Null*: `build/Stride.Runtime.slnf` clean with the exact arguments the new CI job uses
  (`Release`, `StridePlatforms=Windows`, `StrideGraphicsApis=Null`, skipping unit tests and autopack).
  `Stride.Graphics` and `Stride.Engine` also clean on their own.
- *Direct3D11, Direct3D12, Vulkan*: `Stride.Engine` clean under each. Every change here sits inside
  `#if STRIDE_GRAPHICS_API_NULL`, but that is checked rather than assumed.
- *Tests*: none added. The CI job is the regression test — a unit test cannot catch a backend that does
  not compile.
- *Editor*: outstanding, and not meaningful for a backend that renders nothing.
