### PR TITLE
Fix SDSL postfix parser silently dropping a dangling '.' or '['

### DIFF
--- a/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ExpressionParsers/UnaryParsers.Postfix.cs
+++ b/sources/shaders/Stride.Shaders.Parsers/Parsing/SDSL/Parsers/ExpressionParsers/UnaryParsers.Postfix.cs
@@ -21,29 +21,25 @@ public record struct PostfixParser : IParser<Expression>
                 parsed = new AccessorChainExpression(parsed, parsed.Info);
                 while (!scanner.IsEof && Parsers.FollowedByAny(ref scanner, ["[", ".", "++", "--"], out var matched, withSpaces: true, advance: true))
                 {
-                    if (
-                        matched == "["
-                        && Parsers.FollowedByDel(ref scanner, result, ExpressionParser.Expression, out Expression? indexer, withSpaces: true, advance: true)
-                        && Parsers.FollowedBy(ref scanner, Tokens.Char(']'), withSpaces: true, advance: true)
-                    )
+                    if (matched == "[")
                     {
+                        if (!Parsers.FollowedByDel(ref scanner, result, ExpressionParser.Expression, out Expression? indexer, withSpaces: true, advance: true))
+                            return Parsers.Exit(ref scanner, result, out parsed, position, new(SDSLErrorMessages.SDSL0015, scanner[scanner.Position], scanner.Memory));
+                        if (!Parsers.FollowedBy(ref scanner, Tokens.Char(']'), withSpaces: true, advance: true))
+                            return Parsers.Exit(ref scanner, result, out parsed, position, new(SDSLErrorMessages.SDSL0019, scanner[scanner.Position], scanner.Memory));
                         ((AccessorChainExpression)parsed).Accessors.Add(new IndexerExpression(indexer!, indexer!.Info));
                     }
-                    else if (
-                        matched == "."
-                        && Parsers.FollowedByDel(ref scanner, result, PrimaryParsers.Method, out Expression? call, withSpaces: true, advance: true)
-                    )
+                    else if (matched == ".")
                     {
-                        ((AccessorChainExpression)parsed).Accessors.Add(call!);
+                        if (Parsers.FollowedByDel(ref scanner, result, PrimaryParsers.Method, out Expression? call, withSpaces: true, advance: true))
+                            ((AccessorChainExpression)parsed).Accessors.Add(call!);
+                        else if (Parsers.FollowedByDel(ref scanner, result, LiteralsParser.IdentifierBase, out IdentifierBase? accessor, withSpaces: true, advance: true))
+                            ((AccessorChainExpression)parsed).Accessors.Add(accessor!);
+                        else
+                            // A '.' with nothing valid after it must not be silently dropped (e.g. `a.;` or `1..`)
+                            return Parsers.Exit(ref scanner, result, out parsed, position, new(SDSLErrorMessages.SDSL0021, scanner[scanner.Position], scanner.Memory));
                     }
-                    else if (
-                        matched == "."
-                        && Parsers.FollowedByDel(ref scanner, result, LiteralsParser.IdentifierBase, out IdentifierBase? accessor, withSpaces: true, advance: true)
-                    )
-                    {
-                        ((AccessorChainExpression)parsed).Accessors.Add(accessor!);
-                    }
-                    else if (matched == "++" || matched == "--")
+                    else
                     {
                         ((AccessorChainExpression)parsed).Accessors.Add(new PostfixIncrement(matched.ToOperator(), scanner[(scanner.Position - 2)..scanner.Position]));
                         break;

--- a/sources/shaders/Stride.Shaders.Tests/ParsingTests.cs
+++ b/sources/shaders/Stride.Shaders.Tests/ParsingTests.cs
@@ -44,6 +44,42 @@ public class ParsingTests1
         Assert.True(result.Errors.Count > 0, "Expected a parse error for invalid float suffix '1.q' but got none. Errors: " + string.Join("\n", result.Errors.Select(x => x.ToString())));
     }
 
+    // A postfix '.' or '[' with nothing valid after it used to be consumed and silently dropped.
+    [Theory]
+    [InlineData("float i = a.;")]
+    [InlineData("float i = a . ;")]
+    [InlineData("float i = 1..;")]
+    [InlineData("float i = 1.0.;")]
+    [InlineData("float i = a.b.;")]
+    [InlineData("float i = a[;")]
+    [InlineData("float i = a[];")]
+    [InlineData("float i = a[1;")]
+    [InlineData("float i = a[1].;")]
+    public void DanglingPostfixAccessorIsAnError(string statement)
+    {
+        var text = "shader Foo { void Bar() { float a = 0; " + statement + " } };";
+        var result = SDSLParser.Parse(text);
+        Assert.True(result.Errors.Count > 0, "Expected a parse error for '" + statement + "' but got none.");
+    }
+
+    [Theory]
+    [InlineData("float i = a.x;")]
+    [InlineData("float i = a . x;")]
+    [InlineData("float i = a.b.c;")]
+    [InlineData("float i = a[1];")]
+    [InlineData("float i = a[1].x;")]
+    [InlineData("float i = a[1][2];")]
+    [InlineData("float i = a.Foo(1).x;")]
+    [InlineData("float i = a++;")]
+    [InlineData("float i = a[1]++;")]
+    [InlineData("float i = 1.;")]
+    public void PostfixAccessorChainParses(string statement)
+    {
+        var text = "shader Foo { void Bar() { float a = 0; " + statement + " } };";
+        var result = SDSLParser.Parse(text);
+        Assert.True(result.Errors.Count == 0, statement + "\n" + string.Join("\n", result.Errors.Select(x => x.ToString())));
+    }
+
     // [Theory]
     // [MemberData(nameof(GetShaderFilePaths))]
     // public void AnalyseFile(string path)


### PR DESCRIPTION
# PR Details

The SDSL postfix parser consumed a '.' or '[' and then silently dropped it when nothing valid followed, so statements like `a.;`, `1..;` or `a[1;` parsed without any error.

This reports a parse error at that point instead (SDSL0021 for a dangling '.', SDSL0015 for '[' without an expression, SDSL0019 for a missing ']'), and adds negative and positive parsing tests for accessor chains.

Follow-up to #3421, which made `1..` reachable through this path.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.