### PR TITLE
Fix partially voxel GI on 4.4: SDSL mixer, D3D12 root signature, Vulkan MSAA

### DIFF
--- a/sources/engine/Stride.Graphics/Direct3D12/PipelineState.Direct3D12.cs
+++ b/sources/engine/Stride.Graphics/Direct3D12/PipelineState.Direct3D12.cs
@@ -417,7 +417,7 @@ namespace Stride.Graphics
 
                 CopyRootParameters(rootSignatureParameters, rootParamsBuffer, rootParamsBufferSize);
 
-                var staticSamplersBufferSize = rootSignatureParameters.Count * sizeof(StaticSamplerDesc);
+                var staticSamplersBufferSize = immutableSamplers.Count * sizeof(StaticSamplerDesc);
                 var staticSamplersBuffer = AllocateTempMemory(staticSamplersBufferSize);
 
                 CopyStaticSamplers(immutableSamplers, staticSamplersBuffer, staticSamplersBufferSize);

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
@@ -3,6 +3,8 @@
 
 #if STRIDE_GRAPHICS_API_VULKAN
 
+using Vortice.Vulkan;
+
 namespace Stride.Graphics
 {
     /// <summary>
@@ -40,9 +42,39 @@ namespace Stride.Graphics
 
             HasResourceRenaming = false;
 
-            // TODO D3D12
+            // Multisample support was never queried here: every format was reported as
+            // MultisampleCount.None, so Texture.New threw "the maximum supported level is None" for
+            // any multisampled render target - MSAA was simply unusable on Vulkan. Stride.Voxels'
+            // dominant-axis voxelization allocates an 8x target and died on it.
+            //
+            // Only the framebuffer masks are read, not per-format image properties: this runs for
+            // all 256 PixelFormat values at device creation, and the framebuffer limits are what
+            // actually bound a render target's sample count.
+            var physicalDevice = deviceRoot.NativePhysicalDevice;
+            deviceRoot.NativeInstanceApi.vkGetPhysicalDeviceProperties(physicalDevice, out var physicalDeviceProperties);
+            var colorSampleCounts = physicalDeviceProperties.limits.framebufferColorSampleCounts;
+            var depthSampleCounts = physicalDeviceProperties.limits.framebufferDepthSampleCounts;
+
+            static MultisampleCount MaximumSampleCount(VkSampleCountFlags supported)
+            {
+                if ((supported & VkSampleCountFlags.Count8) != 0)
+                    return MultisampleCount.X8;
+                if ((supported & VkSampleCountFlags.Count4) != 0)
+                    return MultisampleCount.X4;
+                if ((supported & VkSampleCountFlags.Count2) != 0)
+                    return MultisampleCount.X2;
+                return MultisampleCount.None;
+            }
+
+            // Reported per format, but computed from the intersection of the colour and depth masks
+            // rather than per format: telling colour and depth formats apart here would need a
+            // predicate Stride does not have on this side, and the two masks are identical on every
+            // driver worth supporting. Erring low only costs a sample count; erring high would hand
+            // out a count the device cannot attach.
+            var maximumMultisampleCount = MaximumSampleCount(colorSampleCounts & depthSampleCounts);
+
             for (int i = 0; i < mapFeaturesPerFormat.Length; i++)
-                mapFeaturesPerFormat[i] = new FeaturesPerFormat((PixelFormat) i, MultisampleCount.None, ComputeShaderFormatSupport.None, FormatSupport.None);
+                mapFeaturesPerFormat[i] = new FeaturesPerFormat((PixelFormat) i, maximumMultisampleCount, ComputeShaderFormatSupport.None, FormatSupport.None);
             //// Check features for each DXGI.Format
             //foreach (var format in Enum.GetValues(typeof(SharpDX.DXGI.Format)))
             //{

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
@@ -42,31 +42,15 @@ namespace Stride.Graphics
 
             HasResourceRenaming = false;
 
-            // Only the framebuffer sample count limits are read, not per-format image properties:
-            // this runs for every PixelFormat at device creation, and the framebuffer limits are what
-            // bound a render target's sample count.
             var physicalDevice = deviceRoot.NativePhysicalDevice;
-            deviceRoot.NativeInstanceApi.vkGetPhysicalDeviceProperties(physicalDevice, out var physicalDeviceProperties);
-            var colorSampleCounts = physicalDeviceProperties.limits.framebufferColorSampleCounts;
-            var depthSampleCounts = physicalDeviceProperties.limits.framebufferDepthSampleCounts;
-
-            static MultisampleCount MaximumSampleCount(VkSampleCountFlags supported)
-            {
-                if ((supported & VkSampleCountFlags.Count8) != 0)
-                    return MultisampleCount.X8;
-                if ((supported & VkSampleCountFlags.Count4) != 0)
-                    return MultisampleCount.X4;
-                if ((supported & VkSampleCountFlags.Count2) != 0)
-                    return MultisampleCount.X2;
-                return MultisampleCount.None;
-            }
-
-            // Use the intersection of the color and depth masks for every format: there is no
-            // color/depth predicate on PixelFormat here, and erring low only costs a sample count.
-            var maximumMultisampleCount = MaximumSampleCount(colorSampleCounts & depthSampleCounts);
+            var instanceApi = deviceRoot.NativeInstanceApi;
 
             for (int i = 0; i < mapFeaturesPerFormat.Length; i++)
-                mapFeaturesPerFormat[i] = new FeaturesPerFormat((PixelFormat) i, maximumMultisampleCount, ComputeShaderFormatSupport.None, FormatSupport.None);
+            {
+                var pixelFormat = (PixelFormat) i;
+                var maximumMultisampleCount = GetMaximumMultisampleCount(instanceApi, physicalDevice, pixelFormat);
+                mapFeaturesPerFormat[i] = new FeaturesPerFormat(pixelFormat, maximumMultisampleCount, ComputeShaderFormatSupport.None, FormatSupport.None);
+            }
             //// Check features for each DXGI.Format
             //foreach (var format in Enum.GetValues(typeof(SharpDX.DXGI.Format)))
             //{
@@ -87,6 +71,29 @@ namespace Stride.Graphics
             //    //mapFeaturesPerFormat[(int)dxgiFormat] = new FeaturesPerFormat((PixelFormat)dxgiFormat, maximumMultisampleCount, computeShaderFormatSupport, formatSupport);
             //    mapFeaturesPerFormat[(int)dxgiFormat] = new FeaturesPerFormat((PixelFormat)dxgiFormat, maximumMultisampleCount, formatSupport);
             //}
+        }
+
+        private static MultisampleCount GetMaximumMultisampleCount(VkInstanceApi instanceApi, VkPhysicalDevice physicalDevice, PixelFormat pixelFormat)
+        {
+            if (!VulkanConvertExtensions.TryConvertPixelFormat(pixelFormat, out var format, out _, out _))
+                return MultisampleCount.None;
+
+            // Same usage as Texture.CreateImage for a render target or depth stencil of that format
+            var usage = VkImageUsageFlags.TransferSrc | VkImageUsageFlags.TransferDst;
+            usage |= Texture.IsDepthFormat(pixelFormat) ? VkImageUsageFlags.DepthStencilAttachment : VkImageUsageFlags.ColorAttachment;
+
+            var result = instanceApi.vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, VkImageType.Image2D, VkImageTiling.Optimal, usage, VkImageCreateFlags.None, out var imageFormatProperties);
+            if (result != VkResult.Success)
+                return MultisampleCount.None;
+
+            var sampleCounts = imageFormatProperties.sampleCounts;
+            if ((sampleCounts & VkSampleCountFlags.Count8) != 0)
+                return MultisampleCount.X8;
+            if ((sampleCounts & VkSampleCountFlags.Count4) != 0)
+                return MultisampleCount.X4;
+            if ((sampleCounts & VkSampleCountFlags.Count2) != 0)
+                return MultisampleCount.X2;
+            return MultisampleCount.None;
         }
     }
 }

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
@@ -42,14 +42,9 @@ namespace Stride.Graphics
 
             HasResourceRenaming = false;
 
-            // Multisample support was never queried here: every format was reported as
-            // MultisampleCount.None, so Texture.New threw "the maximum supported level is None" for
-            // any multisampled render target - MSAA was simply unusable on Vulkan. Stride.Voxels'
-            // dominant-axis voxelization allocates an 8x target and died on it.
-            //
-            // Only the framebuffer masks are read, not per-format image properties: this runs for
-            // all 256 PixelFormat values at device creation, and the framebuffer limits are what
-            // actually bound a render target's sample count.
+            // Only the framebuffer sample count limits are read, not per-format image properties:
+            // this runs for every PixelFormat at device creation, and the framebuffer limits are what
+            // bound a render target's sample count.
             var physicalDevice = deviceRoot.NativePhysicalDevice;
             deviceRoot.NativeInstanceApi.vkGetPhysicalDeviceProperties(physicalDevice, out var physicalDeviceProperties);
             var colorSampleCounts = physicalDeviceProperties.limits.framebufferColorSampleCounts;
@@ -66,11 +61,8 @@ namespace Stride.Graphics
                 return MultisampleCount.None;
             }
 
-            // Reported per format, but computed from the intersection of the colour and depth masks
-            // rather than per format: telling colour and depth formats apart here would need a
-            // predicate Stride does not have on this side, and the two masks are identical on every
-            // driver worth supporting. Erring low only costs a sample count; erring high would hand
-            // out a count the device cannot attach.
+            // Use the intersection of the color and depth masks for every format: there is no
+            // color/depth predicate on PixelFormat here, and erring low only costs a sample count.
             var maximumMultisampleCount = MaximumSampleCount(colorSampleCounts & depthSampleCounts);
 
             for (int i = 0; i < mapFeaturesPerFormat.Length; i++)

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
@@ -48,7 +48,7 @@ namespace Stride.Graphics
             for (int i = 0; i < mapFeaturesPerFormat.Length; i++)
             {
                 var pixelFormat = (PixelFormat) i;
-                var maximumMultisampleCount = GetMaximumMultisampleCount(instanceApi, physicalDevice, pixelFormat);
+                var maximumMultisampleCount = GetMaximumMultisampleCount(deviceRoot, instanceApi, physicalDevice, pixelFormat);
                 mapFeaturesPerFormat[i] = new FeaturesPerFormat(pixelFormat, maximumMultisampleCount, ComputeShaderFormatSupport.None, FormatSupport.None);
             }
             //// Check features for each DXGI.Format
@@ -73,14 +73,23 @@ namespace Stride.Graphics
             //}
         }
 
-        private static MultisampleCount GetMaximumMultisampleCount(VkInstanceApi instanceApi, VkPhysicalDevice physicalDevice, PixelFormat pixelFormat)
+        private static MultisampleCount GetMaximumMultisampleCount(GraphicsDevice deviceRoot, VkInstanceApi instanceApi, VkPhysicalDevice physicalDevice, PixelFormat pixelFormat)
         {
             if (!VulkanConvertExtensions.TryConvertPixelFormat(pixelFormat, out var format, out _, out _))
                 return MultisampleCount.None;
 
             // Same usage as Texture.CreateImage for a render target or depth stencil of that format
             var usage = VkImageUsageFlags.TransferSrc | VkImageUsageFlags.TransferDst;
-            usage |= Texture.IsDepthFormat(pixelFormat) ? VkImageUsageFlags.DepthStencilAttachment : VkImageUsageFlags.ColorAttachment;
+            if (Texture.IsDepthFormat(pixelFormat))
+            {
+                usage |= VkImageUsageFlags.DepthStencilAttachment;
+                // CreateImage substitutes a supported depth-stencil format, so query the one it would really create
+                format = Texture.GetFallbackDepthStencilFormat(deviceRoot, format);
+            }
+            else
+            {
+                usage |= VkImageUsageFlags.ColorAttachment;
+            }
 
             var result = instanceApi.vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, VkImageType.Image2D, VkImageTiling.Optimal, usage, VkImageCreateFlags.None, out var imageFormatProperties);
             if (result != VkResult.Success)

--- a/sources/engine/Stride.Graphics/Vulkan/VulkanConvertExtensions.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/VulkanConvertExtensions.cs
@@ -283,6 +283,16 @@ namespace Stride.Graphics
 
         public static void ConvertPixelFormat(PixelFormat inputFormat, out VkFormat format, out int pixelSize, out bool compressed)
         {
+            if (!TryConvertPixelFormat(inputFormat, out format, out pixelSize, out compressed))
+                throw new InvalidOperationException("Unsupported texture format: " + inputFormat);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="PixelFormat"/> to its Vulkan equivalent.
+        /// </summary>
+        /// <returns><c>true</c> if the format has a Vulkan equivalent; otherwise <c>false</c> and <paramref name="format"/> is <see cref="VkFormat.Undefined"/>.</returns>
+        public static bool TryConvertPixelFormat(PixelFormat inputFormat, out VkFormat format, out int pixelSize, out bool compressed)
+        {
             compressed = false;
 
             // TODO VULKAN: Complete supported formats
@@ -672,8 +682,12 @@ namespace Stride.Graphics
                     pixelSize = 2; // 8bpp
                     break;
                 default:
-                    throw new InvalidOperationException("Unsupported texture format: " + inputFormat);
+                    format = VkFormat.Undefined;
+                    pixelSize = 0;
+                    return false;
             }
+
+            return true;
         }
 
         public static unsafe VkColorComponentFlags ConvertColorWriteChannels(ColorWriteChannels colorWriteChannels)

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Processing/ClearBuffer.sdsl
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Processing/ClearBuffer.sdsl
@@ -6,9 +6,20 @@ namespace Stride.Rendering.Voxels
     {
         stage RWBuffer<uint> buffer;
         int offset;
+
+        // Direct3D11 allows at most 65535 thread groups per dispatch dimension, so a purely
+        // one-dimensional dispatch cannot address more than 65535 * 1024 elements. A 256^3
+        // anisotropic clipmap needs three times that, so the groups are spread over X and Y and
+        // the linear index is recomposed here. rowLength is how many elements one row of groups
+        // covers, and count bounds the last row, which generally overshoots.
+        int rowLength;
+        int count;
+
         override void Compute()
         {
-            buffer[streams.DispatchThreadId.x + offset] = 0;
+            uint index = streams.DispatchThreadId.x + streams.DispatchThreadId.y * (uint)rowLength;
+            if (index < (uint)count)
+                buffer[index + offset] = 0;
         }
     };
 }

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Processing/ClearBuffer.sdsl
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Processing/ClearBuffer.sdsl
@@ -7,11 +7,12 @@ namespace Stride.Rendering.Voxels
         stage RWBuffer<uint> buffer;
         int offset;
 
-        // Direct3D11 allows at most 65535 thread groups per dispatch dimension, so a purely
-        // one-dimensional dispatch cannot address more than 65535 * 1024 elements. A 256^3
-        // anisotropic clipmap needs three times that, so the groups are spread over X and Y and
-        // the linear index is recomposed here. rowLength is how many elements one row of groups
-        // covers, and count bounds the last row, which generally overshoots.
+        // A dispatch may have at most 65535 thread groups per dimension, on every API alike
+        // (D3D11 and D3D12's D3D1x_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION, Vulkan's minimum
+        // maxComputeWorkGroupCount), so a one-dimensional dispatch cannot address more than
+        // 65535 * 1024 elements. A 256^3 anisotropic clipmap needs three times that, so the groups
+        // are spread over X and Y and the linear index is recomposed here. rowLength is how many
+        // elements one row of groups covers, and count bounds the last row, which overshoots.
         int rowLength;
         int count;
 

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Processing/ClearBuffer.sdsl
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Processing/ClearBuffer.sdsl
@@ -7,12 +7,9 @@ namespace Stride.Rendering.Voxels
         stage RWBuffer<uint> buffer;
         int offset;
 
-        // A dispatch may have at most 65535 thread groups per dimension, on every API alike
-        // (D3D11 and D3D12's D3D1x_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION, Vulkan's minimum
-        // maxComputeWorkGroupCount), so a one-dimensional dispatch cannot address more than
-        // 65535 * 1024 elements. A 256^3 anisotropic clipmap needs three times that, so the groups
-        // are spread over X and Y and the linear index is recomposed here. rowLength is how many
-        // elements one row of groups covers, and count bounds the last row, which overshoots.
+        // A dispatch has at most 65535 thread groups per dimension, so the groups are spread over X and Y
+        // and the linear index is recomposed here. rowLength is the elements one row of groups covers;
+        // count bounds the last row, which overshoots.
         int rowLength;
         int count;
 

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Shaders/VoxelStorageTextureClipmapShader.sdsl
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/Shaders/VoxelStorageTextureClipmapShader.sdsl
@@ -63,7 +63,7 @@ shader VoxelStorageTextureClipmapShader<float voxelSizeT, float clipCountT, floa
 
         float mipBase = floor(mipmap);
 
-        float4 offsetScale = perMapOffsetScale[mipBase];
+        float4 offsetScale = perMapOffsetScale[(int)mipBase];
         pos = pos * offsetScale.w + offsetScale.xyz;
 
         if (mipBase >= clipCountT)
@@ -114,10 +114,10 @@ shader VoxelStorageTextureClipmapShader<float voxelSizeT, float clipCountT, floa
         float mipBase = floor(mipmap);
 
 
-        float4 offsetScale = perMapOffsetScale[mipBase];
+        float4 offsetScale = perMapOffsetScale[(int)mipBase];
         float3 posFine = pos * offsetScale.w + offsetScale.xyz;
 
