### PR TITLE
Fix new projects whose name contains spaces (#3356)

### DIFF
--- a/sources/engine/Stride.Assets/Templates/DotNetNewTemplateGenerator.cs
+++ b/sources/engine/Stride.Assets/Templates/DotNetNewTemplateGenerator.cs
@@ -104,7 +104,9 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
 
     public override bool Generate(SessionTemplateGeneratorParameters parameters)
     {
-        var sdpkg = InstantiateFiles(parameters);
+        // The session saves its own solution at Session.SolutionPath, named from the New Project
+        // dialog, so the template's solution (named after the project) is not wanted here.
+        var sdpkg = InstantiateFiles(parameters, skipSolution: true);
         if (sdpkg == null)
             return false;
         InstantiateAssetPacks(parameters, sdpkg);
@@ -176,8 +178,9 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
     /// <summary>
     /// Phase 1 — invokes the dotnet new bootstrapper. Writes the project tree under
     /// <see cref="TemplateGeneratorParameters.OutputDirectory"/> and returns the generated .sdpkg path.
+    /// <paramref name="skipSolution"/> asks the template not to emit its solution file.
     /// </summary>
-    protected virtual string? InstantiateFiles(SessionTemplateGeneratorParameters parameters)
+    protected virtual string? InstantiateFiles(SessionTemplateGeneratorParameters parameters, bool skipSolution = false)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         parameters.Validate();
@@ -198,7 +201,9 @@ public class DotNetNewTemplateGenerator : SessionTemplateGenerator
             return null;
         }
 
-        var values = parameters.TryGetTag(ParameterValuesKey) ?? new Dictionary<string, string>();
+        var values = new Dictionary<string, string>(parameters.TryGetTag(ParameterValuesKey) ?? new Dictionary<string, string>());
+        if (skipSolution)
+            values["skipSolution"] = "true";
 
         // The dotnet new sourceName substitution is fed by the project name; this is the same
         // value the user typed in GameStudio's New-Project name field.

--- a/sources/tools/Stride.TemplateGenerator/TemplatePreprocessor.cs
+++ b/sources/tools/Stride.TemplateGenerator/TemplatePreprocessor.cs
@@ -1271,8 +1271,10 @@ internal class TemplatePreprocessor
         // JumpyClone.Windows/ + JumpyClone.Linux/ — the .Game suffix on the shared lib is
         // preserved to mirror what samples already use.
         sb.AppendLine("  \"sourceName\": \"MyTemplate\",");
+        EmitCompactNameForm(sb);
         sb.AppendLine("  \"symbols\": {");
 
+        EmitCompactNameSymbol(sb);
         EmitBaseParameterSymbols(sb);
         if (Sdtpl?.HasParameter("HDR") == true)             EmitHDRSymbol(sb);
         if (Sdtpl?.HasParameter("graphicsProfile") == true) EmitGraphicsProfileSymbol(sb);
@@ -1291,8 +1293,9 @@ internal class TemplatePreprocessor
     }
 
     /// <summary>
-    /// Emits the sibling <c>dotnetcli.host.json</c> hiding internal params: <c>updateOnly</c> is set
-    /// programmatically (Update Platforms), so <c>isVisible:false</c> keeps it out of the UI/help.
+    /// Emits the sibling <c>dotnetcli.host.json</c> hiding internal params: <c>updateOnly</c>
+    /// (Update Platforms) and <c>skipSolution</c> (New Game) are set programmatically by GameStudio,
+    /// so <c>isVisible:false</c> keeps them out of the UI/help.
     /// </summary>
     private static void EmitHostJson(string configDir)
     {
@@ -1302,6 +1305,9 @@ internal class TemplatePreprocessor
               "symbolInfo": {
                 "updateOnly": {
                   "isVisible": "false"
+                },
+                "skipSolution": {
+                  "isVisible": "false"
                 }
               }
             }
@@ -1309,10 +1315,47 @@ internal class TemplatePreprocessor
     }
 
     /// <summary>
