### PR TITLE
stride: fetch the asset packs on demand so 'new' can use them (fixes #3380)

### DIFF
--- a/sources/launcher/Stride.Cli/Core/StrideVersionManager.cs
+++ b/sources/launcher/Stride.Cli/Core/StrideVersionManager.cs
@@ -301,12 +301,19 @@ public sealed class StrideVersionManager
     // template package from an unrelated local source (e.g. the VS offline packages folder) is not picked up.
     private const string TemplateTag = "stride-template";
 
+    // The asset packs are the one template package nothing depends on: Stride.GameStudio deliberately declares no
+    // dependency on it, since the packs are optional content nobody should pay for at install time. Installing a
+    // Stride version therefore never puts it in the store, which is why discovery alone never finds it.
+    private const string AssetPacksPackageId = "Stride.Templates.AssetPacks";
+
     /// <summary>
     ///   Opens a template registry over the installed template packages compatible with the given version,
     ///   plus any explicitly requested <paramref name="extraPackages"/> (a package id or a local .nupkg path).
+    ///   The asset packs are fetched first when the store has no compatible copy, since nothing installs them.
     ///   Returns null if none could be installed. The caller owns the returned registry and must dispose it.
     /// </summary>
-    public async Task<DotNetNewTemplateRegistry?> OpenTemplateRegistry(PackageVersion version, IEnumerable<string>? extraPackages = null)
+    public async Task<DotNetNewTemplateRegistry?> OpenTemplateRegistry(
+        PackageVersion version, IEnumerable<string>? extraPackages = null, CancellationToken cancellationToken = default)
     {
         // Keep template-engine state under a CLI-owned, per-version directory so it stays isolated
         // from the user's global `dotnet new` installation and is deterministic regardless of whether
@@ -314,6 +321,8 @@ public sealed class StrideVersionManager
         var profileDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "stride", "cli", "templates", version.ToString());
+
+        await EnsureAssetPacksInstalled(version, cancellationToken);
 
         var registry = new DotNetNewTemplateRegistry(version.ToString(), profileDir);
         var installedAny = false;
@@ -332,6 +341,50 @@ public sealed class StrideVersionManager
         return registry;
     }
 
+    /// <summary>
+    ///   Downloads the asset packs when the store holds no copy compatible with <paramref name="version"/>, so
+    ///   that discovery can find them. Game Studio fetches the same package the same way when its New Game dialog
+    ///   first offers the packs. Best effort: without a reachable source the packs are simply left out.
+    /// </summary>
+    private async Task EnsureAssetPacksInstalled(PackageVersion version, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Ask the local store with the same accessor discovery uses, so an installed copy it would accept is
+            // never downloaded again.
+            if (store.GetLocalPackages(AssetPacksPackageId)
+                .Any(package => IsCompatible(package.GetDependencyFloor(TemplateMarkerDependencyId), version)))
+                return;
+
+            // Filter by the rule discovery applies, so a download is never spent on a package that would then be
+            // skipped for targeting a newer engine.
+            var candidate = (await store.FindSourcePackagesById(AssetPacksPackageId, cancellationToken))
+                .Where(package => IsCompatible(MarkerFloor(package), version))
+                .OrderByDescending(package => package.Version)
+                .FirstOrDefault();
+            if (candidate is not null)
+                await store.InstallPackage(candidate.Id, candidate.Version, candidate.TargetFrameworks, progress: null);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // An unreadable package folder, an unreachable source or a failed download. The packs are optional, so
+            // none of it should stop `new` from working with the templates that are installed; the editor swallows
+            // the same failures for the same reason. Nothing is printed because the caller owns the status line.
+        }
+    }
+
+    // A template package suits the requested engine when its marker names an engine no newer. An unmarked package
+    // has unknown compatibility, so it never qualifies here; discovery keeps its own last-resort fallback.
+    private static bool IsCompatible(PackageVersion? markerFloor, PackageVersion version)
+        => markerFloor is { } floor && floor.CompareTo(version) <= 0;
+
+    // The engine version a package from a source was built against. The installed counterpart is
+    // NugetLocalPackage.GetDependencyFloor, which reads the same marker from the extracted nuspec.
+    private static PackageVersion? MarkerFloor(NugetServerPackage package)
+        => package.Dependencies
+            .FirstOrDefault(dependency => string.Equals(dependency.Item1, TemplateMarkerDependencyId, StringComparison.OrdinalIgnoreCase))
+            ?.Item2.MinVersion;
+
     // The directories to install into the registry: one per discovered template package, plus any explicit
     // extra packages.
     private IEnumerable<string> ResolveTemplatePackages(PackageVersion version, IEnumerable<string>? extraPackages)
