### PR TITLE
Shader: Keep logical groups contiguous

### DIFF
--- a/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
+++ b/sources/engine/Stride.Assets/Effect/EffectCompileCommand.cs
@@ -59,6 +59,8 @@ namespace Stride.Assets.Effect
         {
             writer.Write(DataSerializer.BinaryFormatVersion);
             writer.Write(EffectBytecode.MagicHeader);
+            writer.Write(ShaderCompilerVersion.Shader);
+            writer.Write(ShaderCompilerVersion.Effect);
         }
 
         protected override Task<ResultStatus> DoCommandOverride(ICommandContext commandContext)

--- a/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.LightProbes.cs
+++ b/sources/engine/Stride.Engine/Rendering/Compositing/ForwardRenderer.LightProbes.cs
@@ -351,6 +351,9 @@ namespace Stride.Rendering.Compositing
                 // context.CommandList.Draw...
             }
 
+            // The tetrahedron ids were just rendered into, and the opaque pass samples them
+            drawContext.CommandList.ResourceBarrierTransition(ibl, BarrierLayout.ShaderResource);
+
             // Set LightProbes resources
         SetGPUResources:
             foreach (var renderFeature in context.RenderSystem.RenderFeatures)

--- a/sources/engine/Stride.Graphics/BufferPool.cs
+++ b/sources/engine/Stride.Graphics/BufferPool.cs
@@ -52,6 +52,8 @@ namespace Stride.Graphics
 
         public void Dispose()
         {
+            Unmap();
+
 #pragma warning disable 162 // Unreachable code detected
             if (UseBufferOffsets)
                 allocator.ReleaseReference(constantBuffer);
@@ -81,17 +83,25 @@ namespace Stride.Graphics
 #pragma warning disable 162
             if (UseBufferOffsets && mappedConstantBuffer.Resource != null)
             {
-                using (new DefaultCommandListLock(commandList))
+                // The device tears its resources down before the allocator owning this pool, so at that
+                // point the buffer is already gone and its mapping went with it. Unmapping it anyway is a
+                // null dereference on Direct3D 12 and a crash on MoltenVK
+                if (mappedConstantBuffer.Resource.LifetimeState == GraphicsResourceLifetimeState.Active)
                 {
-                    commandList.UnmapSubResource(mappedConstantBuffer);
-                    mappedConstantBuffer = new MappedResource();
+                    using (new DefaultCommandListLock(commandList))
+                        commandList.UnmapSubResource(mappedConstantBuffer);
                 }
+
+                mappedConstantBuffer = new MappedResource();
             }
 #pragma warning restore 162
         }
 
         public void Reset()
         {
+            // Pools stay mapped for the whole frame, so this is where the previous frame's mapping ends
+            Unmap();
+
 #pragma warning disable 162
             if (UseBufferOffsets)
             {

--- a/sources/engine/Stride.Graphics/ResourceGroupAllocator.cs
+++ b/sources/engine/Stride.Graphics/ResourceGroupAllocator.cs
@@ -77,9 +77,15 @@ namespace Stride.Graphics
             currentBufferPoolIndex = -1;
         }
 
+        /// <summary>
+        ///   Makes constant buffer writes visible to the GPU.
+        /// </summary>
+        /// <remarks>
+        ///   Pools stay mapped until <see cref="Reset"/>, so resource group data can still be updated during
+        ///   the draw phase. The memory is host coherent, so there is nothing to do here.
+        /// </remarks>
         public void Flush()
         {
-            currentBufferPool?.Unmap();
         }
 
         public ResourceGroup AllocateResourceGroup()
@@ -125,8 +131,8 @@ namespace Stride.Graphics
 
         private void SetupNextBufferPool()
         {
-            Flush();
-
+            // The pool we are leaving stays mapped: allocations already handed out from it keep a pointer
+            // into it, and they can still be written until the end of the frame
             currentBufferPoolIndex++;
             if (currentBufferPoolIndex >= bufferPools.Count)
             {

--- a/sources/shaders/Stride.Shaders.Compilers/FileShaderCache.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/FileShaderCache.cs
@@ -28,11 +28,9 @@ public class FileShaderCache(IVirtualFileProvider fileProvider, string basePath 
     private readonly object lockObject = new();
     private readonly ShaderCache memoryCache = new();
 
-    // Cache files are stamped in the SPIR-V header: Generator identifies our shader cache, Schema is the
-    // format version. A mismatch (including old 0/0 headers) is treated as stale and forces a recompile,
-    // which overwrites the file in place. Bump CacheFormatVersion on any incompatible .spv cache change.
+    // Cache files carry this id and ShaderCompilerVersion.Shader in their SPIR-V header; anything else
+    // is stale and gets recompiled in place
     private const int ShaderCacheGeneratorId = 0x5344534C; // 'SDSL'
-    private const int CacheFormatVersion = 1;
 
     public bool Exists(string name)
     {
@@ -156,7 +154,7 @@ public class FileShaderCache(IVirtualFileProvider fileProvider, string basePath 
 
     private static void Serialize(BinaryWriter writer, ShaderBuffers buffers, ObjectId hash)
     {
-        var header = new SpirvHeader("1.4", generator: ShaderCacheGeneratorId, bound: 1, schema: CacheFormatVersion);
+        var header = new SpirvHeader("1.4", generator: ShaderCacheGeneratorId, bound: 1, schema: ShaderCompilerVersion.Shader);
         var bytecode = SpirvBytecode.CreateBytecodeFromBuffers(header, computeBounds: true, buffers.Context.GetBuffer(), buffers.Buffer);
         writer.Write(bytecode);
     }
@@ -179,7 +177,7 @@ public class FileShaderCache(IVirtualFileProvider fileProvider, string basePath 
             return false;
 
         var header = SpirvHeader.Read(span);
-        if (header.Generator != ShaderCacheGeneratorId || header.Schema != CacheFormatVersion)
+        if (header.Generator != ShaderCacheGeneratorId || header.Schema != ShaderCompilerVersion.Shader)
             return false;
 
         result = ShaderBuffers.CreateFromSpan(span);

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.CBuffers.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.CBuffers.cs
@@ -255,6 +255,13 @@ namespace Stride.Shaders.Compilers.SDSL
             foreach (var cbuffersEntry in cbuffersByNames)
             {
                 var cbuffers = cbuffersEntry.ToList();
+
+                // CreateLogicalGroup expects each logical group to be a single contiguous run of members,
+                // and a group can be declared by several shaders. OrderBy is stable, so declaration order
+                // is kept inside a group.
+                if (cbuffers.Count > 1)
+                    cbuffers = [.. cbuffers.OrderBy(x => x.LogicalGroup ?? string.Empty, StringComparer.Ordinal)];
+
                 var cbuffersSpan = CollectionsMarshal.AsSpan(cbuffers);
 
                 // In all cases, we update name to one without .0 .1 suffix

--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.cs
@@ -120,15 +120,17 @@ public partial class ShaderMixer(IExternalShaderLoader shaderLoader)
         // Process reflection
         ProcessReflection(globalContext, context, temp, options);
 
-        // Ensure each resource group has cbuffer entries first (ordering expected by consumers)
+        // Ensure each resource group has cbuffer entries first (ordering expected by consumers), and each
+        // logical group in a single contiguous run (expected by CreateLogicalGroup). Ordering must be stable,
+        // consumers index a group's resources by declaration order.
         foreach (var group in globalContext.Reflection.ResourceGroups)
         {
-            group.Entries.Sort((a, b) =>
-            {
-                var aIsCb = a.Class == EffectParameterClass.ConstantBuffer ? 0 : 1;
-                var bIsCb = b.Class == EffectParameterClass.ConstantBuffer ? 0 : 1;
-                return aIsCb.CompareTo(bIsCb);
-            });
+            var orderedEntries = group.Entries
+                .OrderBy(x => x.Class == EffectParameterClass.ConstantBuffer ? 0 : 1)
+                .ThenBy(x => x.LogicalGroup ?? string.Empty, StringComparer.Ordinal)
+                .ToList();
+            group.Entries.Clear();
+            group.Entries.AddRange(orderedEntries);
         }
 
         SimplifyNotSupportedConstantsInShader(context, temp);

--- a/sources/shaders/Stride.Shaders.Effects/EffectBytecode.cs
+++ b/sources/shaders/Stride.Shaders.Effects/EffectBytecode.cs
@@ -22,6 +22,12 @@ public sealed class EffectBytecode
     ///   A constant value representing the <em>magic header</em> stored in front of an Effect bytecode
     ///   to avoid reading old versions.
     /// </summary>
+    /// <remarks>
+    ///   Only for changes to the serialized layout itself. To invalidate caches because the compiler
+    ///   now produces a different output, bump a <see cref="ShaderCompilerVersion"/> instead.
+    ///   Changing this one also rejects the precompiled bytecodes checked in under
+    ///   Stride.Graphics/Shaders.Bytecodes and Shaders093.Bytecodes, which then have to be regenerated.
+    /// </remarks>
     public const uint MagicHeader = 0xEFFEC009;  // NOTE: If EffectBytecode is changed, this number must be changed manually
 
 

--- a/sources/shaders/Stride.Shaders.Effects/EffectResourceGroupDescription.cs
+++ b/sources/shaders/Stride.Shaders.Effects/EffectResourceGroupDescription.cs
@@ -25,7 +25,8 @@ public class EffectResourceGroupDescription
     public EffectConstantBufferDescription ConstantBuffer { get; set; }
 
     /// <summary>
-    ///   All resource entries in this group, ordered: ConstantBuffer entry first, then other resources.
+    ///   All resource entries in this group, ordered: ConstantBuffer entry first, then other resources
+    ///   grouped by <see cref="EffectResourceEntry.LogicalGroup"/>, in declaration order.
     /// </summary>
     public List<EffectResourceEntry> Entries { get; set; } = [];
 

--- a/sources/shaders/Stride.Shaders.Effects/ShaderCompilerVersion.cs
+++ b/sources/shaders/Stride.Shaders.Effects/ShaderCompilerVersion.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Stride.Shaders;
+
+/// <summary>
+///   Versions of the Shader compiler output, used to invalidate the Shader caches.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Shader caches are keyed on Shader inputs and never on compiler code, so a compiler change that
+///     alters the output does not invalidate them by itself: users would silently keep the old output
+///     and the change would look like it did nothing. Bumping one of these versions is what does it.
+///   </para>
+///   <para>
+///     There are two caches, one derived from the other. <c>FileShaderCache</c> holds the SPIR-V compiled
+///     from each Shader class, and is stamped with <see cref="Shader"/>. The Effect caches
+///     (<see cref="ShaderMixinObjectId"/> at runtime, <c>EffectCompileCommand</c> in the asset build) hold
+///     what is derived from that SPIR-V, and are keyed on both <see cref="Shader"/> and <see cref="Effect"/>.
+///     So a <see cref="Shader"/> bump invalidates everything, while an <see cref="Effect"/> bump leaves the
+///     SPIR-V cache alone.
+///   </para>
+///   <para>
+///     This is not <see cref="EffectBytecode.MagicHeader"/>, which only changes when the serialized
+///     layout of <see cref="EffectBytecode"/> itself changes.
+///   </para>
+/// </remarks>
+public static class ShaderCompilerVersion
+{
+    /// <summary>
+    ///   Bump when the SPIR-V compiled from a Shader changes: a different constant buffer layout, resource
+    ///   order, or code generation. Invalidates the Shader cache and the Effect caches.
+    /// </summary>
+    public const int Shader = 2;
+
+    /// <summary>
+    ///   Bump when what is derived from the SPIR-V changes while the SPIR-V does not: reflection, or the
+    ///   bytecode compiled from it for each graphics API. Invalidates the Effect caches only.
+    /// </summary>
+    public const int Effect = 0;
+}

--- a/sources/shaders/Stride.Shaders.Effects/ShaderMixinObjectId.cs
+++ b/sources/shaders/Stride.Shaders.Effects/ShaderMixinObjectId.cs
@@ -75,6 +75,8 @@ namespace Stride.Shaders
             // Write to memory stream
             memStream.Position = 0;
             writer.Write(EffectBytecode.MagicHeader); // Write the effect bytecode magic header
+            writer.Write(ShaderCompilerVersion.Shader);
+            writer.Write(ShaderCompilerVersion.Effect);
             writer.Write(mixin);
 
             writer.Write(effectCompilerParameters.Platform);
@@ -94,6 +96,8 @@ namespace Stride.Shaders
             // Write to memory stream
             memStream.Position = 0;
             writer.Write(EffectBytecode.MagicHeader); // Write the effect bytecode magic header
+            writer.Write(ShaderCompilerVersion.Shader);
+            writer.Write(ShaderCompilerVersion.Effect);
             writer.Write(effectName);
 
             writer.Write(compilerParameters.EffectParameters.Platform);


### PR DESCRIPTION
# PR Details

A logical group is assumed to be one contiguous run: `CreateLogicalGroup` scans until it hits a member that is not in the group, and stops there. But a group can be declared by several shaders (`cbuffer PerView.Lighting` comes from `LightClustered`, `DirectLightGroupPerView`, the `ShadowMap` shaders, `LightSkyboxShader` and more), and the parts were only grouped by cbuffer name, so their order followed the mixin order.

Light probes interleave: `PerView.LightProbes` lands between two `PerView.Lighting` declarations and splits the run. Everything after the split is then outside the group and never filled in.

* **Constant buffer**: only the cluster values were written. `LightCount`, `Lights`, the shadow cascade arrays, `AmbientLight`, `SkyMatrix`, `Intensity` and `SphericalColors` kept whatever the recycled buffer held, so the scene flickered a different colour every frame.
* **Descriptors**: the shadow map texture and the skybox cubemap were never bound and kept stale descriptors, so shadows and skybox were wrong.

Fixed by ordering the parts by logical group, so each group ends up in one run. The resource ordering is stable because consumers index a group positionally in declaration order.

Three related changes come with it:

* **A missing barrier**: the light probe tetrahedron ids texture was sampled by the opaque pass while still in the render target layout.
* **Constant buffer pools now stay mapped for the whole frame**, so the draw phase patches done by light probes and VR actually land. They were unmapped at the end of `Prepare`, which made those writes undefined on Vulkan and Direct3D12, while Direct3D11 always worked. A pool can now still be mapped at device teardown, after its buffer is gone, so `BufferPool` skips the unmap then (a null dereference on Direct3D12, a crash on MoltenVK).
* **Shader caches are now versioned**, otherwise cached bytecode would silently bring the old layout back. `ShaderCompilerVersion.Shader` covers the SPIR-V compiled from each shader class and invalidates everything (this fix bumps it); `ShaderCompilerVersion.Effect` covers what is derived from the SPIR-V and invalidates the effect caches only. An earlier version bumped `EffectBytecode.MagicHeader` instead, which rejects the 21 precompiled bytecodes checked in under `Stride.Graphics`; the header now stays for layout changes only.

A light probe render test, and two fixes found while writing it, follow in a PR stacked on this one.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] All new and existing tests passed.
- [x] I have built and run the editor to try this change out.
