### PR TITLE
Vulkan: Texture.Format reports the depth-stencil format the device really uses

### DIFF
--- a/sources/engine/Stride.Graphics/Texture.cs
+++ b/sources/engine/Stride.Graphics/Texture.cs
@@ -491,10 +491,13 @@ namespace Stride.Graphics
             ParentTexture = parentTexture;
             ParentTexture?.AddReferenceInternal();
 
-            textureDescription = description;
+            var deviceDescription = description;
+            AdjustDescriptionForDevice(ref deviceDescription);
+
+            textureDescription = deviceDescription;
             textureViewDescription = viewDescription;
             RowStride = ComputeRowPitch(0);
-            mipmapDescriptions = Image.CalculateMipMapDescription(description);
+            mipmapDescriptions = Image.CalculateMipMapDescription(deviceDescription);
             SizeInBytes = ArraySize * mipmapDescriptions?.Sum(mip => mip.MipmapSize) ?? 0;
 
             ViewWidth = Math.Max(1, Width >> MipLevel);
@@ -503,11 +506,11 @@ namespace Stride.Graphics
 
             if (ViewFormat == PixelFormat.None)
             {
-                textureViewDescription.Format = description.Format;
+                textureViewDescription.Format = deviceDescription.Format;
             }
             if (ViewFlags == TextureFlags.None)
             {
-                textureViewDescription.Flags = description.Flags;
+                textureViewDescription.Flags = deviceDescription.Flags;
             }
 
             // Check that the Texture View flags are compatible with the parent Texture's flags
@@ -545,6 +548,13 @@ namespace Stride.Graphics
         ///   An array of <see cref="DataBox"/> pointing to the data to initialize the Texture's sub-resources.
         /// </param>
         private partial void InitializeFromImpl(DataBox[] dataBoxes);
+
+        /// <summary>
+        ///   Lets the graphics backend replace a format the device cannot use with the one it will really create,
+        ///   so the description describes the Texture that exists rather than the one that was asked for.
+        /// </summary>
+        /// <param name="description">The description to adjust in place.</param>
+        partial void AdjustDescriptionForDevice(ref TextureDescription description);
 
         /// <summary>
         ///   Releases the Texture data.

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDevice.Vulkan.cs
@@ -84,6 +84,43 @@ namespace Stride.Graphics
         internal VkInstance NativeInstance => GraphicsAdapterFactory.GetInstance(IsDebugMode).NativeInstance;
         internal VkInstanceApi NativeInstanceApi => GraphicsAdapterFactory.GetInstance(IsDebugMode).NativeInstanceApi;
 