+    /// The form of the name used for project names, namespaces and assembly names: whitespace
+    /// removed ("My Test 2" → <c>MyTest2</c>), a dot before a digit turned into an underscore
+    /// ("Game 1.5" → <c>Game1_5</c>, where the engine alone would give <c>Game1._5</c>), then the
+    /// engine's <c>safe_namespace</c> pass for the remaining characters a C# identifier cannot
+    /// contain ("2D Game" → <c>_2DGame</c>).
+    /// </summary>
+    private static void EmitCompactNameForm(StringBuilder sb)
+    {
+        sb.AppendLine("""
+              "forms": {
+                "stripWhitespace": { "identifier": "replace", "pattern": "\\s+", "replacement": "" },
+                "dotBeforeDigit":  { "identifier": "replace", "pattern": "\\.(?=[0-9])", "replacement": "_" },
+                "compactName":     { "identifier": "chain", "steps": [ "stripWhitespace", "dotBeforeDigit", "safe_namespace" ] }
+              },
+        """);
+    }
+
+    /// <summary>
+    /// Substitutes the compact form of the name (<see cref="EmitCompactNameForm"/>) for
+    /// <c>MyTemplate</c> in both file contents and file names. Left to sourceName alone, the
+    /// engine uses its <c>safe_namespace</c> form in contents but the raw <c>-n</c> value in file
+    /// names, so "The Quiet Archive" produced <c>The Quiet Archive.Game/The Quiet Archive.Game.csproj</c>
+    /// while the .slnx, the ProjectReferences and the sdpkg path all said
+    /// <c>The_Quiet_Archive.Game</c>, and the project could not load (#3356). A symbol whose
+    /// <c>replaces</c> / <c>fileRename</c> token equals sourceName overrides the engine's own
+    /// substitutions (the later operation wins for an identical token). The root directory
+    /// (<c>preferNameDirectory</c>) keeps the raw name.
+    /// </summary>
+    private static void EmitCompactNameSymbol(StringBuilder sb)
+    {
+        sb.AppendLine("""
+                "projectName": { "type": "derived", "valueSource": "name", "valueTransform": "compactName", "replaces": "MyTemplate", "fileRename": "MyTemplate" },
+        """);
+    }
+
+    /// <summary>
     /// Always-emitted: Platforms multichoice + env-bind / computed-bool chain turning the "Host"
     /// sentinel into per-platform Active bools used by sources/modifiers, plus the
-    /// <c>updateOnly</c> flag UpdatePlatforms uses to skip the game library + .sln (hidden from the
-    /// UI via dotnetcli.host.json).
+    /// <c>updateOnly</c> flag UpdatePlatforms uses to skip the game library + .sln and the
+    /// <c>skipSolution</c> flag New Game uses to skip the .sln alone (both hidden from the UI via
+    /// dotnetcli.host.json).
     /// </summary>
     private static void EmitBaseParameterSymbols(StringBuilder sb)
     {
@@ -1336,6 +1379,12 @@ internal class TemplatePreprocessor
                   "type": "parameter",
                   "datatype": "bool",
                   "description": "Emit only per-platform exec projects (skip game library + .sln). Used by GameStudio's Update Platforms flow.",
+                  "defaultValue": "false"
+                },
+                "skipSolution": {
+                  "type": "parameter",
+                  "datatype": "bool",
+                  "description": "Do not emit the .sln; the caller writes its own. Used by GameStudio's New Game flow.",
                   "defaultValue": "false"
                 },
                 "envOS":     { "type": "bind", "binding": "env:OS",     "defaultValue": "" },
@@ -1455,6 +1504,7 @@ internal class TemplatePreprocessor
                 { "condition": "(!iOsActive)",     "exclude": [ "MyTemplate.iOS/**"     ] },
                 { "condition": "(!AndroidActive)", "exclude": [ "MyTemplate.Android/**" ] },
                 { "condition": "(updateOnly)",     "exclude": [ "MyTemplate.Game/**", "*.slnx" ] },
