### PR TITLE
Logging cleanup: listener levels, build labels, MSBuild relay, asset compiler output

### DIFF
--- a/docs/debugging/logging.md
+++ b/docs/debugging/logging.md
@@ -1,0 +1,98 @@
+# Logging
+
+How log messages are filtered in Stride, and how to see them while working on the engine or Game
+Studio. For crashes, see [crash-reporting.md](crash-reporting.md).
+
+## Two filters
+
+A message passes two filters before it is displayed.
+
+1. **The logger that emits it.** Every `Logger` has a minimum level (`ActivateLog`). Below it the
+   message is never created, so this is the cheap filter. Global loggers (`GlobalLogger.GetLogger(module)`)
+   start at Info, from `Logger.MinimumLevelEnabled`. `GlobalLogger.SetModuleLevel(module, level)` sets
+   the level of a module's logger, whether it already exists or is created later.
+2. **The listener that displays it.** Every `LogListener` has a `MinimumLevel` (default Debug, so it
+   lets everything through) and `ModuleLevels`, per-module overrides keyed by the message's `Module`.
+   A listener can stay quiet overall while following a few modules in detail.
+
+Both are needed: the emitter level saves the cost of messages nobody wants, the listener level lets
+several sinks (console, debugger, a log pane) show different amounts of the same stream.
+
+Severity and module are metadata, so filters act on them. How much of that metadata gets printed is
+the formatter's choice.
+
+## Game Studio
+
+Game Studio routes everything logged through `GlobalLogger` to the attached debugger's output
+(the VS Output pane), in Debug builds only. What reaches it is configured in
+`%APPDATA%\stride\GameStudioSettings.conf`, under the `Logging` keys. They are read once at startup,
+so a change needs a restart.
+
+| Key | Default | In the Settings dialog |
+|---|---|---|
+| `Logging/DebugOutputLevel` | `Warning` | yes, under Logging |
+| `Logging/DebugOutputModuleLevels` | `GraphicsDevice: Debug`, `GraphicsDebug: Debug` | no, file only |
+| `Logging/SourceModuleLevels` | `AssetBuilderService`, `EffectCompilerCache`, `Preview`, `Quantum`: `Debug` | no, file only |
+
+- `DebugOutputLevel` is the general level of the debugger output listener. Warning by default because
+  Info and Verbose volume, during an asset build or a NuGet restore, slows the debugger noticeably.
+- `DebugOutputModuleLevels` overrides it per module. The two graphics modules default to Debug: that is
+  where the backends report the validation layer status and messages, and they are quiet without a
+  debug device (`/DebugEditorGraphics`).
+- `SourceModuleLevels` sets the emitting level of global loggers. The defaults cover the loggers shown
+  in the debug window (Help > Show debug window), so those pages get their full history.
+
+The file is sparse: only what you set is written, everything else keeps its default. The two maps
+merge over their defaults, so one entry overrides one module and the others stay as they are.
+To silence a default entry, set it explicitly to a higher level.
+
+Levels are `Debug`, `Verbose`, `Info`, `Warning`, `Error`, `Fatal`.
+
+### Examples
+
+See Info from everything, and follow the build engine step by step:
+
+```yaml
+!SettingsFile
+Settings:
+    Logging/DebugOutputLevel: Info
+    Logging/DebugOutputModuleLevels:
+        BuildStep: Debug
+```
+
+Keep the default Warning level but silence the graphics modules:
+
+```yaml
+    Logging/DebugOutputModuleLevels:
+        GraphicsDevice: Warning
+        GraphicsDebug: Warning
+```
+
+Make a global logger emit Debug so its debug page shows everything, or so it can be followed in the
+debugger output:
+
+```yaml
+    Logging/SourceModuleLevels:
+        Preview: Debug
+    Logging/DebugOutputModuleLevels:
+        Preview: Debug
+```
+
+Both entries are needed, one per filter. The `Preview` logger starts at Info, so without the first
+its Debug calls return without creating a message, and no listener setting can show what was never
+emitted. Without the second, the debugger output listener drops the messages, since its general
+level is Warning.
+
+### Build pane
+
+The Build pane shows what MSBuild reports for the project build, relayed with its severity and
+location: errors and warnings appear as `file(line,col): CODE: text`. The asset compiler runs with
+`--verbose` under Game Studio and its output travels as Verbose, hidden by default; turn on the Verbose
+toggle to see it. Its errors and warnings keep their severity, so they show in colour regardless.
+
+## Games
+
+A `Game` attaches a `ConsoleLogListener` to `GlobalLogger`. `Game.ConsoleLogLevel` sets its level.
+`ConsoleLogMode` decides whether a console window is opened for it: `Always`, `None`, or `Auto`,
+which opens one for Debug builds when no debugger is attached. An attached debugger receives every
+message that passes the level, whatever the mode.

--- a/sources/assets/Stride.AssetCompiler/LogListenerRedirectToAction.cs
+++ b/sources/assets/Stride.AssetCompiler/LogListenerRedirectToAction.cs
@@ -20,20 +20,8 @@ namespace Stride.AssetCompiler
             this.logger = logger;
         }
 
-        /// <summary>
-        /// Gets or sets the minimum log level handled by this listener.
-        /// </summary>
-        /// <value>The minimum log level.</value>
-        public LogMessageType LogLevel { get; set; }
-
         protected override void OnLog(ILogMessage logMessage)
         {
-            // Always log when debugger is attached
-            if (logMessage.Type < LogLevel)
-            {
-                return;
-            }
-
             var color = ConsoleColor.Gray;
 
             // set the color depending on the message log level

--- a/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilder.cs
@@ -405,39 +405,30 @@ namespace Stride.AssetCompiler
             var assetItem = (AssetItem)e.Step.Tag;
             var assetRef = assetItem.ToReference();
             var project = assetItem.Package;
+            var assetFile = assetItem.FullPath.ToOSPath();
             var stepLogger = e.Step.Logger;
             // TODO: Big review of the log infrastructure of CompilerApp & BuildEngine!
             if (stepLogger != null)
             {
+                // Attach the asset file so the console can print a navigable origin; a message that already
+                // has one keeps it, along with its position.
                 foreach (var message in stepLogger.Messages.Where(x => x.IsAtLeast(LogMessageType.Warning)))
                 {
-                    builderOptions.Logger.Log(message);
+                    builderOptions.Logger.Log(message is AssetLogMessage { File.Length: > 0 } ? message : AssetLogMessage.From(project, assetRef, message, assetFile));
                 }
             }
-            switch (e.Step.Status)
+            var (type, code) = e.Step.Status switch
             {
                 // This case should never happen
-                case ResultStatus.NotProcessed:
-                    builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, LogMessageType.Fatal, AssetMessageCode.InternalCompilerError, assetRef.Location));
-                    break;
-                case ResultStatus.Successful:
-                    builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, LogMessageType.Verbose, AssetMessageCode.CompilationSucceeded, assetRef.Location));
-                    break;
-                case ResultStatus.Failed:
-                    builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, LogMessageType.Error, AssetMessageCode.CompilationFailed, assetRef.Location));
-                    break;
-                case ResultStatus.Cancelled:
-                    builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, LogMessageType.Verbose, AssetMessageCode.CompilationCancelled, assetRef.Location));
-                    break;
-                case ResultStatus.NotTriggeredWasSuccessful:
-                    builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, LogMessageType.Verbose, AssetMessageCode.AssetUpToDate, assetRef.Location));
-                    break;
-                case ResultStatus.NotTriggeredPrerequisiteFailed:
-                    builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, LogMessageType.Error, AssetMessageCode.PrerequisiteFailed, assetRef.Location));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+                ResultStatus.NotProcessed => (LogMessageType.Fatal, AssetMessageCode.InternalCompilerError),
+                ResultStatus.Successful => (LogMessageType.Verbose, AssetMessageCode.CompilationSucceeded),
+                ResultStatus.Failed => (LogMessageType.Error, AssetMessageCode.CompilationFailed),
+                ResultStatus.Cancelled => (LogMessageType.Verbose, AssetMessageCode.CompilationCancelled),
+                ResultStatus.NotTriggeredWasSuccessful => (LogMessageType.Verbose, AssetMessageCode.AssetUpToDate),
+                ResultStatus.NotTriggeredPrerequisiteFailed => (LogMessageType.Error, AssetMessageCode.PrerequisiteFailed),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+            builderOptions.Logger.Log(new AssetLogMessage(project, assetRef, type, code, assetRef.Location) { File = assetFile });
             e.Step.StepProcessed -= BuildStepProcessed;
         }
 

