### PR TITLE
Simplify PR template (free-text sections instead of checkboxes)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,19 @@
-# PR Details
-
-<!--- Provide a general summary of your changes in the Title of this PR -->
 <!--- Describe your changes in detail here -->
 <!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->
 
 ## Related Issue
 
-<!--- If suggesting a new feature or change, please discuss it in an issue first -->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
+<!--- New features and changes should be discussed in an issue first. -->
+<!--- Bug fixes should link an issue with steps to reproduce. -->
+<!--- Link the issue here (use "Fixes #1234" to auto-close it on merge): -->
 
-## Types of changes
+## How did you test this?
 
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+<!--- e.g. added unit tests, built and ran the editor, tested a sample game. -->
+<!--- Editor changes should be tried out in the editor, since CI does not cover it. -->
 
-- [ ] Docs change / refactoring / dependency upgrade
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+## Anything else reviewers should know?
 
-## Checklist
+<!--- Breaking changes? Documentation that needs updating? Areas you want feedback on? -->
 
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-
-- [ ] My change requires a change to the documentation.
-- [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
-- [ ] **I have built and run the editor to try this change out.**
-
-<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
-<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->
+<!--- Open this PR as a draft if it isn't ready yet (click the arrow next to 'Create pull request'). -->


### PR DESCRIPTION
Simplifies the PR template so pull requests no longer show an incomplete task counter ("0 of 8 tasks") in the PR list.
Every `- [ ]` in a description counts toward that badge, and since almost nobody ticks all the boxes, every PR looked unfinished forever.

Changes:
- Replaced the "Types of changes" and "Checklist" checkbox lists with free-text sections.
- Removed "All new and existing tests passed", tests now run on every PR in CI.
- Kept the important signals as prompts instead: issue link (with a `Fixes #1234` hint), how the change was tested (editor changes should still be tried in the editor, CI does not cover it fully), breaking changes and documentation impact.

<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## How did you test this?

No code change, github template only.