### PR TITLE
Bug fix: Remove `redMaterial` field from AsyncCollisionTriggerDemo

### DIFF
--- a/samples/Tutorials/CSharpIntermediate/CSharpIntermediate/CSharpIntermediate.Game/05_Async/AsyncCollisionTriggerDemo.cs
+++ b/samples/Tutorials/CSharpIntermediate/CSharpIntermediate/CSharpIntermediate.Game/05_Async/AsyncCollisionTriggerDemo.cs
@@ -10,7 +10,6 @@ namespace CSharpIntermediate.Code
     public class AsyncCollisionTriggerDemo : AsyncScript
     {
         private Material yellowMaterial;
-        private Material redMaterial;
 
         public override async Task Execute()
         {
@@ -47,7 +46,6 @@ namespace CSharpIntermediate.Code
         public override void Cancel()
         {
             Content.Unload(yellowMaterial);
-            Content.Unload(redMaterial);
         }
     }
 }


### PR DESCRIPTION
## Related Issue

It was always null since the field is never assigned. This caused an exception while I was testing #3360.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->