### PR TITLE
[Engineering] fix: profiler result page never clamped below 1

### DIFF
--- a/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
+++ b/sources/engine/Stride.Engine/Profiling/GameProfilingSystem.cs
@@ -149,7 +149,7 @@ namespace Stride.Profiling
             var availableDisplayHeight = viewportHeight - 2 * TextRowHeight - 3 * TopRowHeight;
             var elementsPerPage = (int)Math.Floor(availableDisplayHeight / TextRowHeight);
             numberOfPages = (uint)Math.Ceiling(profilingResults.Count / (float)elementsPerPage);
-            CurrentResultPage = Math.Min(CurrentResultPage, numberOfPages);
+            CurrentResultPage = Math.Max(1, Math.Min(CurrentResultPage, numberOfPages));
 
             char sortByTimeIndicator = SortingMode == GameProfilingSorting.ByTime ? 'v' : ' ';
             char sortByAvgTimeIndicator = SortingMode == GameProfilingSorting.ByAverageTime ? 'v' : ' ';


### PR DESCRIPTION
# PR Details

Split out of #3388 as requested in review.

`GameProfilingSystem` clamps `CurrentResultPage` against the page count. On the first frames after profiling is enabled there are no results yet, so the page count is 0 and the page is clamped to 0, where it stays: once results arrive the profiler shows "PAGE 0 OF N" over an empty list. The clamp now never goes below page 1.

Verified with the in-game profiler (F2 / P in the VoxelGI demo): the first page shows its results right after enabling.

## Related Issue

None filed; small enough to be its own fix.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

---
<sub>⚠️ Written with AI assistance (Claude Code), driven and verified by me; needs a real review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
