### PR TITLE
Fix matrix truncating cast reading rows and columns swapped

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Builder.Expressions.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Building/Builder.Expressions.cs
@@ -522,7 +522,14 @@ public partial class SpirvBuilder
             || (valueType is not ScalarType && valueType is not VectorType && valueType is not MatrixType))
             throw new NotImplementedException($"Cast only work between numeral types (cast from {valueType} to {castType})");
 
-        Span<int> values = stackalloc int[castType is MatrixType m ? m.Rows : 1];
+        // One entry per column of the SPIR-V matrix (i.e. per HLSL row), since MatrixType.Columns
+        // is the OpTypeMatrix column count and MatrixType.Rows the size of each column vector.
+        Span<int> values = stackalloc int[castType is MatrixType m ? m.Columns : 1];
+
+        // How many entries of values the truncating step below actually fills; only a matrix
+        // source produces one per column, everything else produces a single value that the
+        // expanding step broadcasts.
+        var valueCount = 1;
 
         // Truncating
         switch (valueType, castType)
@@ -571,18 +578,21 @@ public partial class SpirvBuilder
                 throw new InvalidOperationException($"Can't cast from {m1} to {m2} (larger matrix)");
             case (MatrixType m1, MatrixType m2) when m1.Rows >= m2.Rows && m1.Columns >= m2.Columns:
                 {
-                    Span<int> shuffleIndices = stackalloc int[m2.Columns];
-                    for (int j = 0; j < m2.Columns; ++j)
+                    // Extract each of the m2.Columns leading matrix columns, and shorten it from
+                    // m1.Rows down to m2.Rows components when the column vectors also shrink.
+                    Span<int> shuffleIndices = stackalloc int[m2.Rows];
+                    for (int j = 0; j < m2.Rows; ++j)
                         shuffleIndices[j] = j;
-                    for (int i = 0; i < m2.Rows; ++i)
+                    for (int i = 0; i < m2.Columns; ++i)
                     {
-                        values[i] = Insert(new OpCompositeExtract(context.GetOrRegister(new VectorType(m1.BaseType, m1.Columns)), context.Bound++, valueId, [i])).ResultId;
-                        if (m1.Columns != m2.Columns)
+                        values[i] = Insert(new OpCompositeExtract(context.GetOrRegister(new VectorType(m1.BaseType, m1.Rows)), context.Bound++, valueId, [i])).ResultId;
+                        if (m1.Rows != m2.Rows)
                         {
-                            values[i] = Insert(new OpVectorShuffle(context.GetOrRegister(new VectorType(m1.BaseType, m2.Columns)), context.Bound++, values[i], values[i], new(shuffleIndices))).ResultId;
+                            values[i] = Insert(new OpVectorShuffle(context.GetOrRegister(new VectorType(m1.BaseType, m2.Rows)), context.Bound++, values[i], values[i], new(shuffleIndices))).ResultId;
                         }
                     }
-                    valueType = new VectorType(m1.BaseType, m2.Columns);
+                    valueType = new VectorType(m1.BaseType, m2.Rows);
+                    valueCount = m2.Columns;
                     break;
                 }
         }
@@ -597,7 +607,7 @@ public partial class SpirvBuilder
                 VectorType s => (s.Size, new VectorType(castType.GetElementType(), s.Size)),
                 _ => throw new NotSupportedException($"Unsupported type for element-wise cast: {valueType}"),
             };
-            for (int i = 0; i < values.Length; ++i)
+            for (int i = 0; i < valueCount; ++i)
             {
                 var rowValue = values[i];
                 if (rowValue == 0)
@@ -645,7 +655,7 @@ public partial class SpirvBuilder
                 values[i] = typeCasting.IdResult!.Value;
 
                 // Update type
-                if (i == values.Length - 1)
+                if (i == valueCount - 1)
                     valueType = castTypeSameSize;
             }
         }

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -733,6 +733,85 @@ new ShaderMacro("class", "shader"),
         TestCore($"MSAADepthResolverShader{samples}", shaderSource, "./assets/Stride/SDSL");
     }
 