+                { "condition": "(skipSolution)",   "exclude": [ "*.slnx" ] },
                 { "exclude": [ ".sdtpl/**" ] }
         """);
         if (Sdtpl?.HasParameter("HDR") == true && Sdtpl?.HasParameter("GraphicsProfile") == true)

--- a/sources/tools/Stride.Templates.Tests/StrideGameTemplateSmokeTests.cs
+++ b/sources/tools/Stride.Templates.Tests/StrideGameTemplateSmokeTests.cs
@@ -103,6 +103,8 @@ public class StrideGameTemplateSmokeTests
                 }
 
                 InstantiateUpdateOnlyAndValidate(workspace, projectName: "SmokeUpdateOnly");
+                InstantiateSpacedNameAndValidate(workspace, projectName: "Smoke Spaced Game");
+                InstantiateSkipSolutionAndValidate(workspace, projectName: "SmokeSkipSolution");
                 InstantiateAssetPackAndValidate(workspace, gameProjectName: "SmokeBlankGame");
             }
             finally
@@ -178,6 +180,63 @@ public class StrideGameTemplateSmokeTests
         Assert.False(Directory.Exists(Path.Combine(instantiated, $"{projectName}.Game")),
             $"updateOnly must not regenerate the shared game library {projectName}.Game/ (issue #3262)");
         Assert.Empty(Directory.EnumerateFiles(instantiated, "*.slnx", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
+    /// stride-game with <c>skipSolution=true</c> (what GameStudio's New Game flow passes, since the
+    /// session writes its own solution) must emit the projects but no solution file.
+    /// </summary>
+    private void InstantiateSkipSolutionAndValidate(string workspace, string projectName)
+    {
+        var newResult = RunDotnet(workspace, "new", "stride-game", "-n", projectName,
+            "--skipSolution", "true", "--platforms", "windows");
+        Assert.True(newResult.exitCode == 0, $"dotnet new stride-game --skipSolution failed:\n{newResult.output}");
+
+        var instantiated = Path.Combine(workspace, projectName);
+        Assert.True(Directory.Exists(Path.Combine(instantiated, $"{projectName}.Game")),
+            $"skipSolution must still emit the game library {projectName}.Game/ under {instantiated}");
+        Assert.True(Directory.Exists(Path.Combine(instantiated, $"{projectName}.Windows")),
+            $"skipSolution must still emit the exec project {projectName}.Windows/ under {instantiated}");
+        Assert.Empty(Directory.EnumerateFiles(instantiated, "*.slnx", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
+    /// Regression for #3356: a project name with spaces. The template engine used to substitute
+    /// the name in file contents through its safe form (<c>Smoke_Spaced_Game</c>) but rename
+    /// files with the raw value, so the .slnx and the exec project pointed at
+    /// <c>Smoke_Spaced_Game.Game/…csproj</c> while the file on disk was
+    /// <c>Smoke Spaced Game.Game/….csproj</c>. Contents and file names must now both use the
+    /// compact form (<c>SmokeSpacedGame</c>); only the root directory keeps the raw name.
+    /// </summary>
+    private void InstantiateSpacedNameAndValidate(string workspace, string projectName)
+    {
+        var newResult = RunDotnet(workspace, "new", "stride-game", "-n", projectName, "--platforms", "windows");
+        Assert.True(newResult.exitCode == 0, $"dotnet new stride-game -n \"{projectName}\" failed:\n{newResult.output}");
+
+        var instantiated = Path.Combine(workspace, projectName);
+        Assert.True(Directory.Exists(instantiated), $"Root dir must keep the raw name, expected {instantiated}");
+
+        var compactName = projectName.Replace(" ", "");
+        var libraryCsproj = Path.Combine(instantiated, $"{compactName}.Game", $"{compactName}.Game.csproj");
+        Assert.True(File.Exists(libraryCsproj), $"Expected library csproj at {libraryCsproj}");
+        var windowsCsproj = Path.Combine(instantiated, $"{compactName}.Windows", $"{compactName}.Windows.csproj");
+        Assert.True(File.Exists(windowsCsproj), $"Expected exec csproj at {windowsCsproj}");
+
+        // Every project path the solution and the exec project reference must exist on disk.
+        var slnx = Path.Combine(instantiated, $"{compactName}.slnx");
+        Assert.True(File.Exists(slnx), $"Expected solution at {slnx}");
+        foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(File.ReadAllText(slnx), "Path=\"([^\"]+)\""))
+        {
+            var referenced = Path.Combine(instantiated, m.Groups[1].Value);
+            Assert.True(File.Exists(referenced), $"{Path.GetFileName(slnx)} references missing project {referenced}");
+        }
+        var windowsCsprojText = File.ReadAllText(windowsCsproj);
+        foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(windowsCsprojText, "<ProjectReference Include=\"([^\"]+)\""))
+        {
+            var referenced = Path.Combine(Path.GetDirectoryName(windowsCsproj)!, m.Groups[1].Value);
+            Assert.True(File.Exists(referenced), $"{Path.GetFileName(windowsCsproj)} references missing project {referenced}");
+        }
+        Assert.Contains($"<RootNamespace>{compactName}.Windows</RootNamespace>", windowsCsprojText);
     }
 
     /// <summary>

--- a/sources/tools/Stride.Templates.Tests/StrideGameTemplateSmokeTests.cs
+++ b/sources/tools/Stride.Templates.Tests/StrideGameTemplateSmokeTests.cs
@@ -223,17 +223,20 @@ public class StrideGameTemplateSmokeTests
         Assert.True(File.Exists(windowsCsproj), $"Expected exec csproj at {windowsCsproj}");
 
         // Every project path the solution and the exec project reference must exist on disk.
+        // The templates write MSBuild-style backslash paths; MSBuild accepts them on every OS,
+        // File.Exists does not, so normalize them to the host separator.
+        static string ToHostPath(string msbuildPath) => msbuildPath.Replace('\\', Path.DirectorySeparatorChar);
         var slnx = Path.Combine(instantiated, $"{compactName}.slnx");
         Assert.True(File.Exists(slnx), $"Expected solution at {slnx}");
         foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(File.ReadAllText(slnx), "Path=\"([^\"]+)\""))
         {
-            var referenced = Path.Combine(instantiated, m.Groups[1].Value);
+            var referenced = Path.Combine(instantiated, ToHostPath(m.Groups[1].Value));
             Assert.True(File.Exists(referenced), $"{Path.GetFileName(slnx)} references missing project {referenced}");
         }
         var windowsCsprojText = File.ReadAllText(windowsCsproj);
         foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(windowsCsprojText, "<ProjectReference Include=\"([^\"]+)\""))
         {
-            var referenced = Path.Combine(Path.GetDirectoryName(windowsCsproj)!, m.Groups[1].Value);
+            var referenced = Path.Combine(Path.GetDirectoryName(windowsCsproj)!, ToHostPath(m.Groups[1].Value));
             Assert.True(File.Exists(referenced), $"{Path.GetFileName(windowsCsproj)} references missing project {referenced}");
         }
         Assert.Contains($"<RootNamespace>{compactName}.Windows</RootNamespace>", windowsCsprojText);


### PR DESCRIPTION
# PR Details

With a project name containing spaces, the template engine renamed files with the raw name
(The Quiet Archive.Game.csproj) but substituted its safe form in file contents
(The_Quiet_Archive.Game.csproj), so the solution, the exec project and the sdpkg path pointed
at files that did not exist.

- Both now use a compact form of the name: whitespace removed, a dot before a digit becomes
  an underscore, then the engine's identifier cleanup. "The Quiet Archive" -> TheQuietArchive,
  "Game 1.5" -> Game1_5, "2D Game" -> _2DGame. The root directory keeps the raw name.
- Game Studio saves its own solution, named from the New Project dialog, so it now passes a
  hidden skipSolution parameter instead of leaving the template's solution behind when the
  names differ.
- Smoke test cases for a name with spaces and for skipSolution.

Verified with dotnet new, stride new, and a build of the generated project. The Game Studio
dialog itself was not exercised interactively.

## Related Issue

Fixes #3356