+        private readonly Dictionary<PixelFormat, PixelFormat> supportedDepthStencilFormats = new();
+
+        /// <summary>
+        ///   Gets the depth-stencil format the device will really use for <paramref name="format"/>.
+        /// </summary>
+        /// <remarks>
+        ///   Vulkan guarantees only that one of <c>D24_UNORM_S8_UINT</c> or <c>D32_SFLOAT_S8_UINT</c> is supported as a
+        ///   depth-stencil attachment, so a requested format may be substituted. The answer depends only on the physical
+        ///   device, so it is resolved once and cached. Formats without a stencil are returned unchanged.
+        /// </remarks>
+        internal PixelFormat GetSupportedDepthStencilFormat(PixelFormat format)
+        {
+            lock (supportedDepthStencilFormats)
+            {
+                if (supportedDepthStencilFormats.TryGetValue(format, out var supported))
+                    return supported;
+
+                supported = format;
+                if (format is PixelFormat.D24_UNorm_S8_UInt or PixelFormat.D32_Float_S8X24_UInt)
+                {
+                    // The requested one first, so a device that supports it keeps it
+                    foreach (var candidate in new[] { format, PixelFormat.D32_Float_S8X24_UInt, PixelFormat.D24_UNorm_S8_UInt })
+                    {
+                        NativeInstanceApi.vkGetPhysicalDeviceFormatProperties(NativePhysicalDevice, VulkanConvertExtensions.ConvertPixelFormat(candidate), out var formatProperties);
+                        if ((formatProperties.optimalTilingFeatures & VkFormatFeatureFlags.DepthStencilAttachment) != 0)
+                        {
+                            supported = candidate;
+                            break;
+                        }
+                    }
+                }
+
+                supportedDepthStencilFormats.Add(format, supported);
+                return supported;
+            }
+        }
+
         internal struct BufferInfo
         {
             public long FenceValue;

--- a/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/GraphicsDeviceFeatures.Vulkan.cs
@@ -75,21 +75,19 @@ namespace Stride.Graphics
 
         private static MultisampleCount GetMaximumMultisampleCount(GraphicsDevice deviceRoot, VkInstanceApi instanceApi, VkPhysicalDevice physicalDevice, PixelFormat pixelFormat)
         {
+            var isDepthFormat = Texture.IsDepthFormat(pixelFormat);
+            if (isDepthFormat)
+            {
+                // A texture of this format is created with the one the device supports, so answer for that one
+                pixelFormat = deviceRoot.GetSupportedDepthStencilFormat(pixelFormat);
+            }
+
             if (!VulkanConvertExtensions.TryConvertPixelFormat(pixelFormat, out var format, out _, out _))
                 return MultisampleCount.None;
 
             // Same usage as Texture.CreateImage for a render target or depth stencil of that format
             var usage = VkImageUsageFlags.TransferSrc | VkImageUsageFlags.TransferDst;
-            if (Texture.IsDepthFormat(pixelFormat))
-            {
-                usage |= VkImageUsageFlags.DepthStencilAttachment;
-                // CreateImage substitutes a supported depth-stencil format, so query the one it would really create
-                format = Texture.GetFallbackDepthStencilFormat(deviceRoot, format);
-            }
-            else
-            {
-                usage |= VkImageUsageFlags.ColorAttachment;
-            }
+            usage |= isDepthFormat ? VkImageUsageFlags.DepthStencilAttachment : VkImageUsageFlags.ColorAttachment;
 
             var result = instanceApi.vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, VkImageType.Image2D, VkImageTiling.Optimal, usage, VkImageCreateFlags.None, out var imageFormatProperties);
             if (result != VkResult.Success)

--- a/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/PipelineState.Vulkan.cs
@@ -223,7 +223,7 @@ namespace Stride.Graphics
                         colorAttachmentFormats[i] = VulkanConvertExtensions.ConvertPixelFormat(*(renderTargetFormat + i));
 
                     var depthAttachmentFormat = output.DepthStencilFormat != PixelFormat.None
-                        ? Texture.GetFallbackDepthStencilFormat(GraphicsDevice, VulkanConvertExtensions.ConvertPixelFormat(output.DepthStencilFormat))
+                        ? VulkanConvertExtensions.ConvertPixelFormat(GraphicsDevice.GetSupportedDepthStencilFormat(output.DepthStencilFormat))
                         : VkFormat.Undefined;
 
                     var renderingCreateInfo = new VkPipelineRenderingCreateInfo

--- a/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
+++ b/sources/engine/Stride.Graphics/Vulkan/Texture.Vulkan.cs
@@ -102,6 +102,14 @@ namespace Stride.Graphics
         private bool importedImageHandled;
         partial void TryInitializeImportedImage();
 
+        partial void AdjustDescriptionForDevice(ref TextureDescription description)
+        {
+            // The device may not support the requested depth-stencil format, and CreateImage would substitute
+            // another one, so record the format the image will really have.
+            if ((description.Flags & TextureFlags.DepthStencil) != 0)
+                description.Format = GraphicsDevice.GetSupportedDepthStencilFormat(description.Format);
+        }
+
         private partial void InitializeFromImpl(DataBox[] dataBoxes = null)
         {
             importedImageHandled = false;
@@ -122,12 +130,6 @@ namespace Stride.Graphics
             GetViewSliceBounds(ViewType, ref arraySlice, ref mipLevel, out var arrayOrDepthCount, out var mipCount);
             var arrayCount = Dimension == TextureDimension.Texture3D ? 1 : arrayOrDepthCount;
             NativeResourceRange = new VkImageSubresourceRange(NativeImageAspect, (uint) mipLevel, (uint) mipCount, (uint) arraySlice, (uint) arrayCount);
-
-            // For depth-stencil formats, automatically fall back to a supported one
-            if (IsDepthStencil && HasStencil)
-            {
-                NativeFormat = GetFallbackDepthStencilFormat(GraphicsDevice, NativeFormat);
-            }
 
             if (Usage == GraphicsResourceUsage.Staging)
             {
@@ -713,27 +715,6 @@ namespace Stride.Graphics
         private static int CalculateMipCount(int width, int height, int minimumSizeLastMip = 4)
         {
             return Math.Min(CalculateMipCountFromSize(width, minimumSizeLastMip), CalculateMipCountFromSize(height, minimumSizeLastMip));
-        }
-
-        internal static VkFormat GetFallbackDepthStencilFormat(GraphicsDevice device, VkFormat format)
-        {
-            if (format == VkFormat.D16UnormS8Uint || format == VkFormat.D24UnormS8Uint || format == VkFormat.D32SfloatS8Uint)
-            {
-                var fallbackFormats = new[] { format, VkFormat.D32SfloatS8Uint, VkFormat.D24UnormS8Uint, VkFormat.D16UnormS8Uint };
-
-                foreach (var fallbackFormat in fallbackFormats)
-                {
-                    device.NativeInstanceApi.vkGetPhysicalDeviceFormatProperties(device.NativePhysicalDevice, fallbackFormat, out var formatProperties);
-
-                    if ((formatProperties.optimalTilingFeatures & VkFormatFeatureFlags.DepthStencilAttachment) != 0)
-                    {
-                        format = fallbackFormat;
-                        break;
-                    }
-                }
-            }
-
-            return format;
         }
 
         internal static bool IsDepthFormat(PixelFormat format)


### PR DESCRIPTION
# PR Details

Vulkan does not guarantee any specific depth+stencil format, only that one of `D24_UNORM_S8_UINT` or `D32_SFLOAT_S8_UINT` works as a depth-stencil attachment. Texture creation already substituted a supported one, but only in `NativeFormat`. `Texture.Format` kept the format that was requested, so the description did not describe the image.

Anything reading `Texture.Format` could then disagree with the device. The multisample feature table was one case, fixed separately in #3382.

## Changes

- `GraphicsDevice.GetSupportedDepthStencilFormat`: resolves the format once per device and caches it. It only depends on the physical device.
- New `AdjustDescriptionForDevice` hook, called before the description is stored, so `Format`, `ViewFormat`, `RowStride`, `SizeInBytes` and the mipmap descriptions all describe the image that exists. No-op on Direct3D.
- Removed the late `NativeFormat` patch in `InitializeFromImpl` and the old `Texture.GetFallbackDepthStencilFormat`, which was recomputed at every texture and pipeline state creation.

This is what `SwapChainGraphicsPresenter` already does for back buffer formats: it writes the surface format it really got back into `Description.BackBufferFormat`.

**Behaviour change:** on a device without `D24_UNORM_S8_UINT` (AMD, most mobile), a depth buffer requested as `D24_UNorm_S8_UInt` now reports `D32_Float_S8X24_UInt`.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have built and run the editor to try this change out.

Builds clean on Direct3D11, Direct3D12 and Vulkan. Not run on a device lacking `D24_UNORM_S8_UINT`, so the substitution path itself is untested: on hardware that supports the format, nothing changes.
