### PR TITLE
Fix Vulkan crash vkCreateSwapchainKHR when closing the scene editor

### DIFF
--- a/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Services/EditorGameController.cs
+++ b/sources/editor/Stride.Assets.Presentation/AssetEditors/GameEditor/Services/EditorGameController.cs
@@ -184,8 +184,8 @@ namespace Stride.Assets.Presentation.AssetEditors.GameEditor.Services
             {
                 if (serviceRegistry != null)
                     await serviceRegistry.DisposeAsync();
+                // The game disposes its own window, after the loop's last present.
                 Game.Exit();
-                GameForm?.Dispose();
             }, int.MaxValue)
             // Ensure the properties are correctly set, even in case of a failure (default continuation)
             .ContinueWith(t =>

--- a/sources/engine/Stride.Games/GameBase.cs
+++ b/sources/engine/Stride.Games/GameBase.cs
@@ -683,7 +683,7 @@ namespace Stride.Games
                         // no-draw ticks avoids re-presenting undefined/stale back-buffer content
                         // (flip-model discards after Present) and, on D3D12, avoids emitting a
                         // barrier-only command list that trips the perf warning.
-                        EndDraw(drawFrame);
+                        EndDraw(drawFrame && !IsExiting);
                     }
                 }
 

--- a/sources/engine/Stride.Graphics/Vulkan/SwapChainGraphicsPresenter.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/SwapChainGraphicsPresenter.Vulkan.cs
@@ -403,8 +403,11 @@ namespace Stride.Graphics
                 .Where((properties, index) => (properties.queueFlags & VkQueueFlags.Graphics) != 0 && GraphicsDevice.NativeInstanceApi.vkGetPhysicalDeviceSurfaceSupportKHR(GraphicsDevice.NativePhysicalDevice, (uint)index, surface, out var supported) == VkResult.Success && supported)
                 .Select((properties, index) => index).First();
 
-            // Surface format
-            GraphicsDevice.NativeInstanceApi.vkGetPhysicalDeviceSurfaceFormatsKHR(GraphicsDevice.NativePhysicalDevice, surface, out uint surfaceFormatCount);
+            // Surface format. A failed query reports no format, and the fallback below then reads
+            // the first one, so check it here.
+            GraphicsDevice.CheckResult(
+                GraphicsDevice.NativeInstanceApi.vkGetPhysicalDeviceSurfaceFormatsKHR(GraphicsDevice.NativePhysicalDevice, surface, out uint surfaceFormatCount),
+                "vkGetPhysicalDeviceSurfaceFormatsKHR");
             Span<VkSurfaceFormatKHR> surfaceFormats = stackalloc VkSurfaceFormatKHR[(int)surfaceFormatCount];
             GraphicsDevice.NativeInstanceApi.vkGetPhysicalDeviceSurfaceFormatsKHR(GraphicsDevice.NativePhysicalDevice, surface, surfaceFormats);
             var backBufferFormat = VulkanConvertExtensions.ConvertPixelFormat(Description.BackBufferFormat);
@@ -427,8 +430,12 @@ namespace Stride.Graphics
                 Description.BackBufferFormat = VulkanConvertExtensions.ConvertPixelFormat(backBufferFormat);
             }
 
-            // Create swapchain
-            GraphicsDevice.NativeInstanceApi.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(GraphicsDevice.NativePhysicalDevice, surface, out var surfaceCapabilities);
+            // Create swapchain. A failed query leaves the capabilities zeroed, which silently builds
+            // a 0x0 depth buffer and an invalid preTransform, so report it here rather than let
+            // vkCreateSwapchainKHR fail with a generic error further down.
+            GraphicsDevice.CheckResult(
+                GraphicsDevice.NativeInstanceApi.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(GraphicsDevice.NativePhysicalDevice, surface, out var surfaceCapabilities),
+                "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
 
             // Match currentTransform so the engine skips the rotation compose pass (saves a vsync
             // on Android tile-based GPUs). Renderer folds the rotation into the projection.


### PR DESCRIPTION
The editor disposed the game form from a script task, which runs inside a tick, so the rest of that tick presented to a destroyed window. The game window disposes itself once the message loop sees the exit request.

Also skip the present on the exiting tick, since Draw is skipped there, and check the surface queries in CreateSwapChain: a failed query left the capabilities zeroed and built a zero-size depth buffer.

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

