### PR TITLE
Fix slider tick snapping for collapsed ranges

### DIFF
--- a/sources/engine/Stride.UI.Tests/Layering/SliderTests.cs
+++ b/sources/engine/Stride.UI.Tests/Layering/SliderTests.cs
@@ -226,6 +226,19 @@ namespace Stride.UI.Tests.Layering
             Utilities.AssertAreNearlyEqual(0.4f, slider.Value);
         }
 
+        [Fact]
+        public void TestTickSnappingWithCollapsedRange()
+        {
+            foreach (var bound in new[] { 0f, 5f, -5f })
+            {
+                var slider = new Slider { Minimum = bound, Maximum = bound, Value = bound };
+
+                slider.ShouldSnapToTicks = true;
+
+                Assert.Equal(bound, slider.Value);
+            }
+        }
+
         /// <summary>
         /// Test the <see cref="Slider.MeasureOverride"/> method.
         /// </summary>

--- a/sources/engine/Stride.UI/Controls/Slider.cs
+++ b/sources/engine/Stride.UI/Controls/Slider.cs
@@ -310,6 +310,9 @@ namespace Stride.UI.Controls
         /// <returns>The value adjusted to the closest tick</returns>
         protected float CalculateClosestTick(float rawValue)
         {
+            if (Maximum == Minimum)
+                return Minimum;
+
             var absoluteValue = rawValue - Minimum;
             var step = (Maximum - Minimum) / TickFrequency;
             var times = MathF.Round(absoluteValue / step);


### PR DESCRIPTION
Fixes #3394

### Summary

When a slider's minimum and maximum are equal, tick snapping currently calculates a zero step and produces `NaN` through `0 / 0`. This change returns the single valid bound from `CalculateClosestTick` for collapsed ranges.

Regression coverage includes collapsed ranges at `0`, `5`, and `-5`, while the existing normal-range slider tests continue to pass.

### Validation

- Focused regression test: 1 passed
- `Stride.UI.Tests.Layering.SliderTests`: 8 passed
