### PR TITLE
fix: Shader EyeMS assigned to the wrong data

### DIFF
--- a/sources/engine/Stride.Rendering/Rendering/TransformRenderFeature.cs
+++ b/sources/engine/Stride.Rendering/Rendering/TransformRenderFeature.cs
@@ -205,7 +205,7 @@ namespace Stride.Rendering
                             ((Vector3)renderModelObjectInfo.World.Row2).Length(),
                             ((Vector3)renderModelObjectInfo.World.Row3).Length());
 
-                        perDrawData.EyeMS = new Vector4(perDrawData.WorldInverse.M41, perDrawData.WorldInverse.M42, perDrawData.WorldInverse.M43, 1.0f);
+                        perDrawData.EyeMS = new Vector4(perDrawData.WorldViewInverse.M41, perDrawData.WorldViewInverse.M42, perDrawData.WorldViewInverse.M43, 1.0f);
 
                         *perDraw = perDrawData;
                     }


### PR DESCRIPTION
# PR Details
See change, EyeMS is described as `Eye vector in model space. Default to = (World*View)^-1[M41,M42,M43,1.0]` in Transformation.sdsl

## Related Issue
None - Nothing in the source even uses that property.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**