### PR TITLE
Re-adds attributes to ShaderClass

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Shader.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Shader.cs
@@ -66,6 +66,7 @@ public partial class ShaderClass(Identifier name, TextLocation info) : ShaderDec
     public ShaderParameterDeclarations? Generics { get; set; }
     public List<IdentifierBase> Mixins { get; set; } = [];
     public bool Internal { get; set; }
+    public ShaderAttributeList? Attributes { get; set; }
 
     // Note: We should make this method incremental (called many times in ShaderMixer)
     //       And possibly do the type deduplicating at the same time? (TypeDuplicateRemover)

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderClassParser.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderClassParser.cs
@@ -66,6 +66,9 @@ public record struct ShaderClassParser : IParser<ShaderClass>
         var position = scanner.Position;
         var tmp = position;
         var @internal = false;
+        var hasAttributes = ShaderAttributeListParser.AttributeList(ref scanner, result, out var attributes) && Parsers.Spaces0(ref scanner, result, out _);
+        if (hasAttributes)
+            tmp = scanner.Position;
         if (Tokens.Literal("internal", ref scanner, advance: true) && Parsers.Spaces1(ref scanner, result, out _))
         {
             @internal = true;
@@ -87,6 +90,8 @@ public record struct ShaderClassParser : IParser<ShaderClass>
             {
                 parsed = new ShaderClass(identifier, scanner[..]);
                 parsed.Internal = @internal;
+                if (hasAttributes)
+                    parsed.Attributes = attributes;
                 if (Tokens.Char('<', ref scanner, advance: true))
                 {
                     ParameterParsers.Declarations(ref scanner, result, out var generics);

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderClassParser.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderClassParser.cs
@@ -66,7 +66,7 @@ public record struct ShaderClassParser : IParser<ShaderClass>
         var position = scanner.Position;
         var tmp = position;
         var @internal = false;
-        var hasAttributes = ShaderAttributeListParser.AttributeList(ref scanner, result, out var attributes) && Parsers.Spaces0(ref scanner, result, out _);
+        var hasAttributes = ShaderAttributeListParser.AttributeList(ref scanner, result, out var attributes);
         if (hasAttributes)
             tmp = scanner.Position;
         if (Tokens.Literal("internal", ref scanner, advance: true) && Parsers.Spaces1(ref scanner, result, out _))

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderElementParsers.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderElementParsers.cs
@@ -38,6 +38,7 @@ public record struct ShaderElementParsers : IParser<ShaderElement>
             }
             else if (Method(ref scanner, result, out var method))
             {
+                Parsers.FollowedBy(ref scanner, Tokens.Char(';'), withSpaces: true, advance: true);
                 parsed = method;
                 return true;
             }

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderFileParsers.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ShaderParsers/ShaderFileParsers.cs
@@ -27,7 +27,8 @@ public record struct ShaderFileParser : IParser<ShaderFile>
             }
             else if (
                 (
-                    Tokens.Literal("class", ref scanner)
+                    Tokens.Char('[', ref scanner)
+                    || Tokens.Literal("class", ref scanner)
                     || Tokens.Literal("shader", ref scanner)
                     || Parsers.SequenceOf(ref scanner, ["internal", "shader"])
                 )

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/StatementParsers/StatementParsers.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/StatementParsers/StatementParsers.cs
@@ -221,7 +221,7 @@ public record struct ExpressionStatementParser : IParser<Statement>
         var position = scanner.Position;
         if (
             ExpressionParser.Expression(ref scanner, result, out var expression)
-            && Parsers.FollowedBy(ref scanner, Tokens.Char(';'), advance: true)
+            && Parsers.FollowedBy(ref scanner, Tokens.Char(';'), withSpaces: true, advance: true)
         )
         {
             parsed = new ExpressionStatement(expression, scanner[position..scanner.Position]);

--- a/sources/shaders/Stride.Shaders.Tests/ParsingTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/ParsingTests.cs
@@ -17,6 +17,11 @@ public class ParsingTests1
         {
             yield return new object[] { file };
         }
+        files = Directory.GetFiles("assets/SDSL", "*.sdsl", SearchOption.AllDirectories);
+        foreach (var file in files)
+        {
+            yield return new object[] { file };
+        }
     }
 
     [Theory]

--- a/sources/shaders/Stride.Shaders.Tests/Stride.Shaders.Tests.csproj
+++ b/sources/shaders/Stride.Shaders.Tests/Stride.Shaders.Tests.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))/sdk/Stride.Build.Sdk.Tests/Sdk/Sdk.props" />
   <PropertyGroup>
     <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
