### PR TITLE
chore: small cleanup in shader api

### DIFF
--- a/sources/shaders/Stride.Shaders.Compilers/ShaderLoaderBase.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/ShaderLoaderBase.cs
@@ -83,11 +83,6 @@ public abstract class ShaderLoaderBase(IShaderCache fileCache) : IExternalShader
             isFromCache = false;
             return true;
         }
-        catch
-        {
-            compilingShaders.TryRemove(key, out _);
-            throw;
-        }
         finally
         {
             compilingShaders.TryRemove(key, out _);

--- a/sources/shaders/Stride.Shaders/ShaderClassCode.cs
+++ b/sources/shaders/Stride.Shaders/ShaderClassCode.cs
@@ -42,19 +42,10 @@ namespace Stride.Shaders
         /// <returns>A class name as a <see cref="System.String" /> that represents this instance.</returns>
         public string ToClassName()
         {
-            if (GenericArguments == null)
+            if (GenericArguments == null || GenericArguments.Length == 0)
                 return ClassName;
 
-            var result = new StringBuilder();
-            result.Append(ClassName);
-            if (GenericArguments != null && GenericArguments.Length > 0)
-            {
-                result.Append('<');
-                result.Append(string.Join(",", GenericArguments));
-                result.Append('>');
-            }
-
-            return result.ToString();
+            return $"{ClassName}<{string.Join(",", GenericArguments)}>";
         }
 
         public override string ToString()

--- a/sources/shaders/Stride.Shaders/ShaderClassCode.cs
+++ b/sources/shaders/Stride.Shaders/ShaderClassCode.cs
@@ -3,9 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
-using System.Text;
 
 using Stride.Core;
 


### PR DESCRIPTION
# PR Details
In ShaderLoaderBase, redundant catch, finally already runs when an exception occurs.
In ShaderClassCode, empty array doesn't necessitate a stringbuilder, if that ever could be the case. Interpolation is more succinct than an sb and does create similar codegen.

## Related Issue
None

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**