### PR TITLE
Build only the test suites a run needs

### DIFF
--- a/.github/workflows/test-android-game.yml
+++ b/.github/workflows/test-android-game.yml
@@ -17,8 +17,8 @@ on:
         description: 'vstest --filter expression forwarded to the on-device runner (blank = all tests)'
         type: string
         default: ''
-      project:
-        description: 'Single test .csproj to build/run (blank = all Android suites)'
+      projects:
+        description: 'Test .csproj paths to build/run, separated by ; (blank = detected automatically using test-filter, or all)'
         type: string
         default: ''
       commit-sha:
@@ -45,7 +45,7 @@ on:
       test-filter:
         default: ''
         type: string
-      project:
+      projects:
         default: ''
         type: string
       commit-sha:
@@ -70,7 +70,8 @@ on:
 
 
 concurrency:
-  group: test-android-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  # A manual run, direct or through test-gold-gen, never cancels or queues behind another one
+  group: test-android-game-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -161,19 +162,26 @@ jobs:
 
       - name: Resolve build target / suite
         run: |
-          # `project` set (gold-gen: one suite only) → that .csproj's APK + run-suites.sh.
-          # Unset → use-combined=true (default): Combined.csproj — all suites in one APK,
-          # one install, one process run (faster build/testing).
-          # use-combined=false → slnf build + per-suite APKs + per-suite install/run.
-          PROJ="${{ github.event.inputs.project || inputs.project }}"
+          # The suites this run needs: the `projects` list if given, else the ones `test-filter` can hit,
+          # else all (blank). See build/tools/Stride.TestSuites.
+          SUITES=$(dotnet run --project build/tools/Stride.TestSuites -- \
+                     --projects "${{ github.event.inputs.projects || inputs.projects }}" \
+                     --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" | tr '\n' ' ')
+          echo "Suites needed: ${SUITES:-all}"
+          echo "STRIDE_TEST_SUITES=$SUITES" >> "$GITHUB_ENV"
+          # use-combined=true (default): Combined.csproj — the needed suites in one APK, one install, one
+          # process run. use-combined=false → slnf build + per-suite APKs + per-suite install/run.
           USE_COMBINED="${{ github.event.inputs.use-combined || inputs.use-combined || 'true' }}"
-          if [ -n "$PROJ" ]; then
-            echo "ANDROID_BUILD_TARGET=$PROJ" >> "$GITHUB_ENV"
-            echo "ANDROID_TEST_SUITES=$(basename "$PROJ" .csproj)" >> "$GITHUB_ENV"
-            echo "ANDROID_RUN_SCRIPT=tests/android/run-suites.sh" >> "$GITHUB_ENV"
-          elif [ "$USE_COMBINED" = "true" ]; then
+          if [ "$USE_COMBINED" = "true" ]; then
             echo "ANDROID_BUILD_TARGET=sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj" >> "$GITHUB_ENV"
             echo "ANDROID_RUN_SCRIPT=tests/android/run-combined.sh" >> "$GITHUB_ENV"
+          elif [ -n "$SUITES" ]; then
+            # The Android solution filter narrowed to the needed suites; per-suite APKs land under
+            # bin/Tests/<Suite>/Android-Vulkan/<Config>/. Run step iterates ANDROID_TEST_SUITES.
+            TARGET=$(dotnet run --project build/tools/Stride.TestSuites -- --projects "$SUITES" --slnf build/Stride.Tests.Game.Android.slnf)
+            echo "ANDROID_BUILD_TARGET=$TARGET" >> "$GITHUB_ENV"
+            echo "ANDROID_RUN_SCRIPT=tests/android/run-suites.sh" >> "$GITHUB_ENV"
+            { echo "ANDROID_TEST_SUITES<<EOF"; echo $SUITES | tr ' ' '\n'; echo "EOF"; } >> "$GITHUB_ENV"
           else
             # slnf path: one build evaluates the graph once; per-suite APKs land under
             # bin/Tests/<Suite>/Android-Vulkan/<Config>/. Run step iterates ANDROID_TEST_SUITES.
@@ -220,6 +228,7 @@ jobs:
           dotnet build "$ANDROID_BUILD_TARGET" \
             -nr:false -v:m -p:WarningLevel=0 \
             -p:StrideSkipAutoPack=true \
+            -p:StrideCombinedSuites="$STRIDE_TEST_SUITES" \
             ${{ inputs.upload-binlog && '-bl:build.binlog' || '' }} \
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
             -p:StridePlatforms=Android \

--- a/.github/workflows/test-gold-gen.yml
+++ b/.github/workflows/test-gold-gen.yml
@@ -2,11 +2,12 @@ name: Test Gold Generation
 
 # Fast, on-demand gold-image generation across platforms. Thin orchestrator: it calls the
 # existing reusable test-*-game.yml workflows (the canonical PR gate) with two extra knobs —
-# `test-filter` (run one test) and `project` (build/test one suite) — then gathers every
+# `test-filter` (run some tests) and `projects` (build/test some suites) — then gathers every
 # platform's rendered output into a single downloadable zip, and optionally promotes it to gold.
 #
 # Why a separate workflow: dispatched directly it skips main.yml's runtime-build gate, and
-# `project`/`test-filter` cut the build+run down to the one suite/test you're adding gold for.
+# a `test-filter` alone cuts the build+run down to the suites that can run it (see
+# build/tools/Stride.TestSuites), and `projects` overrides that choice.
 #
 # Generating brand-new gold makes the platform jobs go RED ("reference image missing") — that's
 # expected. The `gather` job runs regardless: download its `gold-images` artifact (or point
@@ -58,8 +59,8 @@ on:
         description: 'dotnet test --filter / vstest filter (blank = all tests)'
         type: string
         default: ''
-      project:
-        description: 'Single test .csproj to build/test (blank = whole GPU solution)'
+      projects:
+        description: 'Test .csproj paths to build/test, separated by ; (blank = detected automatically using test-filter, or all)'
         type: string
         default: ''
       build-type:
@@ -87,14 +88,20 @@ on:
         description: Also remove redundant existing gold (dedup) before committing
         type: boolean
         default: false
+      upload-binlog:
+        description: Upload each lane's build binlog
+        type: boolean
+        default: false
 
 permissions:
   checks: write
   contents: read
 
 concurrency:
-  group: test-gold-gen-${{ github.ref }}-${{ inputs.build-type }}
-  cancel-in-progress: true
+  # Runs that push gold to the same branch queue behind each other; runs that only test go side by
+  # side. Nothing is cancelled: a promote cut short has already pushed part of its gold.
+  group: test-gold-gen-${{ github.ref }}-${{ inputs.update-gold == 'none' && github.run_id || inputs.update-gold }}
+  cancel-in-progress: false
 
 jobs:
   # Surfaces what happens to this run's gold up-front (no `needs:`, so it shows within seconds of
@@ -143,7 +150,8 @@ jobs:
       build-type: ${{ inputs.build-type }}
       graphics-api: ${{ inputs.graphics-api }}
       test-filter: ${{ inputs.test-filter }}
-      project: ${{ inputs.project }}
+      projects: ${{ inputs.projects }}
+      upload-binlog: ${{ inputs.upload-binlog }}
       commit-sha: ${{ inputs.commit-sha }}
       # Generating new gold makes tests "fail" (missing/changed reference) — expected; tolerate it so
       # the run stays green and doesn't email. Build failures still fail (the Build step isn't gated).
@@ -156,7 +164,8 @@ jobs:
     with:
       build-type: ${{ inputs.build-type }}
       test-filter: ${{ inputs.test-filter }}
-      project: ${{ inputs.project }}
+      projects: ${{ inputs.projects }}
+      upload-binlog: ${{ inputs.upload-binlog }}
       commit-sha: ${{ inputs.commit-sha }}
       # Generating new gold makes tests "fail" (missing/changed reference) — expected; tolerate it so
       # the run stays green and doesn't email. Build failures still fail (the Build step isn't gated).
@@ -169,7 +178,8 @@ jobs:
     with:
       build-type: ${{ inputs.build-type }}
       test-filter: ${{ inputs.test-filter }}
-      project: ${{ inputs.project }}
+      projects: ${{ inputs.projects }}
+      upload-binlog: ${{ inputs.upload-binlog }}
       commit-sha: ${{ inputs.commit-sha }}
       # Generating new gold makes tests "fail" (missing/changed reference) — expected; tolerate it so
       # the run stays green and doesn't email. Build failures still fail (the Build step isn't gated).
@@ -182,7 +192,8 @@ jobs:
     with:
       build-type: ${{ inputs.build-type }}
       test-filter: ${{ inputs.test-filter }}
-      project: ${{ inputs.project }}
+      projects: ${{ inputs.projects }}
+      upload-binlog: ${{ inputs.upload-binlog }}
       commit-sha: ${{ inputs.commit-sha }}
       # Generating new gold makes tests "fail" (missing/changed reference) — expected; tolerate it so
       # the run stays green and doesn't email. Build failures still fail (the Build step isn't gated).
@@ -195,7 +206,8 @@ jobs:
     with:
       build-type: ${{ inputs.build-type }}
       test-filter: ${{ inputs.test-filter }}
-      project: ${{ inputs.project }}
+      projects: ${{ inputs.projects }}
+      upload-binlog: ${{ inputs.upload-binlog }}
       commit-sha: ${{ inputs.commit-sha }}
       # Generating new gold makes tests "fail" (missing/changed reference) — expected; tolerate it so
       # the run stays green and doesn't email. Build failures still fail (the Build step isn't gated).

--- a/.github/workflows/test-gold-gen.yml
+++ b/.github/workflows/test-gold-gen.yml
@@ -152,6 +152,8 @@ jobs:
       test-filter: ${{ inputs.test-filter }}
       projects: ${{ inputs.projects }}
       upload-binlog: ${{ inputs.upload-binlog }}
+      # Gold for the API-neutral suites lives on Direct3D11 too; the PR gate runs them elsewhere
+      api-neutral-suites: true
       commit-sha: ${{ inputs.commit-sha }}
       # Generating new gold makes tests "fail" (missing/changed reference) — expected; tolerate it so
       # the run stays green and doesn't email. Build failures still fail (the Build step isn't gated).

--- a/.github/workflows/test-ios-game.yml
+++ b/.github/workflows/test-ios-game.yml
@@ -17,8 +17,8 @@ on:
         description: 'vstest --filter expression forwarded to the on-device runner (blank = all tests)'
         type: string
         default: ''
-      project:
-        description: 'Single test .csproj to build/run (blank = Combined .app aggregating all suites)'
+      projects:
+        description: 'Test .csproj paths to build/run, separated by ; (blank = detected automatically using test-filter, or all)'
         type: string
         default: ''
       commit-sha:
@@ -45,7 +45,7 @@ on:
       test-filter:
         default: ''
         type: string
-      project:
+      projects:
         default: ''
         type: string
       commit-sha:
@@ -71,7 +71,8 @@ on:
     - cron: '43 2 * * *'
 
 concurrency:
-  group: test-ios-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  # A manual run, direct or through test-gold-gen, never cancels or queues behind another one
+  group: test-ios-game-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -146,44 +147,27 @@ jobs:
             xcrun -find "$tool" >/dev/null 2>&1 || echo "::warning::could not resolve $tool"
           done
 
-      - name: Start iOS Simulator (background)
-        # Kick the simulator boot off early so its ~50s first-boot data migration
-        # (PreferencesMigrator etc.) happens in parallel with the build. We block on
-        # readiness in a later step right before tests run.
-        run: |
-          set -e
-          UDID=$(xcrun simctl list devices --json | python3 -c '
-          import json, sys
-          d = json.load(sys.stdin)["devices"]
-          for runtime in sorted((k for k in d if k.startswith("com.apple.CoreSimulator.SimRuntime.iOS-")), reverse=True):
-            for x in d[runtime]:
-              if x.get("isAvailable") and "iPhone" in x["name"]:
-                print(x["udid"]); sys.exit(0)
-          sys.exit(1)
-          ')
-          if [ -z "$UDID" ]; then
-            echo "::error::No available iPhone simulator runtime found"
-            xcrun simctl list devices
-            exit 1
-          fi
-          echo "Booting $UDID"
-          xcrun simctl boot $UDID
-          echo "IOS_SIM_UDID=$UDID" >> $GITHUB_ENV
-
       - name: Resolve build target / suite
         run: |
-          # `project` set (gold-gen: one suite only) → that .csproj's .app (~4 min build).
-          # Unset → use-combined=true (default): Combined.csproj — all suites in one .app,
-          # one install, one process run (faster build/testing).
-          # use-combined=false → slnf build + per-suite .apps + per-suite install/run.
-          PROJ="${{ github.event.inputs.project || inputs.project }}"
+          # The suites this run needs: the `projects` list if given, else the ones `test-filter` can hit,
+          # else all (blank). See build/tools/Stride.TestSuites.
+          SUITES=$(dotnet run --project build/tools/Stride.TestSuites -- \
+                     --projects "${{ github.event.inputs.projects || inputs.projects }}" \
+                     --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" | tr '\n' ' ')
+          echo "Suites needed: ${SUITES:-all}"
+          echo "STRIDE_TEST_SUITES=$SUITES" >> "$GITHUB_ENV"
+          # use-combined=true (default): Combined.csproj — the needed suites in one .app, one install, one
+          # process run. use-combined=false → slnf build + per-suite .apps + per-suite install/run.
           USE_COMBINED="${{ github.event.inputs.use-combined || inputs.use-combined || 'true' }}"
-          if [ -n "$PROJ" ]; then
-            echo "IOS_BUILD_TARGET=$PROJ" >> "$GITHUB_ENV"
-            echo "IOS_TEST_SUITES=$(basename "$PROJ" .csproj)" >> "$GITHUB_ENV"
-          elif [ "$USE_COMBINED" = "true" ]; then
+          if [ "$USE_COMBINED" = "true" ]; then
             echo "IOS_BUILD_TARGET=sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj" >> "$GITHUB_ENV"
             echo "IOS_TEST_SUITES=Stride.Tests.Combined" >> "$GITHUB_ENV"
+          elif [ -n "$SUITES" ]; then
+            # The iOS solution filter narrowed to the needed suites; per-suite .app bundles land under
+            # bin/Tests/<Suite>/iOS-Vulkan/<Config>/<Suite>.app. Run step iterates IOS_TEST_SUITES.
+            TARGET=$(dotnet run --project build/tools/Stride.TestSuites -- --projects "$SUITES" --slnf build/Stride.Tests.Game.iOS.slnf)
+            echo "IOS_BUILD_TARGET=$TARGET" >> "$GITHUB_ENV"
+            { echo "IOS_TEST_SUITES<<EOF"; echo $SUITES | tr ' ' '\n'; echo "EOF"; } >> "$GITHUB_ENV"
           else
             # slnf path: one build evaluates the graph once; per-suite .app bundles land under
             # bin/Tests/<Suite>/iOS-Vulkan/<Config>/<Suite>.app. Run step iterates IOS_TEST_SUITES.
@@ -205,6 +189,31 @@ jobs:
             } >> "$GITHUB_ENV"
           fi
 
+      - name: Start iOS Simulator (background)
+        # Kick the simulator boot off early so its ~50s first-boot data migration
+        # (PreferencesMigrator etc.) happens in parallel with the build. We block on
+        # readiness in a later step right before tests run. It comes after the resolve step:
+        # a cold boot next to the resolver's restore and build stretched that step to 3 min.
+        run: |
+          set -e
+          UDID=$(xcrun simctl list devices --json | python3 -c '
+          import json, sys
+          d = json.load(sys.stdin)["devices"]
+          for runtime in sorted((k for k in d if k.startswith("com.apple.CoreSimulator.SimRuntime.iOS-")), reverse=True):
+            for x in d[runtime]:
+              if x.get("isAvailable") and "iPhone" in x["name"]:
+                print(x["udid"]); sys.exit(0)
+          sys.exit(1)
+          ')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator runtime found"
+            xcrun simctl list devices
+            exit 1
+          fi
+          echo "Booting $UDID"
+          xcrun simctl boot $UDID
+          echo "IOS_SIM_UDID=$UDID" >> $GITHUB_ENV
+
       - name: Build iOS test .app bundle
         # No explicit RuntimeIdentifier: passing one as a global property leaks into the host
         # net10.0 build (used to load assemblies into the AssetCompiler) and crashes its
@@ -214,6 +223,7 @@ jobs:
           dotnet build "$IOS_BUILD_TARGET" \
             -nr:false -v:m -p:WarningLevel=0 \
             -p:StrideSkipAutoPack=true \
+            -p:StrideCombinedSuites="$STRIDE_TEST_SUITES" \
             ${{ inputs.upload-binlog && '-bl:build.binlog' || '' }} \
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
             -p:StridePlatforms=iOS
@@ -241,7 +251,7 @@ jobs:
           $config = "${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}"
           $filter = "${{ github.event.inputs.test-filter || inputs.test-filter }}"
           $repeat = "${{ github.event.inputs.repeat || inputs.repeat || '1' }}"
-          # IOS_TEST_SUITES is single-line (Combined / project=set) OR multi-line (slnf path).
+          # IOS_TEST_SUITES is single-line (Combined) OR multi-line (slnf path).
           # Loop over them — one suite means one launch (matches the Combined case identically).
           $suites = ($env:IOS_TEST_SUITES -split "`n") | Where-Object { $_ -ne '' }
           $worstExit = 0

--- a/.github/workflows/test-linux-game.yml
+++ b/.github/workflows/test-linux-game.yml
@@ -21,8 +21,8 @@ on:
         description: 'Rerun the filtered GPU test set up to N times, stop on first failure (flake hunting). 1 = single run (default).'
         type: number
         default: 1
-      project:
-        description: 'Single test .csproj path to build/test (blank = whole GPU + Runtime solutions)'
+      projects:
+        description: 'Test .csproj paths to build/test, separated by ; (blank = detected automatically using test-filter, or all)'
         type: string
         default: ''
       commit-sha:
@@ -44,7 +44,7 @@ on:
       repeat:
         default: 1
         type: number
-      project:
+      projects:
         default: ''
         type: string
       commit-sha:
@@ -60,7 +60,8 @@ on:
         type: boolean
 
 concurrency:
-  group: test-linux-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  # A manual run, direct or through test-gold-gen, never cancels or queues behind another one
+  group: test-linux-game-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -125,9 +126,15 @@ jobs:
         run: |
           # createdump (DOTNET_DbgMiniDumpName) won't create the parent dir; ensure it exists up front.
           mkdir -p "$GITHUB_WORKSPACE/TestResults"
-          # `project` (a single .csproj) narrows the build+test to one suite; blank = whole GPU + Runtime solutions.
-          PROJ="${{ github.event.inputs.project || inputs.project }}"
-          echo "STRIDE_TEST_TARGET=${PROJ:-build/Stride.Tests.Game.GPU.slnf}" >> "$GITHUB_ENV"
+          # The GPU solution filter narrowed to the suites this run needs: the `projects` list if given,
+          # else the ones `test-filter` can hit, else the whole filter. See build/tools/Stride.TestSuites.
+          # The Runtime (non-GPU) solution below still builds and runs unless `projects` is given.
+          TARGET=$(dotnet run --project build/tools/Stride.TestSuites -- \
+                     --projects "${{ github.event.inputs.projects || inputs.projects }}" \
+                     --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" \
+                     --slnf build/Stride.Tests.Game.GPU.slnf)
+          echo "Build/test target: $TARGET"
+          echo "STRIDE_TEST_TARGET=$TARGET" >> "$GITHUB_ENV"
           echo "STRIDE_TEST_FILTER=${{ github.event.inputs.test-filter || inputs.test-filter }}" >> "$GITHUB_ENV"
       - name: Build GPU tests
         run: |
@@ -141,7 +148,7 @@ jobs:
             -p:StridePlatforms=Linux \
             -p:StrideGraphicsApis=Vulkan
       - name: Build non-GPU game tests
-        if: ${{ (github.event.inputs.project || inputs.project) == '' }}
+        if: ${{ (github.event.inputs.projects || inputs.projects) == '' }}
         run: |
           dotnet build build/Stride.Tests.Game.Runtime.slnf \
             -p:StrideTestRuntimeIdentifier=linux-x64 \
@@ -179,7 +186,7 @@ jobs:
               -- RunConfiguration.MaxCpuCount=1 || { ec=$?; echo "Run $i failed (exit $ec); stopping."; exit $ec; }
           done
       - name: Test non-GPU
-        if: ${{ !cancelled() && (github.event.inputs.project || inputs.project) == '' }}
+        if: ${{ !cancelled() && (github.event.inputs.projects || inputs.projects) == '' }}
         continue-on-error: ${{ inputs.tolerate-test-failures == true }}
         run: |
           dotnet test build/Stride.Tests.Game.Runtime.slnf \

--- a/.github/workflows/test-linux-game.yml
+++ b/.github/workflows/test-linux-game.yml
@@ -126,48 +126,36 @@ jobs:
         run: |
           # createdump (DOTNET_DbgMiniDumpName) won't create the parent dir; ensure it exists up front.
           mkdir -p "$GITHUB_WORKSPACE/TestResults"
-          # The GPU solution filter narrowed to the suites this run needs: the `projects` list if given,
-          # else the ones `test-filter` can hit, else the whole filter. See build/tools/Stride.TestSuites.
-          # The Runtime (non-GPU) solution below still builds and runs unless `projects` is given.
+          # The game test solution narrowed to the suites this run needs: the `projects` list if given,
+          # else the ones `test-filter` can hit, else the whole solution. See build/tools/Stride.TestSuites.
           TARGET=$(dotnet run --project build/tools/Stride.TestSuites -- \
                      --projects "${{ github.event.inputs.projects || inputs.projects }}" \
                      --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" \
-                     --slnf build/Stride.Tests.Game.GPU.slnf)
+                     --slnf build/Stride.Tests.Game.Desktop.slnf)
+          if [ -z "$TARGET" ]; then echo "::error::None of the needed suites is in build/Stride.Tests.Game.Desktop.slnf"; exit 1; fi
           echo "Build/test target: $TARGET"
           echo "STRIDE_TEST_TARGET=$TARGET" >> "$GITHUB_ENV"
           echo "STRIDE_TEST_FILTER=${{ github.event.inputs.test-filter || inputs.test-filter }}" >> "$GITHUB_ENV"
-      - name: Build GPU tests
+      - name: Build
         run: |
           dotnet build "$STRIDE_TEST_TARGET" \
             -p:StrideTestRuntimeIdentifier=linux-x64 \
             -p:StrideSkipAutoPack=true \
             -nr:false \
-            ${{ inputs.upload-binlog && '-bl:build-gpu.binlog' || '' }} \
+            ${{ inputs.upload-binlog && '-bl:build.binlog' || '' }} \
             -v:m -p:WarningLevel=0 \
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
             -p:StridePlatforms=Linux \
             -p:StrideGraphicsApis=Vulkan
-      - name: Build non-GPU game tests
-        if: ${{ (github.event.inputs.projects || inputs.projects) == '' }}
-        run: |
-          dotnet build build/Stride.Tests.Game.Runtime.slnf \
-            -p:StrideTestRuntimeIdentifier=linux-x64 \
-            -p:StrideSkipAutoPack=true \
-            -nr:false \
-            ${{ inputs.upload-binlog && '-bl:build-runtime.binlog' || '' }} \
-            -v:m -p:WarningLevel=0 \
-            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
-            -p:StridePlatforms=Linux \
-            -p:StrideGraphicsApis=Vulkan
-      - name: Upload build binlogs
+      - name: Upload build binlog
         # failure() so we still get the binlog when Build dies (most useful case)
         if: failure() || inputs.upload-binlog
         uses: actions/upload-artifact@v7
         with:
           name: build-binlog-linux-game
-          path: build-*.binlog
+          path: build.binlog
           if-no-files-found: ignore
-      - name: Test GPU
+      - name: Test
         if: success() || failure()
         continue-on-error: ${{ inputs.tolerate-test-failures == true }}
         run: |
@@ -185,17 +173,6 @@ jobs:
               "${FILTER_ARG[@]}" \
               -- RunConfiguration.MaxCpuCount=1 || { ec=$?; echo "Run $i failed (exit $ec); stopping."; exit $ec; }
           done
-      - name: Test non-GPU
-        if: ${{ !cancelled() && (github.event.inputs.projects || inputs.projects) == '' }}
-        continue-on-error: ${{ inputs.tolerate-test-failures == true }}
-        run: |
-          dotnet test build/Stride.Tests.Game.Runtime.slnf \
-            --no-build \
-            --logger:trx --results-directory TestResults \
-            --blame-hang-timeout 5m --blame-hang-dump-type full \
-            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
-            -p:StrideGraphicsApis=Vulkan \
-            -- RunConfiguration.MaxCpuCount=1
       - name: Publish Test Report
         if: always()
         uses: phoenix-actions/test-reporting@v16

--- a/.github/workflows/test-macos-game.yml
+++ b/.github/workflows/test-macos-game.yml
@@ -144,48 +144,36 @@ jobs:
         run: |
           # createdump (DOTNET_DbgMiniDumpName) won't create the parent dir; ensure it exists up front.
           mkdir -p "$GITHUB_WORKSPACE/TestResults"
-          # The GPU solution filter narrowed to the suites this run needs: the `projects` list if given,
-          # else the ones `test-filter` can hit, else the whole filter. See build/tools/Stride.TestSuites.
-          # The Runtime (non-GPU) solution below still builds and runs unless `projects` is given.
+          # The game test solution narrowed to the suites this run needs: the `projects` list if given,
+          # else the ones `test-filter` can hit, else the whole solution. See build/tools/Stride.TestSuites.
           TARGET=$(dotnet run --project build/tools/Stride.TestSuites -- \
                      --projects "${{ github.event.inputs.projects || inputs.projects }}" \
                      --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" \
-                     --slnf build/Stride.Tests.Game.GPU.slnf)
+                     --slnf build/Stride.Tests.Game.Desktop.slnf)
+          if [ -z "$TARGET" ]; then echo "::error::None of the needed suites is in build/Stride.Tests.Game.Desktop.slnf"; exit 1; fi
           echo "Build/test target: $TARGET"
           echo "STRIDE_TEST_TARGET=$TARGET" >> "$GITHUB_ENV"
           echo "STRIDE_TEST_FILTER=${{ github.event.inputs.test-filter || inputs.test-filter }}" >> "$GITHUB_ENV"
-      - name: Build GPU tests
+      - name: Build
         run: |
           dotnet build "$STRIDE_TEST_TARGET" \
             -p:StrideTestRuntimeIdentifier=osx-arm64 \
             -p:StrideSkipAutoPack=true \
             -nr:false \
-            ${{ inputs.upload-binlog && '-bl:build-gpu.binlog' || '' }} \
+            ${{ inputs.upload-binlog && '-bl:build.binlog' || '' }} \
             -v:m -p:WarningLevel=0 \
             -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
             -p:StridePlatforms=macOS \
             -p:StrideGraphicsApis=Vulkan
-      - name: Build non-GPU game tests
-        if: ${{ (github.event.inputs.projects || inputs.projects) == '' }}
-        run: |
-          dotnet build build/Stride.Tests.Game.Runtime.slnf \
-            -p:StrideTestRuntimeIdentifier=osx-arm64 \
-            -p:StrideSkipAutoPack=true \
-            -nr:false \
-            ${{ inputs.upload-binlog && '-bl:build-runtime.binlog' || '' }} \
-            -v:m -p:WarningLevel=0 \
-            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
-            -p:StridePlatforms=macOS \
-            -p:StrideGraphicsApis=Vulkan
-      - name: Upload build binlogs
+      - name: Upload build binlog
         # failure() so we still get the binlog when Build dies (most useful case)
         if: failure() || inputs.upload-binlog
         uses: actions/upload-artifact@v7
         with:
           name: build-binlog-macos-game
-          path: build-*.binlog
+          path: build.binlog
           if-no-files-found: ignore
-      - name: Test GPU
+      - name: Test
         if: success() || failure()
         continue-on-error: ${{ inputs.tolerate-test-failures == true }}
         run: |
@@ -241,27 +229,6 @@ jobs:
             echo "::endgroup::"
           done
           exit $worst
-      - name: Test non-GPU
-        if: ${{ !cancelled() && (github.event.inputs.projects || inputs.projects) == '' }}
-        continue-on-error: ${{ inputs.tolerate-test-failures == true }}
-        run: |
-          CONFIG="${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}"
-          # Same .app-hosted exclusion as Test GPU (Audio.Tests is in both slnfs).
-          EXCLUDE=""
-          for app in bin/Tests/*/macOS-Vulkan/$CONFIG/*.app; do
-            [ -e "$app" ] || continue
-            EXCLUDE="$EXCLUDE${EXCLUDE:+ & }FullyQualifiedName!~$(basename "$app" .app)"
-          done
-          FILTER_ARG=()
-          if [ -n "$EXCLUDE" ]; then FILTER_ARG=(--filter "$EXCLUDE"); fi
-          dotnet test build/Stride.Tests.Game.Runtime.slnf \
-            --no-build \
-            --logger:trx --results-directory TestResults \
-            --blame-hang-timeout 5m --blame-hang-dump-type full \
-            -p:Configuration=${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }} \
-            -p:StrideGraphicsApis=Vulkan \
-            "${FILTER_ARG[@]}" \
-            -- RunConfiguration.MaxCpuCount=1
       - name: Publish Test Report
         if: always()
         uses: phoenix-actions/test-reporting@v16

--- a/.github/workflows/test-macos-game.yml
+++ b/.github/workflows/test-macos-game.yml
@@ -21,8 +21,8 @@ on:
         description: 'Rerun the filtered GPU test set up to N times, stop on first failure (flake hunting). 1 = single run (default).'
         type: number
         default: 1
-      project:
-        description: 'Single test .csproj path to build/test (blank = whole GPU + Runtime solutions)'
+      projects:
+        description: 'Test .csproj paths to build/test, separated by ; (blank = detected automatically using test-filter, or all)'
         type: string
         default: ''
       commit-sha:
@@ -44,7 +44,7 @@ on:
       repeat:
         default: 1
         type: number
-      project:
+      projects:
         default: ''
         type: string
       commit-sha:
@@ -60,7 +60,8 @@ on:
         type: boolean
 
 concurrency:
-  group: test-macos-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
+  # A manual run, direct or through test-gold-gen, never cancels or queues behind another one
+  group: test-macos-game-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}
   cancel-in-progress: true
 
 jobs:
@@ -90,8 +91,9 @@ jobs:
           ref: ${{ (github.event.inputs.commit-sha != '' && github.event.inputs.commit-sha) || (inputs.commit-sha != '' && inputs.commit-sha) || github.ref }}
           exclude: samples
       - name: Install macOS Workload
-        # Single-project builds (gold-gen) dispatch all TFMs of referenced engine projects,
-        # including net10.0-macos; the slnf path never does, so this only bites project mode.
+        # Building a suite project on its own dispatched all TFMs of the referenced engine projects,
+        # including net10.0-macos. The target is now always a solution filter, which never does, so
+        # this is only a safety net.
         uses: ./.github/actions/stride-workload
         with:
           workloads: macos
@@ -142,9 +144,15 @@ jobs:
         run: |
           # createdump (DOTNET_DbgMiniDumpName) won't create the parent dir; ensure it exists up front.
           mkdir -p "$GITHUB_WORKSPACE/TestResults"
-          # `project` (a single .csproj) narrows the build+test to one suite; blank = whole GPU + Runtime solutions.
-          PROJ="${{ github.event.inputs.project || inputs.project }}"
-          echo "STRIDE_TEST_TARGET=${PROJ:-build/Stride.Tests.Game.GPU.slnf}" >> "$GITHUB_ENV"
+          # The GPU solution filter narrowed to the suites this run needs: the `projects` list if given,
+          # else the ones `test-filter` can hit, else the whole filter. See build/tools/Stride.TestSuites.
+          # The Runtime (non-GPU) solution below still builds and runs unless `projects` is given.
+          TARGET=$(dotnet run --project build/tools/Stride.TestSuites -- \
+                     --projects "${{ github.event.inputs.projects || inputs.projects }}" \
+                     --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" \
+                     --slnf build/Stride.Tests.Game.GPU.slnf)
+          echo "Build/test target: $TARGET"
+          echo "STRIDE_TEST_TARGET=$TARGET" >> "$GITHUB_ENV"
           echo "STRIDE_TEST_FILTER=${{ github.event.inputs.test-filter || inputs.test-filter }}" >> "$GITHUB_ENV"
       - name: Build GPU tests
         run: |
@@ -158,7 +166,7 @@ jobs:
             -p:StridePlatforms=macOS \
             -p:StrideGraphicsApis=Vulkan
       - name: Build non-GPU game tests
-        if: ${{ (github.event.inputs.project || inputs.project) == '' }}
+        if: ${{ (github.event.inputs.projects || inputs.projects) == '' }}
         run: |
           dotnet build build/Stride.Tests.Game.Runtime.slnf \
             -p:StrideTestRuntimeIdentifier=osx-arm64 \
@@ -234,7 +242,7 @@ jobs:
           done
           exit $worst
       - name: Test non-GPU
-        if: ${{ !cancelled() && (github.event.inputs.project || inputs.project) == '' }}
+        if: ${{ !cancelled() && (github.event.inputs.projects || inputs.projects) == '' }}
         continue-on-error: ${{ inputs.tolerate-test-failures == true }}
         run: |
           CONFIG="${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}"

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -30,8 +30,8 @@ on:
         description: 'Rerun the filtered test set up to N times, stop on first failure (flake hunting). 1 = single run (default).'
         type: number
         default: 1
-      project:
-        description: 'Single test .csproj path to build/test (blank = whole GPU solution filter)'
+      projects:
+        description: 'Test .csproj paths to build/test, separated by ; (blank = detected automatically using test-filter, or all)'
         type: string
         default: ''
       commit-sha:
@@ -56,7 +56,7 @@ on:
       repeat:
         default: 1
         type: number
-      project:
+      projects:
         default: ''
         type: string
       commit-sha:
@@ -72,7 +72,8 @@ on:
         type: boolean
 
 concurrency:
-  group: test-windows-game-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}-${{ github.event.inputs.graphics-api || inputs.graphics-api || 'all' }}
+  # A manual run, direct or through test-gold-gen, never cancels or queues behind another one
+  group: test-windows-game-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}-${{ github.event.inputs.build-type || inputs.build-type || 'Debug' }}-${{ github.event.inputs.graphics-api || inputs.graphics-api || 'all' }}
   cancel-in-progress: true
 
 jobs:
@@ -164,9 +165,13 @@ jobs:
       - name: Resolve build/test target
         shell: pwsh
         run: |
-          # `project` (a single .csproj) narrows the build+test to one suite; blank = whole GPU solution filter.
-          $proj = "${{ github.event.inputs.project || inputs.project }}"
-          $target = if ($proj) { $proj } else { 'build\Stride.Tests.Game.GPU.slnf' }
+          # The GPU solution filter narrowed to the suites this run needs: the `projects` list if given,
+          # else the ones `test-filter` can hit, else the whole filter. See build/tools/Stride.TestSuites.
+          $target = dotnet run --project build/tools/Stride.TestSuites -- `
+            --projects "${{ github.event.inputs.projects || inputs.projects }}" `
+            --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" `
+            --slnf build/Stride.Tests.Game.GPU.slnf
+          Write-Host "Build/test target: $target"
           Add-Content $env:GITHUB_ENV "STRIDE_TEST_TARGET=$target"
           Add-Content $env:GITHUB_ENV "STRIDE_TEST_FILTER=${{ github.event.inputs.test-filter || inputs.test-filter }}"
       - name: Build

--- a/.github/workflows/test-windows-game.yml
+++ b/.github/workflows/test-windows-game.yml
@@ -67,6 +67,11 @@ on:
       tolerate-test-failures:
         default: false
         type: boolean
+      # Internal (test-gold-gen): also build and test the API-neutral suites, on Direct3D11 only.
+      # The PR gate runs those through test-windows-game-api-neutral.yml instead.
+      api-neutral-suites:
+        default: false
+        type: boolean
       upload-binlog:
         default: false
         type: boolean
@@ -165,16 +170,22 @@ jobs:
       - name: Resolve build/test target
         shell: pwsh
         run: |
-          # The GPU solution filter narrowed to the suites this run needs: the `projects` list if given,
-          # else the ones `test-filter` can hit, else the whole filter. See build/tools/Stride.TestSuites.
+          # The solution narrowed to the suites this run needs: the `projects` list if given, else the
+          # ones `test-filter` can hit, else the whole solution. See build/tools/Stride.TestSuites.
+          # The API-neutral suites only ever run on Direct3D11: that job takes the whole game test
+          # solution when narrowed or asked for them, the other APIs stay on the GPU solution. A job
+          # whose solution has none of the needed suites gets an empty target and builds nothing.
+          $projects = "${{ github.event.inputs.projects || inputs.projects }}"
+          $filter = "${{ github.event.inputs.test-filter || inputs.test-filter }}"
+          $neutral = '${{ matrix.graphics-api }}' -eq 'Direct3D11' -and ($projects -or $filter -or '${{ inputs.api-neutral-suites }}' -eq 'true')
+          $slnf = if ($neutral) { 'build/Stride.Tests.Game.Desktop.slnf' } else { 'build/Stride.Tests.Game.GPU.slnf' }
           $target = dotnet run --project build/tools/Stride.TestSuites -- `
-            --projects "${{ github.event.inputs.projects || inputs.projects }}" `
-            --filter "${{ github.event.inputs.test-filter || inputs.test-filter }}" `
-            --slnf build/Stride.Tests.Game.GPU.slnf
-          Write-Host "Build/test target: $target"
+            --projects "$projects" --filter "$filter" --slnf $slnf
+          Write-Host "Build/test target: $(if ($target) { $target } else { '(nothing)' })"
           Add-Content $env:GITHUB_ENV "STRIDE_TEST_TARGET=$target"
           Add-Content $env:GITHUB_ENV "STRIDE_TEST_FILTER=${{ github.event.inputs.test-filter || inputs.test-filter }}"
       - name: Build
+        if: env.STRIDE_TEST_TARGET != ''
         run: |
           dotnet build $env:STRIDE_TEST_TARGET `
             -p:StrideTestRuntimeIdentifier=win-x64 `
@@ -195,7 +206,7 @@ jobs:
           path: build.binlog
           if-no-files-found: ignore
       - name: Test
-        if: success() || failure()
+        if: (success() || failure()) && env.STRIDE_TEST_TARGET != ''
         continue-on-error: ${{ inputs.tolerate-test-failures == true }}
         run: |
           $repeat = [int]("${{ github.event.inputs.repeat || inputs.repeat || '1' }}")
@@ -217,7 +228,7 @@ jobs:
             }
           }
       - name: Publish Test Report
-        if: always()
+        if: always() && env.STRIDE_TEST_TARGET != ''
         uses: phoenix-actions/test-reporting@v16
         with:
           name: 'Test Report: Windows Game ${{ matrix.graphics-api }}'

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ project.lock.json
 # Auto-generated version overlay (Stride.WorktreeVersion.targets / Stride.GitVersion.targets)
 /sources/shared/SharedAssemblyInfo.Generated.cs
 
+# Solution filters narrowed to the suites a run needs (build/tools/Stride.TestSuites)
+*.filtered.slnf

--- a/build/Stride.Tests.Game.Desktop.slnf
+++ b/build/Stride.Tests.Game.Desktop.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "Stride.slnx",
+    "projects": [
+      "..\\sources\\engine\\Stride.Audio.Tests\\Stride.Audio.Tests.csproj",
+      "..\\sources\\engine\\Stride.Engine.NoAssets.Tests\\Stride.Engine.NoAssets.Tests.csproj",
+      "..\\sources\\engine\\Stride.Engine.Tests\\Stride.Engine.Tests.csproj",
+      "..\\sources\\engine\\Stride.Graphics.Tests.10_0\\Stride.Graphics.Tests.10_0.csproj",
+      "..\\sources\\engine\\Stride.Graphics.Tests.11_0\\Stride.Graphics.Tests.11_0.csproj",
+      "..\\sources\\engine\\Stride.Graphics.Tests\\Stride.Graphics.Tests.csproj",
+      "..\\sources\\engine\\Stride.Input.Tests\\Stride.Input.Tests.csproj",
+      "..\\sources\\engine\\Stride.Navigation.Tests\\Stride.Navigation.Tests.csproj",
+      "..\\sources\\engine\\Stride.Particles.Tests\\Stride.Particles.Tests.csproj",
+      "..\\sources\\engine\\Stride.Physics.Tests\\Stride.Physics.Tests.csproj",
+      "..\\sources\\engine\\Stride.UI.Tests\\Stride.UI.Tests.csproj"
+    ]
+  }
+}

--- a/build/tools/Stride.TestSuites/Program.cs
+++ b/build/tools/Stride.TestSuites/Program.cs
@@ -1,0 +1,210 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+// Resolves which test suites a run needs, so a CI lane or a local build only builds those: either the
+// explicit list given with --projects, or the suites a `dotnet test --filter` expression can hit.
+// Suites are the test projects Stride.Tests.Combined references; for a filter, each is scanned for its
+// test methods (syntax only, no compilation) and the filter is evaluated against their fully qualified
+// names with the same engine vstest uses, so the tool and the run agree.
+//
+// "Every suite" is the answer whenever the tool is unsure: nothing given, a filter it cannot parse, or
+// one that matches no test at all. Over-inclusion only costs build time.
+
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
+
+const string Usage = """
+    Stride.TestSuites: which test suites a run needs.
+
+      --projects <list>       explicit suites, as .csproj paths or names (separated by ; , space or newline)
+      --filter <expression>   else the vstest filter to resolve (FullyQualifiedName~X|Name=Y, etc.)
+      --combined <csproj>     the meta project listing the suites (default: sources/tests/Stride.Tests.Combined)
+      --slnf <file>           write <file>.filtered.slnf keeping only the needed suites and print its path,
+                              or print <file> itself when every suite is needed
+
+    Without --slnf, prints the needed suites' names one per line, and nothing when every suite is needed.
+    """;
+
+string? filter = null, combined = null, projects = null, slnf = null;
+for (var i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--projects": projects = args[++i]; break;
+        case "--filter": filter = args[++i]; break;
+        case "--combined": combined = args[++i]; break;
+        case "--slnf": slnf = args[++i]; break;
+        default: Console.Error.WriteLine(Usage); return 2;
+    }
+}
+
+combined ??= Path.Combine(FindRepoRoot(), "sources", "tests", "Stride.Tests.Combined", "Stride.Tests.Combined.csproj");
+if (!File.Exists(combined))
+{
+    Console.Error.WriteLine($"Not found: {combined}");
+    return 2;
+}
+
+// Empty means every suite
+var needed = Resolve(projects, filter, combined);
+
+if (slnf is null)
+{
+    foreach (var suite in needed)
+        Console.WriteLine(suite);
+    return 0;
+}
+
+Console.WriteLine(FilterSolution(slnf, needed, combined));
+return 0;
+
+static List<string> Resolve(string? projects, string? filter, string combined)
+{
+    if (!string.IsNullOrWhiteSpace(projects))
+    {
+        return projects.Split([';', ',', ' ', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(SuiteName)
+            .ToList();
+    }
+
+    if (string.IsNullOrWhiteSpace(filter))
+        return [];
+
+    var expression = new FilterExpressionWrapper(filter);
+    if (expression.ParseError is not null)
+    {
+        Console.Error.WriteLine($"Filter not understood ({expression.ParseError}), every suite is needed.");
+        return [];
+    }
+
+    var matching = SuitesOf(combined)
+        .Where(suite => TestsIn(suite).Any(test => Matches(expression, test)))
+        .Select(SuiteName)
+        .ToList();
+    if (matching.Count == 0)
+        Console.Error.WriteLine("No suite has a test matching the filter, every suite is needed.");
+    return matching;
+}
+
+// The suites are the ProjectReference items Stride.Tests.Combined tags as suites, as MSBuild evaluates
+// them, so attribute order or formatting in the csproj does not matter.
+static List<string> SuitesOf(string combined)
+{
+    var msbuild = Process.Start(new ProcessStartInfo("dotnet", $"msbuild \"{combined}\" -nologo -getItem:ProjectReference")
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+    })!;
+    var json = msbuild.StandardOutput.ReadToEnd();
+    var errors = msbuild.StandardError.ReadToEnd();
+    msbuild.WaitForExit();
+    if (msbuild.ExitCode != 0)
+        throw new InvalidOperationException($"dotnet msbuild -getItem failed:\n{errors}\n{json}");
+
+    var directory = Path.GetDirectoryName(Path.GetFullPath(combined))!;
+    return JsonDocument.Parse(json).RootElement
+        .GetProperty("Items").GetProperty("ProjectReference").EnumerateArray()
+        .Where(item => item.TryGetProperty("StrideTestSuiteRef", out var tag) && tag.GetString() == "true")
+        .Select(item => Path.GetFullPath(Path.Combine(directory, item.GetProperty("Identity").GetString()!)))
+        .ToList();
+}
+
+// Every method carrying a test attribute in the suite's sources, as namespace.Type.Method. Scans the
+// directory rather than the csproj's Compile items, which can only over-include.
+static IEnumerable<TestMethod> TestsIn(string csproj)
+{
+    var directory = Path.GetDirectoryName(csproj)!;
+    foreach (var file in Directory.EnumerateFiles(directory, "*.cs", SearchOption.AllDirectories))
+    {
+        var relative = Path.GetRelativePath(directory, file);
+        if (relative.StartsWith("bin", StringComparison.OrdinalIgnoreCase) || relative.StartsWith("obj", StringComparison.OrdinalIgnoreCase))
+            continue;
+
+        var root = CSharpSyntaxTree.ParseText(File.ReadAllText(file)).GetRoot();
+        foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            if (!method.AttributeLists.SelectMany(list => list.Attributes).Any(IsTestAttribute))
+                continue;
+
+            var types = method.Ancestors().OfType<TypeDeclarationSyntax>().Reverse().Select(type => type.Identifier.Text);
+            var ns = method.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault()?.Name.ToString();
+            var typeName = string.Join("+", types);
+            yield return new TestMethod(ns is null ? typeName : $"{ns}.{typeName}", method.Identifier.Text);
+        }
+    }
+}
+
+// Fact, Theory, SkippableFact, and the repo's own attributes deriving from them.
+static bool IsTestAttribute(AttributeSyntax attribute)
+{
+    var name = attribute.Name.ToString();
+    name = name[(name.LastIndexOf('.') + 1)..];
+    if (name.EndsWith("Attribute", StringComparison.Ordinal))
+        name = name[..^"Attribute".Length];
+    return name.EndsWith("Fact", StringComparison.Ordinal) || name.EndsWith("Theory", StringComparison.Ordinal);
+}
+
+static bool Matches(FilterExpressionWrapper expression, TestMethod test)
+{
+    var fullyQualifiedName = $"{test.Type}.{test.Method}";
+    return expression.Evaluate(property => property switch
+    {
+        "FullyQualifiedName" => fullyQualifiedName,
+        "Name" => test.Method,
+        "DisplayName" => fullyQualifiedName,
+        _ => null,
+    });
+}
+
+// A solution filter next to the original with only the needed suites; other projects in it (the
+// runner, helpers) are kept. The original is the answer when every suite is needed, or when none of the
+// needed suites is in this filter, which would otherwise build nothing.
+static string FilterSolution(string slnf, List<string> needed, string combined)
+{
+    if (needed.Count == 0)
+        return slnf;
+
+    var suites = SuitesOf(combined).Select(SuiteName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    var root = JsonNode.Parse(File.ReadAllText(slnf))!;
+    var projects = root["solution"]!["projects"]!.AsArray().Select(project => project!.GetValue<string>()).ToList();
+
+    var kept = projects
+        .Where(project => !suites.Contains(SuiteName(project)) || needed.Contains(SuiteName(project), StringComparer.OrdinalIgnoreCase))
+        .ToList();
+    if (kept.Count == projects.Count)
+        return slnf;
+    if (!kept.Any(project => suites.Contains(SuiteName(project))))
+    {
+        Console.Error.WriteLine($"None of the needed suites is in {slnf}, keeping it whole.");
+        return slnf;
+    }
+
+    root["solution"]!["projects"] = new JsonArray(kept.Select(project => (JsonNode?)JsonValue.Create(project)).ToArray());
+    var filtered = Path.ChangeExtension(slnf, ".filtered.slnf");
+    File.WriteAllText(filtered, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    return filtered;
+}
+
+// A suite is named by its csproj path or by its bare name. Solution filters and user input write
+// paths with backslashes, which Linux and macOS do not take as separators, and names contain dots
+// (Stride.Graphics.Tests.10_0), so only a .csproj extension is stripped.
+static string SuiteName(string project)
+{
+    var name = Path.GetFileName(project.Replace('\\', '/'));
+    return name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ? name[..^".csproj".Length] : name;
+}
+
+static string FindRepoRoot()
+{
+    for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        if (File.Exists(Path.Combine(directory.FullName, "Stride.sln")) || Directory.Exists(Path.Combine(directory.FullName, ".git")))
+            return directory.FullName;
+    return Directory.GetCurrentDirectory();
+}
+
+record TestMethod(string Type, string Method);

--- a/build/tools/Stride.TestSuites/Program.cs
+++ b/build/tools/Stride.TestSuites/Program.cs
@@ -24,8 +24,9 @@ const string Usage = """
       --projects <list>       explicit suites, as .csproj paths or names (separated by ; , space or newline)
       --filter <expression>   else the vstest filter to resolve (FullyQualifiedName~X|Name=Y, etc.)
       --combined <csproj>     the meta project listing the suites (default: sources/tests/Stride.Tests.Combined)
-      --slnf <file>           write <file>.filtered.slnf keeping only the needed suites and print its path,
-                              or print <file> itself when every suite is needed
+      --slnf <file>           write <file>.filtered.slnf keeping only the needed suites and print its path;
+                              print <file> itself when every suite is needed, nothing when none of the
+                              needed suites is in it
 
     Without --slnf, prints the needed suites' names one per line, and nothing when every suite is needed.
     """;
@@ -162,8 +163,8 @@ static bool Matches(FilterExpressionWrapper expression, TestMethod test)
 }
 
 // A solution filter next to the original with only the needed suites; other projects in it (the
-// runner, helpers) are kept. The original is the answer when every suite is needed, or when none of the
-// needed suites is in this filter, which would otherwise build nothing.
+// runner, helpers) are kept. The original is the answer when every suite is needed. Nothing is the
+// answer when none of the needed suites is in this filter: the run has nothing to build from it.
 static string FilterSolution(string slnf, List<string> needed, string combined)
 {
     if (needed.Count == 0)
@@ -180,8 +181,8 @@ static string FilterSolution(string slnf, List<string> needed, string combined)
         return slnf;
     if (!kept.Any(project => suites.Contains(SuiteName(project))))
     {
-        Console.Error.WriteLine($"None of the needed suites is in {slnf}, keeping it whole.");
-        return slnf;
+        Console.Error.WriteLine($"None of the needed suites is in {slnf}, nothing to build from it.");
+        return "";
     }
 
     root["solution"]!["projects"] = new JsonArray(kept.Select(project => (JsonNode?)JsonValue.Create(project)).ToArray());

--- a/build/tools/Stride.TestSuites/Stride.TestSuites.csproj
+++ b/build/tools/Stride.TestSuites/Stride.TestSuites.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Opt out of Stride SDK -->
+    <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
+    <StrideCodeAnalysis>false</StrideCodeAnalysis>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Syntax-only parsing of the test sources, no compilation. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <!-- The very filter engine vstest applies the test filter with, so the tool and the run agree. -->
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="18.0.1" />
+  </ItemGroup>
+</Project>

--- a/sources/engine/Stride.Graphics.Regression/GameTestBase.cs
+++ b/sources/engine/Stride.Graphics.Regression/GameTestBase.cs
@@ -661,8 +661,7 @@ namespace Stride.Graphics.Regression
         }
 
         // Help text appended to gold comparison failures: a CompareGold pointer plus a ready
-        // `gh workflow run test-gold-gen` command pre-filtered to the failing test class, with the
-        // broader whole-suite / everything scopes shown too.
+        // `gh workflow run test-gold-gen` command pre-filtered to the failing test class.
         private static string GoldHelp(Type testType, bool suggestPromote)
         {
             var (repo, branch) = RepoAndBranch.Value;
@@ -673,17 +672,10 @@ namespace Stride.Graphics.Regression
                     + $" --ref {(string.IsNullOrEmpty(branch) ? "<branch>" : branch)}";
             var promote = suggestPromote ? " -f update-gold=auto" : "";
 
-            // Build only this suite's project (not the whole solution). The csproj is named by the
-            // assembly (unlike the namespace-based test filter); emitted only when it actually exists.
-            var assembly = testType.Assembly.GetName().Name;
-            var projectRel = $"sources/engine/{assembly}/{assembly}.csproj";
-            var project = "";
-            try { if (File.Exists(Path.Combine(GetTestsRootDirectory(), projectRel))) project = $" -f project={projectRel}"; }
-            catch { /* root not resolvable (e.g. Android) — omit, builds all */ }
-
+            // The filter alone is enough: the workflow builds only the suites it can hit.
             return $"Regenerate gold on CI (or review/promote locally with CompareGold -- tests/compare-gold.cmd):{Environment.NewLine}"
-                 + $"  gh workflow run test-gold-gen.yml{ctx}{project} -f test-filter='FullyQualifiedName~{testType.FullName}'{promote}{Environment.NewLine}"
-                 + $"  (widen: trim -f test-filter to a namespace; remove -f project to span all assemblies)";
+                 + $"  gh workflow run test-gold-gen.yml{ctx} -f test-filter='FullyQualifiedName~{testType.FullName}'{promote}{Environment.NewLine}"
+                 + $"  (widen: trim -f test-filter to a namespace, or join tests with |)";
         }
 
         // Resolved once per process: repo/branch don't change within a run, and the lookup shells

--- a/sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj
+++ b/sources/tests/Stride.Tests.Combined/Stride.Tests.Combined.csproj
@@ -53,6 +53,19 @@
                       Properties="$(_StrideSuiteRefProperties)"
                       StrideTestSuiteRef="true" />
   </ItemGroup>
+  <!-- -p:StrideCombinedSuites="<name> <name> ..." keeps only those suites (by project file name), so a
+       run that only needs a few tests builds and bundles a few suites. build/tools/Stride.TestSuites
+       computes the list from a test filter. Blank keeps every suite. Space separated on the command
+       line, since MSBuild splits a -p: value on semicolons and commas; those are accepted here too. -->
+  <ItemGroup Condition="'$(StrideCombinedSuites)' != ''">
+    <_StrideWantedSuite Include="$([MSBuild]::Unescape($(StrideCombinedSuites.Replace(',', ';').Replace(' ', ';'))))" />
+    <!-- Suite refs keyed by project name, each remembering its reference spec, minus the wanted ones -->
+    <_StrideSuiteRef Include="@(ProjectReference->WithMetadataValue('StrideTestSuiteRef', 'true'))">
+      <Spec>%(Identity)</Spec>
+    </_StrideSuiteRef>
+    <_StrideDroppedSuite Include="@(_StrideSuiteRef->'%(Filename)')" Exclude="@(_StrideWantedSuite)" />
+    <ProjectReference Remove="@(_StrideDroppedSuite->'%(Spec)')" />
+  </ItemGroup>
   <Import Project="$(StrideRoot)sources/sdk/Stride.Build.Sdk.MultiPlatform.Tests/Sdk/Sdk.targets" />
 
   <!-- Per-suite asset bundle collection. Every suite emits data/db/bundles/default.bundle


### PR DESCRIPTION
# PR Details

CI test lanes now build only the test suites a run needs.

* **`build/tools/Stride.TestSuites`** answers "which suites does this run need?": the `--projects` list, or else the suites a `--filter` can hit. For a filter it scans each suite's sources with Roslyn for test methods and evaluates the filter on them with vstest's own engine, so the tool and the run agree. Whenever it is unsure (no input, a filter it cannot parse, no match) the answer is every suite. `--slnf` writes a solution filter narrowed to those suites.
* **`Stride.Tests.Combined`** takes `-p:StrideCombinedSuites="<name> <name>"` and bundles only those suites and their assets. iOS and Android use it.
* **One desktop solution**: Linux and macOS built and tested the GPU and the API-neutral solutions in separate steps, the latter always in full and without the filter. Both now go through a new `build/Stride.Tests.Game.Desktop.slnf` listing every suite, narrowed like everything else. The Windows Direct3D11 job takes it too when narrowed or when a gold run asks for it (`api-neutral-suites`), so Particles or Audio golds can be regenerated there; Direct3D12 and Vulkan stay on the GPU solution and skip their build when none of the needed suites is in it. Blank input keeps today's solutions, so the PR gate is unchanged.
* **Inputs**: `project` becomes `projects` and takes several paths, since a filter often spans suites. The gold hint printed by failing tests drops it: the filter alone gets the right suites built. Gold runs can upload the lanes' binlogs.
* **Concurrency**: manual runs no longer cancel each other (the lanes' ref-keyed groups were cancelling each other's jobs when called from a gold run). Runs that push gold to the same branch queue, the others go side by side. The iOS simulator boots after the resolve step, whose restore and build took three minutes next to a cold boot.

In one-test gold runs the iOS build went from 18 min to 5 to 10, Android from 5.7 to 3.8, Linux from two builds and two test steps to one each. The runners themselves vary two to three fold between runs.

## Types of changes

- [x] Build / CI

## Checklist

- [x] All new and existing tests passed.
