### PR TITLE
Fix NullReferenceException when Geometry shader reads input array fields directly

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Analysis/ReadWriteAnalyzer.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Spirv/Processing/Interfaces/Analysis/ReadWriteAnalyzer.cs
@@ -79,6 +79,12 @@ internal static class ReadWriteAnalyzer
                     patchInstructionIds.Add(functionParameter.ResultId, s2.Kind);
                     methodInfo.HasStreamAccess = true;
                 }
+                else if (type is PointerType { BaseType: ArrayType { BaseType: StreamsType s3 } })
+                {
+                    // Geometry shader per-vertex input array (e.g. `Input input[3]`): indexing it yields a StreamsType access chain, same as PatchType.
+                    patchInstructionIds.Add(functionParameter.ResultId, s3.Kind);
+                    methodInfo.HasStreamAccess = true;
+                }
             }
             else if (i.Op is Op.OpLoad && new OpLoad(ref i) is { } load)
             {
@@ -177,12 +183,13 @@ internal static class ReadWriteAnalyzer
             {
                 var currentBase = accessChain.BaseId;
 
-                // In case it's a patch access, i.e. patch[0], mark the access as being a stream
+                // In case it's a patch or geometry-input-array access, i.e. patch[0] or input[0],
+                // mark the access as being a stream
                 if (patchInstructionIds.TryGetValue(currentBase, out var patchStreamKind))
                 {
                     var patchVariableId = accessChain.Indexes.Elements.Span[0];
                     if (accessChain.Indexes.Elements.Length > 1)
-                        throw new InvalidOperationException("OpAccessChain on PatchType can have only 1 element");
+                        throw new InvalidOperationException("OpAccessChain on PatchType/array-of-Streams can have only 1 element");
                     streamsInstructionIds.Add(accessChain.ResultId, patchStreamKind);
                 }
                 else

--- a/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/StrideShaderTests.cs
@@ -64,6 +64,29 @@ public class StrideShaderTests
             string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
     }
 
+    // Regression: a Geometry shader reading a stage-input stream field directly through the input
+    // array element (`input[i].Field`), not just via a whole-struct `streams = input[i]` assignment,
+    // used to crash StreamAccessPatcher with a NullReferenceException. ReadWriteAnalyzer only
+    // recognized `PointerType { BaseType: StreamsType }` as a stream access on OpVariable/
+    // OpFunctionParameter, but a GS per-vertex input parameter (`Input input[3]`) is
+    // `PointerType { BaseType: ArrayType { BaseType: StreamsType } }`, so `input[i].Field` reads were
+    // never marked as "Read" and the field never got an InputStructFieldIndex.
+    [Fact]
+    public void GeometryShaderInputArrayFieldAccessDoesNotCrashCompiler()
+    {
+        var loader = new ShaderLoader("./assets/SDSL/CompilerTests");
+        var shaderMixer = new ShaderMixer(loader);
+        shaderMixer.ShaderLoader.LoadExternalBuffer("GSInputArrayFieldAccess", [], out _, out _, out _);
+
+        var log = new Stride.Core.Diagnostics.LoggerResult();
+        Assert.True(shaderMixer.MergeSDSL(new ShaderClassSource("GSInputArrayFieldAccess"), new ShaderMixer.Options(true), log, out var bytecode, out _, out _, out _),
+            string.Join(Environment.NewLine, log.Messages.Select(m => m.Text)));
+
+        File.WriteAllBytes("GSInputArrayFieldAccess.spv", bytecode);
+        var validationResult = Spv.ValidateFile("GSInputArrayFieldAccess.spv");
+        Assert.True(validationResult.IsValid, validationResult.Output);
+    }
+
     // Reflection reports a multidimensional cbuffer array as a flat element count
     // (float4 Data2D[2][3] => 6 elements), matching fxc and the runtime parameter layout.
     [Fact]

--- a/sources/shaders/assets/SDSL/CompilerTests/GSInputArrayFieldAccess.sdsl
+++ b/sources/shaders/assets/SDSL/CompilerTests/GSInputArrayFieldAccess.sdsl
@@ -1,0 +1,43 @@
+// Compiler regression: a Geometry shader that reads a stage-input stream field directly
+// through the input array element (`input[i].Field`), not just via a whole-struct
+// `streams = input[i]` assignment.
+//
+// ReadWriteAnalyzer only recognized a stream-typed OpVariable/OpFunctionParameter when its type
+// was `PointerType { BaseType: StreamsType }` directly, but a GS per-vertex input parameter
+// (`Input input[3]`) is actually `PointerType { BaseType: ArrayType { BaseType: StreamsType } }`.
+// Because of that, `input[i].Field` reads were never marked as "Read" on the underlying stream,
+// so the field never made it into the generated GS_INPUT struct (no InputStructFieldIndex), and
+// StreamAccessPatcher later crashed with a NullReferenceException on
+// `streamInfo.InputStructFieldIndex!.Value`.
+namespace Stride.Shaders.Tests;
+
+shader GSInputArrayFieldAccess
+{
+	stream float4 Position : POSITION;
+	stream float4 ShadingPosition : SV_Position;
+	stream float3 Normal : NORMAL;
+	stream float4 ColorTarget : SV_Target0;
+
+	void VSMain()
+	{
+		streams.ShadingPosition = streams.Position;
+	}
+
+	[maxvertexcount(3)]
+	void GSMain(triangle Input input[3], inout TriangleStream<Output> triangleStream)
+	{
+		for (int i = 0; i < 3; i++)
+		{
+			streams = input[i];
+			// Direct field access on the input array element (not just a whole-struct copy).
+			streams.Normal = input[i].Normal;
+			triangleStream.Append(streams);
+		}
+		triangleStream.RestartStrip();
+	}
+
+	void PSMain()
+	{
+		streams.ColorTarget = float4(streams.Normal, 1);
+	}
+}


### PR DESCRIPTION
# PR Details

ReadWriteAnalyzer didn't recognize a Geometry shader's per-vertex input array parameter (PointerType<ArrayType<StreamsType>>) as a stream access, so direct field reads like input[i].Position were never tracked — leaving InputStructFieldIndex unset and crashing StreamAccessPatcher with an NRE. Adds the missing case plus a regression test (GSInputArrayFieldAccess.sdsl).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**

<!--- Open this PR as a draft if it isn't ready yet, you can do so by clicking on the arrow next to the 'Create pull request' button. -->
<!--- You will be able to set it back as ready to be reviewed anytime after it has been created. -->