+    // Issue #3323: LightProbeShader truncates a float3x4 to a float3x3, and it is the only
+    // engine shader casting a non-square matrix. That cast used to emit invalid SPIR-V, so
+    // any scene with enough light probes to form a tetrahedron failed to render.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    public void LightProbeShaderCompiles(int samples)
+    {
+        // LightProbeRenderer puts LightProbeShader in the environmentLights slot that holds
+        // EnvironmentLight when light probes are off.
+        var shaderSource = EnvironmentLightMixin(samples, new ShaderClassSource("LightProbeShader", 3));
+
+        TestCore($"LightProbeShader{samples}", shaderSource, "./assets/Stride/SDSL");
+    }
+
+    /// <summary>
+    /// Builds the pixel side of a forward shading effect around a single environment light, the
+    /// way ForwardLightingRenderFeature composes one. Only what an environment light needs is
+    /// included: the material streams it reads, and the shading stage it writes into.
+    /// </summary>
+    private static ShaderMixinSource EnvironmentLightMixin(int multisampleCount, ShaderSource environmentLight)
+    {
+        ShaderMixinSource Compose(params ShaderClassCode[] mixins)
+        {
+            var source = new ShaderMixinSource();
+            source.Mixins.AddRange(mixins);
+            source.Macros.AddRange(
+            [
+                new ShaderMacro("STRIDE_RENDER_TARGET_COUNT", "1"),
+                new ShaderMacro("STRIDE_MULTISAMPLE_COUNT", multisampleCount.ToString()),
+                new ShaderMacro("STRIDE_GRAPHICS_API_DIRECT3D", "1"),
+                new ShaderMacro("STRIDE_GRAPHICS_API_DIRECT3D11", "1"),
+                new ShaderMacro("STRIDE_GRAPHICS_PROFILE", "40960"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_9_1", "37120"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_9_2", "37376"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_9_3", "37632"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_10_0", "40960"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_10_1", "41216"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_11_0", "45056"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_11_1", "45312"),
+                new ShaderMacro("GRAPHICS_PROFILE_LEVEL_11_2", "45568"),
+                new ShaderMacro("class", "shader"),
+            ]);
+            return source;
+        }
+
+        var root = Compose(
+            new ShaderClassSource("ShaderBase"),
+            new ShaderClassSource("ShadingBase"),
+            new ShaderClassSource("TransformationBase"),
+            new ShaderClassSource("NormalStream"),
+            new ShaderClassSource("TransformationWAndVP"),
+            new ShaderClassSource("NormalFromNormalMapping"),
+            new ShaderClassSource("MaterialSurfacePixelStageCompositor"));
+
+        var environmentLights = new ShaderArraySource();
+        environmentLights.Add(environmentLight);
+        root.Compositions.Add("environmentLights", environmentLights);
+
+        var shadingSurfaces = new ShaderArraySource();
+        shadingSurfaces.Add(new ShaderClassSource("MaterialSurfaceShadingDiffuseLambert", "false"));
+        var lightingAndShading = Compose(new ShaderClassSource("MaterialSurfaceLightingAndShading"));
+        lightingAndShading.Compositions.Add("surfaces", shadingSurfaces);
+
+        var materialLayers = new ShaderArraySource();
+        materialLayers.Add(Compose(new ShaderClassSource("MaterialSurfaceDiffuse")));
+        materialLayers.Add(lightingAndShading);
+
+        var materialPixelStage = Compose(new ShaderClassSource("MaterialSurfaceArray"));
+        materialPixelStage.Compositions.Add("layers", materialLayers);
+        root.Compositions.Add("materialPixelStage", materialPixelStage);
+
+        root.Compositions.Add("streamInitializerPixelStage", Compose(
+            new ShaderClassSource("MaterialStream"),
+            new ShaderClassSource("MaterialPixelShadingStream")));
+
+        return root;
+    }
+
     private static void TestCore(string shaderName, ShaderMixinSource shaderSource, params string[] searchPaths)
     {
         var shaderMixer = new ShaderMixer(new ShaderLoader(searchPaths));

--- a/sources/shaders/assets/SDSL/RenderTests/MatrixTruncatingCast.sdsl
+++ b/sources/shaders/assets/SDSL/RenderTests/MatrixTruncatingCast.sdsl
@@ -1,0 +1,35 @@
+// PSMain(ExpectedResult=#0A141E01)
+
+namespace Stride.Shaders.Tests;
+
+// Regression: casting a matrix to a smaller matrix must keep the leading rows and
+// columns. The truncation used to read MatrixType.Rows/Columns the wrong way round
+// (they are stored HLSL-style, so Rows is the SPIR-V column vector size), which
+// produced an OpCompositeExtract with a mismatched result type and skipped the
+// component truncation entirely.
+shader MatrixTruncatingCast
+{
+    stream float4 ColorTarget : SV_Target0;
+
+    void PSMain()
+    {
+        // float3x4: 3 rows of 4 components.
+        float3x4 m34 = float3x4(10, 0, 0, 100,
+                                 0, 20, 0, 200,
+                                 0, 0, 30, 300);
+
+        // Truncate the columns: the fourth column (100/200/300) must be dropped.
+        float3x3 m33 = (float3x3)m34;
+        float3 v = mul(m33, float3(1, 1, 1));
+
+        // Truncate the rows: keep the first two rows of the source.
+        float2x4 m24 = (float2x4)m34;
+        float value = m24[1][3];
+
+        // Broadcasting an int scalar needs an element-wise conversion per row.
+        float2x2 zero = (float2x2)0;
+        v += float3(zero[0][0], zero[0][1], zero[1][1]);
+
+        streams.ColorTarget = float4(v.x, v.y, v.z, value) / float4(255.0, 255.0, 255.0, 200.0 * 255.0);
+    }
+}


### PR DESCRIPTION
# PR Details

Fixes #3323: placing enough light probes to form a tetrahedron made the forward shading effect fail SPIR-V validation, so the scene never finished rendering.

`SpirvBuilder.Convert` read `MatrixType.Rows` and `MatrixType.Columns` the wrong way round when truncating a matrix. The type stores its dimensions HLSL-style, so `Columns` is the `OpTypeMatrix` column count and `Rows` is the size of each column vector.
The swap cancels out for square sources, so only `LightProbeShader` was affected: it is the only engine shader casting a `float3x4`.

The same routine also sized its value buffer by `Rows` and converted more entries than the truncating step filled, so `(float2x2)0` threw at compile time.

Tests: a render test covering row and column truncation, checking output pixels on Direct3D11 and Vulkan, plus a test compiling the real `LightProbeShader` in the `environmentLights` slot. Both fail with the fix reverted.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->