### PR TITLE
Fix compiler crash when reporting a call to an abstract shader method

### DIFF
--- a/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.cs
+++ b/sources/shaders/Stride.Shaders.Compilers/SDSL/ShaderMixer.cs
@@ -1029,7 +1029,7 @@ public partial class ShaderMixer(IExternalShaderLoader shaderLoader)
                         // We currently do not allow calling base stage method from a non-stage method
                         // (if we were to allow them later, we would need to tweak following detection code as ShaderIndex comparison is only valid for items within the same MixinNode)
                         if (foundInStage)
-                            throw new InvalidOperationException($"Method {context.Names[functionId]} was found but a base call can't be performed on a stage method from a non-stage method");
+                            throw new InvalidOperationException($"Method {methodGroupEntry.Name} was found but a base call can't be performed on a stage method from a non-stage method");
 
                         // Is it a base call? if yes, find the direct parent
                         // Let's find the method in same group just before ours
@@ -1045,11 +1045,11 @@ public partial class ShaderMixer(IExternalShaderLoader shaderLoader)
                         }
 
                         if (!baseMethodFound)
-                            throw new InvalidOperationException($"Can't find a base method for {context.Names[functionId]}");
+                            throw new InvalidOperationException($"Can't find a base method for {methodGroupEntry.Name}");
                     }
 
                     if ((selectedMethod.Flags & FunctionFlagsMask.Abstract) != 0)
-                        throw new InvalidOperationException($"Trying to call an abstract method {selectedMethod.Shader.ShaderName}.{context.Names[functionId]}");
+                        throw new InvalidOperationException($"Trying to call an abstract method {selectedMethod.Shader.ShaderName}.{methodGroupEntry.Name}");
                     functionId = selectedMethod.MethodId;
 
                     memberAccesses.Add(memberAccess.ResultId, functionId);


### PR DESCRIPTION
# PR Details

Fixes a `KeyNotFoundException` crash in `ShaderMixer` when a shader calls an abstract method.

Abstract methods have their whole function body (including `OpName`) erased before the call-site check runs, so `context.Names[functionId]` throws instead of raising the intended `InvalidOperationException`. Now uses `methodGroupEntry.Name`, which is captured earlier and never erased.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->