-        offsetScale = perMapOffsetScale[mipBase + 1];
+        offsetScale = perMapOffsetScale[(int)mipBase + 1];
         float3 posCoarse = pos * offsetScale.w + offsetScale.xyz;
         if (mipBase >= clipCountT)
         {

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Sean Boettger <sean@whypenguins.com>
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Sean Boettger <sean@whypenguins.com>
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Collections.Generic;
@@ -246,6 +246,30 @@ namespace Stride.Rendering.Voxels
         Stride.Rendering.ComputeEffect.ComputeEffectShader BufferToTextureColumns;
         Stride.Rendering.ComputeEffect.ComputeEffectShader ClearBuffer;
 
+
+        /// <summary>
+        /// Thread group counts for clearing <paramref name="elementCount"/> buffer elements, spread
+        /// over two dimensions.
+        /// </summary>
+        /// <remarks>
+        /// Direct3D11 rejects a dispatch with more than 65535 groups in any one dimension, which
+        /// caps a one-dimensional clear at about 67 million elements. A 256^3 clipmap storing six
+        /// directions needs 201 million, so it failed outright. ClearBuffer recomposes the linear
+        /// index from X and Y, using <paramref name="rowLength"/> as the width of one row of groups.
+        /// </remarks>
+        static Int3 ClearDispatch(int elementCount, out int rowLength)
+        {
+            const int threadsPerGroup = 1024;
+            const int maxGroupsPerDimension = 65535;
+
+            var groups = (elementCount + threadsPerGroup - 1) / threadsPerGroup;
+            var groupsX = Math.Min(groups, maxGroupsPerDimension);
+            var groupsY = (groups + groupsX - 1) / groupsX;
+
+            rowLength = groupsX * threadsPerGroup;
+            return new Int3(groupsX, groupsY, 1);
+        }
+
         public void PostProcess(VoxelStorageContext storageContext, RenderDrawContext drawContext, ProcessedVoxelVolume data)
         {
             if (Math.Max(Math.Max(ClipMapResolution.X, ClipMapResolution.Y), ClipMapResolution.Z) < 32)
@@ -363,15 +387,20 @@ namespace Stride.Rendering.Voxels
             {
                 //Clear all
                 ClearBuffer.ThreadNumbers = new Int3(1024, 1, 1);
-                ClearBuffer.ThreadGroupCounts = new Int3(FragmentsBuffer.ElementCount / 1024, 1, 1);
+                ClearBuffer.ThreadGroupCounts = ClearDispatch(FragmentsBuffer.ElementCount, out var fragmentsRowLength);
                 ClearBuffer.Parameters.Set(ClearBufferKeys.offset, 0);
+                ClearBuffer.Parameters.Set(ClearBufferKeys.rowLength, fragmentsRowLength);
+                ClearBuffer.Parameters.Set(ClearBufferKeys.count, FragmentsBuffer.ElementCount);
             }
             else
             {
                 //Clear next clipmap buffer
+                var clipMapElements = (int)(ClipMapResolution.X * ClipMapResolution.Y * ClipMapResolution.Z * storageUints);
                 ClearBuffer.ThreadNumbers = new Int3(1024, 1, 1);
-                ClearBuffer.ThreadGroupCounts = new Int3((int)(ClipMapResolution.X * ClipMapResolution.Y * ClipMapResolution.Z * storageUints) / 1024, 1, 1);
+                ClearBuffer.ThreadGroupCounts = ClearDispatch(clipMapElements, out var clipMapRowLength);
                 ClearBuffer.Parameters.Set(ClearBufferKeys.offset, (int)(((ClipMapCurrent+1) % ClipMapCount) * ClipMapResolution.X * ClipMapResolution.Y * ClipMapResolution.Z * storageUints));
+                ClearBuffer.Parameters.Set(ClearBufferKeys.rowLength, clipMapRowLength);
+                ClearBuffer.Parameters.Set(ClearBufferKeys.count, clipMapElements);
             }
             ((RendererBase)ClearBuffer).Draw(drawContext);
         }

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
@@ -248,17 +248,17 @@ namespace Stride.Rendering.Voxels
 
 
         /// <summary>
-        /// Thread group counts for clearing <paramref name="elementCount"/> buffer elements, spread
-        /// over two dimensions.
+        /// Computes the thread group counts for clearing <paramref name="elementCount"/> buffer
+        /// elements, spread over two dispatch dimensions.
         /// </summary>
-        /// <remarks>
-        /// Direct3D11 rejects a dispatch with more than 65535 groups in any one dimension, which
-        /// caps a one-dimensional clear at about 67 million elements. A 256^3 clipmap storing six
-        /// directions needs 201 million, so it failed outright. ClearBuffer recomposes the linear
-        /// index from X and Y, using <paramref name="rowLength"/> as the width of one row of groups.
-        /// </remarks>
+        /// <param name="elementCount">How many elements the clear covers.</param>
+        /// <param name="rowLength">How many elements one row of groups covers, for the shader to recompose a linear index.</param>
+        /// <returns>The group counts to dispatch <c>ClearBuffer</c> with.</returns>
         static Int3 ClearDispatch(int elementCount, out int rowLength)
         {
+            // Every API caps a dispatch at 65535 groups per dimension, which caps a one-dimensional
+            // clear at about 67 million elements. A 256^3 clipmap storing six directions needs 201
+            // million, so it failed outright; the shader recomposes the index from X and Y.
             const int threadsPerGroup = 1024;
             const int maxGroupsPerDimension = 65535;
 

--- a/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
+++ b/sources/engine/Stride.Voxels/Voxels/Voxelization/VoxelStorage/VoxelStorageClipmaps.cs
@@ -248,8 +248,7 @@ namespace Stride.Rendering.Voxels
 
 
         /// <summary>
-        /// Computes the thread group counts for clearing <paramref name="elementCount"/> buffer
-        /// elements, spread over two dispatch dimensions.
+        /// Computes the thread group counts for clearing <paramref name="elementCount"/> buffer elements, spread over two dispatch dimensions.
         /// </summary>
         /// <param name="elementCount">How many elements the clear covers.</param>
         /// <param name="rowLength">How many elements one row of groups covers, for the shader to recompose a linear index.</param>

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/SDSLC.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/SDSLC.cs
@@ -122,6 +122,13 @@ public record struct SDSLC(IExternalShaderLoader ShaderLoader)
             {
                 // Ignore (using C# codegen for now)
             }
+            else if (declaration is UsingShaderNamespace)
+            {
+                // Ignore: shader classes are resolved by name across every loaded namespace, so a
+                // `using` at the top of an .sdsl file carries no information the compiler needs.
+                // Erroring on it took down every shader that has one — Stride.Voxels'
+                // LightVoxelShader among them, which made voxel GI unusable.
+            }
             else
             {
                 log.Error($"Compiling declaration [{declaration.GetType()}] is not implemented");

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/SDSLC.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/SDSLC.cs
@@ -124,10 +124,12 @@ public record struct SDSLC(IExternalShaderLoader ShaderLoader)
             }
             else if (declaration is UsingShaderNamespace)
             {
-                // Ignore: shader classes are resolved by name across every loaded namespace, so a
-                // `using` at the top of an .sdsl file carries no information the compiler needs.
-                // Erroring on it took down every shader that has one — Stride.Voxels'
-                // LightVoxelShader among them, which made voxel GI unusable.
+                // A `using` names a namespace to look in. The loader resolves a shader class by its
+                // name alone - one .sdsl file per class, found by file name, as the previous
+                // compiler's ShaderSourceManager did - so the namespace is already known to be
+                // unique across a project and the directive adds nothing to resolution. It is
+                // accepted and skipped; reporting it as unsupported rejected every shader that has
+                // one.
             }
             else
             {

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/SDSLC.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/SDSLC.cs
@@ -124,12 +124,8 @@ public record struct SDSLC(IExternalShaderLoader ShaderLoader)
             }
             else if (declaration is UsingShaderNamespace)
             {
-                // A `using` names a namespace to look in. The loader resolves a shader class by its
-                // name alone - one .sdsl file per class, found by file name, as the previous
-                // compiler's ShaderSourceManager did - so the namespace is already known to be
-                // unique across a project and the directive adds nothing to resolution. It is
-                // accepted and skipped; reporting it as unsupported rejected every shader that has
-                // one.
+                // Ignore: shader classes are resolved by name across every loaded namespace, so a
+                // `using` declaration carries no information the compiler needs.
             }
             else
             {

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
@@ -211,6 +211,51 @@ public partial class ShaderMixer
     }
 
     // Emit reflection (except ConstantBuffers which was emitted during ComputeCBufferReflection)
+    /// <summary>
+    /// The first unordered access register a Direct3D11 pixel shader may use.
+    /// <para>
+    /// D3D11 puts UAVs and render targets in one register space, so a pixel shader's UAVs have to
+    /// start past its render targets - FXC otherwise rejects the shader with X4509. The engine
+    /// already assumes this: CommandList.OMSetSingleUnorderedAccessView binds with
+    /// <c>UAVStartSlot: currentRenderTargetViewsActiveCount</c> and indexes
+    /// <c>slot - currentRenderTargetViewsActiveCount</c>, which is negative if a UAV took u0.
+    /// </para>
+    /// <para>
+    /// Counted as the highest output Location plus one, so multiple render targets are handled,
+    /// and left at 0 when the module has no pixel shader - a compute shader keeps u0.
+    /// </para>
+    /// </summary>
+    private static int FirstUnorderedAccessSlot(SpirvContext context)
+    {
+        var outputVariables = new HashSet<int>();
+        var locations = new Dictionary<int, int>();
+        var fragmentInterface = new HashSet<int>();
+
+        foreach (var i in context)
+        {
+            if (i.Op == Specification.Op.OpVariable && (OpVariable)i is { StorageClass: Specification.StorageClass.Output } variable)
+                outputVariables.Add(variable.ResultId);
+            else if (i.Op == Specification.Op.OpDecorate
+                && (OpDecorate)i is { Decoration: Specification.Decoration.Location, DecorationParameters: { } location } decorate)
+                locations[decorate.Target] = location.Span[0];
+            else if (i.Op == Specification.Op.OpEntryPoint
+                && (OpEntryPoint)i is { ExecutionModel: Specification.ExecutionModel.Fragment } entryPoint)
+            {
+                foreach (var interfaceId in entryPoint.InterfaceIds.Elements.Span)
+                    fragmentInterface.Add(interfaceId);
+            }
+        }
+
+        var firstSlot = 0;
+        foreach (var variableId in fragmentInterface)
+        {
+            if (outputVariables.Contains(variableId) && locations.TryGetValue(variableId, out var location))
+                firstSlot = Math.Max(firstSlot, location + 1);
+        }
+
+        return firstSlot;
+    }
+
     private unsafe void ProcessReflection(MixinGlobalContext globalContext, SpirvContext context, SpirvBuffer buffer, Options options)
     {
         Span<int> slotCounts = stackalloc int[options.ResourcesRegisterSeparate ? 4 : 1];
@@ -221,6 +266,12 @@ public partial class ShaderMixer
         ref var samplerSlot = ref slotCounts[options.ResourcesRegisterSeparate ? 1 : 0];
         ref var cbufferSlot = ref slotCounts[options.ResourcesRegisterSeparate ? 2 : 0];
         ref var uavSlot = ref slotCounts[options.ResourcesRegisterSeparate ? 3 : 0];
+
+        // Only in the separate (Direct3D11) register space: a pixel shader's UAVs start past its
+        // render targets. Vulkan and D3D12 share one counter and one descriptor set, where the
+        // rule does not exist. See FirstUnorderedAccessSlot.
+        if (options.ResourcesRegisterSeparate)
+            uavSlot = FirstUnorderedAccessSlot(context);
 
         // TODO: do this once at root level and reuse for child mixin
         var samplerStates = new Dictionary<int, Graphics.SamplerStateDescription>();

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
@@ -266,7 +266,7 @@ public partial class ShaderMixer
 
         // Only in the separate (Direct3D11) register space: a pixel shader's UAVs start past its
         // render targets. Vulkan and D3D12 share one counter and one descriptor set, where the
-        // rule does not exist. See FirstUnorderedAccessSlot.
+        // rule does not exist. See GetFirstUnorderedAccessSlot.
         if (options.ResourcesRegisterSeparate)
             uavSlot = GetFirstUnorderedAccessSlot(context);
 

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
@@ -212,21 +212,21 @@ public partial class ShaderMixer
 
     // Emit reflection (except ConstantBuffers which was emitted during ComputeCBufferReflection)
     /// <summary>
-    /// The first unordered access register a Direct3D11 pixel shader may use.
-    /// <para>
-    /// D3D11 puts UAVs and render targets in one register space, so a pixel shader's UAVs have to
-    /// start past its render targets - FXC otherwise rejects the shader with X4509. The engine
-    /// already assumes this: CommandList.OMSetSingleUnorderedAccessView binds with
-    /// <c>UAVStartSlot: currentRenderTargetViewsActiveCount</c> and indexes
-    /// <c>slot - currentRenderTargetViewsActiveCount</c>, which is negative if a UAV took u0.
-    /// </para>
-    /// <para>
-    /// Counted as the highest output Location plus one, so multiple render targets are handled,
-    /// and left at 0 when the module has no pixel shader - a compute shader keeps u0.
-    /// </para>
+    /// Retrieves the first unordered access register a pixel shader may bind, past its render
+    /// targets.
     /// </summary>
-    private static int FirstUnorderedAccessSlot(SpirvContext context)
+    /// <remarks>
+    /// Counted as the highest output <c>Location</c> plus one, so several render targets are
+    /// handled; 0 when the module has no pixel shader, so a compute shader keeps <c>u0</c>.
+    /// </remarks>
+    /// <returns>The register index of the first UAV slot.</returns>
+    private static int GetFirstUnorderedAccessSlot(SpirvContext context)
     {
+        // Direct3D 11 puts UAVs and render targets in one register space, so a pixel shader's
+        // UAVs have to start past its render targets - FXC otherwise rejects the shader with
+        // X4509. The engine already assumes this: CommandList.OMSetSingleUnorderedAccessView
+        // binds with UAVStartSlot = currentRenderTargetViewsActiveCount and indexes
+        // slot - currentRenderTargetViewsActiveCount, which goes negative if a UAV took u0.
         var outputVariables = new HashSet<int>();
         var locations = new Dictionary<int, int>();
         var fragmentInterface = new HashSet<int>();
@@ -271,7 +271,7 @@ public partial class ShaderMixer
         // render targets. Vulkan and D3D12 share one counter and one descriptor set, where the
         // rule does not exist. See FirstUnorderedAccessSlot.
         if (options.ResourcesRegisterSeparate)
-            uavSlot = FirstUnorderedAccessSlot(context);
+            uavSlot = GetFirstUnorderedAccessSlot(context);
 
         // TODO: do this once at root level and reuse for child mixin
         var samplerStates = new Dictionary<int, Graphics.SamplerStateDescription>();

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.Reflection.cs
@@ -222,11 +222,8 @@ public partial class ShaderMixer
     /// <returns>The register index of the first UAV slot.</returns>
     private static int GetFirstUnorderedAccessSlot(SpirvContext context)
     {
-        // Direct3D 11 puts UAVs and render targets in one register space, so a pixel shader's
-        // UAVs have to start past its render targets - FXC otherwise rejects the shader with
-        // X4509. The engine already assumes this: CommandList.OMSetSingleUnorderedAccessView
-        // binds with UAVStartSlot = currentRenderTargetViewsActiveCount and indexes
-        // slot - currentRenderTargetViewsActiveCount, which goes negative if a UAV took u0.
+        // Direct3D 11 shares one register space between UAVs and render targets, so a pixel shader's
+        // UAVs start past its render targets; CommandList binds them with the same offset.
         var outputVariables = new HashSet<int>();
         var locations = new Dictionary<int, int>();
         var fragmentInterface = new HashSet<int>();

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.cs
@@ -326,7 +326,16 @@ public partial class ShaderMixer(IExternalShaderLoader shaderLoader)
             {
                 if (variable.Value.Type is PointerType pointer && pointer.BaseType is ShaderSymbol or ArrayType { BaseType: ShaderSymbol })
                 {
-                    var compositionMixins = mixinSource.Compositions[variable.Key];
+                    // Every piece of context needed to act on this is in scope, and the dictionary
+                    // indexer would throw a bare "The given key was not present" instead.
+                    if (!mixinSource.Compositions.TryGetValue(variable.Key, out var compositionMixins))
+                        throw new InvalidOperationException(
+                            $"No composition was supplied for '{variable.Key}', declared as '{variable.Value.Type}' by shader '{shader.ShaderName}', "
+                            + $"while merging the mixin node '{currentCompositionPath ?? "<root>"}' (root: {mixinNode.IsRoot}). "
+                            + $"That node only has [{string.Join(", ", mixinSource.Compositions.Keys)}]. "
+                            + $"A `stage compose` is the usual cause: the shader declaring it was promoted to this node, "
+                            + $"but its value was supplied at a nested composition path and nothing carried it up.");
+
                     var isCompositionArray = pointer.BaseType is ArrayType { BaseType: ShaderSymbol };
 
                     if (!isCompositionArray && compositionMixins.Length != 1)

--- a/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
@@ -815,3 +815,19 @@ public sealed partial record ExternalType(string Name, ShaderExpressionList? Gen
 {
     public override string ToString() => Generics != null && Generics.Values.Count > 0 ? $"{Name}<{string.Join(",", Generics.Values)}>" : Name;
 }
+
+public static class SymbolTypeExtensions
+{
+    /// <summary>
+    /// Opaque resource types: images - which covers textures and typed buffers alike, both being
+    /// an OpTypeImage - and samplers.
+    /// <para>
+    /// Vulkan forbids OpStore to them (VUID-StandaloneSpirv-OpTypeImage-06924), so they live in
+    /// UniformConstant storage and are handed to a method as the caller's pointer rather than
+    /// copied into a Function-storage temporary. Both of those rules used to be spelled out as
+    /// their own `is TextureType or SamplerType` list, and both had forgotten typed buffers.
+    /// </para>
+    /// </summary>
+    public static bool IsOpaqueResource(this SymbolType type)
+        => type is TextureType or SamplerType or BufferType;
+}

--- a/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
@@ -69,18 +69,33 @@ public abstract record SymbolType()
 
         // Preserves the full vector/scalar type (e.g. float2 stays float2). Defaults to float4 when no template given (HLSL default).
         static SymbolType ResolveReturnType(TypeName? templateTypeName)
-            => templateTypeName == null ? new VectorType(ScalarType.Float, 4) : templateTypeName.Type!;
+            => WidenImageElementType(templateTypeName == null ? new VectorType(ScalarType.Float, 4) : templateTypeName.Type!);
 
         // Typed buffers only allow scalar/vector element types.
         static SymbolType ResolveBufferReturnType(TypeName? templateTypeName)
         {
-            var templateType = templateTypeName?.Type ?? new VectorType(ScalarType.Float, 4);
+            var templateType = WidenImageElementType(templateTypeName?.Type ?? new VectorType(ScalarType.Float, 4));
             return templateType switch
             {
                 VectorType or ScalarType => templateType,
                 _ => throw new NotSupportedException($"Unsupported template type {templateType} for Buffer"),
             };
         }
+
+        // An image - texture or typed buffer alike - cannot deliver 16-bit values: Vulkan requires
+        // its sampled type to be a 32-bit int, 64-bit int or 32-bit float
+        // (VUID-StandaloneSpirv-OpTypeImage-04656), and there is no extension that lifts it.
+        //
+        // Nothing is lost. The 16 bits live in the resource's pixel format, not in the shader's
+        // declaration: the texture unit decodes the stored halfs and delivers 32-bit floats to the
+        // registers, for free. `half` is already an alias of `float` in shader model 5 anyway, and
+        // code that wants native 16-bit registers converts after the read.
+        static SymbolType WidenImageElementType(SymbolType elementType) => elementType switch
+        {
+            ScalarType { Type: Scalar.Half } => ScalarType.Float,
+            VectorType { BaseType: ScalarType { Type: Scalar.Half }, Size: var size } => new VectorType(ScalarType.Float, size),
+            _ => elementType,
+        };
 
         SymbolType? foundType = name switch
         {

--- a/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
@@ -837,15 +837,15 @@ public sealed partial record ExternalType(string Name, ShaderExpressionList? Gen
 public static class SymbolTypeExtensions
 {
     /// <summary>
-    /// Opaque resource types: images - which covers textures and typed buffers alike, both being
-    /// an OpTypeImage - and samplers.
-    /// <para>
-    /// Vulkan forbids OpStore to them (VUID-StandaloneSpirv-OpTypeImage-06924), so they live in
-    /// UniformConstant storage and are handed to a method as the caller's pointer rather than
-    /// copied into a Function-storage temporary. Both of those rules used to be spelled out as
-    /// their own `is TextureType or SamplerType` list, and both had forgotten typed buffers.
-    /// </para>
+    /// Determines whether a type is an opaque resource: an image, which covers textures and typed
+    /// buffers alike, or a sampler.
     /// </summary>
+    /// <remarks>
+    /// SPIR-V forbids an OpStore to an opaque resource (VUID-StandaloneSpirv-OpTypeImage-06924),
+    /// so it lives in UniformConstant storage and is handed to a method as the caller's pointer
+    /// rather than copied into a Function-storage temporary.
+    /// </remarks>
+    /// <returns>True for textures, typed buffers and samplers.</returns>
     public static bool IsOpaqueResource(this SymbolType type)
         => type is TextureType or SamplerType or BufferType;
 }

--- a/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
@@ -82,17 +82,9 @@ public abstract record SymbolType()
             };
         }
 
-        // An image - texture or typed buffer alike - is declared with a 32-bit sampled type. The
-        // SPIR-V the compiler emits is Stride's own dialect, cross-compiled to every backend, and
-        // OpTypeImage's sampled type must be a 32-bit int, 64-bit int or 32-bit float
-        // (VUID-StandaloneSpirv-OpTypeImage-04656) for the SPIR-V to be valid at all.
-        //
-        // This is also what FXC did: from shader model 4 on, `half` is an alias of `float` in
-        // HLSL, kept for language compatibility only, so `Texture3D<half4>` declared a 32-bit
-        // register there too. The 16 bits live in the resource's pixel format, not in the shader's
-        // declaration - the texture unit decodes the stored halfs and delivers floats to the
-        // registers. Code that wants native 16-bit arithmetic uses min16float and converts after
-        // the read, as it had to before.
+        // Vulkan requires an image's sampled type to be 32-bit int, 64-bit int or 32-bit float
+        // (VUID-StandaloneSpirv-OpTypeImage-04656). The 16 bits live in the pixel format, so
+        // widening the element type loses nothing.
         static SymbolType WidenImageElementType(SymbolType elementType) => elementType switch
         {
             ScalarType { Type: Scalar.Half } => ScalarType.Float,
@@ -837,13 +829,11 @@ public sealed partial record ExternalType(string Name, ShaderExpressionList? Gen
 public static class SymbolTypeExtensions
 {
     /// <summary>
-    /// Determines whether a type is an opaque resource: an image, which covers textures and typed
-    /// buffers alike, or a sampler.
+    /// Whether the type is an opaque resource (texture, typed buffer or sampler).
     /// </summary>
     /// <remarks>
-    /// SPIR-V forbids an OpStore to an opaque resource (VUID-StandaloneSpirv-OpTypeImage-06924),
-    /// so it lives in UniformConstant storage and is handed to a method as the caller's pointer
-    /// rather than copied into a Function-storage temporary.
+    /// SPIR-V forbids OpStore to these (VUID-StandaloneSpirv-OpTypeImage-06924): they live in
+    /// UniformConstant storage and are passed to methods as the caller's pointer.
     /// </remarks>
     /// <returns>True for textures, typed buffers and samplers.</returns>
     public static bool IsOpaqueResource(this SymbolType type)

--- a/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Core/SymbolTypes.cs
@@ -82,14 +82,17 @@ public abstract record SymbolType()
             };
         }
 
-        // An image - texture or typed buffer alike - cannot deliver 16-bit values: Vulkan requires
-        // its sampled type to be a 32-bit int, 64-bit int or 32-bit float
-        // (VUID-StandaloneSpirv-OpTypeImage-04656), and there is no extension that lifts it.
+        // An image - texture or typed buffer alike - is declared with a 32-bit sampled type. The
+        // SPIR-V the compiler emits is Stride's own dialect, cross-compiled to every backend, and
+        // OpTypeImage's sampled type must be a 32-bit int, 64-bit int or 32-bit float
+        // (VUID-StandaloneSpirv-OpTypeImage-04656) for the SPIR-V to be valid at all.
         //
-        // Nothing is lost. The 16 bits live in the resource's pixel format, not in the shader's
-        // declaration: the texture unit decodes the stored halfs and delivers 32-bit floats to the
-        // registers, for free. `half` is already an alias of `float` in shader model 5 anyway, and
-        // code that wants native 16-bit registers converts after the read.
+        // This is also what FXC did: from shader model 4 on, `half` is an alias of `float` in
+        // HLSL, kept for language compatibility only, so `Texture3D<half4>` declared a 32-bit
+        // register there too. The 16 bits live in the resource's pixel format, not in the shader's
+        // declaration - the texture unit decodes the stored halfs and delivers floats to the
+        // registers. Code that wants native 16-bit arithmetic uses min16float and converts after
+        // the read, as it had to before.
         static SymbolType WidenImageElementType(SymbolType elementType) => elementType switch
         {
             ScalarType { Type: Scalar.Half } => ScalarType.Float,

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -295,6 +295,17 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
                 if (paramDefinition.Modifiers == ParameterModifiers.Ref
                     || pointerParamType.BaseType is TextureType or SamplerType)
                 {
+                    // `InterlockedMax(buffer[i], ...)`: indexing a typed buffer yields the texel's
+                    // value, never a pointer to it, so the atomic has nothing to operate on. Ask
+                    // for the texel pointer instead - the one instruction that produces one.
+                    if (paramDefinition.Modifiers == ParameterModifiers.Ref
+                        && Arguments.Values[i] is AccessorChainExpression accessorChain
+                        && accessorChain.TryCompileAsTexelPointer(table, compiler, out var texelPointer))
+                    {
+                        compiledParams[i] = texelPointer.Id;
+                        continue;
+                    }
+
                     var paramPointer = Arguments.Values[i].Compile(table, compiler);
                     if (context.ReverseTypes[paramPointer.TypeId] is not PointerType)
                         table.AddError(new(Arguments.Values[i].Info,
@@ -669,6 +680,53 @@ public partial class AccessorChainExpression(Expression source, TextLocation inf
     public List<Expression> Accessors { get; set; } = [];
 
     private SpirvValue[]? intermediateValues;
+
+    /// <summary>
+    /// Compiles a trailing <c>buffer[i]</c> into an <c>OpImageTexelPointer</c> - a pointer to that
+    /// one texel - rather than the image read indexing normally produces. Returns false when the
+    /// chain is not an atomic-capable buffer index, leaving the caller to compile it normally.
+    /// <para>
+    /// A typed buffer is not memory the shader can point into: it is a storage image, so SDSL
+    /// compiles <c>buffer[i]</c> to an OpImageRead and <c>buffer[i] = x</c> to an OpImageWrite,
+    /// both of which deal in values. An atomic needs the memory itself, and OpImageTexelPointer is
+    /// the only instruction that hands it over. Its result may only be consumed by atomics, which
+    /// is why this is offered to the `ref` argument path instead of being how every index compiles.
+    /// </para>
+    /// </summary>
+    public bool TryCompileAsTexelPointer(SymbolTable table, CompilerUnit compiler, out SpirvValue texelPointer)
+    {
+        texelPointer = default;
+
+        if (Accessors.Count == 0 || Accessors[^1] is not IndexerExpression indexer)
+            return false;
+
+        var lastIndex = Accessors.Count - 1;
+        var baseType = lastIndex > 0 ? Accessors[lastIndex - 1].Type : Source.Type;
+        if (baseType is not PointerType { BaseType: BufferType bufferType })
+            return false;
+
+        // Image atomics are only defined on 32-bit integer texels, which is also the only case
+        // where the image declares a format - see SpirvContext.GetStorageImageFormat.
+        if (bufferType.BaseType is not ScalarType { Type: Scalar.UInt or Scalar.Int })
+            return false;
+
+        var (builder, context) = compiler;
+
+        // Fills intermediateValues, and is cached, so this is the walk the caller would have done.
+        CompileHelper(table, compiler);
+
+        // The image operand stays a pointer to the image; it must not be loaded into a value.
+        var image = intermediateValues![lastIndex];
+        var coordinate = builder.Convert(context, indexer.Index.CompileAsValue(table, compiler), ScalarType.Int);
+        var pointerType = new PointerType(bufferType.BaseType, Specification.StorageClass.Image);
+
+        var instruction = builder.Insert(new OpImageTexelPointer(
+            context.GetOrRegister(pointerType), context.Bound++,
+            image.Id, coordinate.Id, context.CompileConstant((int)0).Id));
+
+        texelPointer = new SpirvValue(instruction.ResultId, instruction.ResultType);
+        return true;
+    }
 
     public override void SetValue(SymbolTable table, CompilerUnit compiler, SpirvValue rvalue)
     {

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -1281,9 +1281,29 @@ public partial class AccessorChainExpression(Expression source, TextLocation inf
                         }
                     }
                     break;
-                // Array indexer for shader compositions
-                case (PointerType { BaseType: ArrayType { BaseType: ShaderSymbol } }, IndexerExpression { Index: IntegerLiteral { Value: var compositionIndex } }):
-                    throw new NotImplementedException();
+                // Array indexer for shader compositions.
+                // Nothing is resolved here: the composition array has no runtime existence, so this
+                // only has to leave an OpAccessChain whose base is the composition variable and whose
+                // index is a constant. ShaderMixer.ProcessMemberAccessAndForeach recognises exactly
+                // that shape, reads the constant, maps the result id to compositions[index] and NOPs
+                // the chain out. Hence the IntegerLiteral guard: a dynamic index has no composition
+                // to resolve to at mix time.
+                case (PointerType { BaseType: ArrayType { BaseType: ShaderSymbol compositionType } } p, IndexerExpression { Index: IntegerLiteral } indexer):
+                    {
+                        if (compiler == null)
+                        {
+                            indexer.Index.ProcessSymbol(table);
+                            accessor.Type = new PointerType(compositionType, p.StorageClass);
+                            break;
+                        }
+
+                        var indexerValue = indexer.Index.CompileAsValue(table, compiler);
+                        PushAccessChainId(accessChainIds, indexerValue.Id);
+                        break;
+                    }
+                case (PointerType { BaseType: ArrayType { BaseType: ShaderSymbol } }, IndexerExpression indexer2):
+                    throw new NotImplementedException(
+                        $"Shader compositions can only be indexed with a constant: '{indexer2.Index}' is resolved at mix time, not at runtime.");
                 // Array indexer for arrays
                 case (PointerType { BaseType: ArrayType { BaseType: var t } } p, IndexerExpression indexer):
                     {

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -375,8 +375,8 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
     /// <list type="bullet">
     /// <item>ref: atomic intrinsics (InterlockedAdd, etc.) need the actual memory pointer
     /// (Workgroup, StorageBuffer, ...).</item>
-    /// <item>Opaque types: Vulkan forbids OpStore to them
-    /// (VUID-StandaloneSpirv-OpTypeImage-06924), so they cannot live in a Function variable.</item>
+    /// <item>Opaque resources (see <see cref="SymbolTypeExtensions.IsOpaqueResource"/>): Vulkan
+    /// forbids OpStore to them, so they cannot live in a Function variable.</item>
     /// <item>Geometry streams: appending goes through OpEmitVertexSDSL and the stage's output
     /// variables, so the object holds nothing to copy - and the copy outlived the parameter, which
     /// the interface processor removes from the signature, leaving SPIR-V reading an id that no
@@ -388,7 +388,8 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
     private static bool IsPassedByPointer(FunctionParameter parameter)
         => parameter.Type is PointerType pointerType
             && (parameter.Modifiers == ParameterModifiers.Ref
-                || pointerType.BaseType is TextureType or SamplerType or GeometryStreamType);
+                || pointerType.BaseType.IsOpaqueResource()
+                || pointerType.BaseType is GeometryStreamType);
 
     protected void ProcessOutputArguments(SymbolTable table, CompilerUnit compiler, FunctionType functionType, Span<int> compiledParams)
     {

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -287,13 +287,7 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
 
             if (paramDefinition.Type is PointerType pointerParamType)
             {
-                // For ref params or opaque types (image/sampler), pass the original pointer directly.
-                // - ref: required for atomic intrinsics (InterlockedAdd, etc.) that need
-                //   the actual memory pointer (Workgroup, StorageBuffer, etc.).
-                // - opaque types: Vulkan forbids OpStore to these types (VUID-StandaloneSpirv-OpTypeImage-06924),
-                //   so they cannot be copied into Function-storage variables.
-                if (paramDefinition.Modifiers == ParameterModifiers.Ref
-                    || pointerParamType.BaseType is TextureType or SamplerType)
+                if (IsPassedByPointer(paramDefinition))
                 {
                     // `InterlockedMax(buffer[i], ...)`: indexing a typed buffer yields the texel's
                     // value, never a pointer to it, so the atomic has nothing to operate on. Ask
@@ -375,6 +369,27 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
             throw new InvalidOperationException($"Function {Name} was called with {Arguments.Values.Count} arguments but there was {(defaultParameters > 0 ? $"between {functionType.ParameterTypes.Count - defaultParameters} and {functionType.ParameterTypes.Count}" : functionType.ParameterTypes.Count)} expected (methodDefaultParameters={(methodDefaultParameters == null ? "null" : $"[{string.Join(",", methodDefaultParameters.Value.DefaultValues)}]({methodDefaultParameters.Value.DefaultValues.Length} values)")}, missing={missingParameters})");
     }
 
+    /// <summary>
+    /// Whether an argument is handed to the callee as the caller's own pointer instead of being
+    /// copied into a function-local temporary.
+    /// <list type="bullet">
+    /// <item>ref: atomic intrinsics (InterlockedAdd, etc.) need the actual memory pointer
+    /// (Workgroup, StorageBuffer, ...).</item>
+    /// <item>Opaque types: Vulkan forbids OpStore to them
+    /// (VUID-StandaloneSpirv-OpTypeImage-06924), so they cannot live in a Function variable.</item>
+    /// <item>Geometry streams: appending goes through OpEmitVertexSDSL and the stage's output
+    /// variables, so the object holds nothing to copy - and the copy outlived the parameter, which
+    /// the interface processor removes from the signature, leaving SPIR-V reading an id that no
+    /// longer exists.</item>
+    /// </list>
+    /// The input and output sides both consult this: copying a result back out of something that
+    /// was never copied in would write through a pointer the callee already holds.
+    /// </summary>
+    private static bool IsPassedByPointer(FunctionParameter parameter)
+        => parameter.Type is PointerType pointerType
+            && (parameter.Modifiers == ParameterModifiers.Ref
+                || pointerType.BaseType is TextureType or SamplerType or GeometryStreamType);
+
     protected void ProcessOutputArguments(SymbolTable table, CompilerUnit compiler, FunctionType functionType, Span<int> compiledParams)
     {
         var (builder, context) = compiler;
@@ -382,7 +397,7 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
         for (int i = 0; i < Arguments.Values.Count; i++)
         {
             var paramDefinition = functionType.ParameterTypes[i];
-            if (paramDefinition.Modifiers.HasFlag(ParameterModifiers.Out))
+            if (paramDefinition.Modifiers.HasFlag(ParameterModifiers.Out) && !IsPassedByPointer(paramDefinition))
             {
                 var paramDefinitionType = (PointerType)paramDefinition.Type;
                 var paramVariable = compiledParams[i];

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -370,22 +370,11 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
     }
 
     /// <summary>
-    /// Whether an argument is handed to the callee as the caller's own pointer instead of being
-    /// copied into a function-local temporary.
+    /// Whether an argument is passed as the caller's pointer instead of being copied into a function-local temporary.
     /// </summary>
     /// <remarks>
-    /// Three kinds of parameter are handed to the callee as the caller's own pointer rather than
-    /// as a copy in a Function variable:
-    /// <list type="bullet">
-    /// <item><c>ref</c>: atomic intrinsics (InterlockedAdd, ...) need the actual memory pointer
-    /// (Workgroup, StorageBuffer, ...).</item>
-    /// <item>Opaque resources (see <see cref="SymbolTypeExtensions.IsOpaqueResource"/>): SPIR-V
-    /// forbids OpStore to them, so they cannot live in a Function variable.</item>
-    /// <item>Geometry streams: appending goes through OpEmitVertexSDSL and the stage's output
-    /// variables, so the object holds nothing to copy.</item>
-    /// </list>
-    /// The input and output sides both consult this: copying a result back out of something that
-    /// was never copied in would write through a pointer the callee already holds.
+    /// Applies to <c>ref</c> parameters (atomics need the actual memory pointer), opaque resources
+    /// (SPIR-V forbids OpStore to them) and geometry streams (nothing to copy). Used for both input and output arguments.
     /// </remarks>
     /// <returns>True when the argument is passed as a pointer, false when it is copied.</returns>
     private static bool IsPassedByPointer(FunctionParameter parameter)
@@ -701,21 +690,13 @@ public partial class AccessorChainExpression(Expression source, TextLocation inf
     private SpirvValue[]? intermediateValues;
 
     /// <summary>
-    /// Compiles a trailing <c>buffer[i]</c> into an <c>OpImageTexelPointer</c>, a pointer to that
-    /// one texel, for an atomic to operate on.
+    /// Compiles a trailing <c>buffer[i]</c> into an <c>OpImageTexelPointer</c> for use by atomics.
     /// </summary>
     /// <remarks>
-    /// A typed buffer is not memory the shader can point into: it is a storage image, so SDSL
-    /// compiles <c>buffer[i]</c> to an OpImageRead and <c>buffer[i] = x</c> to an OpImageWrite,
-    /// both of which deal in values. An atomic needs the memory itself, and OpImageTexelPointer is
-    /// the only instruction that hands it over. Its result may only be consumed by atomics, which
-    /// is why this is offered to the <c>ref</c> argument path instead of being how every index
-    /// compiles.
+    /// A typed buffer is a storage image, so normal indexing produces an image read/write; atomics
+    /// need a pointer, and OpImageTexelPointer results may only be consumed by atomics, hence this
+    /// is only used on the <c>ref</c> argument path. Returns false when the chain is not a buffer index.
     /// </remarks>
-    /// <returns>
-    /// True with the texel pointer when the chain is an atomic-capable buffer index; false
-    /// otherwise, leaving the caller to compile the chain as an ordinary read.
-    /// </returns>
     public bool TryCompileAsTexelPointer(SymbolTable table, CompilerUnit compiler, out SpirvValue texelPointer)
     {
         texelPointer = default;
@@ -1362,13 +1343,9 @@ public partial class AccessorChainExpression(Expression source, TextLocation inf
                         }
                     }
                     break;
-                // Array indexer for shader compositions.
-                // Nothing is resolved here: the composition array has no runtime existence, so this
-                // only has to leave an OpAccessChain whose base is the composition variable and whose
-                // index is a constant. ShaderMixer.ProcessMemberAccessAndForeach recognises exactly
-                // that shape, reads the constant, maps the result id to compositions[index] and NOPs
-                // the chain out. Hence the IntegerLiteral guard: a dynamic index has no composition
-                // to resolve to at mix time.
+                // Array indexer for shader compositions: emit an OpAccessChain with a constant index,
+                // which ShaderMixer.ProcessMemberAccessAndForeach resolves to compositions[index] at
+                // mix time. A dynamic index has no composition to resolve to, hence the IntegerLiteral guard.
                 case (PointerType { BaseType: ArrayType { BaseType: ShaderSymbol compositionType } } p, IndexerExpression { Index: IntegerLiteral } indexer):
                     {
                         if (compiler == null)

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/Expression.cs
@@ -372,19 +372,22 @@ public partial class MethodCall(Identifier name, ShaderExpressionList arguments,
     /// <summary>
     /// Whether an argument is handed to the callee as the caller's own pointer instead of being
     /// copied into a function-local temporary.
+    /// </summary>
+    /// <remarks>
+    /// Three kinds of parameter are handed to the callee as the caller's own pointer rather than
+    /// as a copy in a Function variable:
     /// <list type="bullet">
-    /// <item>ref: atomic intrinsics (InterlockedAdd, etc.) need the actual memory pointer
+    /// <item><c>ref</c>: atomic intrinsics (InterlockedAdd, ...) need the actual memory pointer
     /// (Workgroup, StorageBuffer, ...).</item>
-    /// <item>Opaque resources (see <see cref="SymbolTypeExtensions.IsOpaqueResource"/>): Vulkan
+    /// <item>Opaque resources (see <see cref="SymbolTypeExtensions.IsOpaqueResource"/>): SPIR-V
     /// forbids OpStore to them, so they cannot live in a Function variable.</item>
     /// <item>Geometry streams: appending goes through OpEmitVertexSDSL and the stage's output
-    /// variables, so the object holds nothing to copy - and the copy outlived the parameter, which
-    /// the interface processor removes from the signature, leaving SPIR-V reading an id that no
-    /// longer exists.</item>
+    /// variables, so the object holds nothing to copy.</item>
     /// </list>
     /// The input and output sides both consult this: copying a result back out of something that
     /// was never copied in would write through a pointer the callee already holds.
-    /// </summary>
+    /// </remarks>
+    /// <returns>True when the argument is passed as a pointer, false when it is copied.</returns>
     private static bool IsPassedByPointer(FunctionParameter parameter)
         => parameter.Type is PointerType pointerType
             && (parameter.Modifiers == ParameterModifiers.Ref
@@ -698,17 +701,21 @@ public partial class AccessorChainExpression(Expression source, TextLocation inf
     private SpirvValue[]? intermediateValues;
 
     /// <summary>
-    /// Compiles a trailing <c>buffer[i]</c> into an <c>OpImageTexelPointer</c> - a pointer to that
-    /// one texel - rather than the image read indexing normally produces. Returns false when the
-    /// chain is not an atomic-capable buffer index, leaving the caller to compile it normally.
-    /// <para>
+    /// Compiles a trailing <c>buffer[i]</c> into an <c>OpImageTexelPointer</c>, a pointer to that
+    /// one texel, for an atomic to operate on.
+    /// </summary>
+    /// <remarks>
     /// A typed buffer is not memory the shader can point into: it is a storage image, so SDSL
     /// compiles <c>buffer[i]</c> to an OpImageRead and <c>buffer[i] = x</c> to an OpImageWrite,
     /// both of which deal in values. An atomic needs the memory itself, and OpImageTexelPointer is
     /// the only instruction that hands it over. Its result may only be consumed by atomics, which
-    /// is why this is offered to the `ref` argument path instead of being how every index compiles.
-    /// </para>
-    /// </summary>
+    /// is why this is offered to the <c>ref</c> argument path instead of being how every index
+    /// compiles.
+    /// </remarks>
+    /// <returns>
+    /// True with the texel pointer when the chain is an atomic-capable buffer index; false
+    /// otherwise, leaving the caller to compile the chain as an ordinary read.
+    /// </returns>
     public bool TryCompileAsTexelPointer(SymbolTable table, CompilerUnit compiler, out SpirvValue texelPointer)
     {
         texelPointer = default;

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/ShaderElements.MethodOrMember.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/AST/ShaderElements.MethodOrMember.cs
@@ -491,10 +491,8 @@ public partial class ShaderMethod(
 
     private static PointerType GenerateParameterType(MethodParameter p)
     {
-        // Opaque types (image/sampler) must use UniformConstant storage class —
-        // Vulkan forbids OpStore to these types (VUID-StandaloneSpirv-OpTypeImage-06924),
-        // so they cannot be copied into Function-storage variables.
-        if (p.Type is TextureType or SamplerType)
+        // Opaque resources must use UniformConstant storage: see SymbolTypeExtensions.IsOpaqueResource.
+        if (p.Type!.IsOpaqueResource())
             return new PointerType(p.Type!, Specification.StorageClass.UniformConstant);
 
         return new PointerType(p.Type!, Specification.StorageClass.Function);

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
@@ -180,7 +180,7 @@ public partial class SpirvContext
                 t.Depth, t.Arrayed ? 1 : 0, t.Multisampled ? 1 : 0, t.Sampled, t.Format, null)).IdResult,
             SamplerType st => Buffer.AddData(new OpTypeSampler(id)).IdResult,
             BufferType b => Buffer.AddData(new OpTypeImage(id, GetOrRegister(b.BaseType), Specification.Dim.Buffer,
-                2, 0, 0, b.WriteAllowed ? 2 : 1, Specification.ImageFormat.Unknown, null)).IdResult,
+                2, 0, 0, b.WriteAllowed ? 2 : 1, GetStorageImageFormat(b), null)).IdResult,
             AppendStructuredBufferType ab => RegisterAppendOrConsumeStructuredBufferType("Append", ab.BaseType),
             ConsumeStructuredBufferType cb => RegisterAppendOrConsumeStructuredBufferType("Consume", cb.BaseType),
             StructuredBufferType b => RegisterStructuredBufferType(b),
@@ -223,6 +223,26 @@ public partial class SpirvContext
 
         return bufferType;
     }
+
+    /// <summary>
+    /// The Image Format an <c>RWBuffer&lt;T&gt;</c> declares.
+    /// <para>
+    /// Unknown is fine for everything except <c>OpImageTexelPointer</c>, which the spec forbids on
+    /// an image of unknown format - and that instruction is the only way to get a pointer to a
+    /// texel, which is what an atomic needs. Image atomics are in turn only defined on 32-bit
+    /// integer texels, so a concrete format is declared exactly there and Unknown is kept
+    /// everywhere else, leaving float buffers byte-for-byte as they were.
+    /// </para>
+    /// </summary>
+    private static Specification.ImageFormat GetStorageImageFormat(BufferType bufferType)
+        => bufferType.WriteAllowed
+            ? bufferType.BaseType switch
+            {
+                ScalarType { Type: Scalar.UInt } => Specification.ImageFormat.R32ui,
+                ScalarType { Type: Scalar.Int } => Specification.ImageFormat.R32i,
+                _ => Specification.ImageFormat.Unknown,
+            }
+            : Specification.ImageFormat.Unknown;
 
     private int RegisterByteAddressBufferType(ByteAddressBufferType byteAddressBufferType)
     {

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
@@ -225,15 +225,16 @@ public partial class SpirvContext
     }
 
     /// <summary>
-    /// The Image Format an <c>RWBuffer&lt;T&gt;</c> declares.
-    /// <para>
-    /// Unknown is fine for everything except <c>OpImageTexelPointer</c>, which the spec forbids on
-    /// an image of unknown format - and that instruction is the only way to get a pointer to a
-    /// texel, which is what an atomic needs. Image atomics are in turn only defined on 32-bit
-    /// integer texels, so a concrete format is declared exactly there and Unknown is kept
-    /// everywhere else, leaving float buffers byte-for-byte as they were.
-    /// </para>
+    /// Retrieves the image format an <c>RWBuffer&lt;T&gt;</c> declares.
     /// </summary>
+    /// <remarks>
+    /// Unknown serves everything except <c>OpImageTexelPointer</c>, which the spec forbids on an
+    /// image of unknown format - and that instruction is the only way to a texel's pointer, which
+    /// an atomic needs. Image atomics are only defined on 32-bit integer texels, so a concrete
+    /// format is declared exactly there and Unknown is kept everywhere else, leaving float
+    /// buffers as they were.
+    /// </remarks>
+    /// <returns>A concrete format for a writable 32-bit integer buffer, Unknown otherwise.</returns>
     private static Specification.ImageFormat GetStorageImageFormat(BufferType bufferType)
         => bufferType.WriteAllowed
             ? bufferType.BaseType switch

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/SpirvContext.Types.cs
@@ -228,11 +228,8 @@ public partial class SpirvContext
     /// Retrieves the image format an <c>RWBuffer&lt;T&gt;</c> declares.
     /// </summary>
     /// <remarks>
-    /// Unknown serves everything except <c>OpImageTexelPointer</c>, which the spec forbids on an
-    /// image of unknown format - and that instruction is the only way to a texel's pointer, which
-    /// an atomic needs. Image atomics are only defined on 32-bit integer texels, so a concrete
-    /// format is declared exactly there and Unknown is kept everywhere else, leaving float
-    /// buffers as they were.
+    /// A concrete format is only needed for <c>OpImageTexelPointer</c> (atomics), which is only
+    /// defined on 32-bit integer texels; every other buffer keeps Unknown.
     /// </remarks>
     /// <returns>A concrete format for a writable 32-bit integer buffer, Unknown otherwise.</returns>
     private static Specification.ImageFormat GetStorageImageFormat(BufferType bufferType)

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Cleanup/DeadCodeRemover.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Cleanup/DeadCodeRemover.cs
@@ -194,5 +194,24 @@ internal static class DeadCodeRemover
 
         // Remove OpName/OpDecorate
         context.RemoveNameAndDecorations(removedIds);
+
+        // An execution mode belongs to its entry point: [numthreads] on a compute shader, the
+        // input/output topology on a geometry shader. Removing the function without it left the
+        // mode pointing at an id nothing defines, which is invalid SPIR-V - a mixin whose base
+        // declares its own CSMain produces exactly that, the base being dead once the most derived
+        // one is wrapped.
+        foreach (var i in context)
+        {
+            if (i.Op == Op.OpExecutionMode && (OpExecutionMode)i is { } executionMode)
+            {
+                if (removedIds.Contains(executionMode.EntryPoint))
+                    SpirvBuilder.SetOpNop(i.Data.Memory.Span);
+            }
+            else if (i.Op == Op.OpEntryPoint && (OpEntryPoint)i is { } entryPoint)
+            {
+                if (removedIds.Contains(entryPoint.EntryPoint))
+                    SpirvBuilder.SetOpNop(i.Data.Memory.Span);
+            }
+        }
     }
 }

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Cleanup/DeadCodeRemover.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Cleanup/DeadCodeRemover.cs
@@ -195,11 +195,8 @@ internal static class DeadCodeRemover
         // Remove OpName/OpDecorate
         context.RemoveNameAndDecorations(removedIds);
 
-        // An execution mode belongs to its entry point: [numthreads] on a compute shader, the
-        // input/output topology on a geometry shader. Removing the function without it left the
-        // mode pointing at an id nothing defines, which is invalid SPIR-V - a mixin whose base
-        // declares its own CSMain produces exactly that, the base being dead once the most derived
-        // one is wrapped.
+        // Remove the execution modes ([numthreads], geometry topology) of removed entry points,
+        // otherwise they reference an id nothing defines.
         foreach (var i in context)
         {
             if (i.Op == Op.OpExecutionMode && (OpExecutionMode)i is { } executionMode)

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
@@ -1,4 +1,4 @@
-using Stride.Shaders.Core;
+﻿using Stride.Shaders.Core;
 using Stride.Shaders.Spirv.Building;
 using Stride.Shaders.Spirv.Core;
 using Stride.Shaders.Spirv.Core.Buffers;
@@ -55,20 +55,67 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
 
         public record Result(List<EntryPointInfo> EntryPoints, List<ShaderInputAttributeDescription> InputAttributes);
 
+        /// <summary>
+        /// Collects the functions declared inside a composition, which are only ever reachable
+        /// through their composition variable and so can never be the shader's entry point.
+        /// </summary>
+        /// <remarks>
+        /// A composition that happens to inherit the same base as the shader it is composed into
+        /// inherits that base's entry point too, and lands in the same method group. Picking the
+        /// group's last member then picks the composition's copy: Stride.Voxels' Voxel2x2x2Mipmap
+        /// composes a Voxel2x2x2Mipmapper and both derive from ComputeShaderBase, so CSMain
+        /// resolved to the composition's, which calls the empty base Compute(). The real body -
+        /// and, once dead code was removed, the mipmap textures with it - disappeared, and voxel
+        /// GI silently contributed nothing.
+        /// </remarks>
+        static HashSet<int> CollectCompositionFunctions(SpirvBuffer buffer)
+        {
+            var result = new HashSet<int>();
+            var depth = 0;
+
+            foreach (var i in buffer)
+            {
+                switch (i.Op)
+                {
+                    case Op.OpCompositionSDSL:
+                        depth++;
+                        break;
+                    case Op.OpCompositionEndSDSL:
+                        depth--;
+                        break;
+                    case Op.OpFunction when depth > 0:
+                        result.Add(((OpFunction)i).ResultId);
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        private HashSet<int> compositionFunctions = [];
+
         Symbol? ResolveEntryPoint(SymbolTable table, string name)
         {
             table.TryResolveSymbol(name, out var entryPoint);
-            return entryPoint?.Type switch
+            if (entryPoint?.Type is not FunctionGroupType)
+                return entryPoint;
+
+            // Last one wins, so that a shader's override beats the base it overrides.
+            for (var i = entryPoint.GroupMembers.Length - 1; i >= 0; i--)
             {
-                FunctionGroupType => entryPoint.GroupMembers[^1],
-                _ => entryPoint
-            };
+                if (!compositionFunctions.Contains(entryPoint.GroupMembers[i].IdRef))
+                    return entryPoint.GroupMembers[i];
+            }
+
+            return null;
         }
 
         public Result Process(SymbolTable table, SpirvBuffer buffer, SpirvContext context)
         {
             // OpEntryPoint emission is deferred to allow fixups (e.g. adding dummy DS inputs for HS-internal outputs)
             var entryPoints = new List<EntryPointInfo>();
+
+            compositionFunctions = CollectCompositionFunctions(buffer);
 
             var entryPointVS = ResolveEntryPoint(table, "VSMain");
             var entryPointHS = ResolveEntryPoint(table, "HSMain");

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
@@ -285,6 +285,10 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
             foreach (var ep in entryPoints)
                 context.Add(new OpEntryPoint(ep.Model, ep.Id, ep.Name, [.. ep.InterfaceVariables]));
 
+            // Entry points had their geometry stream parameter removed as their wrapper was
+            // generated; any other method carrying one has to lose it too.
+            RemoveGeometryStreamParameters(buffer, context);
+
             // This will remove a lot of unused methods, resources and variables
             // (while following proper rules to preserve rgroup, cbuffer, logical groups, etc.)
             DeadCodeRemover.RemoveUnreferencedCode(buffer, context, analysisResult, liveAnalysis);
@@ -292,6 +296,91 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
             return new(entryPoints, inputAttributes);
         }
 
+
+        /// <summary>
+        /// Drops geometry stream output parameters from every method that still has one, and the
+        /// matching argument from every call to them.
+        /// <para>
+        /// A <c>TriangleStream&lt;Output&gt;</c> parameter carries no data - appending goes through
+        /// OpEmitVertexSDSL and the stage's output variables - but it cannot be dropped earlier:
+        /// EntryPointWrapperGenerator reads the output topology off it to emit the OutputPoints /
+        /// OutputLineStrip / OutputTriangleStrip execution mode. So it survives until here, where
+        /// the entry point has already been stripped of it and everything else still has to be.
+        /// </para>
+        /// <para>
+        /// The function type is rewritten through GetOrRegister rather than in place: a method and
+        /// the entry point calling it share one OpTypeFunction when their signatures match, and
+        /// mutating it for one silently rewrites the other - which is how the entry point's own
+        /// removal left such a method with more parameters than its type declared.
+        /// </para>
+        /// </summary>
+        private static void RemoveGeometryStreamParameters(SpirvBuffer buffer, SpirvContext context)
+        {
+            // Which parameter index each function loses.
+            var removedParameters = new Dictionary<int, int>();
+
+            var currentFunction = 0;
+            var currentFunctionIndex = 0;
+            var parameterIndex = 0;
+            for (var index = 0; index < buffer.Count; index++)
+            {
+                var i = buffer[index];
+                if (i.Data.Op == Op.OpFunction && (OpFunction)i is { } function)
+                {
+                    currentFunction = function.ResultId;
+                    currentFunctionIndex = index;
+                    parameterIndex = 0;
+                }
+                else if (i.Data.Op == Op.OpFunctionParameter && (OpFunctionParameter)i is { } parameter)
+                {
+                    if (context.ReverseTypes.TryGetValue(parameter.ResultType, out var parameterType)
+                        && parameterType is PointerType { BaseType: GeometryStreamType })
+                    {
+                        removedParameters[currentFunction] = parameterIndex;
+                        SpirvBuilder.SetOpNop(i.Data.Memory.Span);
+
+                        // Drop it from the function's own type too, unless a shared type already
+                        // lost it when the entry point sharing that signature was rewritten.
+                        var declaringFunction = (OpFunction)buffer[currentFunctionIndex];
+                        if (context.ReverseTypes.TryGetValue(declaringFunction.FunctionType, out var declaredType)
+                            && declaredType is FunctionType functionType
+                            && parameterIndex < functionType.ParameterTypes.Count)
+                        {
+                            var remainingParameters = new List<FunctionParameter>(functionType.ParameterTypes);
+                            remainingParameters.RemoveAt(parameterIndex);
+                            declaringFunction.FunctionType = context.GetOrRegister(functionType with { ParameterTypes = remainingParameters });
+                        }
+                    }
+                    parameterIndex++;
+                }
+            }
+
+            if (removedParameters.Count == 0)
+                return;
+
+            // Rebuild the calls: an argument cannot be dropped in place, the instruction is shorter.
+            for (var index = 0; index < buffer.Count; index++)
+            {
+                if (buffer[index].Data.Op != Op.OpFunctionCall)
+                    continue;
+
+                var call = (OpFunctionCall)buffer[index];
+                if (!removedParameters.TryGetValue(call.Function, out var removedIndex))
+                    continue;
+
+                var arguments = call.Arguments.Elements.Span;
+                if (removedIndex >= arguments.Length)
+                    continue;
+
+                Span<int> remaining = new int[arguments.Length - 1];
+                arguments[..removedIndex].CopyTo(remaining);
+                arguments[(removedIndex + 1)..].CopyTo(remaining[removedIndex..]);
+
+                var (resultType, resultId, function) = (call.ResultType, call.ResultId, call.Function);
+                buffer.RemoveRange(index, 1);
+                buffer.Insert(index, new OpFunctionCall(resultType, resultId, function, new(remaining)));
+            }
+        }
 
         static int FindOutputPatchSize(SpirvContext context, Symbol entryPoint)
         {

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
@@ -1,4 +1,4 @@
-﻿using Stride.Shaders.Core;
+using Stride.Shaders.Core;
 using Stride.Shaders.Spirv.Building;
 using Stride.Shaders.Spirv.Core;
 using Stride.Shaders.Spirv.Core.Buffers;
@@ -60,16 +60,16 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
         /// through their composition variable and so can never be the shader's entry point.
         /// </summary>
         /// <remarks>
-        /// A composition that happens to inherit the same base as the shader it is composed into
-        /// inherits that base's entry point too, and lands in the same method group. Picking the
-        /// group's last member then picks the composition's copy: Stride.Voxels' Voxel2x2x2Mipmap
-        /// composes a Voxel2x2x2Mipmapper and both derive from ComputeShaderBase, so CSMain
-        /// resolved to the composition's, which calls the empty base Compute(). The real body -
-        /// and, once dead code was removed, the mipmap textures with it - disappeared, and voxel
-        /// GI silently contributed nothing.
+        /// A composition that inherits the same base as the shader it is composed into inherits
+        /// that base's entry point too, and lands in the same method group; picking the group's
+        /// last member would pick the composition's copy, whose body is the base's empty one.
         /// </remarks>
         static HashSet<int> CollectCompositionFunctions(SpirvBuffer buffer)
         {
+            // Found through Stride.Voxels: Voxel2x2x2Mipmap composes a Voxel2x2x2Mipmapper and
+            // both derive from ComputeShaderBase, so CSMain resolved to the composition's, which
+            // calls the empty base Compute(). The real body - and, once dead code was removed, the
+            // mipmap textures with it - disappeared, and voxel GI silently contributed nothing.
             var result = new HashSet<int>();
             var depth = 0;
 
@@ -347,22 +347,20 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
         /// <summary>
         /// Drops geometry stream output parameters from every method that still has one, and the
         /// matching argument from every call to them.
-        /// <para>
+        /// </summary>
+        /// <remarks>
         /// A <c>TriangleStream&lt;Output&gt;</c> parameter carries no data - appending goes through
         /// OpEmitVertexSDSL and the stage's output variables - but it cannot be dropped earlier:
-        /// EntryPointWrapperGenerator reads the output topology off it to emit the OutputPoints /
-        /// OutputLineStrip / OutputTriangleStrip execution mode. So it survives until here, where
-        /// the entry point has already been stripped of it and everything else still has to be.
-        /// </para>
-        /// <para>
-        /// The function type is rewritten through GetOrRegister rather than in place: a method and
-        /// the entry point calling it share one OpTypeFunction when their signatures match, and
-        /// mutating it for one silently rewrites the other - which is how the entry point's own
-        /// removal left such a method with more parameters than its type declared.
-        /// </para>
-        /// </summary>
+        /// the entry point wrapper reads the output topology off it. So it survives until here,
+        /// where the entry point has already been stripped of it and everything else still has
+        /// to be.
+        /// </remarks>
         private static void RemoveGeometryStreamParameters(SpirvBuffer buffer, SpirvContext context)
         {
+            // The function type is rewritten through GetOrRegister rather than in place: a method
+            // and the entry point calling it share one OpTypeFunction when their signatures match,
+            // and mutating it for one silently rewrites the other - which is how the entry point's
+            // own removal left such a method with more parameters than its type declared.
             // Which parameter index each function loses.
             var removedParameters = new Dictionary<int, int>();
 

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
@@ -355,8 +355,8 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
         {
             // Function types are rewritten through GetOrRegister, not in place: functions with the same
             // signature share one OpTypeFunction, and mutating it for one would rewrite the others.
-            // Which parameter index each function loses.
-            var removedParameters = new Dictionary<int, int>();
+            // Which parameter indices each function loses, in declaration order.
+            var removedParameters = new Dictionary<int, List<int>>();
 
             var currentFunction = 0;
             var currentFunctionIndex = 0;
@@ -375,18 +375,22 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
                     if (context.ReverseTypes.TryGetValue(parameter.ResultType, out var parameterType)
                         && parameterType is PointerType { BaseType: GeometryStreamType })
                     {
-                        removedParameters[currentFunction] = parameterIndex;
+                        if (!removedParameters.TryGetValue(currentFunction, out var removedIndices))
+                            removedParameters[currentFunction] = removedIndices = [];
                         SpirvBuilder.SetOpNop(i.Data.Memory.Span);
 
                         // Drop it from the function's own type too, unless a shared type already
                         // lost it when the entry point sharing that signature was rewritten.
+                        // Earlier removals in this function have already shifted the type's parameters.
+                        var typeIndex = parameterIndex - removedIndices.Count;
+                        removedIndices.Add(parameterIndex);
                         var declaringFunction = (OpFunction)buffer[currentFunctionIndex];
                         if (context.ReverseTypes.TryGetValue(declaringFunction.FunctionType, out var declaredType)
                             && declaredType is FunctionType functionType
-                            && parameterIndex < functionType.ParameterTypes.Count)
+                            && typeIndex < functionType.ParameterTypes.Count)
                         {
                             var remainingParameters = new List<FunctionParameter>(functionType.ParameterTypes);
-                            remainingParameters.RemoveAt(parameterIndex);
+                            remainingParameters.RemoveAt(typeIndex);
                             declaringFunction.FunctionType = context.GetOrRegister(functionType with { ParameterTypes = remainingParameters });
                         }
                     }
@@ -404,20 +408,22 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
                     continue;
 
                 var call = (OpFunctionCall)buffer[index];
-                if (!removedParameters.TryGetValue(call.Function, out var removedIndex))
+                if (!removedParameters.TryGetValue(call.Function, out var removedIndices))
                     continue;
 
                 var arguments = call.Arguments.Elements.Span;
-                if (removedIndex >= arguments.Length)
+                var remaining = new List<int>(arguments.Length);
+                for (var argumentIndex = 0; argumentIndex < arguments.Length; argumentIndex++)
+                {
+                    if (!removedIndices.Contains(argumentIndex))
+                        remaining.Add(arguments[argumentIndex]);
+                }
+                if (remaining.Count == arguments.Length)
                     continue;
-
-                Span<int> remaining = new int[arguments.Length - 1];
-                arguments[..removedIndex].CopyTo(remaining);
-                arguments[(removedIndex + 1)..].CopyTo(remaining[removedIndex..]);
 
                 var (resultType, resultId, function) = (call.ResultType, call.ResultId, call.Function);
                 buffer.RemoveRange(index, 1);
-                buffer.Insert(index, new OpFunctionCall(resultType, resultId, function, new(remaining)));
+                buffer.Insert(index, new OpFunctionCall(resultType, resultId, function, new(remaining.ToArray())));
             }
         }
 

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/InterfaceProcessor.cs
@@ -60,9 +60,8 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
         /// through their composition variable and so can never be the shader's entry point.
         /// </summary>
         /// <remarks>
-        /// A composition that inherits the same base as the shader it is composed into inherits
-        /// that base's entry point too, and lands in the same method group; picking the group's
-        /// last member would pick the composition's copy, whose body is the base's empty one.
+        /// A composition inheriting the same base as its host inherits the base's entry point too and
+        /// lands in the same method group, so it must be excluded when picking the entry point.
         /// </remarks>
         static HashSet<int> CollectCompositionFunctions(SpirvBuffer buffer)
         {
@@ -349,18 +348,13 @@ namespace Stride.Shaders.Spirv.Processing.Interfaces
         /// matching argument from every call to them.
         /// </summary>
         /// <remarks>
-        /// A <c>TriangleStream&lt;Output&gt;</c> parameter carries no data - appending goes through
-        /// OpEmitVertexSDSL and the stage's output variables - but it cannot be dropped earlier:
-        /// the entry point wrapper reads the output topology off it. So it survives until here,
-        /// where the entry point has already been stripped of it and everything else still has
-        /// to be.
+        /// The parameter carries no data (appending goes through OpEmitVertexSDSL) but must survive
+        /// until EntryPointWrapperGenerator has read the output topology off it.
         /// </remarks>
         private static void RemoveGeometryStreamParameters(SpirvBuffer buffer, SpirvContext context)
         {
-            // The function type is rewritten through GetOrRegister rather than in place: a method
-            // and the entry point calling it share one OpTypeFunction when their signatures match,
-            // and mutating it for one silently rewrites the other - which is how the entry point's
-            // own removal left such a method with more parameters than its type declared.
+            // Function types are rewritten through GetOrRegister, not in place: functions with the same
+            // signature share one OpTypeFunction, and mutating it for one would rewrite the others.
             // Which parameter index each function loses.
             var removedParameters = new Dictionary<int, int>();
 

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Transformation/StreamAccessPatcher.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Transformation/StreamAccessPatcher.cs
@@ -181,6 +181,25 @@ internal static class StreamAccessPatcher
                 var targetType = context.ReverseTypes[copyLogical.ResultType];
                 if (targetType is StreamsType { Kind: StreamsKindSDSL.Streams })
                 {
+                    // `streams = input[i]` overwrites the members the stage input carries and leaves
+                    // the rest alone, so the ones it does not carry are read back from the current
+                    // streams rather than defaulted. Zeroing them silently discarded whatever the
+                    // shader had just computed: Stride.Voxels' dominant-axis voxelization picks an
+                    // axis into a stream variable before its emit loop, and `streams = input[i]` at
+                    // the top of that loop reset it to 0 on every vertex, so every triangle was
+                    // projected along the same axis - the geometry shader constant-folded down to
+                    // `if (true)`, and only surfaces already facing that axis voxelized.
+                    var currentStreams = 0;
+                    foreach (var stream in streams)
+                    {
+                        if (!stream.Value.Patch && stream.Value.UsedThisStage && !stream.Value.Input)
+                        {
+                            currentStreams = buffer.Insert(index++,
+                                new OpLoad(context.GetOrRegister(streamsStructType), context.Bound++, streamsVariableId, null, [])).ResultId;
+                            break;
+                        }
+                    }
+
                     foreach (var stream in streams)
                     {
                         // Part of streams?
@@ -197,8 +216,12 @@ internal static class StreamAccessPatcher
                             }
                             else
                             {
-                                // Otherwise use default value
-                                tempIdsForStreamCopy[stream.Value.StreamStructFieldIndex] = context.CreateDefaultConstantComposite(stream.Value.Type).Id;
+                                // Not carried by the input: keep what streams already holds
+                                tempIdsForStreamCopy[stream.Value.StreamStructFieldIndex] = buffer.Insert(index++,
+                                    new OpCompositeExtract(context.GetOrRegister(stream.Value.Type),
+                                        context.Bound++,
+                                        currentStreams,
+                                        [stream.Value.StreamStructFieldIndex])).ResultId;
                             }
                         }
                     }

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Transformation/StreamAccessPatcher.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Transformation/StreamAccessPatcher.cs
@@ -181,14 +181,8 @@ internal static class StreamAccessPatcher
                 var targetType = context.ReverseTypes[copyLogical.ResultType];
                 if (targetType is StreamsType { Kind: StreamsKindSDSL.Streams })
                 {
-                    // `streams = input[i]` overwrites the members the stage input carries and leaves
-                    // the rest alone, so the ones it does not carry are read back from the current
-                    // streams rather than defaulted. Zeroing them silently discarded whatever the
-                    // shader had just computed: Stride.Voxels' dominant-axis voxelization picks an
-                    // axis into a stream variable before its emit loop, and `streams = input[i]` at
-                    // the top of that loop reset it to 0 on every vertex, so every triangle was
-                    // projected along the same axis - the geometry shader constant-folded down to
-                    // `if (true)`, and only surfaces already facing that axis voxelized.
+                    // `streams = input[i]` overwrites the members the stage input carries; the others
+                    // are read back from the current streams rather than defaulted.
                     var currentStreams = 0;
                     foreach (var stream in streams)
                     {

--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Tools/SpirvTools.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Tools/SpirvTools.cs
@@ -355,7 +355,7 @@ public static unsafe class SpirvTools
         try
         {
             OptimizerRegisterPerformancePasses(opt);
-            return RunAndCopy(opt, words);
+            return RunAndCopy(opt, words, env);
         }
         finally
         {
@@ -378,7 +378,7 @@ public static unsafe class SpirvTools
         {
             foreach (var flag in flags)
                 RegisterFlag(opt, flag, preserveInterface);
-            return RunAndCopy(opt, words);
+            return RunAndCopy(opt, words, env);
         }
         finally
         {
@@ -386,7 +386,7 @@ public static unsafe class SpirvTools
         }
     }
 
-    static uint[] RunAndCopy(IntPtr opt, ReadOnlySpan<uint> words)
+    static uint[] RunAndCopy(IntPtr opt, ReadOnlySpan<uint> words, TargetEnv env)
     {
         uint* outPtr = null;
         nuint outCount = 0;
@@ -394,7 +394,15 @@ public static unsafe class SpirvTools
         {
             var r = OptimizerRun(opt, inPtr, (nuint)words.Length, &outPtr, &outCount);
             if (r != Result.Success)
-                throw new InvalidOperationException($"spvOptimizerRun failed: {r}");
+            {
+                // spirv-opt refuses to load a module that does not validate, and says only
+                // "InternalError" about it. The validator knows exactly what is wrong and where,
+                // so ask it rather than leaving the caller with a bare error code.
+                var validation = Validate(words, env);
+                throw new InvalidOperationException(validation is null
+                    ? $"spvOptimizerRun failed: {r} (the module validates, so this is an optimizer failure)"
+                    : $"spvOptimizerRun failed: {r}, because the module does not validate:{Environment.NewLine}{validation}");
+            }
         }
         try
         {

--- a/sources/shaders/Stride.Shaders.Tests/NamespaceTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/NamespaceTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Linq;
+using Stride.Shaders.Compilers.SDSL;
+using Stride.Shaders.Spirv.Core.Buffers;
+using Stride.Shaders.Spirv.Tools;
+using Spv = Stride.Shaders.Spirv.Tools.Spv;
+using Xunit;
+
+namespace Stride.Shaders.Parsers.Tests;
+
+/// <summary>
+/// What namespaces and <c>using</c> directives do in SDSL today: a class is resolved by its name
+/// alone, one file per class, so a using takes no part in resolution and two classes of one name
+/// in different namespaces cannot both be reached. These tests pin that down, so that a change
+/// to it is a decision rather than an accident.
+/// </summary>
+public class NamespaceTests
+{
+    private static (bool ok, string log, string disassembly) Compile(string root, params string[] files)
+    {
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var mixer = new ShaderMixer(loader);
+        foreach (var name in files)
+            mixer.ShaderLoader.LoadExternalBuffer(name, [], out _, out _, out _);
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        var ok = mixer.MergeSDSL(new ShaderClassSource(root), new ShaderMixer.Options(true), log, out var bytecode, out _, out _, out _);
+        var text = string.Join(Environment.NewLine, log.Messages.Select(m => m.Text));
+        var disassembly = ok ? Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true) : "";
+        return (ok, text, disassembly);
+    }
+
+    // A `using` of the namespace a base class lives in compiles, and the base is found.
+    [Fact]
+    public void UsingDirectiveIsAcceptedAndTheClassIsFoundByName()
+    {
+        var (ok, log, disassembly) = Compile("NsUsingRoot", "ComposeSharedBase", "NsUtils", "NsUsingRoot");
+        Assert.True(ok, log);
+        Assert.Contains("NsUtils.One", disassembly);
+    }
+
+    // A `using` of a namespace nothing declares is not an error: the directive takes no part in
+    // resolution, so there is nothing for it to fail to find.
+    [Fact]
+    public void UsingOfAnUnknownNamespaceIsIgnored()
+    {
+        var (ok, log, _) = Compile("NsUnknownUsingRoot", "ComposeSharedBase", "NsUtils", "NsUnknownUsingRoot");
+        Assert.True(ok, log);
+    }
+
+    // Two classes of one name in two namespaces of one file: resolution is by name alone, so the
+    // `using` - which names the first one's namespace - does not pick between them, and the last
+    // declaration in the file is the one mixed in. Documents what happens today, so a compiler
+    // that one day honours namespaces has to change this test knowingly.
+    [Fact]
+    public void SameNameInTwoNamespacesIsNotDisambiguatedByUsing()
+    {
+        var (ok, log, disassembly) = Compile("NsClashRoot", "ComposeSharedBase", "NsClashed", "NsClashRoot");
+        Assert.True(ok, log);
+        // One NsClashed.Which is mixed in, not two.
+        Assert.Equal(1, disassembly.Split("OpName").Count(s => s.Contains("NsClashed.Which")));
+        // And it is the second one - Which() returning 2 - despite the using naming the first's namespace.
+        var constants = System.Text.RegularExpressions.Regex.Matches(disassembly, @"OpConstant %\S+ (\d+)").Select(m => m.Groups[1].Value).ToList();
+        Assert.Contains("2", constants);
+        Assert.DoesNotContain("1", constants);
+    }
+}

--- a/sources/shaders/Stride.Shaders.Tests/RenderingTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/RenderingTests.cs
@@ -91,7 +91,7 @@ public partial class RenderingTests
         File.WriteAllText($"{outputName}.spvdis", Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true));
 
         // Validate SPIR-V
-        var validationResult = Spv.ValidateFile($"{outputName}.spv");
+        var validationResult = Spv.ValidateFile($"{outputName}.spv", targetVulkan: true);
         Assert.True(validationResult.IsValid, validationResult.Output);
 
         // Execute test
@@ -176,7 +176,7 @@ public partial class RenderingTests
             string.Join(Environment.NewLine, log3.Messages.Select(m => m.Text)));
 
         File.WriteAllBytes($"{shaderName3}.spv", bytecode3);
-        var validation = Spv.ValidateFile($"{shaderName3}.spv");
+        var validation = Spv.ValidateFile($"{shaderName3}.spv", targetVulkan: true);
         Assert.True(validation.IsValid, validation.Output);
     }
 
@@ -236,7 +236,7 @@ public partial class RenderingTests
         File.WriteAllText($"{outputName}.spvdis", Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true));
 
         // Validate SPIR-V
-        var validationResult = Spv.ValidateFile($"{outputName}.spv");
+        var validationResult = Spv.ValidateFile($"{outputName}.spv", targetVulkan: true);
         Assert.True(validationResult.IsValid, validationResult.Output);
 
         // Execute test

--- a/sources/shaders/Stride.Shaders.Tests/RenderingTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/RenderingTests.cs
@@ -91,7 +91,8 @@ public partial class RenderingTests
         File.WriteAllText($"{outputName}.spvdis", Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true));
 
         // Validate SPIR-V
-        var validationResult = Spv.ValidateFile($"{outputName}.spv", targetVulkan: true);
+        // Validated the way the effect compiler validates it: against Vulkan's rules only when Vulkan is the target.
+        var validationResult = Spv.ValidateFile($"{outputName}.spv", targetVulkan: backend == RendererBackend.Vulkan);
         Assert.True(validationResult.IsValid, validationResult.Output);
 
         // Execute test
@@ -176,7 +177,7 @@ public partial class RenderingTests
             string.Join(Environment.NewLine, log3.Messages.Select(m => m.Text)));
 
         File.WriteAllBytes($"{shaderName3}.spv", bytecode3);
-        var validation = Spv.ValidateFile($"{shaderName3}.spv", targetVulkan: true);
+        var validation = Spv.ValidateFile($"{shaderName3}.spv");
         Assert.True(validation.IsValid, validation.Output);
     }
 
@@ -236,7 +237,8 @@ public partial class RenderingTests
         File.WriteAllText($"{outputName}.spvdis", Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true));
 
         // Validate SPIR-V
-        var validationResult = Spv.ValidateFile($"{outputName}.spv", targetVulkan: true);
+        // Validated the way the effect compiler validates it: against Vulkan's rules only when Vulkan is the target.
+        var validationResult = Spv.ValidateFile($"{outputName}.spv", targetVulkan: backend == RendererBackend.Vulkan);
         Assert.True(validationResult.IsValid, validationResult.Output);
 
         // Execute test

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -815,4 +815,35 @@ new ShaderMacro("class", "shader"),
         Assert.True(reflection.ResourceBindings.Any(b => b.RawName.EndsWith("WriteTex")), disassembly);
         Assert.Contains("OpImageWrite", disassembly);
     }
+    // Regression: `streams = input[i]` in a geometry shader assigns the members the stage input
+    // carries and must leave every other stream member as it was. It used to default them to zero,
+    // so anything the shader had computed into a stream before its emit loop was wiped on every
+    // vertex. Stride.Voxels' dominant-axis voxelization chooses a projection axis that way: the
+    // axis reset to 0 each iteration, the geometry shader constant-folded to `if (true)`, and only
+    // surfaces already facing that one axis were voxelized - floors and ceilings vanished and the
+    // rest came out striped.
+    //
+    // Checked after LegalizeForHlsl, which is what EffectCompiler hands to SPIRV-Cross: the branch
+    // on the carried value has to still be a branch there, not a folded constant.
+    [Fact]
+    public void GeometryStreamsAssignKeepsMembersTheInputDoesNotCarry()
+    {
+        SpirvCrossSupport.SkipUnlessAvailable();
+
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var shaderMixer = new ShaderMixer(loader);
+        shaderMixer.ShaderLoader.LoadExternalBuffer("GeometryStreamsAssignKeepsOthers", [], out _, out _, out _);
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        Assert.True(shaderMixer.MergeSDSL(new ShaderClassSource("GeometryStreamsAssignKeepsOthers"), new ShaderMixer.Options(true), log, out var bytecode, out _, out _, out _),
+            string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
+
+        var legalized = SpirvTools.LegalizeForHlsl(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, uint>(bytecode.ToArray()));
+        var translator = new SpirvTranslator(legalized.AsMemory());
+        var geometry = translator.GetEntryPoints().First(x => x.ExecutionModel == ExecutionModel.Geometry);
+        var hlsl = translator.Translate(Backend.Hlsl, geometry);
+
+        Assert.DoesNotContain("if (true)", hlsl);
+        Assert.DoesNotContain("if (false)", hlsl);
+    }
 }

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -761,12 +761,8 @@ new ShaderMacro("class", "shader"),
         }
     }
 
-    // Regression: a composition whose shader derives from the same base as the shader it is
-    // composed into used to contribute that base's empty virtual method, overriding the root's
-    // own override. Stride.Voxels' Voxel2x2x2Mipmap composes a Voxel2x2x2Mipmapper and both
-    // derive from ComputeShaderBase, so Compute() resolved to the empty base: the shader
-    // compiled to a bare `ret`, its textures were dead-code-removed along with the body, and
-    // voxel GI contributed exactly nothing.
+    // A composition whose shader derives from the same base as its host must not contribute that
+    // base's virtual method over the root's own override.
     [Fact]
     public void CompositionSharingABaseDoesNotOverrideTheRootsOverride()
     {
@@ -815,16 +811,9 @@ new ShaderMacro("class", "shader"),
         Assert.True(reflection.ResourceBindings.Any(b => b.RawName.EndsWith("WriteTex")), disassembly);
         Assert.Contains("OpImageWrite", disassembly);
     }
-    // Regression: `streams = input[i]` in a geometry shader assigns the members the stage input
-    // carries and must leave every other stream member as it was. It used to default them to zero,
-    // so anything the shader had computed into a stream before its emit loop was wiped on every
-    // vertex. Stride.Voxels' dominant-axis voxelization chooses a projection axis that way: the
-    // axis reset to 0 each iteration, the geometry shader constant-folded to `if (true)`, and only
-    // surfaces already facing that one axis were voxelized - floors and ceilings vanished and the
-    // rest came out striped.
-    //
-    // Checked after LegalizeForHlsl, which is what EffectCompiler hands to SPIRV-Cross: the branch
-    // on the carried value has to still be a branch there, not a folded constant.
+    // `streams = input[i]` in a geometry shader assigns the members the stage input carries and must
+    // leave every other stream member as it was. Checked after LegalizeForHlsl: the branch on the
+    // carried value must still be a branch there, not a folded constant.
     [Fact]
     public void GeometryStreamsAssignKeepsMembersTheInputDoesNotCarry()
     {

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -759,5 +759,60 @@ new ShaderMacro("class", "shader"),
                 Console.WriteLine(hlsl);
             }
         }
+    }
+
+    // Regression: a composition whose shader derives from the same base as the shader it is
+    // composed into used to contribute that base's empty virtual method, overriding the root's
+    // own override. Stride.Voxels' Voxel2x2x2Mipmap composes a Voxel2x2x2Mipmapper and both
+    // derive from ComputeShaderBase, so Compute() resolved to the empty base: the shader
+    // compiled to a bare `ret`, its textures were dead-code-removed along with the body, and
+    // voxel GI contributed exactly nothing.
+    [Fact]
+    public void CompositionSharingABaseDoesNotOverrideTheRootsOverride()
+    {
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var shaderMixer = new ShaderMixer(loader);
+        foreach (var name in new[] { "ComposeSharedBase", "ComposeSharedHelper", "ComposeSharedRoot" })
+            shaderMixer.ShaderLoader.LoadExternalBuffer(name, [], out _, out _, out _);
+
+        var shaderSource = new ShaderMixinSource
+        {
+            Mixins = { new ShaderClassSource("ComposeSharedRoot") },
+            Compositions = { ["helper"] = new ShaderClassSource("ComposeSharedHelper") },
+        };
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        Assert.True(shaderMixer.MergeSDSL(shaderSource, new ShaderMixer.Options(true), log, out var bytecode, out var reflection, out _, out _),
+            string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
+
+        // The body survived, so its texture is still live and reflected.
+        var disassembly = Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true);
+        Assert.True(reflection.ResourceBindings.Any(b => b.RawName.EndsWith("WriteTex")), disassembly);
+        Assert.Contains("OpImageWrite", disassembly);
+    }
+
+    // Control for the above: the very same shader, composing a helper that does not derive from
+    // ComposeSharedBase. This one has always worked, and pins the difference to the shared base.
+    [Fact]
+    public void CompositionWithoutASharedBaseKeepsTheRootsOverride()
+    {
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var shaderMixer = new ShaderMixer(loader);
+        foreach (var name in new[] { "ComposeSharedBase", "ComposePlainHelper", "ComposePlainRoot" })
+            shaderMixer.ShaderLoader.LoadExternalBuffer(name, [], out _, out _, out _);
+
+        var shaderSource = new ShaderMixinSource
+        {
+            Mixins = { new ShaderClassSource("ComposePlainRoot") },
+            Compositions = { ["helper"] = new ShaderClassSource("ComposePlainHelper") },
+        };
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        Assert.True(shaderMixer.MergeSDSL(shaderSource, new ShaderMixer.Options(true), log, out var bytecode, out var reflection, out _, out _),
+            string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
+
+        var disassembly = Spv.Dis(SpirvBytecode.CreateFromSpan(bytecode), DisassemblerFlags.Name | DisassemblerFlags.Id | DisassemblerFlags.InstructionIndex, true);
+        Assert.True(reflection.ResourceBindings.Any(b => b.RawName.EndsWith("WriteTex")), disassembly);
+        Assert.Contains("OpImageWrite", disassembly);
     }
 }

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -835,4 +835,26 @@ new ShaderMacro("class", "shader"),
         Assert.DoesNotContain("if (true)", hlsl);
         Assert.DoesNotContain("if (false)", hlsl);
     }
+
+    // A method with two geometry stream parameters loses both, and its call both arguments.
+    [Fact]
+    public void GeometryStreamsMethodWithTwoStreamParameters()
+    {
+        SpirvCrossSupport.SkipUnlessAvailable();
+
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var shaderMixer = new ShaderMixer(loader);
+        shaderMixer.ShaderLoader.LoadExternalBuffer("GeometryStreamsTwoStreamParameters", [], out _, out _, out _);
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        Assert.True(shaderMixer.MergeSDSL(new ShaderClassSource("GeometryStreamsTwoStreamParameters"), new ShaderMixer.Options(true), log, out var bytecode, out _, out _, out _),
+            string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
+
+        var legalized = SpirvTools.LegalizeForHlsl(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, uint>(bytecode.ToArray()));
+        var translator = new SpirvTranslator(legalized.AsMemory());
+        var geometry = translator.GetEntryPoints().First(x => x.ExecutionModel == ExecutionModel.Geometry);
+        var hlsl = translator.Translate(Backend.Hlsl, geometry);
+
+        Assert.Contains("Append", hlsl);
+    }
 }

--- a/sources/shaders/assets/SDSL/CompilerTests/ComposePlainHelper.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ComposePlainHelper.sdsl
@@ -1,0 +1,10 @@
+// Control for ComposeSharedHelper: same composition, but not deriving from the root's base.
+namespace Stride.Shaders.Tests;
+
+shader ComposePlainHelper
+{
+    float4 Value()
+    {
+        return float4(1, 2, 3, 4);
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/ComposePlainRoot.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ComposePlainRoot.sdsl
@@ -1,0 +1,14 @@
+// Control for ComposeSharedRoot: identical, but the composition does not share the base.
+namespace Stride.Shaders.Tests;
+
+shader ComposePlainRoot : ComposeSharedBase
+{
+    RWTexture3D<float4> WriteTex;
+
+    compose ComposePlainHelper helper;
+
+    override void Compute()
+    {
+        WriteTex[streams.DispatchThreadId] = helper.Value();
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedBase.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedBase.sdsl
@@ -1,0 +1,18 @@
+// A compute base whose entry point delegates to a virtual Compute(), like Stride's
+// ComputeShaderBase.
+namespace Stride.Shaders.Tests;
+
+shader ComposeSharedBase
+{
+    stage stream uint3 DispatchThreadId : SV_DispatchThreadID;
+
+    [numthreads(8, 8, 8)]
+    void CSMain()
+    {
+        Compute();
+    }
+
+    void Compute()
+    {
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedHelper.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedHelper.sdsl
@@ -1,0 +1,11 @@
+// A composition that happens to derive from the same base as the shader it is composed into,
+// and so inherits an empty Compute() it never meant to contribute.
+namespace Stride.Shaders.Tests;
+
+shader ComposeSharedHelper : ComposeSharedBase
+{
+    float4 Value()
+    {
+        return float4(1, 2, 3, 4);
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedRoot.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedRoot.sdsl
@@ -1,0 +1,17 @@
+// Regression: Stride.Voxels' Voxel2x2x2Mipmap composes a Voxel2x2x2Mipmapper, and both derive
+// from ComputeShaderBase. The composition's inherited empty Compute() used to win over the
+// root's override, so the whole shader body vanished - it compiled to a bare `ret`, the mipmap
+// textures were dead-code-removed with it, and voxel GI silently contributed nothing.
+namespace Stride.Shaders.Tests;
+
+shader ComposeSharedRoot : ComposeSharedBase
+{
+    RWTexture3D<float4> WriteTex;
+
+    compose ComposeSharedHelper helper;
+
+    override void Compute()
+    {
+        WriteTex[streams.DispatchThreadId] = helper.Value();
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedRoot.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/ComposeSharedRoot.sdsl
@@ -1,7 +1,5 @@
-// Regression: Stride.Voxels' Voxel2x2x2Mipmap composes a Voxel2x2x2Mipmapper, and both derive
-// from ComputeShaderBase. The composition's inherited empty Compute() used to win over the
-// root's override, so the whole shader body vanished - it compiled to a bare `ret`, the mipmap
-// textures were dead-code-removed with it, and voxel GI silently contributed nothing.
+// A composition sharing the root's base class: the root's override of Compute() must win over
+// the composition's inherited empty one.
 namespace Stride.Shaders.Tests;
 
 shader ComposeSharedRoot : ComposeSharedBase

--- a/sources/shaders/assets/SDSL/CompilerTests/GeometryStreamsAssignKeepsOthers.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/GeometryStreamsAssignKeepsOthers.sdsl
@@ -1,0 +1,51 @@
+// A geometry shader that computes a value into a stream before its emit loop, assigns the stage
+// input over `streams` inside that loop, and then branches on the value it computed.
+//
+// `streams = input[i]` overwrites the members the input carries; the rest have to survive it.
+// Stride.Voxels' dominant-axis voxelization is built on exactly this: VoxelizationMethodDominantAxis
+// picks a projection axis in InitializeFromTriangle, and VoxelStorageClipmapShader's emit loop does
+// `streams = input[i]` before calling Append, which reads the axis back.
+
+namespace Stride.Shaders.Tests;
+
+shader GeometryStreamsAssignKeepsOthers
+{
+    stream float4 Position : POSITION;
+    stream float4 ShadingPosition : SV_Position;
+    stream float4 ColorTarget : SV_Target0;
+    stream float4 Tint;
+
+    // Not carried by the geometry stage input, so `streams = input[i]` must leave it alone.
+    stream int carried;
+
+    void VSMain()
+    {
+        streams.ShadingPosition = streams.Position;
+    }
+
+    [maxvertexcount(3)]
+    void GSMain(triangle Input input[3], inout TriangleStream<Output> outStream)
+    {
+        // Derived from the input so it cannot be folded to a constant on its own.
+        streams.carried = input[0].ShadingPosition.w > 0.5f ? 2 : 1;
+
+        for (int i = 0; i < 3; ++i)
+        {
+            streams = input[i];
+
+            if (streams.carried == 2)
+                streams.Tint = float4(1, 0, 0, 1);
+            else
+                streams.Tint = float4(0, 1, 0, 1);
+
+            outStream.Append(streams);
+        }
+
+        outStream.RestartStrip();
+    }
+
+    void PSMain()
+    {
+        streams.ColorTarget = streams.Tint;
+    }
+}

--- a/sources/shaders/assets/SDSL/CompilerTests/GeometryStreamsAssignKeepsOthers.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/GeometryStreamsAssignKeepsOthers.sdsl
@@ -1,10 +1,6 @@
 // A geometry shader that computes a value into a stream before its emit loop, assigns the stage
 // input over `streams` inside that loop, and then branches on the value it computed.
-//
 // `streams = input[i]` overwrites the members the input carries; the rest have to survive it.
-// Stride.Voxels' dominant-axis voxelization is built on exactly this: VoxelizationMethodDominantAxis
-// picks a projection axis in InitializeFromTriangle, and VoxelStorageClipmapShader's emit loop does
-// `streams = input[i]` before calling Append, which reads the axis back.
 
 namespace Stride.Shaders.Tests;
 

--- a/sources/shaders/assets/SDSL/CompilerTests/GeometryStreamsTwoStreamParameters.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/GeometryStreamsTwoStreamParameters.sdsl
@@ -1,0 +1,42 @@
+// A helper method that takes two geometry stream parameters. Every stream parameter is dropped once
+// the wrappers are generated, so the second one must go too, from the function type and the call.
+
+namespace Stride.Shaders.Tests;
+
+shader GeometryStreamsTwoStreamParameters
+{
+    stream float4 Position : POSITION;
+    stream float4 ShadingPosition : SV_Position;
+    stream float4 ColorTarget : SV_Target0;
+    stream float4 Tint;
+
+    void VSMain()
+    {
+        streams.ShadingPosition = streams.Position;
+    }
+
+    void Emit(inout TriangleStream<Output> a, inout TriangleStream<Output> b)
+    {
+        streams.Tint = float4(1, 0, 0, 1);
+        a.Append(streams);
+        streams.Tint = float4(0, 1, 0, 1);
+        b.Append(streams);
+    }
+
+    [maxvertexcount(6)]
+    void GSMain(triangle Input input[3], inout TriangleStream<Output> outStream)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            streams = input[i];
+            Emit(outStream, outStream);
+        }
+
+        outStream.RestartStrip();
+    }
+
+    void PSMain()
+    {
+        streams.ColorTarget = streams.Tint;
+    }
+}

--- a/sources/shaders/assets/SDSL/CompilerTests/NsClashRoot.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/NsClashRoot.sdsl
@@ -1,0 +1,15 @@
+// Names NsClashed, of which there are two, with a using for the namespace of the first: which
+// one this gets is what the test documents.
+using Stride.Shaders.Parsers.Tests;
+
+namespace Stride.Shaders.Tests;
+
+shader NsClashRoot : ComposeSharedBase, NsClashed
+{
+    RWBuffer<float> Out;
+
+    override void Compute()
+    {
+        Out[0] = Which();
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/NsClashed.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/NsClashed.sdsl
@@ -1,0 +1,23 @@
+// The same class name declared in two namespaces, in one file. Resolution is by class name
+// alone, so only one of the two can ever be reached.
+namespace Stride.Shaders.Parsers.Tests
+{
+    shader NsClashed
+    {
+        float Which()
+        {
+            return 1;
+        }
+    };
+}
+
+namespace Stride.Shaders.Parsers.Tests.NsB
+{
+    shader NsClashed
+    {
+        float Which()
+        {
+            return 2;
+        }
+    };
+}

--- a/sources/shaders/assets/SDSL/CompilerTests/NsUnknownUsingRoot.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/NsUnknownUsingRoot.sdsl
@@ -1,0 +1,16 @@
+// A `using` of a namespace no shader lives in. Since a using takes no part in resolution, it is
+// not an error either. (The key generator copies the directive into C#, so it names a real
+// .NET namespace.)
+using System.Collections.Generic;
+
+namespace Stride.Shaders.Tests;
+
+shader NsUnknownUsingRoot : ComposeSharedBase, NsUtils
+{
+    RWBuffer<float> Out;
+
+    override void Compute()
+    {
+        Out[0] = One();
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/NsUsingRoot.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/NsUsingRoot.sdsl
@@ -1,0 +1,15 @@
+// A `using` of the namespace NsUtils lives in. Resolution is by class name, so the directive
+// changes nothing, but it must be accepted: shaders in the wild carry one.
+using Stride.Shaders.Parsers.Tests;
+
+namespace Stride.Shaders.Tests;
+
+shader NsUsingRoot : ComposeSharedBase, NsUtils
+{
+    RWBuffer<float> Out;
+
+    override void Compute()
+    {
+        Out[0] = One();
+    }
+};

--- a/sources/shaders/assets/SDSL/CompilerTests/NsUtils.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/NsUtils.sdsl
@@ -1,0 +1,10 @@
+// A class in a namespace of its own, for the using tests.
+namespace Stride.Shaders.Parsers.Tests;
+
+shader NsUtils
+{
+    float One()
+    {
+        return 1;
+    }
+};

--- a/sources/shaders/assets/SDSL/ComputeTests/CSBufferAsParameter.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSBufferAsParameter.sdsl
@@ -1,0 +1,31 @@
+// PSMain(ExpectedResult=#00000000)
+
+// A typed buffer handed to another method.
+//
+// RWBuffer<uint> is an OpTypeImage, so it is an opaque resource: it must live in UniformConstant
+// storage and be passed as the caller's pointer. Both rules existed for textures and samplers and
+// had forgotten typed buffers, so the argument was copied into a Function-storage temporary -
+// an OpStore to an image, which Vulkan forbids (VUID-StandaloneSpirv-OpTypeImage-06924) - and the
+// call's argument storage class no longer matched the parameter's.
+//
+// Stride.Voxels passes RWBuffer<uint> through its whole write path (VoxelBufferWriter and friends).
+
+namespace Stride.Shaders.Tests;
+
+shader CSBufferAsParameter
+{
+    stage stream uint3 DispatchThreadId : SV_DispatchThreadID;
+
+    RWBuffer<uint> Output;
+
+    void WriteAt(RWBuffer<uint> target, uint index, uint value)
+    {
+        target[index] = value;
+    }
+
+    [numthreads(32, 32, 1)]
+    void CSMain()
+    {
+        WriteAt(Output, streams.DispatchThreadId.x, 1);
+    }
+}

--- a/sources/shaders/assets/SDSL/ComputeTests/CSBufferAsParameter.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSBufferAsParameter.sdsl
@@ -1,14 +1,7 @@
 // PSMain(ExpectedResult=#00000000)
 
-// A typed buffer handed to another method.
-//
-// RWBuffer<uint> is an OpTypeImage, so it is an opaque resource: it must live in UniformConstant
-// storage and be passed as the caller's pointer. Both rules existed for textures and samplers and
-// had forgotten typed buffers, so the argument was copied into a Function-storage temporary -
-// an OpStore to an image, which SPIR-V forbids (VUID-StandaloneSpirv-OpTypeImage-06924) - and the
-// call's argument storage class no longer matched the parameter's.
-//
-// Stride.Voxels passes RWBuffer<uint> through its whole write path (VoxelBufferWriter and friends).
+// A typed buffer handed to another method. RWBuffer<uint> is an OpTypeImage, so it is an opaque
+// resource: it must live in UniformConstant storage and be passed as the caller's pointer.
 
 namespace Stride.Shaders.Tests;
 

--- a/sources/shaders/assets/SDSL/ComputeTests/CSBufferAsParameter.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSBufferAsParameter.sdsl
@@ -5,7 +5,7 @@
 // RWBuffer<uint> is an OpTypeImage, so it is an opaque resource: it must live in UniformConstant
 // storage and be passed as the caller's pointer. Both rules existed for textures and samplers and
 // had forgotten typed buffers, so the argument was copied into a Function-storage temporary -
-// an OpStore to an image, which Vulkan forbids (VUID-StandaloneSpirv-OpTypeImage-06924) - and the
+// an OpStore to an image, which SPIR-V forbids (VUID-StandaloneSpirv-OpTypeImage-06924) - and the
 // call's argument storage class no longer matched the parameter's.
 //
 // Stride.Voxels passes RWBuffer<uint> through its whole write path (VoxelBufferWriter and friends).

--- a/sources/shaders/assets/SDSL/ComputeTests/CSBufferAtomics.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSBufferAtomics.sdsl
@@ -1,0 +1,34 @@
+// PSMain(ExpectedResult=#00000000)
+
+// Atomics on a typed buffer.
+//
+// `RWBuffer<uint>` is a storage image, not memory the shader can point into: `Output[i]` compiles
+// to an image read, so an atomic has no pointer to work on. The ref-argument path asks for an
+// OpImageTexelPointer instead, which in turn only exists on an image declaring a concrete format.
+//
+// Like CSByteAddressBuffer, the buffer is never bound - what this covers is that the shader
+// compiles, that the SPIR-V validates (OpImageTexelPointer is rejected outright on an Unknown
+// format), that SPIRV-Cross turns it back into InterlockedMax/InterlockedAdd on an RWBuffer for
+// D3D11, and that the result runs.
+
+namespace Stride.Shaders.Tests;
+
+shader CSBufferAtomics
+{
+    stage stream uint3 DispatchThreadId : SV_DispatchThreadID;
+
+    RWBuffer<uint> Output;
+
+    [numthreads(32, 32, 1)]
+    void CSMain()
+    {
+        uint previous;
+        InterlockedMax(Output[0], streams.DispatchThreadId.x, previous);
+        InterlockedAdd(Output[1], 1);
+
+        // The plain write path (OpImageWrite) has to keep working alongside the atomic one.
+        // One address per thread: FXC rejects an unconditional write to a shared address from
+        // every thread with X3694, and that would be the test's bug, not the compiler's.
+        Output[2 + streams.DispatchThreadId.x] = previous;
+    }
+}

--- a/sources/shaders/assets/SDSL/ComputeTests/CSBufferAtomics.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSBufferAtomics.sdsl
@@ -1,15 +1,8 @@
 // PSMain(ExpectedResult=#00000000)
 
-// Atomics on a typed buffer.
-//
-// `RWBuffer<uint>` is a storage image, not memory the shader can point into: `Output[i]` compiles
-// to an image read, so an atomic has no pointer to work on. The ref-argument path asks for an
-// OpImageTexelPointer instead, which in turn only exists on an image declaring a concrete format.
-//
-// Like CSByteAddressBuffer, the buffer is never bound - what this covers is that the shader
-// compiles, that the SPIR-V validates (OpImageTexelPointer is rejected outright on an Unknown
-// format), that SPIRV-Cross turns it back into InterlockedMax/InterlockedAdd on an RWBuffer for
-// D3D11, and that the result runs.
+// Atomics on a typed buffer: `Output[i]` must compile to an OpImageTexelPointer on an image with
+// a concrete format. Like CSByteAddressBuffer, the buffer is never bound; this covers compilation,
+// SPIR-V validation and the SPIRV-Cross round trip to InterlockedMax/InterlockedAdd.
 
 namespace Stride.Shaders.Tests;
 

--- a/sources/shaders/assets/SDSL/ComputeTests/CSExecModeOverride.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSExecModeOverride.sdsl
@@ -1,0 +1,33 @@
+// PSMain(ExpectedResult=#00000000)
+
+// A compute shader whose inherited CSMain is overridden, so the base's function becomes dead.
+//
+// An execution mode belongs to its entry point - [numthreads] here - and the dead code remover
+// removed the function without it, leaving `OpExecutionMode %n LocalSize ...` pointing at an id
+// nothing defines. spirv-opt then refused the whole module, reporting only "InternalError".
+//
+// Stride hits this with ComputeEffectShader: the root's CSMain dies once the composed compute
+// shader's own CSMain is the one wrapped as the entry point.
+
+namespace Stride.Shaders.Tests;
+
+shader CSExecModeBase
+{
+    stage stream uint3 DispatchThreadId : SV_DispatchThreadID;
+
+    [numthreads(8, 8, 8)]
+    void CSMain()
+    {
+    }
+}
+
+shader CSExecModeOverride : CSExecModeBase
+{
+    RWBuffer<uint> Output;
+
+    [numthreads(8, 8, 8)]
+    override void CSMain()
+    {
+        Output[streams.DispatchThreadId.x] = 1;
+    }
+}

--- a/sources/shaders/assets/SDSL/ComputeTests/CSExecModeOverride.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSExecModeOverride.sdsl
@@ -1,13 +1,7 @@
 // PSMain(ExpectedResult=#00000000)
 
 // A compute shader whose inherited CSMain is overridden, so the base's function becomes dead.
-//
-// An execution mode belongs to its entry point - [numthreads] here - and the dead code remover
-// removed the function without it, leaving `OpExecutionMode %n LocalSize ...` pointing at an id
-// nothing defines. spirv-opt then refused the whole module, reporting only "InternalError".
-//
-// Stride hits this with ComputeEffectShader: the root's CSMain dies once the composed compute
-// shader's own CSMain is the one wrapped as the entry point.
+// Its [numthreads] execution mode must be removed with it.
 
 namespace Stride.Shaders.Tests;
 

--- a/sources/shaders/assets/SDSL/ComputeTests/CSHalfTexture.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSHalfTexture.sdsl
@@ -1,0 +1,28 @@
+// PSMain(ExpectedResult=#00000000)
+
+// A texture declared with a 16-bit element type.
+//
+// An image cannot deliver 16-bit values: Vulkan requires its sampled type to be a 32-bit int,
+// 64-bit int or 32-bit float (VUID-StandaloneSpirv-OpTypeImage-04656), with no extension lifting
+// it. The declaration used to emit `OpTypeImage %half`, which no optimizer would even load.
+//
+// Nothing is lost by widening it - the 16 bits live in the resource's pixel format, and the
+// texture unit decodes them into 32-bit registers for free. Stride.Voxels stores its clipmaps as
+// R16G16B16A16_Float and reads them through `Texture3D<half4>`, which is what found this.
+
+namespace Stride.Shaders.Tests;
+
+shader CSHalfTexture
+{
+    stage stream uint3 DispatchThreadId : SV_DispatchThreadID;
+
+    Texture3D<half4> ReadTex;
+    RWTexture3D<half4> WriteTex;
+
+    [numthreads(8, 8, 8)]
+    void CSMain()
+    {
+        half4 value = ReadTex.Load(int4(streams.DispatchThreadId, 0));
+        WriteTex[streams.DispatchThreadId] = value;
+    }
+}

--- a/sources/shaders/assets/SDSL/ComputeTests/CSHalfTexture.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSHalfTexture.sdsl
@@ -2,7 +2,7 @@
 
 // A texture declared with a 16-bit element type.
 //
-// An image cannot deliver 16-bit values: Vulkan requires its sampled type to be a 32-bit int,
+// An image cannot deliver 16-bit values: SPIR-V requires its sampled type to be a 32-bit int,
 // 64-bit int or 32-bit float (VUID-StandaloneSpirv-OpTypeImage-04656), with no extension lifting
 // it. The declaration used to emit `OpTypeImage %half`, which no optimizer would even load.
 //

--- a/sources/shaders/assets/SDSL/ComputeTests/CSHalfTexture.sdsl
+++ b/sources/shaders/assets/SDSL/ComputeTests/CSHalfTexture.sdsl
@@ -1,14 +1,7 @@
 // PSMain(ExpectedResult=#00000000)
 
-// A texture declared with a 16-bit element type.
-//
-// An image cannot deliver 16-bit values: SPIR-V requires its sampled type to be a 32-bit int,
-// 64-bit int or 32-bit float (VUID-StandaloneSpirv-OpTypeImage-04656), with no extension lifting
-// it. The declaration used to emit `OpTypeImage %half`, which no optimizer would even load.
-//
-// Nothing is lost by widening it - the 16 bits live in the resource's pixel format, and the
-// texture unit decodes them into 32-bit registers for free. Stride.Voxels stores its clipmaps as
-// R16G16B16A16_Float and reads them through `Texture3D<half4>`, which is what found this.
+// A texture declared with a 16-bit element type. Vulkan requires a 32-bit sampled type
+// (VUID-StandaloneSpirv-OpTypeImage-04656), so the element type is widened to float.
 
 namespace Stride.Shaders.Tests;
 

--- a/sources/shaders/assets/SDSL/RenderTests/PixelShaderUav.sdsl
+++ b/sources/shaders/assets/SDSL/RenderTests/PixelShaderUav.sdsl
@@ -1,0 +1,34 @@
+// PSMain(ExpectedResult=#01010101)
+
+// A pixel shader that writes a UAV while also writing a render target.
+//
+// Direct3D11 puts UAVs and render targets in one register space, so the UAV cannot take u0 - FXC
+// rejects that with X4509. The engine already assumed the offset (CommandList binds with
+// UAVStartSlot: currentRenderTargetViewsActiveCount) but the compiler numbered UAVs from 0.
+//
+// Vulkan shares one counter for every resource class and has no such rule, so this only bites on
+// the Direct3D11 backend - which is why it is a render test rather than a compute one.
+
+namespace Stride.Shaders.Tests;
+
+shader PixelShaderUav
+{
+    stream float4 Position : POSITION;
+    stream float4 ShadingPosition : SV_Position;
+    stream float4 ColorTarget : SV_Target0;
+
+    RWBuffer<uint> Counter;
+
+    void VSMain()
+    {
+        streams.ShadingPosition = streams.Position;
+    }
+
+    void PSMain()
+    {
+        uint previous;
+        InterlockedAdd(Counter[0], 1, previous);
+
+        streams.ColorTarget = float4(1.0, 1.0, 1.0, 1.0) / 255.0;
+    }
+}

--- a/sources/shaders/assets/SDSL/RenderTests/PixelShaderUav.sdsl
+++ b/sources/shaders/assets/SDSL/RenderTests/PixelShaderUav.sdsl
@@ -1,13 +1,7 @@
 // PSMain(ExpectedResult=#01010101)
 
-// A pixel shader that writes a UAV while also writing a render target.
-//
-// Direct3D11 puts UAVs and render targets in one register space, so the UAV cannot take u0 - FXC
-// rejects that with X4509. The engine already assumed the offset (CommandList binds with
-// UAVStartSlot: currentRenderTargetViewsActiveCount) but the compiler numbered UAVs from 0.
-//
-// Vulkan shares one counter for every resource class and has no such rule, so this only bites on
-// the Direct3D11 backend - which is why it is a render test rather than a compute one.
+// A pixel shader that writes a UAV while also writing a render target. Direct3D11 puts UAVs and
+// render targets in one register space, so the UAV must not take u0 (FXC error X4509).
 
 namespace Stride.Shaders.Tests;
 

--- a/sources/shaders/assets/SDSL/RenderTests/UsingNamespace.sdsl
+++ b/sources/shaders/assets/SDSL/RenderTests/UsingNamespace.sdsl
@@ -1,0 +1,22 @@
+// PSMain(ExpectedResult=#01010101)
+
+// A shader file that opens with a `using` declaration. The compiler used to reject the whole file
+// with "Compiling declaration [UsingShaderNamespace] is not implemented", because it handled
+// ShaderClass and ShaderEffect and errored on anything else. Shader classes resolve by name across
+// namespaces, so the declaration carries nothing and is ignored.
+//
+// Stride.Voxels' LightVoxelShader.sdsl is one such file, and it took voxel GI down with it.
+
+using Stride.Shaders.Tests.SomeNamespace;
+
+namespace Stride.Shaders.Tests;
+
+shader UsingNamespace
+{
+    stream float4 ColorTarget : SV_Target0;
+
+    void PSMain()
+    {
+        streams.ColorTarget = float4(1.0, 1.0, 1.0, 1.0) / 255.0;
+    }
+}

--- a/sources/shaders/assets/SDSL/RenderTests/UsingNamespace.sdsl
+++ b/sources/shaders/assets/SDSL/RenderTests/UsingNamespace.sdsl
@@ -1,11 +1,7 @@
 // PSMain(ExpectedResult=#01010101)
 
-// A shader file that opens with a `using` declaration. The compiler used to reject the whole file
-// with "Compiling declaration [UsingShaderNamespace] is not implemented", because it handled
-// ShaderClass and ShaderEffect and errored on anything else. Shader classes resolve by name across
-// namespaces, so the declaration carries nothing and is ignored.
-//
-// Stride.Voxels' LightVoxelShader.sdsl is one such file, and it took voxel GI down with it.
+// A shader file that opens with a `using` declaration. Shader classes resolve by name across
+// namespaces, so the declaration carries nothing and must be ignored.
 
 using Stride.Shaders.Tests.SomeNamespace;
 

--- a/sources/shaders/assets/SDSL/StreamOutTests/StreamGSMethodCall.sdsl
+++ b/sources/shaders/assets/SDSL/StreamOutTests/StreamGSMethodCall.sdsl
@@ -1,0 +1,49 @@
+// GSMain(ExpectedPrimitiveCount=3, stream.EXTRA_COLOR=(0.498 0.498 0.498 0.498))
+
+// Same as StreamGS, but the geometry shader hands its input array and its output stream to
+// another method instead of appending inline. Stride.Voxels' VoxelizeToFragments does this
+// (`Storage.GenerateTriangles(input, triangleStream)`), and StreamGS does not cover it.
+
+namespace Stride.Shaders.Tests;
+
+shader StreamGSMethodCall
+{
+    stream float4 Position : POSITION;
+    stream float4 ShadingPosition : SV_Position;
+    stream float4 ColorTarget : SV_Target0;
+    stream float4 ExtraColor : EXTRA_COLOR;
+    stream float4 ExtraColor2;
+
+    void VSMain()
+    {
+        streams.ShadingPosition = streams.Position;
+        streams.ExtraColor2 = streams.ExtraColor;
+    }
+
+    void Emit(triangle Input input[3], inout PointStream<Output> outStream)
+    {
+        streams = input[0];
+
+        streams.ShadingPosition = 0.5f * streams.ShadingPosition;
+
+        outStream.Append(streams);
+
+        for (int i = 0; i < 2; ++i)
+        {
+            outStream.Append(streams);
+        }
+
+        outStream.RestartStrip();
+    }
+
+    [maxvertexcount(3)]
+    void GSMain(triangle Input input[3], inout PointStream<Output> outStream)
+    {
+        Emit(input, outStream);
+    }
+
+    void PSMain()
+    {
+        streams.ColorTarget = streams.ExtraColor2;
+    }
+}

--- a/sources/shaders/assets/SDSL/StreamOutTests/StreamGSStreamOnlyParam.sdsl
+++ b/sources/shaders/assets/SDSL/StreamOutTests/StreamGSStreamOnlyParam.sdsl
@@ -1,0 +1,54 @@
+// GSMain(ExpectedPrimitiveCount=3, stream.EXTRA_COLOR=(0.498 0.498 0.498 0.498))
+
+// A method whose *only* parameter is the geometry stream, so removing it leaves a function with
+// no parameters at all. Unlike StreamGSMethodCall, its signature is not shared with the entry
+// point, so nothing else rewrites its OpTypeFunction on its behalf.
+//
+// Stride.Voxels has exactly this shape in VoxelizationMethod: `void RestartStrip(inout
+// TriangleStream<Output> triangleStream)`.
+
+namespace Stride.Shaders.Tests;
+
+shader StreamGSStreamOnlyParam
+{
+    stream float4 Position : POSITION;
+    stream float4 ShadingPosition : SV_Position;
+    stream float4 ColorTarget : SV_Target0;
+    stream float4 ExtraColor : EXTRA_COLOR;
+    stream float4 ExtraColor2;
+
+    void VSMain()
+    {
+        streams.ShadingPosition = streams.Position;
+        streams.ExtraColor2 = streams.ExtraColor;
+    }
+
+    void EmitOne(inout PointStream<Output> outStream)
+    {
+        outStream.Append(streams);
+    }
+
+    void Restart(inout PointStream<Output> outStream)
+    {
+        outStream.RestartStrip();
+    }
+
+    [maxvertexcount(3)]
+    void GSMain(triangle Input input[3], inout PointStream<Output> outStream)
+    {
+        streams = input[0];
+
+        streams.ShadingPosition = 0.5f * streams.ShadingPosition;
+
+        EmitOne(outStream);
+        EmitOne(outStream);
+        EmitOne(outStream);
+
+        Restart(outStream);
+    }
+
+    void PSMain()
+    {
+        streams.ColorTarget = streams.ExtraColor2;
+    }
+}

--- a/sources/shaders/assets/SDSL/StreamOutTests/StreamGSStreamOnlyParam.sdsl
+++ b/sources/shaders/assets/SDSL/StreamOutTests/StreamGSStreamOnlyParam.sdsl
@@ -1,11 +1,7 @@
 // GSMain(ExpectedPrimitiveCount=3, stream.EXTRA_COLOR=(0.498 0.498 0.498 0.498))
 
-// A method whose *only* parameter is the geometry stream, so removing it leaves a function with
-// no parameters at all. Unlike StreamGSMethodCall, its signature is not shared with the entry
-// point, so nothing else rewrites its OpTypeFunction on its behalf.
-//
-// Stride.Voxels has exactly this shape in VoxelizationMethod: `void RestartStrip(inout
-// TriangleStream<Output> triangleStream)`.
+// A method whose only parameter is the geometry stream, so removing it leaves a function with
+// no parameters. Unlike StreamGSMethodCall, its signature is not shared with the entry point.
 
 namespace Stride.Shaders.Tests;
 


### PR DESCRIPTION
# PR Details

`Stride.Voxels` renders correctly on 4.3 and crashes on 4.4: its shaders do not get through the new SDSL compiler. Past the crashes they compile and dispatch, but global illumination contributes exactly zero, with nothing logged. On Direct3D12 and Vulkan both backends throw on the first frame.

Every fix here is a general engine issue that `Stride.Voxels` happens to uncover, not a workaround inside it; the two backend fixes affect any scene. Verified on Direct3D11, Direct3D12 and Vulkan.

**Reproduction:** https://github.com/Nicogo1705/StrideVoxelGI, a Cornell box using `Stride.Voxels` (`dotnet run --project Demo`). It targets `4.4.0-beta5`, so it reproduces every failure below as published; pointed at this branch it renders. `G` toggles the indirect light, `V` cycles the voxel debug views.

## Commits

| Commit | Fix |
|---|---|
| `76c532e` | ignore `using` namespace declarations instead of erroring |
| `80eff8d` | emit the access chain for literal-indexed shader compositions |
| `eafee2e` | name the missing composition instead of `KeyNotFoundException` |
| `692a965` | index `perMapOffsetScale` with an int, not a float |
| `d4288e7` | atomics on typed buffers via `OpImageTexelPointer` |
| `a1b6f29` | drop geometry stream parameters from every method, not just the entry point |
| `6c44263` | typed buffers are opaque resources too; say why the optimizer refused a module |
| `a2791d4` | number pixel shader UAVs after the render targets; drop execution modes with their function |
| `0ace208` | widen image sampled types: an image cannot deliver 16 bits |
| `9e2681b` | clear the voxel buffer with a 2D dispatch (65535 groups per dimension on every API) |
| `ad961c9` | a composition cannot supply the shader's entry point |
| `ba272d0` | `streams = input[i]` keeps the members the stage input does not carry |
| `2f8e603` | **D3D12**: size the static sampler buffer from the samplers, not the root parameters |
| `26a8ed2`, `f741c7a` | **Vulkan**: report the multisample counts the device supports, per format |
| `978bfdd` | drop every geometry stream parameter of a method, not only the last one |
| `fff9a24` | tests pinning down what namespaces and `using` do in SDSL today |

Two of these made GI render zero rather than crash, each by silently deleting code at mix time:

- `ad961c9`: a composition sharing its base with the shader it is composed into won the `CSMain` group, so the mipmap shader compiled to a bare `ret` with no resources.
- `ba272d0`: `streams = input[i]` zeroed everything the input did not carry, wiping the dominant axis each vertex; only surfaces already facing that axis voxelized.

The two backend fixes are not specific to voxels:

- `2f8e603`: the immutable sampler buffer was sized from `rootSignatureParameters.Count` instead of `immutableSamplers.Count`; an effect with more samplers than root parameters overran it (`Destination is too short`).
- `26a8ed2`, `f741c7a`: `GraphicsDeviceFeatures` never queried multisample support on Vulkan, so every format reported `MultisampleCount.None` and `Texture.New` rejected every multisampled render target. The count now comes from `vkGetPhysicalDeviceImageFormatProperties`, per format, with the usage `CreateImage` gives an attachment; formats the device cannot use that way stay at `None`. Note that `CreateImage` still hardcodes `samples = Count1`, so Vulkan never actually creates a multisampled image; that is a separate fix.

## Related Issue

https://github.com/stride3d/stride/issues/3374

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

Every shader fix has a regression test, verified failing with the fix reverted. The two backend fixes need a device and were verified by running the demo on the backend concerned. Game Studio was not run against these changes.

**Removed from this PR:** the two commits that hoisted a `stage compose` value supplied by a nested effect (`4df2f3d`, `6a90900`), as discussed in review. Without them `Stride.Voxels` does not get through the mixer yet: `AttributeSamplers` is supplied under `environmentLights[i]`. The mixer rule is discussed in #3423; `Stride.Voxels` will be adapted once it is settled.

Known limitation left as is: on D3D12, mesa's `spirv_to_dxil` reports `SampledBuffer` / `ImageBuffer` (`Buffer<T>` / `RWBuffer<T>`) as unsupported; the scene renders, but that path is a backend limitation none of this touches.

---
<sub>⚠️ Written with AI assistance (Claude Code), driven and verified by me; needs a real review by someone who knows the SDSL mixer and the SPIR-V interface processor. 🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>

