### PR TITLE
ci: build and ship spirv-cross for win-arm64

### DIFF
--- a/.github/workflows/dep-spirv-cross.yml
+++ b/.github/workflows/dep-spirv-cross.yml
@@ -41,9 +41,39 @@ jobs:
           name: spirv-cross-win-x64
           path: spirv-cross-build/Release/spirv-cross-c-shared.dll
 
+  # Windows ARM64 — same host, MSVC ARM64 cross-compile (as in dep-spirv-tools.yml).
+  build-windows-arm64:
+    name: Build SPIRV-Cross (Windows ARM64)
+    runs-on: windows-2025-vs2026
+    steps:
+      - name: Checkout Stride
+        uses: actions/checkout@v7
+
+      - name: Checkout SPIRV-Cross
+        uses: actions/checkout@v7
+        with:
+          repository: stride3d/SPIRV-Cross
+          ref: ${{ github.event.inputs.branch || 'hlsl_tessel_shader' }}
+          path: spirv-cross-src
+
+      - name: Build
+        shell: pwsh
+        run: |
+          cmake -S spirv-cross-src -B spirv-cross-build -A ARM64 -Thost=x64 `
+            -DSPIRV_CROSS_SHARED=ON `
+            -DSPIRV_CROSS_CLI=OFF `
+            -DSPIRV_CROSS_ENABLE_TESTS=OFF
+          cmake --build spirv-cross-build --config Release --target spirv-cross-c-shared
+
+      - name: Upload build output
+        uses: actions/upload-artifact@v7
+        with:
+          name: spirv-cross-win-arm64
+          path: spirv-cross-build/Release/spirv-cross-c-shared.dll
+
   pack:
     name: Pack & Publish NuGet
-    needs: [build-windows]
+    needs: [build-windows, build-windows-arm64]
     runs-on: windows-2025-vs2026
     steps:
       - name: Checkout
@@ -57,19 +87,27 @@ jobs:
           path: spirv-cross-src
           fetch-depth: 1
 
-      - name: Download Windows artifact
+      - name: Download Windows x64 artifact
         uses: actions/download-artifact@v8
         with:
           name: spirv-cross-win-x64
           path: artifacts/win-x64
 
+      - name: Download Windows ARM64 artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: spirv-cross-win-arm64
+          path: artifacts/win-arm64
+
       - name: Prepare package contents
         shell: pwsh
         run: |
           $destDir = "build/deps/spirv-cross"
-          New-Item -Path "$destDir/win-x64" -ItemType Directory -Force | Out-Null
           # Silk.NET expects the DLL named "spirv-cross"
-          Copy-Item artifacts/win-x64/spirv-cross-c-shared.dll "$destDir/win-x64/spirv-cross.dll"
+          foreach ($rid in 'win-x64', 'win-arm64') {
+            New-Item -Path "$destDir/$rid" -ItemType Directory -Force | Out-Null
+            Copy-Item "artifacts/$rid/spirv-cross-c-shared.dll" "$destDir/$rid/spirv-cross.dll"
+          }
 
       - name: Pack NuGet
         shell: pwsh

--- a/build/deps/spirv-cross/Stride.Dependencies.SpirvCross.nuspec
+++ b/build/deps/spirv-cross/Stride.Dependencies.SpirvCross.nuspec
@@ -10,6 +10,7 @@
   </metadata>
   <files>
     <file src="win-x64/spirv-cross.dll" target="runtimes/win-x64/native/" />
+    <file src="win-arm64/spirv-cross.dll" target="runtimes/win-arm64/native/" />
     <file src="buildTransitive/Stride.Dependencies.SpirvCross.targets" target="buildTransitive/" />
     <!-- Add more platforms as needed:
     <file src="linux-x64/libspirv-cross.so" target="runtimes/linux-x64/native/" />

--- a/build/deps/spirv-cross/buildTransitive/Stride.Dependencies.SpirvCross.targets
+++ b/build/deps/spirv-cross/buildTransitive/Stride.Dependencies.SpirvCross.targets
@@ -1,8 +1,10 @@
 <Project>
   <!-- This package replaces Silk.NET.SPIRV.Cross.Native's spirv-cross.dll with the Stride fork
-       build (stride3d/SPIRV-Cross). Both packages ship runtimes/win-x64/native/spirv-cross.dll,
-       and native file conflict resolution between them is not deterministic (neither DLL has a
-       version resource). Strip Silk's native assets so the fork DLL is the only one deployed. -->
+       build (stride3d/SPIRV-Cross). Both packages ship win-x64 and win-arm64 copies of
+       runtimes/<rid>/native/spirv-cross.dll, and native file conflict resolution between them is
+       not deterministic (neither DLL has a version resource). Strip Silk's native assets so the
+       fork DLL is the only one deployed. The strip is RID-agnostic, so this package has to carry
+       every RID Silk does that Stride supports - otherwise the RID is left with no DLL at all. -->
   <Target Name="_StrideDepsSpirvCrossStripSilkNative" AfterTargets="ResolvePackageAssets">
     <ItemGroup>
       <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Silk.NET.SPIRV.Cross.Native'" />


### PR DESCRIPTION
ci: build and ship spirv-cross for win-arm64

# PR Details

`Stride.Dependencies.SpirvCross` ships `win-x64` only, so on `win-arm64` there is no
`spirv-cross.dll` to load and every shader-bearing asset fails to compile:

```
DllNotFoundException: Could not locate or load native library spirv-cross
```

`Silk.NET.SPIRV.Cross.Native` does have a `win-arm64` build, but this package's targets
strip Silk's native assets wholesale to keep conflict resolution deterministic — and that
strip is RID-agnostic, so on `win-arm64` it removes the only available DLL and puts nothing
back.

So, this PR adds an ARM64 build job (MSVC cross-compile on the same runner, mirroring
`dep-spirv-tools.yml`) and ships the result as `runtimes/win-arm64/native/`.

Windows-on-ARM natives landed in #2644; `spirv-cross` arrived a year later with the SDSL
rewrite and was never given the same treatment.

### Verification

Ran the modified workflow on a fork: both build jobs pass and the nupkg
contains both RIDs. Consuming that package, a `win-arm64` game build gets `spirv-cross.dll`
deployed on its own and runs natively on ARM64 (Direct3D11), and asset compilation works
under an arm64 `dotnet` host.

## Related Issue

No existing issue — regression found while building for `win-arm64`. Context: #2644.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

CI/packaging change, nothing to unit-test. Verified via workflow run, a game build, and
the editor; did not run the test suite.

Just in case, ai was used in process