### PR TITLE
feat: improve crash report perf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,6 +142,7 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/build-launcher.yml'
       - 'build/Stride.Launcher.slnx'
       - 'sources/core/**'
+      - 'sources/crashreport/**'
       - 'sources/launcher/**'
       - 'sources/presentation/**'
       - 'sources/shared/**'

--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.Direct3D.D3D12" Version="1.619.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0-preview.4" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <PackageVersion Include="Microsoft.TemplateEngine.IDE" Version="10.0.100" />
     <PackageVersion Include="Microsoft.TemplateEngine.Edge" Version="10.0.100" />
     <PackageVersion Include="Microsoft.TemplateEngine.Abstractions" Version="10.0.100" />

--- a/sources/crashreport/Stride.CrashReport.TestProbe/Program.cs
+++ b/sources/crashreport/Stride.CrashReport.TestProbe/Program.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Stride.CrashReport;
 
@@ -106,17 +107,18 @@ return 3;
 
 internal static partial class Trigger
 {
-    [DllImport("ucrtbase.dll", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr MemsetWindows(IntPtr dest, int c, IntPtr count);
+    [LibraryImport("ucrtbase.dll", EntryPoint = "memset")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial IntPtr MemsetWindows(IntPtr dest, int c, IntPtr count);
 
-    [DllImport("libc", EntryPoint = "memset")]
-    private static extern IntPtr MemsetUnix(IntPtr dest, int c, IntPtr count);
+    [LibraryImport("libc", EntryPoint = "memset")]
+    private static partial IntPtr MemsetUnix(IntPtr dest, int c, IntPtr count);
 
-    [DllImport("kernel32.dll")]
-    private static extern void RaiseException(uint dwExceptionCode, uint dwExceptionFlags, uint nNumberOfArguments, IntPtr lpArguments);
+    [LibraryImport("kernel32.dll")]
+    private static partial void RaiseException(uint dwExceptionCode, uint dwExceptionFlags, uint nNumberOfArguments, IntPtr lpArguments);
 
-    [DllImport("kernel32.dll")]
-    private static extern uint SetErrorMode(uint uMode);
+    [LibraryImport("kernel32.dll")]
+    private static partial uint SetErrorMode(uint uMode);
 
     // SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX: no crash dialog for the record mode,
     // whose handler (unlike InstallForReporting) leaves the dialog alone.

--- a/sources/crashreport/Stride.CrashReport.TestProbe/Stride.CrashReport.TestProbe.csproj
+++ b/sources/crashreport/Stride.CrashReport.TestProbe/Stride.CrashReport.TestProbe.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Stride.CrashReport.TestProbe</RootNamespace>
     <AssemblyName>Stride.CrashReport.TestProbe</AssemblyName>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stride.CrashReport\Stride.CrashReport.csproj" />

--- a/sources/crashreport/Stride.CrashReport/CrashPolicy.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashPolicy.cs
@@ -95,5 +95,5 @@ public static class CrashPolicy
     }
 
     private static readonly string[] CiVariables =
-        { "CI", "GITHUB_ACTIONS", "TF_BUILD", "JENKINS_URL", "TEAMCITY_VERSION", "GITLAB_CI", "BUILDKITE" };
+        ["CI", "GITHUB_ACTIONS", "TF_BUILD", "JENKINS_URL", "TEAMCITY_VERSION", "GITLAB_CI", "BUILDKITE"];
 }

--- a/sources/crashreport/Stride.CrashReport/CrashPolicy.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashPolicy.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-
 namespace Stride.CrashReport;
 
 /// <summary>How a headless tool handles crashes, from <c>STRIDE_CRASH_MODE</c>.</summary>

--- a/sources/crashreport/Stride.CrashReport/CrashReportAnonymizer.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashReportAnonymizer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/sources/crashreport/Stride.CrashReport/CrashReportData.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashReportData.cs
@@ -2,8 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Text;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Stride.CrashReport;
 

--- a/sources/crashreport/Stride.CrashReport/CrashReportJsonContext.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashReportJsonContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Stride.CrashReport;
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(StoredCrash))]
+[JsonSerializable(typeof(HashSet<string>))]
+internal sealed partial class CrashReportJsonContext : JsonSerializerContext
+{
+}

