### PR TITLE
fix: Don't skip first message in DebugTextSystem

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/DebugTextSystem.cs
@@ -100,7 +100,7 @@ namespace Stride.Profiling
             fastTextRenderer.Begin(Game.GraphicsContext);
 
             // the loop is done backwards so when removing elements from the list you don't change the index of elements that weren't processed already
-            for (int index = overlayMessages.Count - 1; index > 0; index--)
+            for (int index = overlayMessages.Count - 1; index >= 0; index--)
             {
                 var msg = overlayMessages[index];
                 if (msg.TextColor != currentColor)


### PR DESCRIPTION
# PR Details

Pretty simple, the reverse for-loop didn't process all items, now it does.

## Related Issue

Fixes #3377 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