@@ -65,6 +65,7 @@
     <Content Include="..\assets\SDSL\RenderTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\RenderTests\" />
     <Content Include="..\assets\SDSL\ComputeTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\ComputeTests\" />
     <Content Include="..\assets\SDSL\StreamOutTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\StreamOutTests\" />
+    <Content Include="..\assets\SDSL\ParserTests\**" CopyToOutputDirectory="PreserveNewest" LinkBase="assets\SDSL\ParserTests\" />
     <Content Include="..\..\engine\Stride.Graphics\**\*.sdsl" Exclude="**\obj\**;**\bin\**" CopyToOutputDirectory="PreserveNewest" Link="assets\Stride\SDSL\%(Filename)%(Extension)" />
     <Content Include="..\..\engine\Stride.Graphics\**\*.sdfx" Exclude="**\obj\**;**\bin\**" CopyToOutputDirectory="PreserveNewest" Link="assets\Stride\SDFX\%(Filename)%(Extension)" />
     <Content Include="..\..\engine\Stride.Rendering\**\*.sdsl" Exclude="**\obj\**;**\bin\**" CopyToOutputDirectory="PreserveNewest" Link="assets\Stride\SDSL\%(Filename)%(Extension)" />

--- a/sources/shaders/assets/SDSL/ParserTests/AssignmentWithSpaces.sdsl
+++ b/sources/shaders/assets/SDSL/ParserTests/AssignmentWithSpaces.sdsl
@@ -1,0 +1,8 @@
+shader AssignmentWithSpaces
+{
+    void Foo()
+    {
+        float2 p = 1.0f;
+        p.y *= -1.0f ;
+    }
+};

--- a/sources/shaders/assets/SDSL/ParserTests/MacroExpandedMethodTrailingSemicolon.sdsl
+++ b/sources/shaders/assets/SDSL/ParserTests/MacroExpandedMethodTrailingSemicolon.sdsl
@@ -1,0 +1,18 @@
+shader MacroExpandedMethodTrailingSemicolon
+{
+	#define DEFINE_DUMMY_FUNCTION(FUNCTIONNAME)                                   \
+	float3 FUNCTIONNAME##3(float3 p)                                              \
+	{return float3(FUNCTIONNAME(p), FUNCTIONNAME(p), FUNCTIONNAME(p));};
+
+	float dummy(float3 p)
+	{
+		return p.x + p.y + p.z;
+	}
+
+	DEFINE_DUMMY_FUNCTION(dummy)
+
+	float3 CallSite(float3 p)
+	{
+		return dummy3(p);
+	}
+};

--- a/sources/shaders/assets/SDSL/ParserTests/ShaderWithAttributes.sdsl
+++ b/sources/shaders/assets/SDSL/ParserTests/ShaderWithAttributes.sdsl
@@ -1,0 +1,5 @@
+[Foo("Foo")]
+[Bar("Bar")]
+shader ShaderWithAttributes
+{
+};

--- a/sources/shaders/assets/SDSL/ParserTests/ShaderWithAttributesNamespace.sdsl
+++ b/sources/shaders/assets/SDSL/ParserTests/ShaderWithAttributesNamespace.sdsl
@@ -1,0 +1,8 @@
+namespace Stride.Test
+{
+	[Foo("Foo")]
+	[Bar("Bar")]
+	shader ShaderWithAttributesNamespace
+	{
+	};
+}


### PR DESCRIPTION
In previous versions of Stride it was possible to attach arbitrary attributes to a shader class. Our code base was making quite some use of this, for example see https://github.com/vvvv/VL.StandardLibs/blob/main/VL.Stride.TextureFX/shaders/Sources

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->