--- a/sources/crashreport/Stride.CrashReport/CrashReportSender.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashReportSender.cs
@@ -140,7 +140,7 @@ public static class CrashReportSender
         sentryEvent.Level = SentryLevel.Fatal;
         // Group by the crash's signature, not the reporter's stack or message.
         if (!string.IsNullOrEmpty(fingerprint))
-            sentryEvent.SetFingerprint(new[] { fingerprint });
+            sentryEvent.SetFingerprint([fingerprint]);
 
         // Link the crashing thread to the exception so Sentry shows its stack there and the snapshot stacks for the rest.
         if (crashedThreadId is int crashedId && sentryEvent.SentryExceptions != null)

--- a/sources/crashreport/Stride.CrashReport/CrashReportSender.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashReportSender.cs
@@ -1,16 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Reflection;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Sentry;
 
 namespace Stride.CrashReport;
 

--- a/sources/crashreport/Stride.CrashReport/CrashReportText.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashReportText.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Stride.CrashReport;

--- a/sources/crashreport/Stride.CrashReport/CrashSignature.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashSignature.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 
 namespace Stride.CrashReport;

--- a/sources/crashreport/Stride.CrashReport/CrashStore.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashStore.cs
@@ -1,11 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;

--- a/sources/crashreport/Stride.CrashReport/CrashStore.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashStore.cs
@@ -170,7 +170,7 @@ public sealed class CrashStore
         if (!set.Add(key))
             return;
         Directory.CreateDirectory(directory);
-        File.WriteAllText(path, JsonSerializer.Serialize(set));
+        File.WriteAllText(path, JsonSerializer.Serialize(set, CrashReportJsonContext.Default.HashSetString));
     }
 
     private static HashSet<string> Load(string path)
@@ -178,7 +178,7 @@ public sealed class CrashStore
         try
         {
             if (File.Exists(path))
-                return JsonSerializer.Deserialize<HashSet<string>>(File.ReadAllText(path)) ?? new();
+                return JsonSerializer.Deserialize(File.ReadAllText(path), CrashReportJsonContext.Default.HashSetString) ?? [];
         }
         catch (Exception)
         {

--- a/sources/crashreport/Stride.CrashReport/CrashStore.cs
+++ b/sources/crashreport/Stride.CrashReport/CrashStore.cs
@@ -184,7 +184,7 @@ public sealed class CrashStore
         {
             // A corrupt suppression file just means nothing is suppressed; it is rewritten on the next opt-out.
         }
-        return new HashSet<string>();
+        return [];
     }
 
     private static string SuppressKey(string signature, string version) => $"{version}\n{signature}";

--- a/sources/crashreport/Stride.CrashReport/DumpStackWalk.cs
+++ b/sources/crashreport/Stride.CrashReport/DumpStackWalk.cs
@@ -114,10 +114,10 @@ public static class DumpStackWalk
                     frames.Insert(0, new StoredFrame { Function = faultingFrame });
                 // The exception's message is Sentry's subtitle: the native location, the one thing the managed
                 // stack (whose top frame Sentry shows as the culprit) can't tell. The report line says it all.
-                crash.Exceptions = new List<StoredException>
-                {
+                crash.Exceptions =
+                [
                     new() { Type = "NativeCrash", Message = NativeCrashReporting.NativeCrashValue(faultingFrame), Frames = frames },
-                };
+                ];
                 crash.CrashedThreadId = (int)thread.OSThreadId;
                 SetReportException(crash, NativeCrashReporting.NativeCrashMessage(faultingFrame, crash.AffectedAssets.FirstOrDefault(), faultSite));
             }

--- a/sources/crashreport/Stride.CrashReport/DumpStackWalk.cs
+++ b/sources/crashreport/Stride.CrashReport/DumpStackWalk.cs
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Microsoft.Diagnostics.Runtime;
 
 namespace Stride.CrashReport;

--- a/sources/crashreport/Stride.CrashReport/MinidumpReader.cs
+++ b/sources/crashreport/Stride.CrashReport/MinidumpReader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.IO;
 using System.Text;
 
 namespace Stride.CrashReport

--- a/sources/crashreport/Stride.CrashReport/MinidumpWriter.cs
+++ b/sources/crashreport/Stride.CrashReport/MinidumpWriter.cs
@@ -12,7 +12,7 @@ namespace Stride.CrashReport;
 /// Writes a minidump of the current process: thread stacks and module list, not full memory. Windows-only (dbghelp).
 /// </summary>
 [SupportedOSPlatform("windows")]