@@ -344,7 +397,7 @@ public sealed class StrideVersionManager
             .Where(package => package.IsTemplatePackage && package.HasTag(TemplateTag))
             .GroupBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
             .Select(group =>
-                group.Where(package => package.GetDependencyFloor(TemplateMarkerDependencyId) is { } floor && floor.CompareTo(version) <= 0)
+                group.Where(package => IsCompatible(package.GetDependencyFloor(TemplateMarkerDependencyId), version))
                     .OrderByDescending(package => package.Version)
                     .FirstOrDefault()
                 ?? group.Where(package => package.GetDependencyFloor(TemplateMarkerDependencyId) is null)

--- a/sources/launcher/Stride.Cli/Core/StrideVersionManager.cs
+++ b/sources/launcher/Stride.Cli/Core/StrideVersionManager.cs
@@ -350,8 +350,8 @@ public sealed class StrideVersionManager
     {
         try
         {
-            // Ask the local store with the same accessor discovery uses, so an installed copy it would accept is
-            // never downloaded again.
+            // Check the installed store first, with the same compatibility rule discovery applies, so an
+            // installed copy discovery would accept is never downloaded again.
             if (store.GetLocalPackages(AssetPacksPackageId)
                 .Any(package => IsCompatible(package.GetDependencyFloor(TemplateMarkerDependencyId), version)))
                 return;

--- a/sources/launcher/Stride.Cli/NewCommand.cs
+++ b/sources/launcher/Stride.Cli/NewCommand.cs
@@ -176,7 +176,7 @@ internal static class NewCommand
         DotNetNewTemplateRegistry? registry;
         try
         {
-            registry = await manager.OpenTemplateRegistry(version, packages);
+            registry = await manager.OpenTemplateRegistry(version, packages, cancellationToken);
         }
         catch (Exception exception)
         {

--- a/sources/templates/README.md
+++ b/sources/templates/README.md
@@ -7,7 +7,7 @@ Four NuGet packages ship Stride templates for the `dotnet new` engine:
 | **`Stride.Templates.Games`** | `stride-game` (blank NewGame starter) | Bundled with GameStudio installer |
 | **`Stride.Templates.Games.Starters`** | `stride-fps`, `stride-platformer2d`, `stride-topdownrpg`, `stride-thirdpersonplatformer`, `stride-vrsandbox` | nuget.org (CLI install / future template store) |
 | **`Stride.Templates.Samples`** | 18 feature demos (tutorials, games, graphics, physics, UI, particles, input, audio) | nuget.org (CLI install / future template store) |
-| **`Stride.Templates.AssetPacks`** | 4 asset packs as item templates: `stride-pack-buildingblocks`, `stride-pack-animatedmodels`, `stride-pack-materials`, `stride-pack-particles` | nuget.org (downloaded on demand by GameStudio's New Game dialog / CLI install) |
+| **`Stride.Templates.AssetPacks`** | 4 asset packs as item templates: `stride-pack-buildingblocks`, `stride-pack-animatedmodels`, `stride-pack-materials`, `stride-pack-particles` | nuget.org (downloaded on demand by GameStudio's New Game dialog / the `stride` CLI) |
 
 GameStudio's "New Project" dialog and CLI `dotnet new` consume the same packages — there is one template flow, not two.
 
@@ -45,8 +45,9 @@ cd MyGame/MyGame.Game
 dotnet new stride-pack-buildingblocks   # merges the pack's Assets/ + Resources/ into the project
 ```
 
-The `stride` CLI resolves installed template packages automatically; with the AssetPacks package
-present, `stride new stride-pack-buildingblocks` run inside the game library does the same.
+The `stride` CLI needs neither install: it resolves the template packages of the requested Stride
+version and downloads the asset packs the first time they are needed, so `stride new
+stride-pack-buildingblocks` run inside the game library does the same.
 
 `dotnet new -l` after the installs lists every available stride-* short name.
 


### PR DESCRIPTION
# PR Details

`Stride.Templates.AssetPacks` is the one template package nothing pulls in. `Stride.GameStudio` deliberately declares no dependency on it, so installing a Stride version never puts it in the package store, and `stride new` could neither list the `stride-pack-*` item templates nor instantiate one. As the issue points out, `dotnet new install Stride.Templates.AssetPacks` does not help either: that registers the package with the `dotnet new` template cache, while the CLI resolves template packages from the NuGet store.

This takes the third option from the issue, which is what Game Studio already does in `DotNetNewTemplateBridge.GetAssetPackTemplatesAsync`. `OpenTemplateRegistry` now fetches the package before discovery runs, and only when the store holds no copy compatible with the requested engine. The candidate is picked with the same `Stride.Core` marker rule discovery applies, so a package built for a newer engine is never downloaded only to be filtered out afterwards; that rule now sits in one method rather than being written twice. A lookup that fails leaves the packs out instead of failing the command, the way the editor treats the same failure.

I did not take the first option. Making the package a dependency of `Stride.GameStudio` would undo a deliberate decision: the packs are about 19 MB of optional content, and the comment in `Stride.GameStudio.csproj` says they are fetched on demand rather than pulled at install time.

## Related Issue

Fixes #3380

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

`sources/templates/README.md` described the CLI as needing the package to be present already, so two lines there are updated.

There is no test project for `Stride.Cli` and `Stride.Templates.Tests` does not reference it, so I added none; a new project plus entries in `Stride.slnx` and the two test `.slnf` files felt like your call rather than something to fold into a bug fix. The change is CLI-only and does not touch the editor path, so I exercised the built CLI instead of Game Studio.

## How this was checked

`Stride.Cli` is in neither `Stride.slnx` nor any `.slnf`, so no CI lane compiles it and `PackageCli` is the only thing that builds it. Everything below is local, on Ubuntu with .NET 10.0.400, against a package store holding `Stride.Templates.Games` 4.4.0-beta5 and no asset packs.

Before the change, `stride new list --version 4.4.0-beta5` listed only the two `Stride.Templates.Games` templates, `stride new stride-pack-buildingblocks` reported no such template, and `--package Stride.Templates.AssetPacks` changed nothing while still exiting 0. After it, the same list command downloads the package and shows the four packs; a second run takes 1.2 s and downloads nothing; and `stride new stride-pack-buildingblocks` inside a generated game library drops `Assets/BlocksScene.sdscene` and `Resources/Models/Box1x1x1.fbx` into it, leaves the game's own `GameSettings.sdgamesettings` in place and leaks no `.template.config`. Asking for 4.3.0, which is older than the packs' marker, downloads nothing. With the network removed, the command still exits 0 and lists the installed templates without the packs. A forced rebuild reports the same 331 compiler warnings as `master`, none in the changed files.

## Left alone on purpose

`--package <id>` still does nothing when the id is not already in the store, so it cannot reach a package that has never been downloaded. That is the same missing fetch, but fixing it means turning `ResolveTemplatePackages` from an iterator into an async method, which seemed like a separate change. Glad to open an issue for it, or to fold it in here if you would rather have both at once.

Offline, and only until the packs have been cached once, `stride new` now spends about seven seconds in the NuGet lookup before giving up. Caching that failure would avoid the wait at the cost of deciding how long a negative answer stays good, so I left it out. I also kept the failure silent because `new list` draws its status on a single line that a write from here would break; if you would rather see something on stderr, that is easy to add.
