### PR TITLE
Swap positive and negative Z in CubemapRendererBase

### DIFF
--- a/sources/engine/Stride.Engine/Rendering/Skyboxes/CubemapRendererBase.cs
+++ b/sources/engine/Stride.Engine/Rendering/Skyboxes/CubemapRendererBase.cs
@@ -68,10 +68,10 @@ namespace Stride.Rendering.Skyboxes
                         Camera.ViewMatrix = Matrix.LookAtRH(position, position - Vector3.UnitY, -Vector3.UnitZ);
                         break;
                     case CubeMapFace.PositiveZ:
-                        Camera.ViewMatrix = Matrix.LookAtRH(position, position - Vector3.UnitZ, Vector3.UnitY);
+                        Camera.ViewMatrix = Matrix.LookAtRH(position, position + Vector3.UnitZ, Vector3.UnitY);
                         break;
                     case CubeMapFace.NegativeZ:
-                        Camera.ViewMatrix = Matrix.LookAtRH(position, position + Vector3.UnitZ, Vector3.UnitY);
+                        Camera.ViewMatrix = Matrix.LookAtRH(position, position - Vector3.UnitZ, Vector3.UnitY);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
# PR Details

I noticed this while working on an `ISceneRenderer` implementation for rendering cubemaps in my game.

## Issue

The code for the Z direction appears to have been backwards.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

I made the changes in `github.dev`. I did not test them in any way, but I'm confident that they're correct.

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