-public static class MinidumpWriter
+public static partial class MinidumpWriter
 {
     private const int MiniDumpNormal = 0x0;
     private const int MiniDumpWithFullMemory = 0x2;
@@ -229,13 +229,15 @@ public static class MinidumpWriter
         public int ClientPointers; // BOOL
     }
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern IntPtr OpenProcess(uint desiredAccess, bool inheritHandle, uint processId);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr OpenProcess(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, uint processId);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool CloseHandle(IntPtr handle);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(IntPtr handle);
 
-    [DllImport("dbghelp.dll", SetLastError = true)]
-    private static extern bool MiniDumpWriteDump(IntPtr hProcess, uint processId, SafeFileHandle hFile, int dumpType,
+    [LibraryImport("dbghelp.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool MiniDumpWriteDump(IntPtr hProcess, uint processId, SafeFileHandle hFile, int dumpType,
         IntPtr exceptionParam, IntPtr userStreamParam, IntPtr callbackParam);
 }

--- a/sources/crashreport/Stride.CrashReport/MinidumpWriter.cs
+++ b/sources/crashreport/Stride.CrashReport/MinidumpWriter.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;

--- a/sources/crashreport/Stride.CrashReport/NativeCrashReporting.cs
+++ b/sources/crashreport/Stride.CrashReport/NativeCrashReporting.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace Stride.CrashReport

--- a/sources/crashreport/Stride.CrashReport/NativeInvoke.cs
+++ b/sources/crashreport/Stride.CrashReport/NativeInvoke.cs
@@ -15,7 +15,7 @@ namespace Stride.CrashReport
     /// RID-specific publishes like GameStudio). This minimal assembly doesn't reference Stride.Core's
     /// NativeLibraryHelper, so it resolves the library from those locations itself.
     /// </remarks>
-    internal static class NativeInvoke
+    internal static partial class NativeInvoke
     {
         internal const string Library = "libstridecrash";
 
@@ -27,8 +27,8 @@ namespace Stride.CrashReport
 
         /// <summary>Registers the native vectored exception handler. Paths must be absolute; the identity strings
         /// (application/version/environment) ride the reporter's command line; timeoutMs bounds the capture wait.</summary>
-        [DllImport(Library, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal static extern void stride_crash_install(string reporterPath, string dumpDir, uint timeoutMs,
+        [LibraryImport(Library, StringMarshalling = StringMarshalling.Utf16)]
+        internal static partial void stride_crash_install(string reporterPath, string dumpDir, uint timeoutMs,
             string application, string version, string environment);
 
         private static IntPtr Resolve(string name, Assembly assembly, DllImportSearchPath? paths)

--- a/sources/crashreport/Stride.CrashReport/NativeInvoke.cs
+++ b/sources/crashreport/Stride.CrashReport/NativeInvoke.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/sources/crashreport/Stride.CrashReport/StoredCrash.cs
+++ b/sources/crashreport/Stride.CrashReport/StoredCrash.cs
@@ -36,7 +36,7 @@ public sealed class StoredCrash
     public int Count { get; set; } = 1;
 
     /// <summary>The report content (the <see cref="CrashReportData"/> key/value pairs), already anonymized.</summary>
-    public List<CrashEntry> Report { get; set; } = new();
+    public List<CrashEntry> Report { get; set; } = [];
 
     /// <summary>Sibling minidump file name in the same run directory, if one was written.</summary>
     public string DumpFileName { get; set; }
@@ -47,16 +47,16 @@ public sealed class StoredCrash
     public bool DumpIsFullMemory { get; set; }
 
     /// <summary>Scrubbed leaf names of the assets that hit this signature, for the "x N assets" display.</summary>
-    public List<string> AffectedAssets { get; set; } = new();
+    public List<string> AffectedAssets { get; set; } = [];
 
     /// <summary>Local-only path of the failing asset's definition file, offered as an opt-in attachment.</summary>
     public string AssetDefinitionPath { get; set; }
 
     /// <summary>Local-only paths of the failing asset's direct source files (FBX, textures), for a future opt-in attachment.</summary>
-    public List<string> AssetSourcePaths { get; set; } = new();
+    public List<string> AssetSourcePaths { get; set; } = [];
 
     /// <summary>Structured exception chain for a managed crash, so the reporter rebuilds a real Sentry stacktrace. Empty for native.</summary>
-    public List<StoredException> Exceptions { get; set; } = new();
+    public List<StoredException> Exceptions { get; set; } = [];
 
     /// <summary>Managed id of the crashing thread, when known; lets the reporter flag it in the thread list.</summary>
     public int? CrashedThreadId { get; set; }
@@ -65,7 +65,7 @@ public sealed class StoredCrash
     public string CrashedThreadName { get; set; }
 
     /// <summary>Other (non-crashing) threads' callstacks captured at a fatal crash. Empty otherwise.</summary>
-    public List<StoredThread> Threads { get; set; } = new();
+    public List<StoredThread> Threads { get; set; } = [];
 
     /// <summary>One-line label: the exception's first line, else the signature.</summary>
     public string Title()
@@ -111,7 +111,7 @@ public sealed class StoredException
 {
     public string Type { get; set; }
     public string Message { get; set; }
-    public List<StoredFrame> Frames { get; set; } = new();
+    public List<StoredFrame> Frames { get; set; } = [];
 
     /// <summary>Captures a live exception + inner chain (with file/line from PDBs) into a serializable model at the crash site.</summary>
     public static List<StoredException> Capture(Exception exception)
@@ -151,5 +151,5 @@ public sealed class StoredThread
 {
     public int Id { get; set; }
     public string Name { get; set; }
-    public List<StoredFrame> Frames { get; set; } = new();
+    public List<StoredFrame> Frames { get; set; } = [];
 }

--- a/sources/crashreport/Stride.CrashReport/StoredCrash.cs
+++ b/sources/crashreport/Stride.CrashReport/StoredCrash.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 
 namespace Stride.CrashReport;

--- a/sources/crashreport/Stride.CrashReport/StoredCrash.cs
+++ b/sources/crashreport/Stride.CrashReport/StoredCrash.cs
@@ -94,11 +94,9 @@ public sealed class StoredCrash
         return crash;
     }
 
-    public string ToJson() => JsonSerializer.Serialize(this, JsonOptions);
+    public string ToJson() => JsonSerializer.Serialize(this, CrashReportJsonContext.Default.StoredCrash);
 
-    public static StoredCrash FromJson(string json) => JsonSerializer.Deserialize<StoredCrash>(json, JsonOptions);
-
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    public static StoredCrash FromJson(string json) => JsonSerializer.Deserialize(json, CrashReportJsonContext.Default.StoredCrash);
 }
 
 /// <summary>One report key/value pair. Kept as an explicit object (not a dictionary) so insertion order survives the round-trip.</summary>

--- a/sources/crashreport/Stride.CrashReport/Stride.CrashReport.csproj
+++ b/sources/crashreport/Stride.CrashReport/Stride.CrashReport.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <!-- UI-agnostic and cross-platform: shared by the WPF window, the Avalonia launcher, and headless tools -->
     <TargetFramework>$(StrideXplatEditorTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
     <!-- Builds Native/*.cpp into runtimes/<rid>/native/libstridecrash.<ext>: the native crash trigger.
          Windows-only in effect; a no-op stub elsewhere. Deleted once .NET 12's SetFatalErrorHandler lands. -->
     <StrideNativeOutputName>libstridecrash</StrideNativeOutputName>

--- a/sources/crashreport/Stride.CrashReport/ThreadSnapshot.cs
+++ b/sources/crashreport/Stride.CrashReport/ThreadSnapshot.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.Diagnostics.Runtime;
 
 namespace Stride.CrashReport;

--- a/sources/crashreport/Stride.CrashReporter/App.axaml.cs
+++ b/sources/crashreport/Stride.CrashReporter/App.axaml.cs
@@ -44,7 +44,7 @@ public partial class App : Application
             Title = "Save full memory dump",
             SuggestedFileName = suggestedName,
             DefaultExtension = "dmp",
-            FileTypeChoices = new[] { new FilePickerFileType("Minidump") { Patterns = new[] { "*.dmp" } } },
+            FileTypeChoices = [new FilePickerFileType("Minidump") { Patterns = ["*.dmp"] }],
         });
         return file?.TryGetLocalPath();
     }

--- a/sources/crashreport/Stride.CrashReporter/CrashReporterViewModel.cs
+++ b/sources/crashreport/Stride.CrashReporter/CrashReporterViewModel.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Windows.Input;
 
 namespace Stride.CrashReporter;

--- a/sources/crashreport/Stride.CrashReporter/CrashReporterWindow.axaml
+++ b/sources/crashreport/Stride.CrashReporter/CrashReporterWindow.axaml
@@ -45,13 +45,13 @@
            the per-crash checkboxes, and last the rarely used links (one Shift+Tab away from the initial focus). -->
       <StackPanel Margin="4,0,4,8" IsVisible="{Binding ShowSendControls}" IsEnabled="{Binding CanSend}">
         <Grid ColumnDefinitions="*,*" Margin="0,0,0,4">
-          <TextBox Grid.Column="0" Margin="0,0,4,0" Watermark="Your name (optional)" TabIndex="2"
+          <TextBox Grid.Column="0" Margin="0,0,4,0" PlaceholderText="Your name (optional)" TabIndex="2"
                    Text="{Binding FeedbackName}" />
-          <TextBox Grid.Column="1" Margin="4,0,0,0" Watermark="Your email (optional, for follow-up)" TabIndex="3"
+          <TextBox Grid.Column="1" Margin="4,0,0,0" PlaceholderText="Your email (optional, for follow-up)" TabIndex="3"
                    Text="{Binding FeedbackEmail}" />
         </Grid>
         <TextBox Height="52" AcceptsReturn="True" TextWrapping="Wrap" VerticalContentAlignment="Top" TabIndex="4"
-                 Watermark="What were you doing when it crashed? (optional)"
+                 PlaceholderText="What were you doing when it crashed? (optional)"
                  Text="{Binding FeedbackMessage}" />
       </StackPanel>
       <TextBlock Margin="4,0,4,8" TextWrapping="WrapWithOverflow"

--- a/sources/crashreport/Stride.CrashReporter/CrashSession.cs
+++ b/sources/crashreport/Stride.CrashReporter/CrashSession.cs
@@ -103,7 +103,7 @@ internal sealed class CrashSession
 
     // The failing asset's definition file, read from disk and scrubbed of the user name/path (its YAML can
     // reference a source path under the home folder). Null if missing or over the size cap.
-    private static IReadOnlyList<(string Name, byte[] Bytes)> BuildAssetDefinitionAttachment(StoredCrash crash)
+    private static IReadOnlyList<(string Name, byte[] Bytes)>? BuildAssetDefinitionAttachment(StoredCrash crash)
     {
         var path = crash.AssetDefinitionPath;
         if (string.IsNullOrEmpty(path) || !File.Exists(path))
@@ -113,7 +113,7 @@ internal sealed class CrashSession
             if (new FileInfo(path).Length > MaxAssetAttachmentBytes)
                 return null;
             var scrubbed = CrashReportAnonymizer.Scrub(File.ReadAllText(path));
-            return new[] { (Path.GetFileName(path), Encoding.UTF8.GetBytes(scrubbed)) };
+            return [(Path.GetFileName(path), Encoding.UTF8.GetBytes(scrubbed))];
         }
         catch
         {

--- a/sources/crashreport/Stride.CrashReporter/NativeCapture.cs
+++ b/sources/crashreport/Stride.CrashReporter/NativeCapture.cs
@@ -14,7 +14,7 @@ namespace Stride.CrashReporter;
 /// <see cref="StoredCrash"/> the window can show. Capturing from this healthy process — not the corrupt, dying one
 /// — is what makes the dump reliable. Windows-only; a no-op elsewhere.
 /// </summary>
-internal static class NativeCapture
+internal static partial class NativeCapture
 {
     /// <summary>
     /// Runs the out-of-process capture and populates <paramref name="runDirectory"/> with the dump and a
@@ -132,10 +132,14 @@ internal static class NativeCapture
         }
     }
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr OpenEventW(uint desiredAccess, bool inheritHandle, string name);
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool SetEvent(IntPtr handle);
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool CloseHandle(IntPtr handle);
+    [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial IntPtr OpenEventW(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, string name);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetEvent(IntPtr handle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(IntPtr handle);
 }

--- a/sources/crashreport/Stride.CrashReporter/NativeCapture.cs
+++ b/sources/crashreport/Stride.CrashReporter/NativeCapture.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Stride.CrashReport;
 

--- a/sources/crashreport/Stride.CrashReporter/Program.cs
+++ b/sources/crashreport/Stride.CrashReporter/Program.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Globalization;
-using System.Linq;
 using Avalonia;
 using Stride.CrashReport;
 

--- a/sources/launcher/Stride.Cli/CliJsonContext.cs
+++ b/sources/launcher/Stride.Cli/CliJsonContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Stride.Cli;
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal sealed partial class CliJsonContext : JsonSerializerContext
+{
+}

--- a/sources/launcher/Stride.Cli/Core/ManagedVersionStore.cs
+++ b/sources/launcher/Stride.Cli/Core/ManagedVersionStore.cs
@@ -23,7 +23,7 @@ internal sealed class ManagedVersionStore
         if (!File.Exists(filePath))
             return new(StringComparer.OrdinalIgnoreCase);
 
-        return JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(filePath))
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(filePath), CliJsonContext.Default.DictionaryStringString)
             ?? new(StringComparer.OrdinalIgnoreCase);
     }
 
@@ -33,7 +33,7 @@ internal sealed class ManagedVersionStore
 
         // Write to a temporary file then move it into place so a concurrent reader never sees a partial file.
         var temporaryPath = filePath + ".tmp";
-        File.WriteAllText(temporaryPath, JsonSerializer.Serialize(managedVersions, new JsonSerializerOptions { WriteIndented = true }));
+        File.WriteAllText(temporaryPath, JsonSerializer.Serialize(managedVersions, CliJsonContext.Default.DictionaryStringString));
         File.Move(temporaryPath, filePath, overwrite: true);
     }
 }

--- a/sources/shared/NativeCrashHandler.cs
+++ b/sources/shared/NativeCrashHandler.cs
@@ -26,28 +26,30 @@ namespace Stride
     /// Shared by Stride.Graphics.Regression and Stride.Games.AutoTesting (via <see cref="Install"/> from a
     /// ModuleInitializer) and by the asset compiler (via <see cref="InstallFaultingFrameRecorder"/>).
     /// </remarks>
-    internal static class NativeCrashHandler
+    internal static partial class NativeCrashHandler
     {
-        [DllImport("kernel32.dll")]
-        private static extern uint SetErrorMode(uint uMode);
+        [LibraryImport("kernel32.dll")]
+        private static partial uint SetErrorMode(uint uMode);
 
-        [DllImport("dbghelp.dll", SetLastError = true)]
-        private static extern bool MiniDumpWriteDump(IntPtr hProcess, uint processId, IntPtr hFile,
+        [LibraryImport("dbghelp.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool MiniDumpWriteDump(IntPtr hProcess, uint processId, IntPtr hFile,
             uint dumpType, IntPtr exceptionParam, IntPtr userStreamParam, IntPtr callbackParam);
 
-        [DllImport("kernel32.dll")]
-        private static extern IntPtr AddVectoredExceptionHandler(uint first, IntPtr handler);
-        [DllImport("kernel32.dll")]
-        private static extern uint RemoveVectoredExceptionHandler(IntPtr handle);
+        [LibraryImport("kernel32.dll")]
+        private static partial IntPtr AddVectoredExceptionHandler(uint first, IntPtr handler);
+        [LibraryImport("kernel32.dll")]
+        private static partial uint RemoveVectoredExceptionHandler(IntPtr handle);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool GetModuleHandleExW(uint flags, IntPtr address, out IntPtr module);
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool GetModuleHandleExW(uint flags, IntPtr address, out IntPtr module);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern uint GetModuleFileNameW(IntPtr module, [Out] char[] filename, uint size);
+        [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+        private static partial uint GetModuleFileNameW(IntPtr module, [Out] char[] filename, uint size);
 
-        [DllImport("kernel32.dll")]
-        private static extern uint GetCurrentThreadId();
+        [LibraryImport("kernel32.dll")]
+        private static partial uint GetCurrentThreadId();
 
         // PVECTORED_EXCEPTION_HANDLER: LONG (*)(PEXCEPTION_POINTERS). Kept in a static field so the reverse
         // P/Invoke thunk isn't collected while registered.


### PR DESCRIPTION
# PR Details

Use `[LibraryImport]` for native calls and source generation for `System.Text.Json` (to avoid reflection).
Also formatted the files (e.g. remove unnecessary directives).

This prepares the work of eventually trimming the libraries or even using AOT.

## Related Issue

Will be needed for #3414 (if I find a good way of doing it).

## Types of changes

- [x] **Refactoring**

## Checklist

- [x] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**