### PR TITLE
Fix SDSL parser error on vector constructor argument containing a binary expression

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/LiteralParsers/LiteralParsers.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/LiteralParsers/LiteralParsers.cs
@@ -186,9 +186,7 @@ public record struct LiteralsParser : IParser<Literal>
                     while (!scanner.IsEof)
                     {
                         Parsers.Spaces0(ref scanner, result, out _);
-                        if (Vector(ref scanner, result, out var vec))
-                            p.Values.Add(vec);
-                        else if (ExpressionParser.Expression(ref scanner, result, out var exp))
+                        if (ExpressionParser.Expression(ref scanner, result, out var exp))
                             p.Values.Add(exp);
                         else return Parsers.Exit(ref scanner, result, out parsed, position, new(SDSLErrorMessages.SDSL0001, scanner[scanner.Position], scanner.Memory));
                         Parsers.Spaces0(ref scanner, result, out _);

--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/LiteralParsers/LiteralParsers.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/LiteralParsers/LiteralParsers.cs
@@ -417,9 +417,7 @@ public record struct MatrixParser : IParser<MatrixLiteral>
                 {
                     Parsers.Spaces0(ref scanner, result, out _);
 
-                    if (LiteralsParser.Vector(ref scanner, result, out var vector))
-                        p.Values.Add(vector);
-                    else if (ExpressionParser.Expression(ref scanner, result, out var expression))
+                    if (ExpressionParser.Expression(ref scanner, result, out var expression))
                         p.Values.Add(expression);
                     else return Parsers.Exit(ref scanner, result, out parsed, position, orError);
                     Parsers.Spaces0(ref scanner, result, out _);

--- a/sources/shaders/assets/SDSL/ParserTests/MatrixLiteralArgumentWithBinaryExpression.sdsl
+++ b/sources/shaders/assets/SDSL/ParserTests/MatrixLiteralArgumentWithBinaryExpression.sdsl
@@ -1,0 +1,14 @@
+// Regression test: a matrix constructor argument that is itself a binary expression involving
+// a vector constructor (e.g. `float2(1,2) * w`) used to fail to parse. The matrix literal
+// parser tried to match a `Vector` literal for each argument before falling back to a full
+// `Expression`, so it greedily consumed `float2(1,2)` and left the trailing `* w` unparsed,
+// producing an "Unexpected token : *" error. See MatrixParser.Match in LiteralParsers.cs.
+shader MatrixLiteralArgumentWithBinaryExpression
+{
+	float2x2 Test()
+	{
+		float w = 1;
+		float2x2 result = float2x2(float2(1,2), float2(1,2) * w);
+		return result;
+	}
+};

--- a/sources/shaders/assets/SDSL/ParserTests/VectorLiteralArgumentWithBinaryExpression.sdsl
+++ b/sources/shaders/assets/SDSL/ParserTests/VectorLiteralArgumentWithBinaryExpression.sdsl
@@ -1,0 +1,14 @@
+// Regression test: a vector constructor argument that is itself a binary expression involving
+// another vector constructor (e.g. `float2(1,2) * w`) used to fail to parse. The vector literal
+// parser tried to match a `Vector` literal for each argument before falling back to a full
+// `Expression`, so it greedily consumed `float2(1,2)` and left the trailing `* w` unparsed,
+// producing an "Unexpected token : *" error. See LiteralsParser.Vector in LiteralParsers.cs.
+shader VectorLiteralArgumentWithBinaryExpression
+{
+	float4 Test()
+	{
+		float w = 1;
+		float4 result = float4(1, 2, float2(1,2) * w);
+		return result;
+	}
+};


### PR DESCRIPTION
# PR Details

Fix SDSL parser error on vector constructor argument containing a binary expression

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->