--- a/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
+++ b/sources/assets/Stride.AssetCompiler/PackageBuilderApp.cs
@@ -43,6 +43,9 @@ namespace Stride.AssetCompiler
 
         private static Stopwatch clock;
 
+        // Modules are only meaningful when following the compiler's internals (verbose/debug output).
+        private static bool showModule;
+
         private LogListener globalLoggerOnGlobalMessageLogged;
 
         private PackageBuilder builder;
@@ -239,6 +242,7 @@ namespace Stride.AssetCompiler
 
                 // Activate proper log level
                 buildEngineLogger.ActivateLog(options.LoggerType);
+                showModule = options.LoggerType <= LogMessageType.Verbose;
 
                 // Output logs to the console with colored messages
                 if (options.SlavePipe == null)
@@ -452,7 +456,7 @@ namespace Stride.AssetCompiler
                         GlobalLogger.GlobalMessageLogged += fileLogListener;
                     }
 
-                    options.Logger.Info("BuildEngine arguments: " + string.Join(" ", args));
+                    options.Logger.Info("BuildEngine arguments: " + string.Join(" ", args.Select(QuoteArgument)));
                     options.Logger.Info("Starting builder.");
                 }
                 else
@@ -575,21 +579,54 @@ namespace Stride.AssetCompiler
             logger.Info($"Reconciled {changedCount} asset(s) with their base out of {graphs.Count}.");
         }
 
