### PR TITLE
fix(ui): keep Slider.Value inside bounds after bound changes

### DIFF
--- a/sources/engine/Stride.UI.Tests/Layering/SliderTests.cs
+++ b/sources/engine/Stride.UI.Tests/Layering/SliderTests.cs
@@ -116,6 +116,120 @@ namespace Stride.UI.Tests.Layering
             Assert.Equal(1.0f, slider.Value);
         }
         
+        [Fact]
+        public void TestMinimumChangeCoercesValueAndRaisesValueChanged()
+        {
+            var slider = new Slider { Maximum = 10, Value = 2 };
+            var valueChangedCount = 0;
+            slider.ValueChanged += (_, _) => valueChangedCount++;
+
+            slider.Minimum = 5;
+
+            Assert.Equal(5, slider.Value);
+            Assert.Equal(1, valueChangedCount);
+        }
+
+        [Fact]
+        public void TestMaximumChangeCoercesValueAndRaisesValueChanged()
+        {
+            var slider = new Slider { Maximum = 10, Value = 8 };
+            var valueChangedCount = 0;
+            slider.ValueChanged += (_, _) => valueChangedCount++;
+
+            slider.Maximum = 4;
+
+            Assert.Equal(4, slider.Value);
+            Assert.Equal(1, valueChangedCount);
+        }
+
+        [Fact]
+        public void TestMinimumChangeCanCollapseRangeAndCoerceValue()
+        {
+            var slider = new Slider { Maximum = 10, Value = 8 };
+            var valueChangedCount = 0;
+            slider.ValueChanged += (_, _) => valueChangedCount++;
+
+            slider.Minimum = 12;
+
+            Assert.Equal(12, slider.Minimum);
+            Assert.Equal(12, slider.Maximum);
+            Assert.Equal(12, slider.Value);
+            Assert.Equal(1, valueChangedCount);
+        }
+
+        [Fact]
+        public void TestInRangeBoundChangesDoNotRaiseValueChanged()
+        {
+            var slider = new Slider { Maximum = 10, Value = 5 };
+            var valueChangedCount = 0;
+            slider.ValueChanged += (_, _) => valueChangedCount++;
+
+            slider.Minimum = 1;
+            slider.Maximum = 9;
+
+            Assert.Equal(5, slider.Value);
+            Assert.Equal(0, valueChangedCount);
+        }
+
+        [Fact]
+        public void TestBoundChangesReapplyTickSnapping()
+        {
+            var slider = new Slider { Maximum = 10, TickFrequency = 5, Value = 3 };
+            slider.ShouldSnapToTicks = true;
+            var valueChangedCount = 0;
+            slider.ValueChanged += (_, _) => valueChangedCount++;
+
+            slider.Maximum = 9;
+
+            Utilities.AssertAreNearlyEqual(3.6f, slider.Value);
+            Assert.Equal(1, valueChangedCount);
+        }
+
+        [Fact]
+        public void TestBoundChangesKeepSnappedValueWithinRange()
+        {
+            var slider = new Slider { Maximum = 10, TickFrequency = 2.6f, Value = 8 };
+            slider.ShouldSnapToTicks = true;
+
+            slider.Maximum = 4;
+
+            Assert.Equal(4, slider.Value);
+        }
+
+        [Fact]
+        public void TestBoundChangesKeepSnappedValueFiniteForSubnormalRange()
+        {
+            var slider = new Slider { Maximum = 1, TickFrequency = 2, Value = 1 };
+            slider.ShouldSnapToTicks = true;
+
+            slider.Maximum = float.Epsilon;
+
+            Assert.Equal(float.Epsilon, slider.Value);
+        }
+
+        [Fact]
+        public void TestBoundChangesKeepSnappedValueFiniteForExtremeRange()
+        {
+            var slider = new Slider { Maximum = 1, TickFrequency = 2, Value = 0 };
+            slider.ShouldSnapToTicks = true;
+
+            slider.Minimum = float.MinValue;
+            slider.Maximum = float.MaxValue;
+
+            Assert.Equal(0, slider.Value);
+        }
+
+        [Fact]
+        public void TestTickIncrementHandlesExtremeRange()
+        {
+            var slider = new Slider { Minimum = float.MinValue, Maximum = float.MaxValue, TickFrequency = 2, Value = float.MinValue };
+            slider.ShouldSnapToTicks = true;
+
+            slider.Increase();
+
+            Assert.Equal(0, slider.Value);
+        }
+
         /// <summary>
         /// Test the <see cref="Slider.ValueChanged"/> event.
         /// </summary>

--- a/sources/engine/Stride.UI/Controls/Slider.cs
+++ b/sources/engine/Stride.UI/Controls/Slider.cs
@@ -69,7 +69,7 @@ namespace Stride.UI.Controls
 
                 this.value = MathUtil.Clamp(value, Minimum, Maximum);
                 if (ShouldSnapToTicks)
-                    this.value = CalculateClosestTick(this.value);
+                    this.value = MathUtil.Clamp(CalculateClosestTick(this.value), Minimum, Maximum);
 
                 if (Math.Abs(oldValue - this.value) > MathUtil.ZeroTolerance)
                     RaiseEvent(new RoutedEventArgs(ValueChangedEvent));
@@ -313,10 +313,10 @@ namespace Stride.UI.Controls
             if (Maximum == Minimum)
                 return Minimum;
 
-            var absoluteValue = rawValue - Minimum;
-            var step = (Maximum - Minimum) / TickFrequency;
-            var times = MathF.Round(absoluteValue / step);
-            return times * step + Minimum;
+            var absoluteValue = (double)rawValue - Minimum;
+            var step = ((double)Maximum - Minimum) / TickFrequency;
+            var times = Math.Round(absoluteValue / step);
+            return (float)(times * step + Minimum);
         }
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace Stride.UI.Controls
 
         private float CalculateIncreamentValue()
         {
-            return shouldSnapToTicks ? Math.Max(Step, (Maximum - Minimum) / TickFrequency) : Step;
+            return shouldSnapToTicks ? Math.Max(Step, (float)(((double)Maximum - Minimum) / TickFrequency)) : Step;
         }
 
         protected override Vector3 MeasureOverride(Vector3 availableSizeWithoutMargins)
@@ -459,6 +459,7 @@ namespace Stride.UI.Controls
         private void CoerceMaximum(float newValue)
         {
             maximum = MathUtil.Clamp(newValue, minimum, float.MaxValue);
+            Value = Value;
         }
 
         private void InvalidateMeasure(object sender, EventArgs eventArgs)


### PR DESCRIPTION
## Summary
- Re-coerce `Slider.Value` whenever `Minimum` or `Maximum` changes through the shared maximum-coercion path.
- Preserve the normal `ValueChanged` notification when coercion changes the value.
- Keep tick-snapped values inside the updated range, including fractional and extreme float ranges.

## Tests
- `17/17` `Stride.UI.Tests.Layering.SliderTests` passed.
- `179` passed and `3` skipped in the non-rendering `Stride.UI.Tests.Layering` suite.
- Full `Stride.UI.Tests`: `185` passed, `5` skipped, `28` failed because this headless host cannot initialize Direct3D11 (`0x887A002D`); the failures are graphics regression tests.
- The regression tests were observed failing before the production fix and passing after it.

## Scope
The regression coverage includes raising/lowering bounds, collapsed ranges, in-range changes without events, tick snapping, fractional tick frequencies, subnormal ranges, extreme ranges, and tick increments.

An existing related PR, #3399, contains a similar core fix; this PR includes broader regression coverage and the floating-point hardening described above.

Closes #3397