### PR TITLE
Fix Slider value coercion when Maximum changes

### DIFF
--- a/sources/engine/Stride.UI.Tests/Layering/SliderTests.cs
+++ b/sources/engine/Stride.UI.Tests/Layering/SliderTests.cs
@@ -115,6 +115,53 @@ namespace Stride.UI.Tests.Layering
             slider.Value = 10;
             Assert.Equal(1.0f, slider.Value);
         }
+
+        [Fact]
+        public void TestMinimumMaximumChangesCoerceValue()
+        {
+            var slider = new Slider { Maximum = 10, Value = 8 };
+            var valueChangedCount = 0;
+            slider.ValueChanged += (s, e) => valueChangedCount++;
+
+            slider.Maximum = 4;
+
+            Assert.Equal(4, slider.Maximum);
+            Assert.Equal(4, slider.Value);
+            Assert.Equal(1, valueChangedCount);
+
+            slider.Minimum = 5;
+
+            Assert.Equal(5, slider.Minimum);
+            Assert.Equal(5, slider.Maximum);
+            Assert.Equal(5, slider.Value);
+            Assert.Equal(2, valueChangedCount);
+
+            slider.Minimum = 5;
+
+            Assert.Equal(2, valueChangedCount);
+        }
+
+        [Fact]
+        public void TestMinimumMaximumChangesCoerceValueWithSnapping()
+        {
+            var slider = new Slider
+            {
+                Maximum = 10,
+                Value = 8,
+                TickFrequency = 5,
+                ShouldSnapToTicks = true,
+            };
+
+            slider.Maximum = 4;
+
+            Assert.Equal(4, slider.Value);
+
+            slider.Minimum = 5;
+
+            Assert.Equal(5, slider.Minimum);
+            Assert.Equal(5, slider.Maximum);
+            Assert.Equal(5, slider.Value);
+        }
         
         /// <summary>
         /// Test the <see cref="Slider.ValueChanged"/> event.

--- a/sources/engine/Stride.UI/Controls/Slider.cs
+++ b/sources/engine/Stride.UI/Controls/Slider.cs
@@ -459,6 +459,7 @@ namespace Stride.UI.Controls
         private void CoerceMaximum(float newValue)
         {
             maximum = MathUtil.Clamp(newValue, minimum, float.MaxValue);
+            Value = Value;
         }
 
         private void InvalidateMeasure(object sender, EventArgs eventArgs)


### PR DESCRIPTION
## Summary

Re-coerce Slider.Value after Maximum changes so the value remains within the updated bounds.

## Changes

- Re-coerce Value in Slider maximum coercion.
- Add regression coverage for bounds changes, ValueChanged event counts, and tick snapping.

## Testing

- Stride.UI.Tests: 209 passed, 5 skipped, 0 failed.
- Full Stride.slnx run completed on macOS arm64 but reported unrelated platform and sample failures: asset tests, audio/sample screenshot tests, missing x64 .NET host, and an editor GameForm compile issue.