+        // Re-quotes what the shell stripped, so the printed line can be pasted back: only the value of
+        // an --option=value argument, the whole argument otherwise.
+        private static string QuoteArgument(string argument)
+        {
+            if (!argument.Contains(' '))
+                return argument;
+
+            var separator = argument.IndexOf('=');
+            if (argument.StartsWith("--", StringComparison.Ordinal) && separator > 2 && argument.AsSpan(0, separator).IndexOf(' ') < 0)
+                return $"{argument[..(separator + 1)]}\"{argument[(separator + 1)..]}\"";
+
+            return $"\"{argument}\"";
+        }
+
         private static string FormatLog(ILogMessage message)
         {
-            //$filename($row,$column): $error_type $error_code: $error_message
-            //C:\Code\Stride\sources\assets\Stride.AssetCompiler\PackageBuilder.cs(89,13,89,70): warning CS1717: Assignment made to same variable; did you mean to assign something else?
+            // Warnings and errors use the canonical MSBuild/VS format, so they are picked up and navigable:
+            //   origin(line,col): category code: text
+            // The origin is only known for asset messages carrying a file. Lower severities are
+            // not parsed by anyone and stay compact: type, elapsed time, text.
             var builder = new StringBuilder();
             var assetLogMessage = message as AssetLogMessage;
-            // Location
-            if (assetLogMessage != null)
-                builder.Append($"{assetLogMessage.File}({assetLogMessage.Line + 1},{assetLogMessage.Character + 1}): ");
-            // Message type
-            builder.Append(message.Type.ToString().ToLowerInvariant()).Append(" ");
-            builder.Append((clock.ElapsedMilliseconds * 0.001).ToString("0.000"));
-            builder.Append("s: ");
-            builder.Append($"[{message.Module ?? "AssetCompiler"}] ");
-            builder.Append(message.Text);
+            var text = message.Text;
+            if (message.Type >= LogMessageType.Warning)
+            {
+                if (!string.IsNullOrEmpty(assetLogMessage?.File))
+                {
+                    builder.Append(assetLogMessage.File);
+                    if (assetLogMessage.Line > 0 || assetLogMessage.Character > 0)
+                        builder.Append($"({assetLogMessage.Line + 1},{assetLogMessage.Character + 1})");
+                    builder.Append(": ");
+                    text = assetLogMessage.TextWithoutLocation;
+                }
+
+                builder.Append(message.Type == LogMessageType.Warning ? "warning" : "error");
+                if (assetLogMessage != null)
+                    builder.Append(' ').Append(assetLogMessage.MessageCode);
+                builder.Append(": ");
+            }
+            else
+            {
+                builder.Append(message.Type.ToString().ToLowerInvariant()).Append(": ");
+                builder.Append((clock.ElapsedMilliseconds * 0.001).ToString("0.000")).Append("s ");
+            }
+
+            if (showModule && message.Module != null)
+                builder.Append('[').Append(message.Module).Append("] ");
+            builder.Append(text);
             var exceptionInfo = message.ExceptionInfo;
             if (exceptionInfo != null)
             {

--- a/sources/assets/Stride.AssetCompiler/build/Stride.AssetCompiler.targets
+++ b/sources/assets/Stride.AssetCompiler/build/Stride.AssetCompiler.targets
@@ -198,6 +198,15 @@
       <StrideCompileAssetCommandProxy Condition="'$(StrideBuildEngineLogVerbose)' != ''">$(StrideCompileAssetCommandProxy) --verbose</StrideCompileAssetCommandProxy>
       <StrideCompileAssetCommandProxy Condition="'$(StrideBuildEngineLogDebug)' != ''">$(StrideCompileAssetCommandProxy) --debug</StrideCompileAssetCommandProxy>
 
+      <!-- Importance of the compiler's console output. By default it is a few summary lines,
+           kept High so a default-verbosity build shows them. In verbose/debug mode it is per-step
+           detail: Normal, so a host relaying MSBuild messages into its own log (Game Studio) files it
+           as Verbose instead of Info. Errors and warnings are recognised from their canonical format
+           either way. -->
+      <_StrideCompileAssetOutputDetailed Condition="'$(StrideBuildEngineLogVerbose)' != '' Or '$(StrideBuildEngineLogDebug)' != ''">true</_StrideCompileAssetOutputDetailed>
+      <_StrideCompileAssetOutputImportance>High</_StrideCompileAssetOutputImportance>
+      <_StrideCompileAssetOutputImportance Condition="'$(_StrideCompileAssetOutputDetailed)' == 'true'">Normal</_StrideCompileAssetOutputImportance>
+
       <!-- Native-crash capture via the runtime's own createdump, armed on the compiler and, by process
            inheritance, its slaves. All platforms: the compiler no longer registers an in-process vectored handler
            (a managed one is unsupported, dotnet/runtime#119142). Scoped to this Exec's environment, so a game (a
@@ -242,7 +251,7 @@
          cancelled). ErrorAndContinue (not true=WarnAndContinue) keeps the compiler's echoed error lines as errors,
          not warnings; the <Error> below re-fails the build. EnvironmentVariables carries the crash-capture env
          (createdump + crash-dir routing), empty only when both are unset. -->
-    <Exec WorkingDirectory="$(TargetDir)" Command="$(StrideCompileAssetCommandProxy)" EnvironmentVariables="$(_StrideCompileAssetCrashEnvVars)" ContinueOnError="ErrorAndContinue">
+    <Exec WorkingDirectory="$(TargetDir)" Command="$(StrideCompileAssetCommandProxy)" EnvironmentVariables="$(_StrideCompileAssetCrashEnvVars)" ContinueOnError="ErrorAndContinue" StandardOutputImportance="$(_StrideCompileAssetOutputImportance)">
       <Output TaskParameter="ExitCode" PropertyName="_StrideCompileAssetExitCode" />
     </Exec>
 
@@ -265,6 +274,10 @@
     <Warning Condition="'$(_StrideCompileAssetExitCode)' != '0' And '$(_StrideCompileAssetExitCode)' != '1' And '$(_StrideCompileAssetExitCode)' != '2' And '$(_StrideCompileAssetExitCode)' != '100' And '@(_StrideNativeCrashDump)' == ''"
              Text="The asset compiler crashed (exit code $(_StrideCompileAssetExitCode)). A crash report was saved; review and submit it with 'stride crash send'." />
     <Error Condition="'$(_StrideCompileAssetExitCode)' != '0'" Text="Asset compilation failed (exit code $(_StrideCompileAssetExitCode))." />
+
+    <!-- With detailed output the compiler's own summary went out at Normal; this one High line
+         stands in for it, the way the SDK reports a project's output. -->
+    <Message Condition="'$(_StrideCompileAssetOutputDetailed)' == 'true'" Importance="High" Text="Assets -> $(StrideCompileAssetOutputPath)" />
   </Target>
 
   <!-- Clean assets -->

--- a/sources/assets/Stride.Core.Assets/Compiler/AssetDependenciesCompiler.cs
+++ b/sources/assets/Stride.Core.Assets/Compiler/AssetDependenciesCompiler.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Stride.Core.Assets.Analysis;
+using Stride.Core.Assets.Diagnostics;
 using Stride.Core.BuildEngine;
 using Stride.Core.Diagnostics;
 
@@ -139,8 +140,10 @@ public class AssetDependenciesCompiler
 
         public override Task<ResultStatus> Execute(IExecuteContext executeContext, BuilderContext builderContext)
         {
+            var assetItem = AssetItem;
+            var assetFullPath = assetItem.FullPath.ToOSPath();
             foreach (var message in messages)
-                executeContext.Logger.Log(message);
+                executeContext.Logger.Log(AssetLogMessage.From(assetItem.Package, assetItem.ToReference(), message, assetFullPath));
             return Task.FromResult(ResultStatus.Failed);
         }
     }

--- a/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
+++ b/sources/assets/Stride.Core.Assets/Diagnostics/AssetLogMessage.cs
@@ -14,6 +14,11 @@ namespace Stride.Core.Assets.Diagnostics;
 public class AssetLogMessage : LogMessage
 {
     /// <summary>
+    /// The <see cref="LogMessage.Module"/> of every asset message.
+    /// </summary>
+    public const string LogModule = "Asset";
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="AssetLogMessage" /> class.
     /// </summary>
     /// <param name="package">The package.</param>
@@ -22,7 +27,7 @@ public class AssetLogMessage : LogMessage
     /// <param name="messageCode">The message code.</param>
     /// <exception cref="ArgumentNullException">asset</exception>
     public AssetLogMessage(Package? package, IReference? assetReference, LogMessageType type, AssetMessageCode messageCode)
-        : base(null, type, AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString())
+        : base(LogModule, type, AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString())
     {
         Package = package;
         AssetReference = assetReference;
@@ -40,7 +45,7 @@ public class AssetLogMessage : LogMessage
     /// <param name="arguments">The arguments.</param>
     /// <exception cref="ArgumentNullException">asset</exception>
     public AssetLogMessage(Package? package, IReference? assetReference, LogMessageType type, AssetMessageCode messageCode, params object?[] arguments)
-        : base(null, type, string.Format(AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString(), arguments))
+        : base(LogModule, type, string.Format(AssetMessageStrings.ResourceManager.GetString(messageCode.ToString()) ?? messageCode.ToString(), arguments))
     {
         Package = package;
         AssetReference = assetReference;
@@ -56,10 +61,11 @@ public class AssetLogMessage : LogMessage
     /// <param name="type">The type.</param>
     /// <exception cref="ArgumentNullException">asset</exception>
     public AssetLogMessage(Package? package, IReference? assetReference, LogMessageType type, string text)
-        : base(null, type, text)
+        : base(LogModule, type, text)
     {
         Package = package;
         AssetReference = assetReference;
+        MessageCode = AssetMessageCode.CompilationMessage;
         Related = [];
     }
 
@@ -95,15 +101,25 @@ public class AssetLogMessage : LogMessage
 
     public int Character { get; set; }
 
+    /// <summary>
+    /// Gets the text prefixed with the asset location, and the position in the asset when known.
+    /// </summary>
     public override string Text
     {
         get
         {
-            if (AssetReference?.Location != null)
-                return $"{AssetReference.Location}({Line + 1},{Character + 1}): {base.Text}";
-            return base.Text;
+            if (AssetReference?.Location == null)
+                return base.Text;
+            return Line > 0 || Character > 0
+                ? $"{AssetReference.Location}({Line + 1},{Character + 1}): {base.Text}"
+                : $"{AssetReference.Location}: {base.Text}";
         }
     }
+
+    /// <summary>
+    /// Gets the text without the location prefix of <see cref="Text"/>, for formatters that print their own origin.
+    /// </summary>
+    public string TextWithoutLocation => base.Text;
 
     /// <summary>
     /// Gets or sets the message code.

--- a/sources/assets/Stride.Core.Assets/VSProjectHelper.cs
+++ b/sources/assets/Stride.Core.Assets/VSProjectHelper.cs
@@ -352,44 +352,51 @@ public static class VSProjectHelper
             eventSource.ErrorRaised += ErrorRaised;
         }
 
+        /// <summary>
+        /// Prefixes the message with the origin MSBuild reported for it, in the canonical
+        /// <c>file(line,column)</c>, <c>file(line)</c> or <c>file</c> form (line 0 means no position).
+        /// </summary>
+        private static string WithLocation(string? file, int line, int column, string message)
+        {
+            if (string.IsNullOrEmpty(file))
+                return message;
+            if (line <= 0)
+                return $"{file}: {message}";
+            return column > 0 ? $"{file}({line},{column}): {message}" : $"{file}({line}): {message}";
+        }
+
+        /// <summary>
+        /// Prefixes a diagnostic with its code, which the message text alone doesn't carry.
+        /// </summary>
+        private static string WithCode(string? code, string message)
+            => string.IsNullOrEmpty(code) ? message : $"{code}: {message}";
+
         void MessageRaised(object sender, BuildMessageEventArgs e)
         {
-            if (logger is LoggerResult loggerResult)
-            {
-                loggerResult.Module = $"{e.File}({e.LineNumber},{e.ColumnNumber})";
-            }
+            var message = WithLocation(e.File, e.LineNumber, e.ColumnNumber, e.Message);
 
             // Redirect task execution messages to verbose output
             switch (e is TaskCommandLineEventArgs ? MessageImportance.Normal : e.Importance)
             {
                 case MessageImportance.High:
-                    logger.Info(e.Message);
+                    logger.Info(message);
                     break;
                 case MessageImportance.Normal:
-                    logger.Verbose(e.Message);
+                    logger.Verbose(message);
                     break;
                 case MessageImportance.Low:
-                    logger.Debug(e.Message);
+                    logger.Debug(message);
                     break;
             }
         }
 
         void WarningRaised(object sender, BuildWarningEventArgs e)
         {
-            if (logger is LoggerResult loggerResult)
-            {
-                loggerResult.Module = string.Format("{0}({1},{2})", e.File, e.LineNumber, e.ColumnNumber);
-            }
-            logger.Warning(e.Message);
+            logger.Warning(WithLocation(e.File, e.LineNumber, e.ColumnNumber, WithCode(e.Code, e.Message)));
         }
 
         void ErrorRaised(object sender, BuildErrorEventArgs e)
         {
-            if (logger is LoggerResult loggerResult)
-            {
-                loggerResult.Module = $"{e.File}({e.LineNumber},{e.ColumnNumber})";
-            }
-
             if (e.Code == "NETSDK1045")
             {
                 var netVersion = Regex.Match(e.Message, @"\.(NET|net) ?(\d+\.\d+)");
@@ -400,7 +407,7 @@ public static class VSProjectHelper
             }
             else
             {
-                logger.Error(e.Message);
+                logger.Error(WithLocation(e.File, e.LineNumber, e.ColumnNumber, WithCode(e.Code, e.Message)));
             }
         }
     }

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/BuildStepLogger.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/BuildStepLogger.cs
@@ -11,10 +11,13 @@ public class BuildStepLogger : Logger
     private readonly ILogger mainLogger;
     public readonly TimestampLocalLogger StepLogger;
 
+    public const string LogModule = "BuildStep";
+
     public BuildStepLogger(BuildStep buildStep, ILogger mainLogger, DateTime startTime)
     {
         this.buildStep = buildStep;
         this.mainLogger = mainLogger;
+        Module = LogModule;
         StepLogger = new TimestampLocalLogger(startTime);
         // Let's receive all level messages, each logger will filter them itself
         ActivateLog(LogMessageType.Debug);

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
@@ -670,27 +670,27 @@ public class Builder : IDisposable
                     {
                         case ResultStatus.Successful:
                             logType = LogMessageType.Verbose;
-                            logText = "BuildStep {0} was successful.".ToFormat(buildStep.ToString());
+                            logText = "{0} was successful.".ToFormat(buildStep.ToString());
                             break;
 
                         case ResultStatus.Failed:
                             logType = LogMessageType.Error;
-                            logText = "BuildStep {0} failed.".ToFormat(buildStep.ToString());
+                            logText = "{0} failed.".ToFormat(buildStep.ToString());
                             break;
 
                         case ResultStatus.NotTriggeredPrerequisiteFailed:
                             logType = LogMessageType.Error;
-                            logText = "BuildStep {0} failed of previous failed prerequisites.".ToFormat(buildStep.ToString());
+                            logText = "{0} failed of previous failed prerequisites.".ToFormat(buildStep.ToString());
                             break;
 
                         case ResultStatus.Cancelled:
                             logType = LogMessageType.Warning;
-                            logText = "BuildStep {0} cancelled.".ToFormat(buildStep.ToString());
+                            logText = "{0} cancelled.".ToFormat(buildStep.ToString());
                             break;
 
                         case ResultStatus.NotTriggeredWasSuccessful:
                             logType = LogMessageType.Verbose;
-                            logText = "BuildStep {0} is up-to-date and has been skipped".ToFormat(buildStep.ToString());
+                            logText = "{0} is up-to-date and has been skipped".ToFormat(buildStep.ToString());
                             break;
 
                         case ResultStatus.NotProcessed:
@@ -698,7 +698,7 @@ public class Builder : IDisposable
                     }
                     if (logText != null)
                     {
-                        var logMessage = new LogMessage(null, logType, logText);
+                        var logMessage = new LogMessage(executeContext.Logger.Module, logType, logText);
                         executeContext.Logger.Log(logMessage);
                     }
 

--- a/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
+++ b/sources/buildengine/Stride.Core.BuildEngine.Common/Builder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 using Stride.Core.Diagnostics;
 using Stride.Core.Extensions;
@@ -228,6 +229,7 @@ public class Builder : IDisposable
         Cancelled = false;
         IsRunning = true;
         DisableCompressionIds.Clear();
+        var runClock = Stopwatch.StartNew();
 
         // Reseting result map
         var inputHashes = FileVersionTracker.GetDefault();
@@ -268,17 +270,21 @@ public class Builder : IDisposable
                 Logger.Error("Build cancelled.");
                 result = BuildResultCode.Cancelled;
             }
-            else if (stepCounter.Get(ResultStatus.Failed) > 0 || stepCounter.Get(ResultStatus.NotTriggeredPrerequisiteFailed) > 0)
-            {
-                Logger.Error($"Build finished in {stepCounter.Total} steps. Command results: {stepCounter.Get(ResultStatus.Successful)} succeeded, {stepCounter.Get(ResultStatus.NotTriggeredWasSuccessful)} up-to-date, {stepCounter.Get(ResultStatus.Failed)} failed, {stepCounter.Get(ResultStatus.NotTriggeredPrerequisiteFailed)} not triggered due to previous failure.");
-                Logger.Error("Build failed.");
-                result = BuildResultCode.BuildError;
-            }
             else
             {
-                Logger.Info($"Build finished in {stepCounter.Total} steps. Command results: {stepCounter.Get(ResultStatus.Successful)} succeeded, {stepCounter.Get(ResultStatus.NotTriggeredWasSuccessful)} up-to-date, {stepCounter.Get(ResultStatus.Failed)} failed, {stepCounter.Get(ResultStatus.NotTriggeredPrerequisiteFailed)} not triggered due to previous failure.");
-                Logger.Info("Build is successful.");
-                result = BuildResultCode.Successful;
+                var summary = $"Build finished in {stepCounter.Total} steps ({runClock.Elapsed.TotalSeconds:0.0}s). Command results: {stepCounter.Get(ResultStatus.Successful)} succeeded, {stepCounter.Get(ResultStatus.NotTriggeredWasSuccessful)} up-to-date, {stepCounter.Get(ResultStatus.Failed)} failed, {stepCounter.Get(ResultStatus.NotTriggeredPrerequisiteFailed)} not triggered due to previous failure.";
+                if (stepCounter.Get(ResultStatus.Failed) > 0 || stepCounter.Get(ResultStatus.NotTriggeredPrerequisiteFailed) > 0)
+                {
+                    Logger.Error(summary);
+                    Logger.Error("Build failed.");
+                    result = BuildResultCode.BuildError;
+                }
+                else
+                {
+                    Logger.Info(summary);
+                    Logger.Info("Build is successful.");
+                    result = BuildResultCode.Successful;
+                }
             }
         }
         else

--- a/sources/core/Stride.Core.Design.Tests/TestSettings.cs
+++ b/sources/core/Stride.Core.Design.Tests/TestSettings.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 
 using Xunit;
+using Stride.Core.Diagnostics;
 using Stride.Core.Settings;
 
 namespace Stride.Core.Design.Tests;
@@ -162,6 +163,29 @@ public class TestSettings
             Test/Simple/IntValue: 45
             Test/Simple/StringValue: 07/25/2004 18:18:00
         """;
+
+    [Fact]
+    public async Task TestSettingsDictionarySaveAndLoad()
+    {
+        // A map with enum values, defaulted from a callback so the default instance is never shared.
+        var key = new SettingsKey<Dictionary<string, LogMessageType>>("Test/Dictionaries/ModuleLevels", SettingsContainer,
+            () => new Dictionary<string, LogMessageType> { ["Default"] = LogMessageType.Info });
+        Assert.Equal(LogMessageType.Info, key.GetValue()["Default"]);
+
+        key.SetValue(new Dictionary<string, LogMessageType> { ["Graphics"] = LogMessageType.Debug, ["Build"] = LogMessageType.Warning });
+        SettingsContainer.SaveSettingsProfile(SettingsContainer.CurrentProfile, TempPath("TestSettingsDictionary.txt"));
+        var text = await File.ReadAllTextAsync(TempPath("TestSettingsDictionary.txt"));
+        Assert.Contains("Graphics: Debug", text);
+
+        SettingsContainer.ClearSettings();
+        SettingsContainer.LoadSettingsProfile(TempPath("TestSettingsDictionary.txt"), true);
+        key = new SettingsKey<Dictionary<string, LogMessageType>>("Test/Dictionaries/ModuleLevels", SettingsContainer,
+            () => new Dictionary<string, LogMessageType> { ["Default"] = LogMessageType.Info });
+        var levels = key.GetValue();
+        Assert.Equal(2, levels.Count);
+        Assert.Equal(LogMessageType.Debug, levels["Graphics"]);
+        Assert.Equal(LogMessageType.Warning, levels["Build"]);
+    }
 
     [Fact]
     public async Task TestSettingsLoad()

--- a/sources/core/Stride.Core.Tests/TestLogger.cs
+++ b/sources/core/Stride.Core.Tests/TestLogger.cs
@@ -93,6 +93,34 @@ public class TestLogger
     }
 
     [Fact]
+    public void TestGlobalLoggerModuleLevel()
+    {
+        var messages = new List<ILogMessage>();
+        GlobalLogger.GlobalMessageLogged += messages.Add;
+        try
+        {
+            // A configured level applies to a logger created later, over the level GetLogger asks for.
+            GlobalLogger.SetModuleLevel("ModuleLevelLater", LogMessageType.Debug);
+            var later = GlobalLogger.GetLogger("ModuleLevelLater", LogMessageType.Warning);
+            later.Debug("#0");
+            Assert.Single(messages);
+
+            // And to a logger that already exists.
+            var existing = GlobalLogger.GetLogger("ModuleLevelExisting", LogMessageType.Warning);
+            existing.Info("#1");
+            Assert.Single(messages);
+            GlobalLogger.SetModuleLevel("ModuleLevelExisting", LogMessageType.Info);
+            existing.Info("#2");
+            Assert.Equal(2, messages.Count);
+            Assert.Equal("#2", messages[1].Text);
+        }
+        finally
+        {
+            GlobalLogger.GlobalMessageLogged -= messages.Add;
+        }
+    }
+
+    [Fact]
     public void TestCallerInfo()
     {
         var log = new LoggerResult();

--- a/sources/core/Stride.Core/Diagnostics/ConsoleLogListener.cs
+++ b/sources/core/Stride.Core/Diagnostics/ConsoleLogListener.cs
@@ -176,7 +176,12 @@ public partial class ConsoleLogListener : LogListener
             FreeConsole();
             AllocConsole();
 
-            var outputStream = Console.OpenStandardOutput();
+            // The standard output handle keeps pointing at the redirection target, so open the new console directly.
+            var consoleHandle = CreateFile("CONOUT$", GENERIC_WRITE, FILE_SHARE_WRITE, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (consoleHandle.IsInvalid)
+                return;
+
+            Stream outputStream = new FileStream(consoleHandle, FileAccess.Write);
             if (originalStream != null)
             {
                 outputStream = new DualStream(originalStream, outputStream);
@@ -255,6 +260,12 @@ public partial class ConsoleLogListener : LogListener
     }
 
     private const int StdOutConsoleHandle = -11;
+    private const uint GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_WRITE = 0x00000002;
+    private const uint OPEN_EXISTING = 3;
+
+    [LibraryImport("kernel32.dll", EntryPoint = "CreateFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial SafeFileHandle CreateFile(string fileName, uint desiredAccess, uint shareMode, IntPtr securityAttributes, uint creationDisposition, uint flagsAndAttributes, IntPtr templateFile);
 
 #if NET7_0_OR_GREATER
     [LibraryImport("kernel32", SetLastError = true)]

--- a/sources/core/Stride.Core/Diagnostics/ConsoleLogListener.cs
+++ b/sources/core/Stride.Core/Diagnostics/ConsoleLogListener.cs
@@ -18,29 +18,40 @@ namespace Stride.Core.Diagnostics;
 public partial class ConsoleLogListener : LogListener
 {
     /// <summary>
-    /// Gets or sets the minimum log level handled by this listener.
-    /// </summary>
-    /// <value>The minimum log level.</value>
-    public LogMessageType LogLevel { get; set; }
-
-    /// <summary>
     /// Gets or sets the log mode.
     /// </summary>
     /// <value>The log mode.</value>
     public ConsoleLogMode LogMode { get; set; }
 
+    /// <inheritdoc/>
+    protected override bool IsEnabled(ILogMessage logMessage)
+    {
+        // The level applies wherever the message ends up.
+        if (!base.IsEnabled(logMessage))
+            return false;
+
+        // An attached debugger receives every message, whether or not a console would open for it.
+        if (Debugger.IsAttached)
+            return true;
+
+        return LogMode switch
+        {
+            ConsoleLogMode.None => false,
+            ConsoleLogMode.Always => true,
+            _ => Platform.IsRunningDebugAssembly, // Auto: debug builds only, so a shipped game never shows a console
+        };
+    }
+
+    /// <summary>
+    /// Whether this listener opens a console window for its output. <see cref="ConsoleLogMode.Always"/> does
+    /// unconditionally; otherwise not while a debugger already shows the messages.
+    /// </summary>
+    private bool OpensConsole => LogMode == ConsoleLogMode.Always || !Debugger.IsAttached;
+
     protected override void OnLog(ILogMessage logMessage)
     {
-        // filter logs with lower level
-        if (!Debugger.IsAttached && // Always log when debugger is attached
-            (logMessage.Type < LogLevel || LogMode == ConsoleLogMode.None
-            || (!(LogMode == ConsoleLogMode.Auto && Platform.IsRunningDebugAssembly) && LogMode != ConsoleLogMode.Always)))
-        {
-            return;
-        }
-
-        // Make sure the console is opened when the debugger is not attached
-        EnsureConsole();
+        if (OpensConsole)
+            EnsureConsole();
 
 #if STRIDE_PLATFORM_ANDROID
         const string appliName = "Stride";

--- a/sources/core/Stride.Core/Diagnostics/DebugLogListener.cs
+++ b/sources/core/Stride.Core/Diagnostics/DebugLogListener.cs
@@ -10,19 +10,19 @@ namespace Stride.Core.Diagnostics;
 /// </summary>
 public class DebugLogListener : LogListener
 {
-    /// <summary>
-    /// Minimum severity captured; messages below this level are dropped. Defaults to
-    /// <see cref="LogMessageType.Verbose"/> so the listener catches everything unless the host
-    /// raises the threshold (e.g. <see cref="LogMessageType.Warning"/> in a hot path where
-    /// Info/Verbose chatter would slow the debugger).
-    /// </summary>
-    public LogMessageType MinimumLevel { get; set; } = LogMessageType.Verbose;
+    /// <inheritdoc/>
+    protected override bool IsEnabled(ILogMessage logMessage)
+    {
+#if DEBUG
+        return base.IsEnabled(logMessage);
+#else
+        // Debug.WriteLine is compiled out in this build, so nothing can consume the message.
+        return false;
+#endif
+    }
 
     protected override void OnLog(ILogMessage logMessage)
     {
-        if (logMessage.Type < MinimumLevel)
-            return;
-
         Debug.WriteLine(GetDefaultText(logMessage));
         var exceptionMsg = GetExceptionText(logMessage);
         if (!string.IsNullOrEmpty(exceptionMsg))

--- a/sources/core/Stride.Core/Diagnostics/GlobalLogger.cs
+++ b/sources/core/Stride.Core/Diagnostics/GlobalLogger.cs
@@ -17,6 +17,11 @@ public sealed class GlobalLogger : Logger
     /// </summary>
     private static readonly Dictionary<string, Logger> MapModuleNameToLogger = [];
 
+    /// <summary>
+    /// Minimum levels configured per module, applied to the module's logger whenever it is created.
+    /// </summary>
+    private static readonly Dictionary<string, LogMessageType> ModuleMinimumLevels = [];
+
     #endregion
 
     private GlobalLogger(string module)
@@ -117,6 +122,25 @@ public sealed class GlobalLogger : Logger
     }
 
     /// <summary>
+    /// Sets the minimum level of a module's logger, whether it already exists or is created later.
+    /// Unlike <see cref="ActivateLog(Action{Logger})"/>, this is remembered for loggers not yet created.
+    /// </summary>
+    /// <param name="module">The module name.</param>
+    /// <param name="minimumLevel">The minimum level.</param>
+    /// <exception cref="ArgumentNullException">If module name is null</exception>
+    public static void SetModuleLevel(string module, LogMessageType minimumLevel)
+    {
+        ArgumentNullException.ThrowIfNull(module);
+
+        lock (MapModuleNameToLogger)
+        {
+            ModuleMinimumLevels[module] = minimumLevel;
+            if (MapModuleNameToLogger.TryGetValue(module, out var logger))
+                logger.ActivateLog(minimumLevel);
+        }
+    }
+
+    /// <summary>
     /// Gets the <see cref="GlobalLogger"/> associated to the specified module.
     /// </summary>
     /// <param name="module">The module name.</param>
@@ -131,7 +155,7 @@ public sealed class GlobalLogger : Logger
     /// Gets the <see cref="GlobalLogger"/> associated to the specified module.
     /// </summary>
     /// <param name="module">The module name.</param>
-    /// <param name="minimumLevel">Minimum log level (only applied if new logger instance is created)</param>
+    /// <param name="minimumLevel">Minimum log level (only applied if new logger instance is created, and unless <see cref="SetModuleLevel"/> configured one)</param>
     /// <exception cref="ArgumentNullException">If module name is null</exception>
     /// <returns>An instance of a <see cref="Logger"/></returns>
     public static Logger GetLogger(string module, LogMessageType minimumLevel)
@@ -148,7 +172,7 @@ public sealed class GlobalLogger : Logger
             if (!MapModuleNameToLogger.TryGetValue(module, out logger))
             {
                 logger = new GlobalLogger(module);
-                logger.ActivateLog(minimumLevel);
+                logger.ActivateLog(ModuleMinimumLevels.TryGetValue(module, out var configuredLevel) ? configuredLevel : minimumLevel);
                 MapModuleNameToLogger.Add(module, logger);
             }
         }

--- a/sources/core/Stride.Core/Diagnostics/LogListener.cs
+++ b/sources/core/Stride.Core/Diagnostics/LogListener.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Concurrent;
+
 namespace Stride.Core.Diagnostics;
 
 /// <summary>
@@ -37,6 +39,19 @@ public abstract class LogListener : IDisposable
     public Func<ILogMessage, string?> TextFormatter { get; set; }
 
     /// <summary>
+    /// Gets or sets the minimum severity this listener handles; messages below it are dropped.
+    /// Defaults to <see cref="LogMessageType.Debug"/>, which lets everything through.
+    /// </summary>
+    public LogMessageType MinimumLevel { get; set; } = LogMessageType.Debug;
+
+    /// <summary>
+    /// Gets the per-module overrides of <see cref="MinimumLevel"/>, keyed by <see cref="ILogMessage.Module"/>.
+    /// A listener can stay quiet overall while still following a few modules in detail. Safe to
+    /// update while the listener is attached.
+    /// </summary>
+    public ConcurrentDictionary<string, LogMessageType> ModuleLevels { get; } = new();
+
+    /// <summary>
     /// Gets or sets the log count flush limit. Default is on every message.
     /// </summary>
     /// <value>The log count flush limit.</value>
@@ -59,6 +74,22 @@ public abstract class LogListener : IDisposable
     /// </summary>
     /// <param name="logMessage">The log message.</param>
     protected abstract void OnLog(ILogMessage logMessage);
+
+    /// <summary>
+    /// Returns whether a message passes this listener's filter, and so should reach <see cref="OnLog"/>.
+    /// The default compares its severity against <see cref="ModuleLevels"/>, falling back to
+    /// <see cref="MinimumLevel"/>. Override to add conditions of your own.
+    /// </summary>
+    /// <param name="logMessage">The log message.</param>
+    protected virtual bool IsEnabled(ILogMessage logMessage)
+    {
+        var module = logMessage.Module;
+        var minimumLevel = !ModuleLevels.IsEmpty && module is not null && ModuleLevels.TryGetValue(module, out var moduleLevel)
+            ? moduleLevel
+            : MinimumLevel;
+
+        return logMessage.Type >= minimumLevel;
+    }
 
     /// <summary>
     /// Returns a boolean indicating whether the log should be flushed. By default, flushing is occurring if the message has a higher level than <see cref="LogMessageType.Info"/>
@@ -125,6 +156,9 @@ public abstract class LogListener : IDisposable
 
     private void OnLogInternal(ILogMessage logMessage)
     {
+        if (!IsEnabled(logMessage))
+            return;
+
         OnLog(logMessage);
         LogMessageCount++;
         if (ShouldFlush(logMessage))

--- a/sources/editor/Stride.Core.Assets.Editor/Services/EditorDebugTools.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Services/EditorDebugTools.cs
@@ -46,12 +46,14 @@ namespace Stride.Core.Assets.Editor.Services
             }
         }
 
+        /// <summary>
+        /// Shows a logger in a debug page. The page shows what the logger lets through: a global logger's level
+        /// comes from the <c>Logging/SourceModuleLevels</c> editor setting.
+        /// </summary>
         public static IDebugPage CreateLogDebugPage(Logger logger, string title, bool register = true)
         {
             var dispatcher = SessionViewModel.Instance.ServiceProvider.Get<IDispatcherService>();
             dispatcher.EnsureAccess();
-            // Activate all log levels
-            logger.ActivateLog(LogMessageType.Debug);
             var loggerViewModel = new LoggerViewModel(SessionViewModel.Instance.ServiceProvider, logger);
             var page = new DebugLogUserControl(loggerViewModel) { Title = title };
             if (register)

--- a/sources/editor/Stride.Core.Assets.Editor/Settings/EditorSettings.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/Settings/EditorSettings.cs
@@ -6,7 +6,9 @@ using System.IO;
 using System.Linq;
 using Stride.Core.Annotations;
 using Stride.Core.CodeEditorSupport;
+using Stride.Core.Diagnostics;
 using Stride.Core.IO;
+using Stride.Core.Presentation.Quantum.ViewModels;
 using Stride.Core.Settings;
 using Stride.Core.Translation;
 
@@ -26,6 +28,7 @@ namespace Stride.Core.Assets.Editor.Settings
         public static readonly string Environment = Tr._p("Settings", "Environment");
         public static readonly string ExternalTools = Tr._p("Settings", "External tools");
         public static readonly string Interface = Tr._p("Settings", "Interface");
+        public static readonly string Logging = Tr._p("Settings", "Logging");
         public static readonly string Tools = Tr._p("Settings", "Tools");
 
         static EditorSettings()
@@ -95,6 +98,44 @@ namespace Stride.Core.Assets.Editor.Settings
                     ? new List<string> { GraphicsApiDefault, "Direct3D11", "Direct3D12", "Vulkan" }
                     : new List<string> { GraphicsApiDefault, "Vulkan" },
             };
+            DebugOutputLevel = new SettingsKey<LogMessageType>("Logging/DebugOutputLevel", SettingsContainer, LogMessageType.Warning)
+            {
+                DisplayName = $"{Logging}/{Tr._p("Settings", "Debugger output level (Game Studio only)")}",
+                Description = Tr._p("Settings", "Minimum level of the messages Game Studio writes to the attached debugger's output"),
+            };
+            // The module maps are edited in the settings file only: a display name without a category keeps them out of the dialog.
+            DebugOutputModuleLevels = new SettingsKey<Dictionary<string, LogMessageType>>("Logging/DebugOutputModuleLevels", SettingsContainer, () => new Dictionary<string, LogMessageType>
+            {
+                // The graphics device and its validation layer (GraphicsDevice.DebugLogModule): quiet without a debug device.
+                ["GraphicsDevice"] = LogMessageType.Debug,
+                ["GraphicsDebug"] = LogMessageType.Debug,
+            })
+            {
+                DisplayName = "DebugOutputModuleLevels",
+            };
+            SourceModuleLevels = new SettingsKey<Dictionary<string, LogMessageType>>("Logging/SourceModuleLevels", SettingsContainer, () => new Dictionary<string, LogMessageType>
+            {
+                // The global loggers shown in the debug pages need their full history.
+                ["AssetBuilderService"] = LogMessageType.Debug,
+                ["EffectCompilerCache"] = LogMessageType.Debug,
+                ["Preview"] = LogMessageType.Debug,
+                [GraphViewModel.DefaultLoggerName] = LogMessageType.Debug,
+            })
+            {
+                DisplayName = "SourceModuleLevels",
+            };
+        }
+
+        /// <summary>
+        /// Merges the configured entries of a module-level key over its defaults, so an entry in the settings file
+        /// overrides one module without having to repeat the others.
+        /// </summary>
+        public static Dictionary<string, LogMessageType> GetModuleLevels(SettingsKey<Dictionary<string, LogMessageType>> key)
+        {
+            var levels = key.DefaultValue;
+            foreach (var (module, level) in key.GetValue() ?? [])
+                levels[module] = level;
+            return levels;
         }
 
         public static SettingsKey<UFile> DefaultTextEditor { get; }
@@ -127,6 +168,28 @@ namespace Stride.Core.Assets.Editor.Settings
         // Graphics API Game Studio itself loads; applied at startup by GraphicsApiSelector, so it needs a restart.
         public static SettingsKey<string> GraphicsApi { get; }
 
+        // The Logging keys are read once at Game Studio startup, so they need a restart.
+
+        /// <summary>
+        /// Minimum level of the messages Game Studio writes to the attached debugger's output (Debug builds only).
+        /// </summary>
+        public static SettingsKey<LogMessageType> DebugOutputLevel { get; }
+
+        /// <summary>
+        /// Per-module overrides of <see cref="DebugOutputLevel"/>, keyed by log module: a module can be followed in
+        /// detail while the rest stays at the general level. Entries merge over the defaults (see <see cref="GetModuleLevels"/>);
+        /// edited in the settings file only.
+        /// </summary>
+        public static SettingsKey<Dictionary<string, LogMessageType>> DebugOutputModuleLevels { get; }
+
+        /// <summary>
+        /// Minimum level at which the global loggers themselves emit, keyed by log module; below it a message is never
+        /// created, whatever listens. Defaults cover the loggers shown in the debug window (Help > Show debug window), so
+        /// its pages get their full history. Entries merge over the defaults (see <see cref="GetModuleLevels"/>); edited in
+        /// the settings file only.
+        /// </summary>
+        public static SettingsKey<Dictionary<string, LogMessageType>> SourceModuleLevels { get; }
+
         public static bool NeedRestart { get; set; }
 
         public static void Initialize()
@@ -138,6 +201,7 @@ namespace Stride.Core.Assets.Editor.Settings
             UseEffectCompilerServer.ChangesValidated += (s, e) => NeedRestart = true;
             Language.ChangesValidated += (s, e) => NeedRestart = true;
             GraphicsApi.ChangesValidated += (s, e) => NeedRestart = true;
+            DebugOutputLevel.ChangesValidated += (s, e) => NeedRestart = true;
 
             Presentation.Themes.ThemesSettings.ThemeName.ChangesValidated += (s, e) => NeedRestart = true;
         }

--- a/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
+++ b/sources/editor/Stride.Core.Assets.Editor/ViewModel/SessionViewModel.cs
@@ -581,9 +581,7 @@ namespace Stride.Core.Assets.Editor.ViewModel
             AssetViewProperties = new SessionObjectPropertiesViewModel(this);
 
             assetNodesDebugPage = EditorDebugTools.CreateAssetNodesDebugPage(this, "Asset nodes visualizer");
-            var quantumLogger = GlobalLogger.GetLogger(GraphViewModel.DefaultLoggerName);
-            quantumLogger.ActivateLog(LogMessageType.Debug);
-            quantumDebugPage = EditorDebugTools.CreateLogDebugPage(quantumLogger, "Quantum log");
+            quantumDebugPage = EditorDebugTools.CreateLogDebugPage(GlobalLogger.GetLogger(GraphViewModel.DefaultLoggerName), "Quantum log");
             ActiveProperties = AssetViewProperties;
 
             // Initialize the asset collection view model of the main asset view

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -147,6 +147,9 @@ public static class Program
             EditorSettings.GraphicsApi.SetValue(EditorSettings.GraphicsApiDefault);
             EditorSettings.Save();
         }
+        // Source levels of the global loggers, before anything creates them.
+        foreach (var (module, level) in EditorSettings.GetModuleLevels(EditorSettings.SourceModuleLevels))
+            GlobalLogger.SetModuleLevel(module, level);
         Thread.CurrentThread.Name = "Main thread";
 
         try
@@ -209,20 +212,12 @@ public static class Program
 
             //listen to logger for crash report
             GlobalLogger.GlobalMessageLogged += GlobalLoggerOnGlobalMessageLogged;
-            // Route GlobalLogger output to VS Debug pane (no-op in Release).
-            // Warning+ only — Info/Verbose volume slows the debugger noticeably during
-            // asset compile / NuGet restore.
-            // The graphics modules pass in full: that is where the backends report validation layer
-            // status and messages, and they are quiet without a debug device.
-            var debugPaneListener = new DebugLogListener
-            {
-                MinimumLevel = LogMessageType.Warning,
-                ModuleLevels =
-                {
-                    [GraphicsDevice.DebugLogModule] = LogMessageType.Debug,
-                    [nameof(GraphicsDevice)] = LogMessageType.Debug,
-                },
-            };
+            // Route GlobalLogger output to the debugger's output pane (no-op in Release), as configured
+            // by the Logging editor settings: Warning+ by default, since Info/Verbose volume slows the
+            // debugger noticeably, with the graphics modules in full for validation layer messages.
+            var debugPaneListener = new DebugLogListener { MinimumLevel = EditorSettings.DebugOutputLevel.GetValue() };
+            foreach (var (module, level) in EditorSettings.GetModuleLevels(EditorSettings.DebugOutputModuleLevels))
+                debugPaneListener.ModuleLevels[module] = level;
             GlobalLogger.GlobalMessageLogged += debugPaneListener;
 
             mainDispatcher = Dispatcher.CurrentDispatcher;

--- a/sources/editor/Stride.GameStudio/Program.cs
+++ b/sources/editor/Stride.GameStudio/Program.cs
@@ -212,7 +212,18 @@ public static class Program
             // Route GlobalLogger output to VS Debug pane (no-op in Release).
             // Warning+ only — Info/Verbose volume slows the debugger noticeably during
             // asset compile / NuGet restore.
-            GlobalLogger.GlobalMessageLogged += new DebugLogListener { MinimumLevel = LogMessageType.Warning };
+            // The graphics modules pass in full: that is where the backends report validation layer
+            // status and messages, and they are quiet without a debug device.
+            var debugPaneListener = new DebugLogListener
+            {
+                MinimumLevel = LogMessageType.Warning,
+                ModuleLevels =
+                {
+                    [GraphicsDevice.DebugLogModule] = LogMessageType.Debug,
+                    [nameof(GraphicsDevice)] = LogMessageType.Debug,
+                },
+            };
+            GlobalLogger.GlobalMessageLogged += debugPaneListener;
 
             mainDispatcher = Dispatcher.CurrentDispatcher;
             mainDispatcher.InvokeAsync(() =>

--- a/sources/engine/Stride.Engine/Engine/Game.cs
+++ b/sources/engine/Stride.Engine/Engine/Game.cs
@@ -168,14 +168,14 @@ namespace Stride.Engine
             get
             {
                 var consoleLogListener = logListener as ConsoleLogListener;
-                return consoleLogListener != null ? consoleLogListener.LogLevel : default(LogMessageType);
+                return consoleLogListener != null ? consoleLogListener.MinimumLevel : default(LogMessageType);
             }
             set
             {
                 var consoleLogListener = logListener as ConsoleLogListener;
                 if (consoleLogListener != null)
                 {
-                    consoleLogListener.LogLevel = value;
+                    consoleLogListener.MinimumLevel = value;
                 }
             }
         }

--- a/sources/engine/Stride.Graphics/GraphicsDevice.DebugScope.cs
+++ b/sources/engine/Stride.Graphics/GraphicsDevice.DebugScope.cs
@@ -20,7 +20,11 @@ namespace Stride.Graphics;
 /// </summary>
 public partial class GraphicsDevice
 {
-    internal const string DebugLogModule = "GraphicsDebug";
+    /// <summary>
+    ///   Log module of the backend validation/debug-layer messages (see <see cref="DebugLog"/>).
+    ///   General device messages use <c>nameof(GraphicsDevice)</c>.
+    /// </summary>
+    public const string DebugLogModule = "GraphicsDebug";
     internal static readonly Logger DebugLog = GlobalLogger.GetLogger(DebugLogModule);
 
     // Active scope stack (Tier 1: always on, including release — used for log annotation).

--- a/tests/editor/baselines/dpi100/NewGameEditor/build-log-after-run.png
+++ b/tests/editor/baselines/dpi100/NewGameEditor/build-log-after-run.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb2236d7dfe3e1a31e922203da14ecb6951cc9f1763d9abb3f006e1a628afede
-size 177434
+oid sha256:629592b07160ae98acaabae23fe2ac97afd03c7b204a2053c62e87ef33674a59
+size 31801


### PR DESCRIPTION
# PR Details

Started while chasing a Vulkan crash: getting the graphics validation log (gamestudio with arg `/DebugEditorGraphics`) into the VS Output pane meant fixing several loose ends in the logging stack.

### What changes

- **`LogListener` gets a `MinimumLevel` and per-module `ModuleLevels`.** The three copies of a level property (`ConsoleLogListener.LogLevel`, `DebugLogListener.MinimumLevel`, the asset compiler redirect) fold into it. `ConsoleLogMode` now only decides whether a console window opens; an attached debugger no longer bypasses the level.
- **`ConsoleLogListener` double output fixed.** With stdout redirected to a file and no parent console, every line was written twice. The allocated console is now opened through `CONOUT$`.
- **Build engine messages carry a `BuildStep` module** instead of the word in the text.
- **Game Studio build log relay keeps MSBuild's severity, location and code.** Errors and warnings show as `file(line,col): CODE: text`; the location no longer lands in the module field. The asset compiler `Exec` runs at Normal importance only when verbose output was requested, so the pane's Verbose toggle works. Plain `dotnet build` output is unchanged.
- **Asset compiler console uses the canonical format** for warnings and errors: `asset.sdxxx: error Code: text`, navigable from VS and picked up by MSBuild. The elapsed time leaves the code slot, the module is printed only with `--verbose`/`--debug`, the summary line shows the total time, and asset messages carry an `Asset` module.
- **Logging configured from editor settings.** `Logging/DebugOutputLevel` (Settings dialog, default Warning) and two module maps edited in `GameStudioSettings.conf`: `Logging/DebugOutputModuleLevels` for the debugger output pane and `Logging/SourceModuleLevels` for the global loggers' own level. Entries merge over the defaults. The debug pages no longer force their logger to Debug; `GlobalLogger.SetModuleLevel` applies a level to loggers created later. For example, to see Info from everything in the VS Output pane and follow the build engine step by step:

  ```yaml
  Logging/DebugOutputLevel: Info
  Logging/DebugOutputModuleLevels:
      BuildStep: Debug
  ```

- **New doc, `docs/debugging/logging.md`:** the two filters, the Game Studio keys with examples, the asset compiler output format, and the game console listener.

### Behaviour changes to note

- Under a debugger, `ConsoleLogListener` now respects its level, and `Auto` mode no longer opens a console window.
- Filtered messages no longer count towards `LogMessageCount` or trigger `Flush`.
- Game Studio's build pane shows asset compiler detail as Verbose (hidden by default) instead of Info.

### Verified

- `dotnet build` with a broken asset: red, clickable error with the asset file as origin.
- Game Studio build pane, Settings dialog (combo box, sparse save), console output in default, verbose and file-redirected runs.
- New tests: `GlobalLogger.SetModuleLevel`, dictionary settings key round-trip.
