### PR TITLE
fix: priority queue losing order on item removal or reversed inserting

### DIFF
--- a/sources/core/Stride.Core.Tests/TestPriorityQueue.cs
+++ b/sources/core/Stride.Core.Tests/TestPriorityQueue.cs
@@ -85,4 +85,28 @@ public class TestPriorityQueue
             lastItem = value;
         }
     }
+
+    [Fact]
+    public void TestRemovalSingleItem()
+    {
+        var queue = new PriorityQueue<int>();
+        foreach (var value in new[] { 0, 1, 4, 2, 5, 6, 7, 3 })
+            queue.Enqueue(value);
+
+        queue.Remove(5);
+
+        CheckPriorityQueue(queue);
+    }
+
+    [Fact]
+    public void TestRemovalSingleItemAtTheEnd()
+    {
+        var queue = new PriorityQueue<int>();
+        foreach (var value in new[] { 0, 1, 4, 2, 5, 6, 7, 3 })
+            queue.Enqueue(value);
+
+        queue.Remove(7);
+
+        CheckPriorityQueue(queue);
+    }
 }

--- a/sources/core/Stride.Core/Collections/PriorityQueue.cs
+++ b/sources/core/Stride.Core/Collections/PriorityQueue.cs
@@ -52,7 +52,7 @@ public class PriorityQueue<T>
         var parentIndex = index;
         while (true)
         {
-            var childIndex = parentIndex * 2;
+            var childIndex = (parentIndex * 2) + 1;
 
             // Check if there is any child, otherwise we're done
             if (childIndex >= maxCount)
@@ -87,7 +87,7 @@ public class PriorityQueue<T>
         // Bubble elements so that order is respected again
         while (childIndex != 0)
         {
-            var parentIndex = childIndex / 2;
+            var parentIndex = (childIndex - 1) / 2;
 
             // Should we swap with parent?
             if (comparer.Compare(items[childIndex], items[parentIndex]) >= 0)
@@ -133,7 +133,7 @@ public class PriorityQueue<T>
         while (true)
         {
             // Check if there is any child, otherwise we're done
-            var childIndex = parentIndex * 2;
+            var childIndex = (parentIndex * 2) + 1;
             if (childIndex >= maxCount)
                 break;
 


### PR DESCRIPTION
# PR Details

PriorityQueue loses order on Remove/Reverse Inserting

## Related Issue

fix #3398

## Types of changes

internal bug fix

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

i was able to run around 4445 tests but it was stuck on bepu so few are missing, but the list queue tests pass now, also the old ones